### PR TITLE
Add bounded read-only tool loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Adam Agent is a lightweight, inspectable TypeScript coding agent for local software-engineering work.
 
-The repository contains the first answer-only Agent kernel backed by a deterministic fake model. Coding tools, persistence, interactive terminal support, and live model providers have not been added yet. The accepted runtime is Node.js 24 LTS with pnpm 11; Bun is reserved for a later compatibility-tested distribution experiment.
+The repository contains a provider-neutral Agent kernel with root-confined read, recursive list, and literal text-search tools, backed by a deterministic fake model. Write and execute tools, persistence, cancellation, interactive terminal support, and live model providers have not been added yet. The accepted runtime is Node.js 24 LTS with pnpm 11; Bun is reserved for a later compatibility-tested distribution experiment.
 
 ## Development
 
@@ -11,10 +11,10 @@ corepack enable
 pnpm install --frozen-lockfile
 pnpm hooks:install
 pnpm quality:check
-pnpm --silent adam "Introduce yourself"
+pnpm --silent adam "What is this repository?"
 ```
 
-The `adam` command currently exercises the deterministic fake provider; it does not call a live model.
+The `adam` command currently exercises the deterministic fake provider by reading `README.md`; it does not call a live model.
 
 Use `pnpm quality:fix` only when an intentional formatting rewrite is desired. The pre-commit hook is check-only.
 

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -1,4 +1,7 @@
 import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
@@ -8,13 +11,27 @@ const execFileAsync = promisify(execFile);
 const cliPath = fileURLToPath(new URL("../dist/main.js", import.meta.url));
 
 describe("one-shot CLI", () => {
-  test("prints one fake-model answer and exits successfully", async () => {
-    const { stdout, stderr } = await execFileAsync(process.execPath, [
-      cliPath,
-      "Introduce yourself",
-    ]);
+  test("answers a repository question through one read-only tool turn", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-"));
+    const readmePath = join(workspaceRoot, "README.md");
+    const originalReadme = "# Orchard\n\nThis repository grows pears.\n";
 
-    expect(stdout).toBe("Adam Agent received: Introduce yourself\n");
-    expect(stderr).toBe("");
+    try {
+      await writeFile(readmePath, originalReadme, "utf8");
+
+      const { stdout, stderr } = await execFileAsync(
+        process.execPath,
+        [cliPath, "What does this repository grow?"],
+        { cwd: workspaceRoot },
+      );
+
+      expect({ stdout, stderr, readme: await readFile(readmePath, "utf8") }).toEqual({
+        stdout: "This repository grows pears.\n",
+        stderr: "",
+        readme: originalReadme,
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,19 +1,78 @@
 #!/usr/bin/env node
 
-import { AgentSession } from "@adam-agent/agent";
+import {
+  AgentSession,
+  createPermissionPolicy,
+  createReadToolRegistry,
+  type JsonValue,
+} from "@adam-agent/agent";
 import { FakeModelDriver } from "@adam-agent/testkit";
 
 const prompt = process.argv.slice(2).join(" ");
-const model = new FakeModelDriver([
-  { type: "text_delta", text: `Adam Agent received: ${prompt}` },
-  { type: "finish", reason: "stop" },
-]);
-const session = new AgentSession({ model });
+const model = new FakeModelDriver((request) => {
+  const latestMessage = request.messages.at(-1);
+  if (latestMessage?.role === "user") {
+    return [
+      { type: "tool_call_start", id: "read-readme", name: "read_file" },
+      { type: "tool_call_delta", id: "read-readme", json: '{"path":"README.md"}' },
+      { type: "tool_call_end", id: "read-readme" },
+      { type: "finish", reason: "tool_calls" },
+    ];
+  }
+
+  const answer =
+    latestMessage?.role === "tool" && latestMessage.result.status === "completed"
+      ? firstReadmeParagraph(latestMessage.result.output)
+      : "I could not read README.md.";
+  return [
+    { type: "text_delta", text: answer },
+    { type: "finish", reason: "stop" },
+  ];
+});
+const session = new AgentSession({
+  model,
+  tools: createReadToolRegistry({ workspaceRoot: process.cwd() }),
+  permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+});
 const result = await session.run({ text: prompt });
 
 if (result.status === "completed") {
-  process.stdout.write(`${result.answer}\n`);
+  await writeStream(process.stdout, `${result.answer}\n`);
 } else {
-  process.stderr.write(`${result.error.message}\n`);
+  await writeStream(process.stderr, `${result.error.message}\n`);
   process.exitCode = 1;
+}
+
+function firstReadmeParagraph(output: JsonValue): string {
+  const content = readFileContent(output);
+  return (
+    content
+      ?.split(/\r?\n/u)
+      .map((line) => line.trim())
+      .find((line) => line.length > 0 && !line.startsWith("#")) ?? "README.md was empty."
+  );
+}
+
+function readFileContent(output: JsonValue): string | undefined {
+  if (!isJsonObject(output)) {
+    return undefined;
+  }
+  const content = output.content;
+  return typeof content === "string" ? content : undefined;
+}
+
+function isJsonObject(value: JsonValue): value is { readonly content?: JsonValue } {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function writeStream(stream: NodeJS.WriteStream, text: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    stream.write(text, (error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
 }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -8,5 +8,8 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
+  },
+  "dependencies": {
+    "zod": "4.4.3"
   }
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,19 +1,53 @@
+import type {
+  ModelToolDefinition,
+  PermissionPolicy,
+  ToolCall,
+  ToolRegistry,
+  ToolResult,
+} from "./tool-runtime.js";
+
+export {
+  createPermissionPolicy,
+  createReadToolRegistry,
+  type JsonValue,
+  type ModelToolDefinition,
+  type PermissionDecision,
+  type PermissionPolicy,
+  type ToolCall,
+  type ToolEffect,
+  type ToolRegistry,
+  type ToolResult,
+} from "./tool-runtime.js";
+
 export type UserInput = {
   readonly text: string;
 };
 
-export type ModelMessage = {
-  readonly role: "user";
-  readonly content: string;
-};
+export type ModelMessage =
+  | { readonly role: "user"; readonly content: string }
+  | {
+      readonly role: "assistant";
+      readonly content: string;
+      readonly toolCalls: readonly ToolCall[];
+    }
+  | {
+      readonly role: "tool";
+      readonly callId: string;
+      readonly name: string;
+      readonly result: ToolResult;
+    };
 
 export type ModelRequest = {
   readonly messages: readonly ModelMessage[];
+  readonly tools: readonly ModelToolDefinition[];
 };
 
 export type ModelEvent =
   | { readonly type: "text_delta"; readonly text: string }
-  | { readonly type: "finish"; readonly reason: "stop" };
+  | { readonly type: "tool_call_start"; readonly id: string; readonly name: string }
+  | { readonly type: "tool_call_delta"; readonly id: string; readonly json: string }
+  | { readonly type: "tool_call_end"; readonly id: string }
+  | { readonly type: "finish"; readonly reason: "stop" | "tool_calls" };
 
 export interface ModelDriver {
   stream(request: ModelRequest): AsyncIterable<ModelEvent>;
@@ -27,7 +61,7 @@ export type RunResult =
   | {
       readonly status: "failed";
       readonly error: {
-        readonly code: "model_stream_incomplete";
+        readonly code: "model_stream_incomplete" | "model_protocol_invalid";
         readonly message: string;
       };
     };
@@ -37,20 +71,46 @@ export type RuntimeEvent =
   | { readonly type: "model_message_started" }
   | { readonly type: "model_message_delta"; readonly text: string }
   | { readonly type: "model_message_completed"; readonly text: string }
+  | { readonly type: "tool_requested"; readonly callId: string; readonly name: string }
+  | {
+      readonly type: "tool_permission_decided";
+      readonly callId: string;
+      readonly name: string;
+      readonly decision: "allow" | "deny";
+    }
+  | { readonly type: "tool_started"; readonly callId: string; readonly name: string }
+  | {
+      readonly type: "tool_completed";
+      readonly callId: string;
+      readonly name: string;
+      readonly output: Extract<ToolResult, { readonly status: "completed" }>["output"];
+    }
+  | {
+      readonly type: "tool_failed";
+      readonly callId: string;
+      readonly name: string;
+      readonly error: Extract<ToolResult, { readonly status: "failed" }>["error"];
+    }
   | { readonly type: "session_settled"; readonly result: RunResult };
 
 export type RuntimeEventListener = (event: RuntimeEvent) => void;
 
 export type AgentSessionDependencies = {
   readonly model: ModelDriver;
+  readonly tools?: ToolRegistry;
+  readonly permissions?: PermissionPolicy;
 };
 
 export class AgentSession {
   readonly #listeners = new Set<RuntimeEventListener>();
   readonly #model: ModelDriver;
+  readonly #tools: ToolRegistry | undefined;
+  readonly #permissions: PermissionPolicy | undefined;
 
   constructor(dependencies: AgentSessionDependencies) {
     this.#model = dependencies.model;
+    this.#tools = dependencies.tools;
+    this.#permissions = dependencies.permissions;
   }
 
   subscribe(listener: RuntimeEventListener): () => void {
@@ -62,38 +122,222 @@ export class AgentSession {
 
   async run(input: UserInput): Promise<RunResult> {
     this.#emit({ type: "user_message", text: input.text });
-    this.#emit({ type: "model_message_started" });
+    const messages: ModelMessage[] = [{ role: "user", content: input.text }];
+    const toolResultsById = new Map<
+      string,
+      { readonly call: ToolCall; readonly result: ToolResult }
+    >();
 
-    let answer = "";
-    let finished = false;
-    for await (const event of this.#model.stream({
-      messages: [{ role: "user", content: input.text }],
-    })) {
-      if (event.type === "finish") {
-        finished = true;
-        break;
+    while (true) {
+      this.#emit({ type: "model_message_started" });
+      let answer = "";
+      let finishReason: "stop" | "tool_calls" | undefined;
+      let protocolError: string | undefined;
+      const assemblingCalls = new Map<string, ToolCall>();
+      const completedCalls: ToolCall[] = [];
+
+      for await (const event of this.#model.stream({
+        messages: [...messages],
+        tools: this.#tools?.definitions() ?? [],
+      })) {
+        switch (event.type) {
+          case "text_delta":
+            answer += event.text;
+            this.#emit({ type: "model_message_delta", text: event.text });
+            break;
+          case "tool_call_start":
+            if (assemblingCalls.has(event.id)) {
+              protocolError = "The model started the same tool call more than once.";
+            } else {
+              assemblingCalls.set(event.id, {
+                id: event.id,
+                name: event.name,
+                argumentsJson: "",
+              });
+            }
+            break;
+          case "tool_call_delta": {
+            const call = assemblingCalls.get(event.id);
+            if (call === undefined) {
+              protocolError = "The model sent arguments for a tool call that was not started.";
+            } else {
+              assemblingCalls.set(event.id, {
+                ...call,
+                argumentsJson: call.argumentsJson + event.json,
+              });
+            }
+            break;
+          }
+          case "tool_call_end": {
+            const call = assemblingCalls.get(event.id);
+            if (call === undefined) {
+              protocolError = "The model ended a tool call that was not started.";
+            } else {
+              completedCalls.push(call);
+              assemblingCalls.delete(event.id);
+            }
+            break;
+          }
+          case "finish":
+            finishReason = event.reason;
+            break;
+        }
+        if (finishReason !== undefined) {
+          break;
+        }
       }
 
-      answer += event.text;
-      this.#emit({ type: "model_message_delta", text: event.text });
-    }
+      if (finishReason === undefined) {
+        return this.#settleIncompleteStream();
+      }
 
-    if (!finished) {
-      const result: RunResult = {
-        status: "failed",
-        error: {
-          code: "model_stream_incomplete",
-          message: "The model stream ended without a finish event.",
-        },
-      };
-      this.#emit({ type: "session_settled", result });
-      return result;
-    }
+      if (protocolError !== undefined) {
+        return this.#settleProtocolInvalid(protocolError);
+      }
 
-    this.#emit({ type: "model_message_completed", text: answer });
-    const result: RunResult = { status: "completed", answer };
+      this.#emit({ type: "model_message_completed", text: answer });
+      if (finishReason === "stop") {
+        if (completedCalls.length > 0 || assemblingCalls.size > 0) {
+          return this.#settleProtocolInvalid(
+            completedCalls.length > 0
+              ? "The model stopped after completing a tool request."
+              : "The model stopped with an incomplete tool request.",
+          );
+        }
+        const result: RunResult = { status: "completed", answer };
+        this.#emit({ type: "session_settled", result });
+        return result;
+      }
+
+      if (assemblingCalls.size > 0) {
+        return this.#settleProtocolInvalid("The model finished with an incomplete tool request.");
+      }
+
+      if (completedCalls.length === 0) {
+        const result: RunResult = {
+          status: "failed",
+          error: {
+            code: "model_protocol_invalid",
+            message: "The model reported tool calls without a completed request.",
+          },
+        };
+        this.#emit({ type: "session_settled", result });
+        return result;
+      }
+
+      const uniqueCalls = new Map<string, ToolCall>();
+      for (const call of completedCalls) {
+        const priorCall = uniqueCalls.get(call.id);
+        if (priorCall !== undefined) {
+          return this.#settleProtocolInvalid(
+            priorCall.name !== call.name || priorCall.argumentsJson !== call.argumentsJson
+              ? "The model reused a tool call ID with different input."
+              : "The model repeated a tool call ID within one turn.",
+          );
+        }
+        uniqueCalls.set(call.id, call);
+      }
+
+      messages.push({ role: "assistant", content: answer, toolCalls: completedCalls });
+      for (const call of uniqueCalls.values()) {
+        this.#emit({ type: "tool_requested", callId: call.id, name: call.name });
+        const recordedCall = toolResultsById.get(call.id);
+        if (recordedCall !== undefined) {
+          if (
+            recordedCall.call.name !== call.name ||
+            recordedCall.call.argumentsJson !== call.argumentsJson
+          ) {
+            return this.#settleProtocolInvalid(
+              "The model reused a tool call ID with different input.",
+            );
+          }
+          this.#appendToolResult(messages, call, recordedCall.result);
+          continue;
+        }
+        const adapter = this.#tools?.resolve(call.name);
+        if (adapter === undefined) {
+          const result: ToolResult = {
+            status: "failed",
+            error: {
+              code: "unknown_tool",
+              message: `Unknown tool: ${call.name}`,
+            },
+          };
+          toolResultsById.set(call.id, { call, result });
+          this.#appendToolResult(messages, call, result);
+          continue;
+        }
+        const preparedCall = adapter.prepare(call.argumentsJson);
+        if (preparedCall.status === "failed") {
+          toolResultsById.set(call.id, { call, result: preparedCall });
+          this.#appendToolResult(messages, call, preparedCall);
+          continue;
+        }
+        const decision = this.#permissions?.decide(adapter.effect) ?? "deny";
+        this.#emit({
+          type: "tool_permission_decided",
+          callId: call.id,
+          name: call.name,
+          decision,
+        });
+        if (decision !== "allow") {
+          const result: ToolResult = {
+            status: "failed",
+            error: {
+              code: "permission_denied",
+              message: `Permission denied for tool: ${call.name}`,
+            },
+          };
+          toolResultsById.set(call.id, { call, result });
+          this.#appendToolResult(messages, call, result);
+          continue;
+        }
+        this.#emit({ type: "tool_started", callId: call.id, name: call.name });
+        const result = await preparedCall.execute();
+        toolResultsById.set(call.id, { call, result });
+        this.#appendToolResult(messages, call, result);
+      }
+    }
+  }
+
+  #settleIncompleteStream(): RunResult {
+    const result: RunResult = {
+      status: "failed",
+      error: {
+        code: "model_stream_incomplete",
+        message: "The model stream ended without a finish event.",
+      },
+    };
     this.#emit({ type: "session_settled", result });
     return result;
+  }
+
+  #settleProtocolInvalid(message: string): RunResult {
+    const result: RunResult = {
+      status: "failed",
+      error: { code: "model_protocol_invalid", message },
+    };
+    this.#emit({ type: "session_settled", result });
+    return result;
+  }
+
+  #appendToolResult(messages: ModelMessage[], call: ToolCall, result: ToolResult): void {
+    if (result.status === "completed") {
+      this.#emit({
+        type: "tool_completed",
+        callId: call.id,
+        name: call.name,
+        output: result.output,
+      });
+    } else {
+      this.#emit({
+        type: "tool_failed",
+        callId: call.id,
+        name: call.name,
+        error: result.error,
+      });
+    }
+    messages.push({ role: "tool", callId: call.id, name: call.name, result });
   }
 
   #emit(event: RuntimeEvent): void {

--- a/packages/agent/src/tool-runtime.ts
+++ b/packages/agent/src/tool-runtime.ts
@@ -1,0 +1,500 @@
+import { open, opendir, realpath } from "node:fs/promises";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+import { z } from "zod";
+
+export type ToolEffect = "read" | "write" | "execute" | "network" | "delegate" | "administrative";
+
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue };
+
+export type ModelToolDefinition = {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: Readonly<Record<string, unknown>>;
+};
+
+export type ToolCall = {
+  readonly id: string;
+  readonly name: string;
+  readonly argumentsJson: string;
+};
+
+export type ToolResult =
+  | { readonly status: "completed"; readonly output: JsonValue }
+  | {
+      readonly status: "failed";
+      readonly error: {
+        readonly code:
+          | "unknown_tool"
+          | "invalid_tool_input"
+          | "permission_denied"
+          | "outside_workspace"
+          | "not_found"
+          | "tool_io_failed";
+        readonly message: string;
+      };
+    };
+
+type ToolAdapter = {
+  readonly definition: ModelToolDefinition;
+  readonly outputSchema: z.ZodType<JsonValue>;
+  readonly effect: ToolEffect;
+  readonly cancellation: "unsupported";
+  readonly maximumResult: ToolMaximumResultPolicy;
+  prepare(argumentsJson: string): PreparedToolCall | FailedToolResult;
+};
+
+type ToolMaximumResultPolicy = {
+  readonly maximumBytes?: number;
+  readonly maximumEntries?: number;
+  readonly maximumFiles?: number;
+  readonly maximumFileBytes?: number;
+  readonly maximumMatches?: number;
+  readonly maximumMatchCharacters?: number;
+  readonly maximumQueryCharacters?: number;
+};
+
+type FailedToolResult = Extract<ToolResult, { readonly status: "failed" }>;
+
+type PreparedToolCall = {
+  readonly status: "ready";
+  execute(): Promise<ToolResult>;
+};
+
+class ToolExecutionError extends Error {
+  readonly code: FailedToolResult["error"]["code"];
+
+  constructor(code: FailedToolResult["error"]["code"], message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export type ToolRegistry = {
+  definitions(): readonly ModelToolDefinition[];
+  resolve(name: string): ToolAdapter | undefined;
+};
+
+export type PermissionDecision = "allow" | "deny";
+
+export type PermissionPolicy = {
+  decide(effect: ToolEffect): PermissionDecision;
+};
+
+export function createPermissionPolicy(options: {
+  readonly allowedEffects: readonly ToolEffect[];
+}): PermissionPolicy {
+  const allowedEffects = new Set(options.allowedEffects);
+  return {
+    decide(effect) {
+      return allowedEffects.has(effect) ? "allow" : "deny";
+    },
+  };
+}
+
+const readFileInputSchema = z.strictObject({ path: z.string().min(1) });
+const listFilesInputSchema = z.strictObject({ path: z.string().min(1) });
+const readFileMaximumResult = { maximumBytes: 64 * 1024 } as const;
+const listFilesMaximumResult = { maximumEntries: 200 } as const;
+const searchTextMaximumResult = {
+  maximumEntries: 1_000,
+  maximumFiles: 200,
+  maximumFileBytes: 64 * 1024,
+  maximumMatches: 200,
+  maximumMatchCharacters: 1_024,
+  maximumQueryCharacters: 1_024,
+} as const;
+const searchTextInputSchema = z.strictObject({
+  path: z.string().min(1),
+  query: z.string().min(1).max(searchTextMaximumResult.maximumQueryCharacters),
+});
+
+type ListedEntry = {
+  readonly path: string;
+  readonly type: "file" | "directory";
+};
+
+type SearchMatch = {
+  readonly path: string;
+  readonly line: number;
+  readonly column: number;
+  readonly text: string;
+};
+
+const readFileOutputSchema = z.strictObject({
+  path: z.string(),
+  content: z.string().max(readFileMaximumResult.maximumBytes),
+  truncated: z.boolean(),
+});
+const listedEntrySchema = z.strictObject({
+  path: z.string(),
+  type: z.enum(["file", "directory"]),
+});
+const listFilesOutputSchema = z.strictObject({
+  path: z.string(),
+  entries: z.array(listedEntrySchema).max(listFilesMaximumResult.maximumEntries),
+  truncated: z.boolean(),
+});
+const searchMatchSchema = z.strictObject({
+  path: z.string(),
+  line: z.number().int().positive(),
+  column: z.number().int().positive(),
+  text: z.string().max(searchTextMaximumResult.maximumMatchCharacters),
+});
+const searchTextOutputSchema = z.strictObject({
+  path: z.string(),
+  query: z.string().max(searchTextMaximumResult.maximumQueryCharacters),
+  matches: z.array(searchMatchSchema).max(searchTextMaximumResult.maximumMatches),
+  truncated: z.boolean(),
+});
+
+export function createReadToolRegistry(options: { readonly workspaceRoot: string }): ToolRegistry {
+  const workspaceRoot = resolve(options.workspaceRoot);
+  const readFileAdapter: ToolAdapter = {
+    definition: {
+      name: "read_file",
+      description: "Read a UTF-8 text file inside the workspace.",
+      inputSchema: z.toJSONSchema(readFileInputSchema),
+    },
+    outputSchema: readFileOutputSchema,
+    effect: "read",
+    cancellation: "unsupported",
+    maximumResult: readFileMaximumResult,
+    prepare(argumentsJson) {
+      const parsedArguments = parseInput(readFileInputSchema, argumentsJson);
+      if (!parsedArguments.success) {
+        return invalidToolInput();
+      }
+      return {
+        status: "ready",
+        async execute() {
+          return executeSafely(readFileOutputSchema, async () => {
+            const targetPath = await resolveConfinedPath(workspaceRoot, parsedArguments.data.path);
+            const { content, truncated } = await readTextFileBounded(
+              targetPath,
+              readFileMaximumResult.maximumBytes,
+            );
+            return { path: parsedArguments.data.path, content, truncated };
+          });
+        },
+      };
+    },
+  };
+  const listFilesAdapter: ToolAdapter = {
+    definition: {
+      name: "list_files",
+      description: "List files and directories recursively inside the workspace.",
+      inputSchema: z.toJSONSchema(listFilesInputSchema),
+    },
+    outputSchema: listFilesOutputSchema,
+    effect: "read",
+    cancellation: "unsupported",
+    maximumResult: listFilesMaximumResult,
+    prepare(argumentsJson) {
+      const parsedArguments = parseInput(listFilesInputSchema, argumentsJson);
+      if (!parsedArguments.success) {
+        return invalidToolInput();
+      }
+      return {
+        status: "ready",
+        async execute() {
+          return executeSafely(listFilesOutputSchema, async () => {
+            const targetPath = await resolveConfinedPath(workspaceRoot, parsedArguments.data.path);
+            const listing = await collectEntries(
+              workspaceRoot,
+              targetPath,
+              listFilesMaximumResult.maximumEntries,
+            );
+            return {
+              path: parsedArguments.data.path,
+              entries: listing.entries,
+              truncated: listing.truncated,
+            };
+          });
+        },
+      };
+    },
+  };
+  const searchTextAdapter: ToolAdapter = {
+    definition: {
+      name: "search_text",
+      description: "Search for literal text recursively inside workspace files.",
+      inputSchema: z.toJSONSchema(searchTextInputSchema),
+    },
+    outputSchema: searchTextOutputSchema,
+    effect: "read",
+    cancellation: "unsupported",
+    maximumResult: searchTextMaximumResult,
+    prepare(argumentsJson) {
+      const parsedArguments = parseInput(searchTextInputSchema, argumentsJson);
+      if (!parsedArguments.success) {
+        return invalidToolInput();
+      }
+      return {
+        status: "ready",
+        async execute() {
+          return executeSafely(searchTextOutputSchema, async () => {
+            const targetPath = await resolveConfinedPath(workspaceRoot, parsedArguments.data.path);
+            const listing = await collectEntries(
+              workspaceRoot,
+              targetPath,
+              searchTextMaximumResult.maximumEntries,
+            );
+            const matches: SearchMatch[] = [];
+            let searchedFiles = 0;
+            let truncated = listing.truncated;
+            for (const entry of listing.entries) {
+              if (entry.type !== "file") {
+                continue;
+              }
+              if (searchedFiles >= searchTextMaximumResult.maximumFiles) {
+                truncated = true;
+                break;
+              }
+              searchedFiles += 1;
+              const file = await readTextFileBounded(
+                resolve(workspaceRoot, entry.path),
+                searchTextMaximumResult.maximumFileBytes,
+              );
+              const { content } = file;
+              truncated ||= file.truncated;
+              if (content.includes("\0")) {
+                continue;
+              }
+              const matchTextWasTruncated = collectTextMatches(
+                entry.path,
+                content,
+                parsedArguments.data.query,
+                matches,
+                searchTextMaximumResult.maximumMatches + 1,
+                searchTextMaximumResult.maximumMatchCharacters,
+              );
+              truncated ||= matchTextWasTruncated;
+              if (matches.length > searchTextMaximumResult.maximumMatches) {
+                truncated = true;
+                break;
+              }
+            }
+            return {
+              path: parsedArguments.data.path,
+              query: parsedArguments.data.query,
+              matches: matches.slice(0, searchTextMaximumResult.maximumMatches),
+              truncated,
+            };
+          });
+        },
+      };
+    },
+  };
+  const adapters = new Map(
+    [readFileAdapter, listFilesAdapter, searchTextAdapter].map((adapter) => [
+      adapter.definition.name,
+      adapter,
+    ]),
+  );
+
+  return {
+    definitions() {
+      return [...adapters.values()].map((adapter) => adapter.definition);
+    },
+    resolve(name) {
+      return adapters.get(name);
+    },
+  };
+}
+
+async function readTextFileBounded(
+  path: string,
+  maximumBytes: number,
+): Promise<{ readonly content: string; readonly truncated: boolean }> {
+  const file = await open(path, "r");
+  try {
+    const buffer = Buffer.alloc(maximumBytes + 1);
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
+    return {
+      content: buffer.subarray(0, Math.min(bytesRead, maximumBytes)).toString("utf8"),
+      truncated: bytesRead > maximumBytes,
+    };
+  } finally {
+    await file.close();
+  }
+}
+
+async function executeSafely(
+  outputSchema: z.ZodType<JsonValue>,
+  operation: () => Promise<JsonValue>,
+): Promise<ToolResult> {
+  try {
+    const output = outputSchema.safeParse(await operation());
+    if (!output.success) {
+      return {
+        status: "failed",
+        error: { code: "tool_io_failed", message: "The tool produced an invalid result." },
+      };
+    }
+    return { status: "completed", output: output.data };
+  } catch (error) {
+    if (error instanceof ToolExecutionError) {
+      return { status: "failed", error: { code: error.code, message: error.message } };
+    }
+    return {
+      status: "failed",
+      error: { code: "tool_io_failed", message: "The filesystem operation failed." },
+    };
+  }
+}
+
+async function collectEntries(
+  workspaceRoot: string,
+  directoryPath: string,
+  maximumEntries: number,
+): Promise<{ readonly entries: readonly ListedEntry[]; readonly truncated: boolean }> {
+  const entries: ListedEntry[] = [];
+  const visit = async (currentDirectory: string): Promise<boolean> => {
+    const remaining = maximumEntries - entries.length;
+    if (remaining <= 0) {
+      return hasListableEntry(currentDirectory);
+    }
+
+    const directoryEntries = [];
+    const directory = await opendir(currentDirectory);
+    for await (const entry of directory) {
+      if (entry.isDirectory() || entry.isFile()) {
+        directoryEntries.push(entry);
+      }
+      if (directoryEntries.length > remaining) {
+        break;
+      }
+    }
+    directoryEntries.sort((left, right) => left.name.localeCompare(right.name));
+
+    const directoryWasTruncated = directoryEntries.length > remaining;
+    for (const entry of directoryEntries.slice(0, remaining)) {
+      if (entries.length >= maximumEntries) {
+        return true;
+      }
+      const entryPath = resolve(currentDirectory, entry.name);
+      const relativePath = relative(workspaceRoot, entryPath).split(sep).join("/");
+      if (entry.isDirectory()) {
+        entries.push({ path: relativePath, type: "directory" });
+        if (await visit(entryPath)) {
+          return true;
+        }
+      } else {
+        entries.push({ path: relativePath, type: "file" });
+      }
+    }
+
+    return directoryWasTruncated;
+  };
+
+  return { entries, truncated: await visit(directoryPath) };
+}
+
+async function hasListableEntry(directoryPath: string): Promise<boolean> {
+  const directory = await opendir(directoryPath);
+  for await (const entry of directory) {
+    if (entry.isDirectory() || entry.isFile()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function collectTextMatches(
+  path: string,
+  content: string,
+  query: string,
+  matches: SearchMatch[],
+  maximumMatches: number,
+  maximumMatchCharacters: number,
+): boolean {
+  let truncated = false;
+  const lines = content.split(/\r?\n/u);
+  for (const [lineIndex, line] of lines.entries()) {
+    let searchFrom = 0;
+    while (searchFrom <= line.length) {
+      const matchIndex = line.indexOf(query, searchFrom);
+      if (matchIndex === -1) {
+        break;
+      }
+      truncated ||= line.length > maximumMatchCharacters;
+      matches.push({
+        path,
+        line: lineIndex + 1,
+        column: matchIndex + 1,
+        text: line.slice(0, maximumMatchCharacters),
+      });
+      if (matches.length >= maximumMatches) {
+        return truncated;
+      }
+      searchFrom = matchIndex + Math.max(query.length, 1);
+    }
+  }
+  return truncated;
+}
+
+function parseInput<T>(
+  schema: z.ZodType<T>,
+  argumentsJson: string,
+): { readonly success: true; readonly data: T } | { readonly success: false } {
+  let untrustedInput: unknown;
+  try {
+    untrustedInput = JSON.parse(argumentsJson);
+  } catch {
+    return { success: false };
+  }
+
+  const result = schema.safeParse(untrustedInput);
+  return result.success ? { success: true, data: result.data } : { success: false };
+}
+
+function invalidToolInput(): FailedToolResult {
+  return {
+    status: "failed",
+    error: {
+      code: "invalid_tool_input",
+      message: "The tool input did not match its schema.",
+    },
+  };
+}
+
+async function resolveConfinedPath(workspaceRoot: string, requestedPath: string): Promise<string> {
+  if (isAbsolute(requestedPath)) {
+    throw new ToolExecutionError(
+      "outside_workspace",
+      "The requested path must be relative to the workspace root.",
+    );
+  }
+
+  const lexicalPath = resolve(workspaceRoot, requestedPath);
+  if (isOutside(workspaceRoot, lexicalPath)) {
+    throw new ToolExecutionError(
+      "outside_workspace",
+      "The requested path is outside the workspace root.",
+    );
+  }
+
+  const [canonicalRoot, canonicalPath] = await Promise.all([
+    realpath(workspaceRoot),
+    realpath(lexicalPath),
+  ]);
+  if (isOutside(canonicalRoot, canonicalPath)) {
+    throw new ToolExecutionError(
+      "outside_workspace",
+      "The requested path resolves outside the workspace root.",
+    );
+  }
+  return canonicalPath;
+}
+
+function isOutside(root: string, target: string): boolean {
+  const relativePath = relative(root, target);
+  return relativePath === ".." || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath);
+}

--- a/packages/testkit/src/agent-session.test.ts
+++ b/packages/testkit/src/agent-session.test.ts
@@ -1,4 +1,13 @@
-import { AgentSession, type RuntimeEvent } from "@adam-agent/agent";
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  AgentSession,
+  createPermissionPolicy,
+  createReadToolRegistry,
+  type RuntimeEvent,
+} from "@adam-agent/agent";
 import { describe, expect, test } from "vitest";
 
 import { FakeModelDriver } from "./index.js";
@@ -31,13 +40,16 @@ describe("AgentSession", () => {
   });
 
   test("sends the user input to the model driver", async () => {
-    const model = new FakeModelDriver((request) => [
-      {
-        type: "text_delta",
-        text: request.messages[0]?.content ?? "missing user input",
-      },
-      { type: "finish", reason: "stop" },
-    ]);
+    const model = new FakeModelDriver((request) => {
+      const firstMessage = request.messages[0];
+      return [
+        {
+          type: "text_delta",
+          text: firstMessage?.role === "user" ? firstMessage.content : "missing user input",
+        },
+        { type: "finish", reason: "stop" },
+      ];
+    });
     const session = new AgentSession({ model });
 
     const result = await session.run({ text: "Explain this repository" });
@@ -64,5 +76,1232 @@ describe("AgentSession", () => {
       },
     });
     expect(events.at(-1)).toEqual({ type: "session_settled", result });
+  });
+
+  test("answers from one read_file result without changing the repository", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-read-"));
+    const readmePath = join(workspaceRoot, "README.md");
+    const originalReadme = "# Orchard\n\nThis repository grows pears.\n";
+
+    try {
+      await writeFile(readmePath, originalReadme, "utf8");
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-1", name: "read_file" },
+            { type: "tool_call_delta", id: "call-1", json: '{"path":"README.md"}' },
+            { type: "tool_call_end", id: "call-1" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedExpectedResult =
+          latestMessage?.role === "tool" &&
+          latestMessage.callId === "call-1" &&
+          latestMessage.name === "read_file" &&
+          latestMessage.result.status === "completed" &&
+          JSON.stringify(latestMessage.result.output) ===
+            JSON.stringify({ path: "README.md", content: originalReadme, truncated: false });
+
+        return [
+          {
+            type: "text_delta",
+            text: receivedExpectedResult
+              ? "The repository grows pears."
+              : "The repository result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      const result = await session.run({ text: "What does this repository grow?" });
+
+      expect(result).toEqual({
+        status: "completed",
+        answer: "The repository grows pears.",
+      });
+      expect(await readFile(readmePath, "utf8")).toBe(originalReadme);
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("feeds one typed validation failure back for malformed tool input", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-invalid-"));
+
+    try {
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-invalid", name: "read_file" },
+            { type: "tool_call_delta", id: "call-invalid", json: '{"path":42}' },
+            { type: "tool_call_end", id: "call-invalid" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedValidationFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.callId === "call-invalid" &&
+          latestMessage.name === "read_file" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "invalid_tool_input";
+
+        return [
+          {
+            type: "text_delta",
+            text: receivedValidationFailure
+              ? "The read request was invalid."
+              : "The validation result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+      const events: RuntimeEvent[] = [];
+      session.subscribe((event) => events.push(event));
+
+      const result = await session.run({ text: "Read a file using malformed input" });
+
+      expect({
+        result,
+        toolEvents: events.filter((event) => event.type.startsWith("tool_")),
+      }).toEqual({
+        result: {
+          status: "completed",
+          answer: "The read request was invalid.",
+        },
+        toolEvents: [
+          { type: "tool_requested", callId: "call-invalid", name: "read_file" },
+          {
+            type: "tool_failed",
+            callId: "call-invalid",
+            name: "read_file",
+            error: {
+              code: "invalid_tool_input",
+              message: "The tool input did not match its schema.",
+            },
+          },
+        ],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("fails closed with one typed result for an unknown tool", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-unknown-"));
+
+    try {
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-unknown", name: "erase_repository" },
+            { type: "tool_call_delta", id: "call-unknown", json: "{}" },
+            { type: "tool_call_end", id: "call-unknown" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedUnknownToolFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.callId === "call-unknown" &&
+          latestMessage.name === "erase_repository" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "unknown_tool";
+
+        return [
+          {
+            type: "text_delta",
+            text: receivedUnknownToolFailure
+              ? "That tool is unavailable."
+              : "The unknown-tool result was missing.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      const result = await session.run({ text: "Use an unavailable tool" });
+
+      expect(result).toEqual({
+        status: "completed",
+        answer: "That tool is unavailable.",
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("feeds one permission denial back without executing the tool", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-denied-"));
+
+    try {
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-denied", name: "read_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-denied",
+              json: '{"path":"missing-file.md"}',
+            },
+            { type: "tool_call_end", id: "call-denied" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedPermissionDenial =
+          latestMessage?.role === "tool" &&
+          latestMessage.callId === "call-denied" &&
+          latestMessage.name === "read_file" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "permission_denied";
+
+        return [
+          {
+            type: "text_delta",
+            text: receivedPermissionDenial
+              ? "Reading was denied by policy."
+              : "The permission result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: [] }),
+      });
+
+      const result = await session.run({ text: "Read the missing file" });
+
+      expect(result).toEqual({
+        status: "completed",
+        answer: "Reading was denied by policy.",
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("feeds each requested tool result once in order and publishes ordered tool events", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-multiple-"));
+
+    try {
+      await writeFile(join(workspaceRoot, "first.txt"), "alpha\n", "utf8");
+      await writeFile(join(workspaceRoot, "second.txt"), "beta\n", "utf8");
+      const model = new FakeModelDriver((request) => {
+        const toolMessages = request.messages.filter((message) => message.role === "tool");
+        if (toolMessages.length === 0) {
+          return [
+            { type: "tool_call_start", id: "call-first", name: "read_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-first",
+              json: '{"path":"first.txt"}',
+            },
+            { type: "tool_call_end", id: "call-first" },
+            { type: "tool_call_start", id: "call-second", name: "read_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-second",
+              json: '{"path":"second.txt"}',
+            },
+            { type: "tool_call_end", id: "call-second" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedExactlyOnceInOrder =
+          toolMessages.length === 2 &&
+          toolMessages[0]?.callId === "call-first" &&
+          toolMessages[0].result.status === "completed" &&
+          toolMessages[1]?.callId === "call-second" &&
+          toolMessages[1].result.status === "completed";
+        return [
+          {
+            type: "text_delta",
+            text: receivedExactlyOnceInOrder
+              ? "The files contain alpha and beta."
+              : "The tool feedback was duplicated or reordered.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+      const events: RuntimeEvent[] = [];
+      session.subscribe((event) => events.push(event));
+
+      const result = await session.run({ text: "Read both files" });
+
+      expect({
+        result,
+        toolEvents: events.filter((event) => event.type.startsWith("tool_")),
+      }).toEqual({
+        result: {
+          status: "completed",
+          answer: "The files contain alpha and beta.",
+        },
+        toolEvents: [
+          { type: "tool_requested", callId: "call-first", name: "read_file" },
+          {
+            type: "tool_permission_decided",
+            callId: "call-first",
+            name: "read_file",
+            decision: "allow",
+          },
+          { type: "tool_started", callId: "call-first", name: "read_file" },
+          {
+            type: "tool_completed",
+            callId: "call-first",
+            name: "read_file",
+            output: { path: "first.txt", content: "alpha\n", truncated: false },
+          },
+          { type: "tool_requested", callId: "call-second", name: "read_file" },
+          {
+            type: "tool_permission_decided",
+            callId: "call-second",
+            name: "read_file",
+            decision: "allow",
+          },
+          { type: "tool_started", callId: "call-second", name: "read_file" },
+          {
+            type: "tool_completed",
+            callId: "call-second",
+            name: "read_file",
+            output: { path: "second.txt", content: "beta\n", truncated: false },
+          },
+        ],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("lists workspace entries in stable relative-path order", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-list-"));
+
+    try {
+      await mkdir(join(workspaceRoot, "src"));
+      await writeFile(join(workspaceRoot, "zeta.txt"), "zeta\n", "utf8");
+      await writeFile(join(workspaceRoot, "src", "alpha.ts"), "export {};\n", "utf8");
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-list", name: "list_files" },
+            { type: "tool_call_delta", id: "call-list", json: '{"path":"."}' },
+            { type: "tool_call_end", id: "call-list" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const expectedOutput = {
+          path: ".",
+          entries: [
+            { path: "src", type: "directory" },
+            { path: "src/alpha.ts", type: "file" },
+            { path: "zeta.txt", type: "file" },
+          ],
+          truncated: false,
+        };
+        const receivedStableList =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "completed" &&
+          JSON.stringify(latestMessage.result.output) === JSON.stringify(expectedOutput);
+        return [
+          {
+            type: "text_delta",
+            text: receivedStableList
+              ? "The workspace contains src/alpha.ts and zeta.txt."
+              : "The directory listing was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      const result = await session.run({ text: "List the workspace files" });
+
+      expect(result).toEqual({
+        status: "completed",
+        answer: "The workspace contains src/alpha.ts and zeta.txt.",
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("searches workspace text with stable relative locations", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-"));
+
+    try {
+      await mkdir(join(workspaceRoot, "src"));
+      await writeFile(join(workspaceRoot, "README.md"), "Pear trees\nApple trees\n", "utf8");
+      await writeFile(
+        join(workspaceRoot, "src", "fruit.ts"),
+        'export const fruit = "pear";\n',
+        "utf8",
+      );
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-search", name: "search_text" },
+            {
+              type: "tool_call_delta",
+              id: "call-search",
+              json: '{"path":".","query":"pear"}',
+            },
+            { type: "tool_call_end", id: "call-search" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const expectedOutput = {
+          path: ".",
+          query: "pear",
+          matches: [
+            { path: "src/fruit.ts", line: 1, column: 23, text: 'export const fruit = "pear";' },
+          ],
+          truncated: false,
+        };
+        const receivedStableSearch =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "completed" &&
+          JSON.stringify(latestMessage.result.output) === JSON.stringify(expectedOutput);
+        return [
+          {
+            type: "text_delta",
+            text: receivedStableSearch
+              ? "The lowercase match is in src/fruit.ts."
+              : "The search result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      const result = await session.run({ text: "Find lowercase pear" });
+
+      expect(result).toEqual({
+        status: "completed",
+        answer: "The lowercase match is in src/fruit.ts.",
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects lexical traversal with one typed result", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-traversal-"));
+
+    try {
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-traversal", name: "read_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-traversal",
+              json: '{"path":"../outside.txt"}',
+            },
+            { type: "tool_call_end", id: "call-traversal" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedConfinementFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "outside_workspace";
+        return [
+          {
+            type: "text_delta",
+            text: receivedConfinementFailure
+              ? "The path is outside the workspace."
+              : "The confinement result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      const result = await session.run({ text: "Read outside the workspace" });
+
+      expect(result).toEqual({
+        status: "completed",
+        answer: "The path is outside the workspace.",
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a symlink that resolves outside the workspace", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-symlink-root-"));
+    const outsideRoot = await mkdtemp(join(tmpdir(), "adam-agent-symlink-outside-"));
+
+    try {
+      const outsidePath = join(outsideRoot, "secret.txt");
+      await writeFile(outsidePath, "outside secret\n", "utf8");
+      await symlink(outsidePath, join(workspaceRoot, "linked-secret.txt"));
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-symlink", name: "read_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-symlink",
+              json: '{"path":"linked-secret.txt"}',
+            },
+            { type: "tool_call_end", id: "call-symlink" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedConfinementFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "outside_workspace";
+        return [
+          {
+            type: "text_delta",
+            text: receivedConfinementFailure
+              ? "The symlink target is outside the workspace."
+              : "The symlink confinement result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      const result = await session.run({ text: "Read the linked secret" });
+
+      expect(result).toEqual({
+        status: "completed",
+        answer: "The symlink target is outside the workspace.",
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+      await rm(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("fails truthfully when a tool-call turn has no completed request", async () => {
+    const model = new FakeModelDriver((request) => {
+      const latestMessage = request.messages.at(-1);
+      if (latestMessage?.role === "user") {
+        return [
+          { type: "tool_call_start", id: "call-incomplete", name: "read_file" },
+          {
+            type: "tool_call_delta",
+            id: "call-incomplete",
+            json: '{"path":"README.md"}',
+          },
+          { type: "finish", reason: "tool_calls" },
+        ];
+      }
+      return [
+        { type: "text_delta", text: "This turn should not run." },
+        { type: "finish", reason: "stop" },
+      ];
+    });
+    const session = new AgentSession({ model });
+
+    const result = await session.run({ text: "Read the README" });
+
+    expect(result).toEqual({
+      status: "failed",
+      error: {
+        code: "model_protocol_invalid",
+        message: "The model finished with an incomplete tool request.",
+      },
+    });
+  });
+
+  test("executes a retried tool call ID once and reuses its result", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-retry-"));
+
+    try {
+      await writeFile(join(workspaceRoot, "value.txt"), "one\n", "utf8");
+      let round = 0;
+      const model = new FakeModelDriver((request) => {
+        round += 1;
+        if (round <= 2) {
+          return [
+            { type: "tool_call_start", id: "call-retried", name: "read_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-retried",
+              json: '{"path":"value.txt"}',
+            },
+            { type: "tool_call_end", id: "call-retried" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const toolMessages = request.messages.filter((message) => message.role === "tool");
+        const feedback = toolMessages.filter((message) => message.callId === "call-retried");
+        const reusedSameResult =
+          feedback.length === 2 &&
+          feedback[0]?.result.status === "completed" &&
+          feedback[1]?.result.status === "completed" &&
+          JSON.stringify(feedback[0].result) === JSON.stringify(feedback[1].result);
+        return [
+          {
+            type: "text_delta",
+            text: reusedSameResult
+              ? "The retried read was reused."
+              : "The retry result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+      const events: RuntimeEvent[] = [];
+      session.subscribe((event) => events.push(event));
+
+      const result = await session.run({ text: "Read the value, including a provider retry" });
+
+      expect({
+        result,
+        startedEvents: events.filter((event) => event.type === "tool_started"),
+      }).toEqual({
+        result: { status: "completed", answer: "The retried read was reused." },
+        startedEvents: [{ type: "tool_started", callId: "call-retried", name: "read_file" }],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("fails truthfully when stop includes a completed tool request", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-stop-with-tool-"));
+
+    try {
+      await writeFile(join(workspaceRoot, "README.md"), "must not be read\n", "utf8");
+      const model = new FakeModelDriver([
+        { type: "tool_call_start", id: "call-stop", name: "read_file" },
+        { type: "tool_call_delta", id: "call-stop", json: '{"path":"README.md"}' },
+        { type: "tool_call_end", id: "call-stop" },
+        { type: "finish", reason: "stop" },
+      ]);
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+      const events: RuntimeEvent[] = [];
+      session.subscribe((event) => events.push(event));
+
+      const result = await session.run({ text: "Stop with an unhandled tool request" });
+
+      expect({
+        result,
+        startedEvents: events.filter((event) => event.type === "tool_started"),
+      }).toEqual({
+        result: {
+          status: "failed",
+          error: {
+            code: "model_protocol_invalid",
+            message: "The model stopped after completing a tool request.",
+          },
+        },
+        startedEvents: [],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("returns a bounded read_file result with explicit truncation", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-bounded-read-"));
+
+    try {
+      await writeFile(join(workspaceRoot, "large.txt"), "x".repeat(65_537), "utf8");
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-large", name: "read_file" },
+            { type: "tool_call_delta", id: "call-large", json: '{"path":"large.txt"}' },
+            { type: "tool_call_end", id: "call-large" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const boundedOutput =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "completed" &&
+          JSON.stringify(latestMessage.result.output) ===
+            JSON.stringify({ path: "large.txt", content: "x".repeat(65_536), truncated: true });
+        return [
+          {
+            type: "text_delta",
+            text: boundedOutput
+              ? "The read was truncated safely."
+              : "The read result was unbounded.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      const result = await session.run({ text: "Read the large file" });
+
+      expect(result).toEqual({
+        status: "completed",
+        answer: "The read was truncated safely.",
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects conflicting tool calls with the same ID before execution", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-conflicting-id-"));
+
+    try {
+      await writeFile(join(workspaceRoot, "first.txt"), "first\n", "utf8");
+      await writeFile(join(workspaceRoot, "second.txt"), "second\n", "utf8");
+      const model = new FakeModelDriver([
+        { type: "tool_call_start", id: "call-conflict", name: "read_file" },
+        { type: "tool_call_delta", id: "call-conflict", json: '{"path":"first.txt"}' },
+        { type: "tool_call_end", id: "call-conflict" },
+        { type: "tool_call_start", id: "call-conflict", name: "read_file" },
+        { type: "tool_call_delta", id: "call-conflict", json: '{"path":"second.txt"}' },
+        { type: "tool_call_end", id: "call-conflict" },
+        { type: "finish", reason: "tool_calls" },
+      ]);
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+      const events: RuntimeEvent[] = [];
+      session.subscribe((event) => events.push(event));
+
+      const result = await session.run({ text: "Send conflicting calls" });
+
+      expect({
+        result,
+        startedEvents: events.filter((event) => event.type === "tool_started"),
+      }).toEqual({
+        result: {
+          status: "failed",
+          error: {
+            code: "model_protocol_invalid",
+            message: "The model reused a tool call ID with different input.",
+          },
+        },
+        startedEvents: [],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a duplicate tool call ID within one model turn", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-duplicate-id-"));
+
+    try {
+      await writeFile(join(workspaceRoot, "value.txt"), "one\n", "utf8");
+      let round = 0;
+      const model = new FakeModelDriver(() => {
+        round += 1;
+        if (round === 1) {
+          return [
+            { type: "tool_call_start", id: "call-duplicate", name: "read_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-duplicate",
+              json: '{"path":"value.txt"}',
+            },
+            { type: "tool_call_end", id: "call-duplicate" },
+            { type: "tool_call_start", id: "call-duplicate", name: "read_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-duplicate",
+              json: '{"path":"value.txt"}',
+            },
+            { type: "tool_call_end", id: "call-duplicate" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+        return [
+          { type: "text_delta", text: "This turn should not run." },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+      const events: RuntimeEvent[] = [];
+      session.subscribe((event) => events.push(event));
+
+      const result = await session.run({ text: "Send one duplicate ID" });
+
+      expect({
+        result,
+        startedEvents: events.filter((event) => event.type === "tool_started"),
+      }).toEqual({
+        result: {
+          status: "failed",
+          error: {
+            code: "model_protocol_invalid",
+            message: "The model repeated a tool call ID within one turn.",
+          },
+        },
+        startedEvents: [],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects the whole tool turn when one request is incomplete", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-partial-turn-"));
+
+    try {
+      await writeFile(join(workspaceRoot, "first.txt"), "must not be read\n", "utf8");
+      const model = new FakeModelDriver([
+        { type: "tool_call_start", id: "call-complete", name: "read_file" },
+        { type: "tool_call_delta", id: "call-complete", json: '{"path":"first.txt"}' },
+        { type: "tool_call_end", id: "call-complete" },
+        { type: "tool_call_start", id: "call-incomplete", name: "read_file" },
+        {
+          type: "tool_call_delta",
+          id: "call-incomplete",
+          json: '{"path":"second.txt"}',
+        },
+        { type: "finish", reason: "tool_calls" },
+      ]);
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+      const events: RuntimeEvent[] = [];
+      session.subscribe((event) => events.push(event));
+
+      const result = await session.run({ text: "Send one complete and one incomplete call" });
+
+      expect({
+        result,
+        toolEvents: events.filter((event) => event.type.startsWith("tool_")),
+      }).toEqual({
+        result: {
+          status: "failed",
+          error: {
+            code: "model_protocol_invalid",
+            message: "The model finished with an incomplete tool request.",
+          },
+        },
+        toolEvents: [],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("stops listing when the result budget is exhausted", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-list-budget-"));
+    const blockedDirectory = join(workspaceRoot, "zzz-blocked");
+
+    try {
+      await Promise.all(
+        Array.from({ length: 200 }, (_, index) =>
+          writeFile(
+            join(workspaceRoot, `file-${String(index).padStart(3, "0")}.txt`),
+            "x\n",
+            "utf8",
+          ),
+        ),
+      );
+      await mkdir(blockedDirectory, { mode: 0o000 });
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-budget", name: "list_files" },
+            { type: "tool_call_delta", id: "call-budget", json: '{"path":"."}' },
+            { type: "tool_call_end", id: "call-budget" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const serializedResult =
+          latestMessage?.role === "tool" && latestMessage.result.status === "completed"
+            ? JSON.stringify(latestMessage.result.output)
+            : "";
+        const stoppedAtBudget =
+          serializedResult.includes('"truncated":true') &&
+          serializedResult.includes('"path":"file-199.txt"') &&
+          !serializedResult.includes("zzz-blocked");
+        return [
+          {
+            type: "text_delta",
+            text: stoppedAtBudget
+              ? "The listing stopped at its result budget."
+              : "The listing exceeded its result budget.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      const result = await session.run({ text: "List a bounded number of files" });
+
+      expect(result).toEqual({
+        status: "completed",
+        answer: "The listing stopped at its result budget.",
+      });
+    } finally {
+      await chmod(blockedDirectory, 0o700).catch(() => undefined);
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects a duplicate tool-call start before execution", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-duplicate-start-"));
+
+    try {
+      await writeFile(join(workspaceRoot, "value.txt"), "must not be read\n", "utf8");
+      const model = new FakeModelDriver([
+        { type: "tool_call_start", id: "call-start", name: "read_file" },
+        { type: "tool_call_delta", id: "call-start", json: '{"path":"value.txt"}' },
+        { type: "tool_call_start", id: "call-start", name: "read_file" },
+        { type: "tool_call_delta", id: "call-start", json: '{"path":"value.txt"}' },
+        { type: "tool_call_end", id: "call-start" },
+        { type: "finish", reason: "tool_calls" },
+      ]);
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+      const events: RuntimeEvent[] = [];
+      session.subscribe((event) => events.push(event));
+
+      const result = await session.run({ text: "Send a duplicate tool-call start" });
+
+      expect({
+        result,
+        toolEvents: events.filter((event) => event.type.startsWith("tool_")),
+      }).toEqual({
+        result: {
+          status: "failed",
+          error: {
+            code: "model_protocol_invalid",
+            message: "The model started the same tool call more than once.",
+          },
+        },
+        toolEvents: [],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    {
+      label: "arguments",
+      event: { type: "tool_call_delta", id: "orphan", json: "{}" } as const,
+      message: "The model sent arguments for a tool call that was not started.",
+    },
+    {
+      label: "end",
+      event: { type: "tool_call_end", id: "orphan" } as const,
+      message: "The model ended a tool call that was not started.",
+    },
+  ])("rejects an orphaned tool-call $label event", async ({ event, message }) => {
+    const model = new FakeModelDriver([event, { type: "finish", reason: "tool_calls" }]);
+    const session = new AgentSession({ model });
+    const events: RuntimeEvent[] = [];
+    session.subscribe((runtimeEvent) => events.push(runtimeEvent));
+
+    const result = await session.run({ text: "Send a malformed tool-call stream" });
+
+    expect({
+      result,
+      toolEvents: events.filter((runtimeEvent) => runtimeEvent.type.startsWith("tool_")),
+    }).toEqual({
+      result: {
+        status: "failed",
+        error: { code: "model_protocol_invalid", message },
+      },
+      toolEvents: [],
+    });
+  });
+
+  test("does not mark a complete listing as truncated when its final entry is empty", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-exact-list-budget-"));
+
+    try {
+      await Promise.all(
+        Array.from({ length: 199 }, (_, index) =>
+          writeFile(
+            join(workspaceRoot, `file-${String(index).padStart(3, "0")}.txt`),
+            "x\n",
+            "utf8",
+          ),
+        ),
+      );
+      await mkdir(join(workspaceRoot, "zzz-empty"));
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-exact-budget", name: "list_files" },
+            { type: "tool_call_delta", id: "call-exact-budget", json: '{"path":"."}' },
+            { type: "tool_call_end", id: "call-exact-budget" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const serializedResult =
+          latestMessage?.role === "tool" && latestMessage.result.status === "completed"
+            ? JSON.stringify(latestMessage.result.output)
+            : "";
+        const listingIsComplete =
+          serializedResult.includes('"path":"zzz-empty","type":"directory"') &&
+          serializedResult.includes('"truncated":false');
+        return [
+          {
+            type: "text_delta",
+            text: listingIsComplete
+              ? "The exact-budget listing is complete."
+              : "The exact-budget listing was reported incorrectly.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      const result = await session.run({ text: "List exactly the result budget" });
+
+      expect(result).toEqual({
+        status: "completed",
+        answer: "The exact-budget listing is complete.",
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("bounds search match text from a long source line", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-line-budget-"));
+
+    try {
+      await writeFile(join(workspaceRoot, "long.txt"), `needle${"x".repeat(2_000)}\n`, "utf8");
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-search-line", name: "search_text" },
+            {
+              type: "tool_call_delta",
+              id: "call-search-line",
+              json: '{"path":".","query":"needle"}',
+            },
+            { type: "tool_call_end", id: "call-search-line" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const output =
+          latestMessage?.role === "tool" && latestMessage.result.status === "completed"
+            ? latestMessage.result.output
+            : undefined;
+        const serializedOutput = JSON.stringify(output);
+        const bounded =
+          serializedOutput.includes('"truncated":true') &&
+          !serializedOutput.includes("x".repeat(1_025));
+        return [
+          {
+            type: "text_delta",
+            text: bounded ? "The match text was bounded." : "The match text was unbounded.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      const result = await session.run({ text: "Search a long line safely" });
+
+      expect(result).toEqual({ status: "completed", answer: "The match text was bounded." });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects an oversized search query before execution", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-query-budget-"));
+    const query = "x".repeat(1_025);
+
+    try {
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-search-query", name: "search_text" },
+            {
+              type: "tool_call_delta",
+              id: "call-search-query",
+              json: JSON.stringify({ path: ".", query }),
+            },
+            { type: "tool_call_end", id: "call-search-query" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const rejected =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "invalid_tool_input";
+        return [
+          {
+            type: "text_delta",
+            text: rejected ? "The oversized query was rejected." : "The query was accepted.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+      const events: RuntimeEvent[] = [];
+      session.subscribe((event) => events.push(event));
+
+      const result = await session.run({ text: "Search with an oversized query" });
+
+      expect({
+        result,
+        startedEvents: events.filter((event) => event.type === "tool_started"),
+      }).toEqual({
+        result: { status: "completed", answer: "The oversized query was rejected." },
+        startedEvents: [],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("returns matches from the bounded prefix of a truncated file", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-truncated-search-"));
+
+    try {
+      await writeFile(join(workspaceRoot, "large.txt"), `needle\n${"x".repeat(70_000)}`, "utf8");
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-truncated-search", name: "search_text" },
+            {
+              type: "tool_call_delta",
+              id: "call-truncated-search",
+              json: '{"path":".","query":"needle"}',
+            },
+            { type: "tool_call_end", id: "call-truncated-search" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const serializedResult =
+          latestMessage?.role === "tool" && latestMessage.result.status === "completed"
+            ? JSON.stringify(latestMessage.result.output)
+            : "";
+        const keptPrefixMatch =
+          serializedResult.includes('"line":1') && serializedResult.includes('"truncated":true');
+        return [
+          {
+            type: "text_delta",
+            text: keptPrefixMatch
+              ? "The bounded prefix match was returned."
+              : "The bounded prefix match was lost.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = new AgentSession({
+        model,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      const result = await session.run({ text: "Search the bounded file prefix" });
+
+      expect(result).toEqual({
+        status: "completed",
+        answer: "The bounded prefix match was returned.",
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,7 +33,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/testkit
 
-  packages/agent: {}
+  packages/agent:
+    dependencies:
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
 
   packages/testkit:
     dependencies:
@@ -935,6 +939,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@biomejs/biome@2.5.8':
@@ -1727,3 +1734,5 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  zod@4.4.3: {}


### PR DESCRIPTION
## What changed

- extend `AgentSession` with a provider-neutral multi-turn tool loop and stable tool-result feedback
- add Zod-validated, root-confined `read_file`, `list_files`, and literal `search_text` adapters with explicit effect, cancellation, and result-limit policies
- fail closed for malformed streams, duplicate or reused tool-call IDs, invalid input, unknown tools, denied permissions, traversal, and symlink escape
- update the deterministic CLI to answer a repository question through a real read-only tool turn

## Why

This completes reimplementation micro-slice A2 while keeping provider logic, orchestration, permission policy, and filesystem effects separated. Result ledgers prevent provider retries from duplicating tool execution, and bounded reads/searches keep untrusted repository content from producing unbounded tool results.

## Impact

The fake-provider CLI can now inspect `README.md` without mutating the repository. Write, execute, persistence, cancellation support, TUI, and live providers remain out of scope.

## Validation

- `pnpm quality:check` (2 files, 28 tests)
- `pnpm --silent adam "What is this repository?"`
- independent standards and specification re-reviews: no findings
