### PR TITLE
feat: add durable session lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Adam Agent is a lightweight, inspectable TypeScript coding agent for local software-engineering work.
 
-The repository contains a provider-neutral Agent kernel with root-confined read, recursive list, and literal text-search tools, backed by a deterministic fake model. Write and execute tools, persistence, cancellation, interactive terminal support, and live model providers have not been added yet. The accepted runtime is Node.js 24 LTS with pnpm 11; Bun is reserved for a later compatibility-tested distribution experiment.
+The repository contains a provider-neutral Agent kernel with root-confined read, recursive list, and literal text-search tools, canonical event persistence through caller-supplied in-memory and durable project-scoped JSONL stores, cancellation, and per-run turn/token limits, backed by a deterministic fake model. Write and execute tools, approval prompts, resume, interactive terminal support, and live model providers have not been added yet. The accepted runtime is Node.js 24 LTS with pnpm 11; Bun is reserved for a later compatibility-tested distribution experiment.
 
 ## Development
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -2,6 +2,7 @@
 
 import {
   AgentSession,
+  createInMemorySessionStore,
   createPermissionPolicy,
   createReadToolRegistry,
   type JsonValue,
@@ -31,6 +32,7 @@ const model = new FakeModelDriver((request) => {
 });
 const session = new AgentSession({
   model,
+  store: createInMemorySessionStore(),
   tools: createReadToolRegistry({ workspaceRoot: process.cwd() }),
   permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
 });

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,3 +1,6 @@
+import { randomUUID } from "node:crypto";
+
+import type { CanonicalRuntimeEvent, SessionStore } from "./session-store.js";
 import type {
   ModelToolDefinition,
   PermissionPolicy,
@@ -5,6 +8,15 @@ import type {
   ToolRegistry,
   ToolResult,
 } from "./tool-runtime.js";
+
+export {
+  type CanonicalRuntimeEvent,
+  createInMemorySessionStore,
+  createJsonlSessionStore,
+  type SessionEventRecord,
+  type SessionStore,
+  SessionStoreError,
+} from "./session-store.js";
 
 export {
   createPermissionPolicy,
@@ -21,6 +33,14 @@ export {
 
 export type UserInput = {
   readonly text: string;
+};
+
+export type RunOptions = {
+  readonly signal?: AbortSignal;
+  readonly limits?: {
+    readonly maxTurns?: number;
+    readonly maxTokens?: number;
+  };
 };
 
 export type ModelMessage =
@@ -40,6 +60,7 @@ export type ModelMessage =
 export type ModelRequest = {
   readonly messages: readonly ModelMessage[];
   readonly tools: readonly ModelToolDefinition[];
+  readonly signal: AbortSignal;
 };
 
 export type ModelEvent =
@@ -47,6 +68,11 @@ export type ModelEvent =
   | { readonly type: "tool_call_start"; readonly id: string; readonly name: string }
   | { readonly type: "tool_call_delta"; readonly id: string; readonly json: string }
   | { readonly type: "tool_call_end"; readonly id: string }
+  | {
+      readonly type: "usage";
+      readonly inputTokens: number;
+      readonly outputTokens: number;
+    }
   | { readonly type: "finish"; readonly reason: "stop" | "tool_calls" };
 
 export interface ModelDriver {
@@ -59,9 +85,24 @@ export type RunResult =
       readonly answer: string;
     }
   | {
+      readonly status: "cancelled";
+      readonly error: {
+        readonly code: "session_cancelled";
+        readonly message: string;
+      };
+    }
+  | {
       readonly status: "failed";
       readonly error: {
-        readonly code: "model_stream_incomplete" | "model_protocol_invalid";
+        readonly code:
+          | "model_stream_incomplete"
+          | "model_protocol_invalid"
+          | "invalid_run_limits"
+          | "run_already_active"
+          | "session_persistence_failed"
+          | "turn_limit_exceeded"
+          | "token_limit_exceeded"
+          | "token_usage_missing";
         readonly message: string;
       };
     };
@@ -71,6 +112,12 @@ export type RuntimeEvent =
   | { readonly type: "model_message_started" }
   | { readonly type: "model_message_delta"; readonly text: string }
   | { readonly type: "model_message_completed"; readonly text: string }
+  | {
+      readonly type: "model_usage";
+      readonly inputTokens: number;
+      readonly outputTokens: number;
+      readonly totalTokens: number;
+    }
   | { readonly type: "tool_requested"; readonly callId: string; readonly name: string }
   | {
       readonly type: "tool_permission_decided";
@@ -91,14 +138,18 @@ export type RuntimeEvent =
       readonly name: string;
       readonly error: Extract<ToolResult, { readonly status: "failed" }>["error"];
     }
+  | { readonly type: "session_interrupted"; readonly reason: "cancelled" }
   | { readonly type: "session_settled"; readonly result: RunResult };
 
 export type RuntimeEventListener = (event: RuntimeEvent) => void;
+
+class SessionPersistenceError extends Error {}
 
 export type AgentSessionDependencies = {
   readonly model: ModelDriver;
   readonly tools?: ToolRegistry;
   readonly permissions?: PermissionPolicy;
+  readonly store: SessionStore;
 };
 
 export class AgentSession {
@@ -106,11 +157,17 @@ export class AgentSession {
   readonly #model: ModelDriver;
   readonly #tools: ToolRegistry | undefined;
   readonly #permissions: PermissionPolicy | undefined;
+  readonly #store: SessionStore;
+  #activeAbortController: AbortController | undefined;
+  #activeRunId: string | undefined;
+  #nextSequence = 1;
+  #terminalResult: RunResult | undefined;
 
   constructor(dependencies: AgentSessionDependencies) {
     this.#model = dependencies.model;
     this.#tools = dependencies.tools;
     this.#permissions = dependencies.permissions;
+    this.#store = dependencies.store;
   }
 
   subscribe(listener: RuntimeEventListener): () => void {
@@ -120,30 +177,116 @@ export class AgentSession {
     };
   }
 
-  async run(input: UserInput): Promise<RunResult> {
-    this.#emit({ type: "user_message", text: input.text });
+  abort(): void {
+    this.#activeAbortController?.abort();
+  }
+
+  async run(input: UserInput, options: RunOptions = {}): Promise<RunResult> {
+    if (!areRunLimitsValid(options.limits)) {
+      return {
+        status: "failed",
+        error: {
+          code: "invalid_run_limits",
+          message: "Run limits must be positive safe integers.",
+        },
+      };
+    }
+    if (this.#activeAbortController !== undefined) {
+      return {
+        status: "failed",
+        error: {
+          code: "run_already_active",
+          message: "The session already has an active run.",
+        },
+      };
+    }
+    this.#terminalResult = undefined;
+    this.#activeRunId = randomUUID();
+    const abortController = new AbortController();
+    const abortFromCaller = () => abortController.abort(options.signal?.reason);
+    if (options.signal?.aborted === true) {
+      abortFromCaller();
+    } else {
+      options.signal?.addEventListener("abort", abortFromCaller, { once: true });
+    }
+    this.#activeAbortController = abortController;
+    try {
+      try {
+        return await this.#run(input, abortController.signal, options.limits);
+      } catch (error) {
+        if (abortController.signal.aborted && this.#terminalResult === undefined) {
+          return await this.#settleCancelled();
+        }
+        throw error;
+      }
+    } catch (error) {
+      if (error instanceof SessionPersistenceError) {
+        return {
+          status: "failed",
+          error: {
+            code: "session_persistence_failed",
+            message: "The session event could not be persisted.",
+          },
+        };
+      }
+      throw error;
+    } finally {
+      options.signal?.removeEventListener("abort", abortFromCaller);
+      if (this.#activeAbortController === abortController) {
+        this.#activeAbortController = undefined;
+        this.#activeRunId = undefined;
+      }
+    }
+  }
+
+  async #run(
+    input: UserInput,
+    signal: AbortSignal,
+    limits: RunOptions["limits"],
+  ): Promise<RunResult> {
+    await this.#emit({ type: "user_message", text: input.text });
+    if (signal.aborted) {
+      return this.#settleCancelled();
+    }
     const messages: ModelMessage[] = [{ role: "user", content: input.text }];
     const toolResultsById = new Map<
       string,
       { readonly call: ToolCall; readonly result: ToolResult }
     >();
+    let modelTurns = 0;
+    let reportedTokens = 0;
 
     while (true) {
-      this.#emit({ type: "model_message_started" });
+      if (signal.aborted) {
+        return this.#settleCancelled();
+      }
+      if (limits?.maxTurns !== undefined && modelTurns >= limits.maxTurns) {
+        return this.#settleTurnLimitExceeded();
+      }
+      modelTurns += 1;
+      await this.#emit({ type: "model_message_started" });
+      if (signal.aborted) {
+        return this.#settleCancelled();
+      }
       let answer = "";
       let finishReason: "stop" | "tool_calls" | undefined;
       let protocolError: string | undefined;
+      let usageWasReported = false;
       const assemblingCalls = new Map<string, ToolCall>();
       const completedCalls: ToolCall[] = [];
 
       for await (const event of this.#model.stream({
         messages: [...messages],
         tools: this.#tools?.definitions() ?? [],
+        signal,
       })) {
+        if (signal.aborted) {
+          break;
+        }
         switch (event.type) {
           case "text_delta":
             answer += event.text;
-            this.#emit({ type: "model_message_delta", text: event.text });
+            await this.#emit({ type: "model_message_delta", text: event.text });
             break;
           case "tool_call_start":
             if (assemblingCalls.has(event.id)) {
@@ -178,13 +321,39 @@ export class AgentSession {
             }
             break;
           }
+          case "usage": {
+            const totalTokens = event.inputTokens + event.outputTokens;
+            const nextReportedTokens = reportedTokens + totalTokens;
+            if (
+              !isNonnegativeSafeInteger(event.inputTokens) ||
+              !isNonnegativeSafeInteger(event.outputTokens) ||
+              !Number.isSafeInteger(totalTokens) ||
+              !Number.isSafeInteger(nextReportedTokens)
+            ) {
+              protocolError = "The model reported invalid token usage.";
+              break;
+            }
+            usageWasReported = true;
+            reportedTokens = nextReportedTokens;
+            await this.#emit({
+              type: "model_usage",
+              inputTokens: event.inputTokens,
+              outputTokens: event.outputTokens,
+              totalTokens,
+            });
+            break;
+          }
           case "finish":
             finishReason = event.reason;
             break;
         }
-        if (finishReason !== undefined) {
+        if (signal.aborted || finishReason !== undefined) {
           break;
         }
+      }
+
+      if (signal.aborted) {
+        return this.#settleCancelled();
       }
 
       if (finishReason === undefined) {
@@ -195,7 +364,16 @@ export class AgentSession {
         return this.#settleProtocolInvalid(protocolError);
       }
 
-      this.#emit({ type: "model_message_completed", text: answer });
+      await this.#emit({ type: "model_message_completed", text: answer });
+      if (signal.aborted) {
+        return this.#settleCancelled();
+      }
+      if (limits?.maxTokens !== undefined && !usageWasReported) {
+        return this.#settleTokenUsageMissing();
+      }
+      if (limits?.maxTokens !== undefined && reportedTokens >= limits.maxTokens) {
+        return this.#settleTokenLimitExceeded();
+      }
       if (finishReason === "stop") {
         if (completedCalls.length > 0 || assemblingCalls.size > 0) {
           return this.#settleProtocolInvalid(
@@ -205,8 +383,7 @@ export class AgentSession {
           );
         }
         const result: RunResult = { status: "completed", answer };
-        this.#emit({ type: "session_settled", result });
-        return result;
+        return this.#settle(result);
       }
 
       if (assemblingCalls.size > 0) {
@@ -221,8 +398,7 @@ export class AgentSession {
             message: "The model reported tool calls without a completed request.",
           },
         };
-        this.#emit({ type: "session_settled", result });
-        return result;
+        return this.#settle(result);
       }
 
       const uniqueCalls = new Map<string, ToolCall>();
@@ -240,7 +416,13 @@ export class AgentSession {
 
       messages.push({ role: "assistant", content: answer, toolCalls: completedCalls });
       for (const call of uniqueCalls.values()) {
-        this.#emit({ type: "tool_requested", callId: call.id, name: call.name });
+        if (signal.aborted) {
+          return this.#settleCancelled();
+        }
+        await this.#emit({ type: "tool_requested", callId: call.id, name: call.name });
+        if (signal.aborted) {
+          return this.#settleCancelled();
+        }
         const recordedCall = toolResultsById.get(call.id);
         if (recordedCall !== undefined) {
           if (
@@ -251,7 +433,7 @@ export class AgentSession {
               "The model reused a tool call ID with different input.",
             );
           }
-          this.#appendToolResult(messages, call, recordedCall.result);
+          await this.#appendToolResult(messages, call, recordedCall.result);
           continue;
         }
         const adapter = this.#tools?.resolve(call.name);
@@ -264,22 +446,25 @@ export class AgentSession {
             },
           };
           toolResultsById.set(call.id, { call, result });
-          this.#appendToolResult(messages, call, result);
+          await this.#appendToolResult(messages, call, result);
           continue;
         }
         const preparedCall = adapter.prepare(call.argumentsJson);
         if (preparedCall.status === "failed") {
           toolResultsById.set(call.id, { call, result: preparedCall });
-          this.#appendToolResult(messages, call, preparedCall);
+          await this.#appendToolResult(messages, call, preparedCall);
           continue;
         }
         const decision = this.#permissions?.decide(adapter.effect) ?? "deny";
-        this.#emit({
+        await this.#emit({
           type: "tool_permission_decided",
           callId: call.id,
           name: call.name,
           decision,
         });
+        if (signal.aborted) {
+          return this.#settleCancelled();
+        }
         if (decision !== "allow") {
           const result: ToolResult = {
             status: "failed",
@@ -289,18 +474,21 @@ export class AgentSession {
             },
           };
           toolResultsById.set(call.id, { call, result });
-          this.#appendToolResult(messages, call, result);
+          await this.#appendToolResult(messages, call, result);
           continue;
         }
-        this.#emit({ type: "tool_started", callId: call.id, name: call.name });
+        await this.#emit({ type: "tool_started", callId: call.id, name: call.name });
+        if (signal.aborted) {
+          return this.#settleCancelled();
+        }
         const result = await preparedCall.execute();
         toolResultsById.set(call.id, { call, result });
-        this.#appendToolResult(messages, call, result);
+        await this.#appendToolResult(messages, call, result);
       }
     }
   }
 
-  #settleIncompleteStream(): RunResult {
+  async #settleIncompleteStream(): Promise<RunResult> {
     const result: RunResult = {
       status: "failed",
       error: {
@@ -308,29 +496,87 @@ export class AgentSession {
         message: "The model stream ended without a finish event.",
       },
     };
-    this.#emit({ type: "session_settled", result });
-    return result;
+    return this.#settle(result);
   }
 
-  #settleProtocolInvalid(message: string): RunResult {
+  async #settleProtocolInvalid(message: string): Promise<RunResult> {
     const result: RunResult = {
       status: "failed",
       error: { code: "model_protocol_invalid", message },
     };
-    this.#emit({ type: "session_settled", result });
+    return this.#settle(result);
+  }
+
+  async #settleCancelled(): Promise<RunResult> {
+    const result: RunResult = {
+      status: "cancelled",
+      error: {
+        code: "session_cancelled",
+        message: "The session was cancelled.",
+      },
+    };
+    return this.#settle(result, true);
+  }
+
+  async #settleTurnLimitExceeded(): Promise<RunResult> {
+    const result: RunResult = {
+      status: "failed",
+      error: {
+        code: "turn_limit_exceeded",
+        message: "The run reached its model turn limit.",
+      },
+    };
+    return this.#settle(result);
+  }
+
+  async #settleTokenLimitExceeded(): Promise<RunResult> {
+    const result: RunResult = {
+      status: "failed",
+      error: {
+        code: "token_limit_exceeded",
+        message: "The run reached its provider-reported token limit.",
+      },
+    };
+    return this.#settle(result);
+  }
+
+  async #settleTokenUsageMissing(): Promise<RunResult> {
+    const result: RunResult = {
+      status: "failed",
+      error: {
+        code: "token_usage_missing",
+        message: "The provider did not report token usage for an active token limit.",
+      },
+    };
+    return this.#settle(result);
+  }
+
+  async #settle(result: RunResult, interrupted = false): Promise<RunResult> {
+    if (this.#terminalResult !== undefined) {
+      return this.#terminalResult;
+    }
+    this.#terminalResult = result;
+    if (interrupted) {
+      await this.#emit({ type: "session_interrupted", reason: "cancelled" });
+    }
+    await this.#emit({ type: "session_settled", result });
     return result;
   }
 
-  #appendToolResult(messages: ModelMessage[], call: ToolCall, result: ToolResult): void {
+  async #appendToolResult(
+    messages: ModelMessage[],
+    call: ToolCall,
+    result: ToolResult,
+  ): Promise<void> {
     if (result.status === "completed") {
-      this.#emit({
+      await this.#emit({
         type: "tool_completed",
         callId: call.id,
         name: call.name,
         output: result.output,
       });
     } else {
-      this.#emit({
+      await this.#emit({
         type: "tool_failed",
         callId: call.id,
         name: call.name,
@@ -340,9 +586,42 @@ export class AgentSession {
     messages.push({ role: "tool", callId: call.id, name: call.name, result });
   }
 
-  #emit(event: RuntimeEvent): void {
+  async #emit(event: RuntimeEvent): Promise<void> {
+    if (event.type !== "model_message_delta") {
+      const canonicalEvent: CanonicalRuntimeEvent = event;
+      const runId = this.#activeRunId;
+      if (runId === undefined) {
+        throw new Error("Cannot persist a session event without an active run ID.");
+      }
+      try {
+        await this.#store.append({
+          schemaVersion: 1,
+          runId,
+          sequence: this.#nextSequence,
+          event: canonicalEvent,
+        });
+      } catch {
+        throw new SessionPersistenceError();
+      }
+      this.#nextSequence += 1;
+    }
     for (const listener of this.#listeners) {
       listener(event);
     }
   }
+}
+
+function isNonnegativeSafeInteger(value: number): boolean {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+function areRunLimitsValid(limits: RunOptions["limits"]): boolean {
+  return (
+    (limits?.maxTurns === undefined || isPositiveSafeInteger(limits.maxTurns)) &&
+    (limits?.maxTokens === undefined || isPositiveSafeInteger(limits.maxTokens))
+  );
+}
+
+function isPositiveSafeInteger(value: number): boolean {
+  return Number.isSafeInteger(value) && value > 0;
 }

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -1,0 +1,324 @@
+import { createHash } from "node:crypto";
+import { chmod, type FileHandle, mkdir, open, realpath } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { z } from "zod";
+
+import type { RunResult, RuntimeEvent } from "./index.js";
+
+export type CanonicalRuntimeEvent = Exclude<RuntimeEvent, { readonly type: "model_message_delta" }>;
+
+export type SessionEventRecord = {
+  readonly schemaVersion: 1;
+  readonly runId: string;
+  readonly sequence: number;
+  readonly event: CanonicalRuntimeEvent;
+};
+
+export interface SessionStore {
+  append(record: SessionEventRecord): Promise<void>;
+  read(): Promise<readonly SessionEventRecord[]>;
+}
+
+export class SessionStoreError extends Error {
+  readonly code: "session_log_exists" | "session_log_invalid" | "session_log_too_large";
+
+  constructor(
+    code:
+      | "session_log_exists"
+      | "session_log_invalid"
+      | "session_log_too_large" = "session_log_invalid",
+  ) {
+    super(
+      code === "session_log_exists"
+        ? "The session log already exists."
+        : code === "session_log_too_large"
+          ? "The session log exceeds its read limit."
+          : "The session log contains an invalid record.",
+    );
+    this.name = "SessionStoreError";
+    this.code = code;
+  }
+}
+
+const runErrorCodeSchema = z.enum([
+  "model_stream_incomplete",
+  "model_protocol_invalid",
+  "invalid_run_limits",
+  "run_already_active",
+  "session_persistence_failed",
+  "turn_limit_exceeded",
+  "token_limit_exceeded",
+  "token_usage_missing",
+]);
+const runResultSchema: z.ZodType<RunResult> = z.discriminatedUnion("status", [
+  z.strictObject({ status: z.literal("completed"), answer: z.string() }),
+  z.strictObject({
+    status: z.literal("cancelled"),
+    error: z.strictObject({
+      code: z.literal("session_cancelled"),
+      message: z.string(),
+    }),
+  }),
+  z.strictObject({
+    status: z.literal("failed"),
+    error: z.strictObject({ code: runErrorCodeSchema, message: z.string() }),
+  }),
+]);
+const toolErrorSchema = z.strictObject({
+  code: z.enum([
+    "unknown_tool",
+    "invalid_tool_input",
+    "permission_denied",
+    "outside_workspace",
+    "not_found",
+    "tool_io_failed",
+  ]),
+  message: z.string(),
+});
+const canonicalRuntimeEventSchema: z.ZodType<CanonicalRuntimeEvent> = z.discriminatedUnion("type", [
+  z.strictObject({ type: z.literal("user_message"), text: z.string() }),
+  z.strictObject({ type: z.literal("model_message_started") }),
+  z.strictObject({ type: z.literal("model_message_completed"), text: z.string() }),
+  z
+    .strictObject({
+      type: z.literal("model_usage"),
+      inputTokens: z.number().int().nonnegative(),
+      outputTokens: z.number().int().nonnegative(),
+      totalTokens: z.number().int().nonnegative(),
+    })
+    .refine((usage) => usage.totalTokens === usage.inputTokens + usage.outputTokens),
+  z.strictObject({
+    type: z.literal("tool_requested"),
+    callId: z.string(),
+    name: z.string(),
+  }),
+  z.strictObject({
+    type: z.literal("tool_permission_decided"),
+    callId: z.string(),
+    name: z.string(),
+    decision: z.enum(["allow", "deny"]),
+  }),
+  z.strictObject({
+    type: z.literal("tool_started"),
+    callId: z.string(),
+    name: z.string(),
+  }),
+  z.strictObject({
+    type: z.literal("tool_completed"),
+    callId: z.string(),
+    name: z.string(),
+    output: z.json(),
+  }),
+  z.strictObject({
+    type: z.literal("tool_failed"),
+    callId: z.string(),
+    name: z.string(),
+    error: toolErrorSchema,
+  }),
+  z.strictObject({ type: z.literal("session_interrupted"), reason: z.literal("cancelled") }),
+  z.strictObject({ type: z.literal("session_settled"), result: runResultSchema }),
+]);
+const sessionEventRecordSchema: z.ZodType<SessionEventRecord> = z.strictObject({
+  schemaVersion: z.literal(1),
+  runId: z.uuid(),
+  sequence: z.number().int().positive(),
+  event: canonicalRuntimeEventSchema,
+});
+const maxSessionLogBytes = 8 * 1024 * 1024;
+const maxSessionRecordBytes = 1024 * 1024;
+
+export function createInMemorySessionStore(): SessionStore {
+  const records: SessionEventRecord[] = [];
+  let nextSequence = 1;
+  let storedBytes = 0;
+  return {
+    async append(record) {
+      const { record: validatedRecord, storedByteLength } =
+        validateBoundedSessionEventRecord(record);
+      if (validatedRecord.sequence !== nextSequence) {
+        throw new SessionStoreError();
+      }
+      if (storedBytes + storedByteLength > maxSessionLogBytes) {
+        throw new SessionStoreError("session_log_too_large");
+      }
+      records.push(validatedRecord);
+      nextSequence += 1;
+      storedBytes += storedByteLength;
+    },
+    async read() {
+      return validateRecordSequence([...records]);
+    },
+  };
+}
+
+export async function createJsonlSessionStore(options: {
+  readonly workspaceRoot: string;
+  readonly sessionId: string;
+  readonly stateRoot?: string;
+}): Promise<SessionStore> {
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/u.test(options.sessionId)) {
+    throw new TypeError("The session ID must be a safe filename segment.");
+  }
+
+  const canonicalWorkspaceRoot = await realpath(options.workspaceRoot);
+  const projectId = createHash("sha256").update(canonicalWorkspaceRoot).digest("hex");
+  const stateRoot = options.stateRoot ?? defaultStateRoot();
+  const projectsDirectory = join(stateRoot, "projects");
+  const projectDirectory = join(projectsDirectory, projectId);
+  const sessionsDirectory = join(projectDirectory, "sessions");
+  for (const directory of [projectsDirectory, projectDirectory, sessionsDirectory]) {
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    await chmod(directory, 0o700);
+  }
+  const sessionPath = join(sessionsDirectory, `${options.sessionId}.jsonl`);
+  try {
+    const file = await open(sessionPath, "wx", 0o600);
+    try {
+      await file.chmod(0o600);
+      await file.sync();
+    } finally {
+      await file.close();
+    }
+  } catch (error) {
+    if (isNodeError(error) && error.code === "EEXIST") {
+      throw new SessionStoreError("session_log_exists");
+    }
+    throw error;
+  }
+  let nextSequence = 1;
+  let storedBytes = 0;
+  let appendQueue = Promise.resolve();
+
+  return {
+    append(record) {
+      const operation = appendQueue.then(async () => {
+        const {
+          record: validatedRecord,
+          serialized,
+          storedByteLength,
+        } = validateBoundedSessionEventRecord(record);
+        if (validatedRecord.sequence !== nextSequence) {
+          throw new SessionStoreError();
+        }
+        if (storedBytes + storedByteLength > maxSessionLogBytes) {
+          throw new SessionStoreError("session_log_too_large");
+        }
+        const file = await open(sessionPath, "a", 0o600);
+        try {
+          await file.chmod(0o600);
+          await file.writeFile(`${serialized}\n`, "utf8");
+          await file.sync();
+        } finally {
+          await file.close();
+        }
+        nextSequence += 1;
+        storedBytes += storedByteLength;
+      });
+      appendQueue = operation.catch(() => {});
+      return operation;
+    },
+    async read() {
+      await appendQueue;
+      const content = await readBoundedSessionLog(sessionPath);
+      if (content === undefined) {
+        return [];
+      }
+      if (content.length === 0) {
+        return [];
+      }
+      if (!content.endsWith("\n")) {
+        throw new SessionStoreError();
+      }
+      const lines = content.slice(0, -1).split("\n");
+      if (lines.some((line) => Buffer.byteLength(line, "utf8") > maxSessionRecordBytes)) {
+        throw new SessionStoreError("session_log_too_large");
+      }
+      const records = lines.map((line) => parseSessionEventRecord(line));
+      return validateRecordSequence(records);
+    },
+  };
+}
+
+function defaultStateRoot(): string {
+  const { XDG_STATE_HOME: xdgStateHome } = process.env;
+  return xdgStateHome === undefined || xdgStateHome.length === 0
+    ? join(homedir(), ".local", "state", "adam-agent")
+    : join(xdgStateHome, "adam-agent");
+}
+
+async function readBoundedSessionLog(sessionPath: string): Promise<string | undefined> {
+  let file: FileHandle;
+  try {
+    file = await open(sessionPath, "r");
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+
+  try {
+    const { size } = await file.stat();
+    if (!Number.isSafeInteger(size) || size > maxSessionLogBytes) {
+      throw new SessionStoreError("session_log_too_large");
+    }
+    const bytes = Buffer.alloc(size);
+    let offset = 0;
+    while (offset < bytes.length) {
+      const { bytesRead } = await file.read(bytes, offset, bytes.length - offset, offset);
+      if (bytesRead === 0) {
+        break;
+      }
+      offset += bytesRead;
+    }
+    return bytes.subarray(0, offset).toString("utf8");
+  } finally {
+    await file.close();
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}
+
+function parseSessionEventRecord(line: string): SessionEventRecord {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    throw new SessionStoreError();
+  }
+  return validateSessionEventRecord(parsed);
+}
+
+function validateSessionEventRecord(value: unknown): SessionEventRecord {
+  const result = sessionEventRecordSchema.safeParse(value);
+  if (!result.success) {
+    throw new SessionStoreError();
+  }
+  return result.data;
+}
+
+function validateBoundedSessionEventRecord(value: unknown): {
+  readonly record: SessionEventRecord;
+  readonly serialized: string;
+  readonly storedByteLength: number;
+} {
+  const record = validateSessionEventRecord(value);
+  const serialized = JSON.stringify(record);
+  if (Buffer.byteLength(serialized, "utf8") > maxSessionRecordBytes) {
+    throw new SessionStoreError("session_log_too_large");
+  }
+  return { record, serialized, storedByteLength: Buffer.byteLength(serialized, "utf8") + 1 };
+}
+
+function validateRecordSequence(
+  records: readonly SessionEventRecord[],
+): readonly SessionEventRecord[] {
+  if (records.some((record, index) => record.sequence !== index + 1)) {
+    throw new SessionStoreError();
+  }
+  return records;
+}

--- a/packages/testkit/src/agent-session.test.ts
+++ b/packages/testkit/src/agent-session.test.ts
@@ -4,13 +4,27 @@ import { join } from "node:path";
 
 import {
   AgentSession,
+  type AgentSessionDependencies,
+  createInMemorySessionStore,
+  createJsonlSessionStore,
   createPermissionPolicy,
   createReadToolRegistry,
+  type ModelDriver,
   type RuntimeEvent,
+  type SessionEventRecord,
+  type SessionStore,
 } from "@adam-agent/agent";
 import { describe, expect, test } from "vitest";
 
 import { FakeModelDriver } from "./index.js";
+
+const cancelledResult = {
+  status: "cancelled",
+  error: {
+    code: "session_cancelled",
+    message: "The session was cancelled.",
+  },
+} as const;
 
 describe("AgentSession", () => {
   test("an answer-only turn emits ordered events and returns its terminal result", async () => {
@@ -19,7 +33,7 @@ describe("AgentSession", () => {
       { type: "text_delta", text: "Adam." },
       { type: "finish", reason: "stop" },
     ]);
-    const session = new AgentSession({ model });
+    const session = createTestSession({ model });
     const events: RuntimeEvent[] = [];
     session.subscribe((event) => events.push(event));
 
@@ -39,6 +53,629 @@ describe("AgentSession", () => {
     ]);
   });
 
+  test.each(["in-memory", "JSONL"] as const)(
+    "%s store persists canonical events while keeping text deltas live-only",
+    async (storeKind) => {
+      const storeHarness = await createAgentSessionStore(storeKind);
+      const model = new FakeModelDriver([
+        { type: "text_delta", text: "Durable answer." },
+        { type: "finish", reason: "stop" },
+      ]);
+      const { store } = storeHarness;
+      const session = createTestSession({ model, store });
+      const events: RuntimeEvent[] = [];
+      session.subscribe((event) => events.push(event));
+
+      try {
+        const result = await session.run({ text: "Persist this turn" });
+
+        expect({ result, events, records: await store.read() }).toEqual({
+          result: { status: "completed", answer: "Durable answer." },
+          events: [
+            { type: "user_message", text: "Persist this turn" },
+            { type: "model_message_started" },
+            { type: "model_message_delta", text: "Durable answer." },
+            { type: "model_message_completed", text: "Durable answer." },
+            {
+              type: "session_settled",
+              result: { status: "completed", answer: "Durable answer." },
+            },
+          ],
+          records: [
+            {
+              schemaVersion: 1,
+              runId: expect.any(String),
+              sequence: 1,
+              event: { type: "user_message", text: "Persist this turn" },
+            },
+            {
+              schemaVersion: 1,
+              runId: expect.any(String),
+              sequence: 2,
+              event: { type: "model_message_started" },
+            },
+            {
+              schemaVersion: 1,
+              runId: expect.any(String),
+              sequence: 3,
+              event: { type: "model_message_completed", text: "Durable answer." },
+            },
+            {
+              schemaVersion: 1,
+              runId: expect.any(String),
+              sequence: 4,
+              event: {
+                type: "session_settled",
+                result: { status: "completed", answer: "Durable answer." },
+              },
+            },
+          ],
+        });
+      } finally {
+        await storeHarness.cleanup();
+      }
+    },
+  );
+
+  test("fails before publishing or calling the model when the first event cannot persist", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-persistence-failure-"));
+    const stateRoot = join(testRoot, "state");
+    const workspaceRoot = join(testRoot, "workspace");
+    await mkdir(workspaceRoot);
+    const store = await createJsonlSessionStore({
+      stateRoot,
+      workspaceRoot,
+      sessionId: "session-failure",
+    });
+    let modelWasCalled = false;
+    const model = new FakeModelDriver(() => {
+      modelWasCalled = true;
+      return [{ type: "finish", reason: "stop" }];
+    });
+    const session = createTestSession({ model, store });
+    const events: RuntimeEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    try {
+      await chmod(stateRoot, 0o400);
+
+      const result = await session.run({ text: "Do not start" });
+
+      expect({ result, events, modelWasCalled }).toEqual({
+        result: {
+          status: "failed",
+          error: {
+            code: "session_persistence_failed",
+            message: "The session event could not be persisted.",
+          },
+        },
+        events: [],
+        modelWasCalled: false,
+      });
+    } finally {
+      await chmod(stateRoot, 0o700);
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("abort settles an active model wait once as cancelled", async () => {
+    let markModelStarted: (() => void) | undefined;
+    const modelStarted = new Promise<void>((resolve) => {
+      markModelStarted = resolve;
+    });
+    const model: ModelDriver = {
+      async *stream(request) {
+        markModelStarted?.();
+        await new Promise<void>((resolve) => {
+          request.signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+    };
+    const store = createInMemorySessionStore();
+    const session = createTestSession({ model, store });
+    const events: RuntimeEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const pendingResult = session.run({ text: "Wait for cancellation" });
+    await modelStarted;
+    session.abort();
+    session.abort();
+    const result = await pendingResult;
+
+    expect({
+      result,
+      settledEvents: events.filter((event) => event.type === "session_settled"),
+      finalRecord: (await store.read()).at(-1),
+    }).toEqual({
+      result: cancelledResult,
+      settledEvents: [{ type: "session_settled", result: cancelledResult }],
+      finalRecord: {
+        schemaVersion: 1,
+        runId: expect.any(String),
+        sequence: 4,
+        event: { type: "session_settled", result: cancelledResult },
+      },
+    });
+  });
+
+  test("persists one stable run identity and an interruption before cancelled settlement", async () => {
+    let markModelStarted: (() => void) | undefined;
+    const modelStarted = new Promise<void>((resolve) => {
+      markModelStarted = resolve;
+    });
+    const model: ModelDriver = {
+      async *stream(request) {
+        markModelStarted?.();
+        await new Promise<void>((resolve) => {
+          request.signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+    };
+    const store = createInMemorySessionStore();
+    const session = createTestSession({ model, store });
+
+    const pendingResult = session.run({ text: "Persist the interruption" });
+    await modelStarted;
+    session.abort();
+    await pendingResult;
+    const records = await store.read();
+
+    expect(new Set(records.map((record) => record.runId)).size).toBe(1);
+    expect(records[0]?.runId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
+    );
+    expect(records.map((record) => record.event.type)).toEqual([
+      "user_message",
+      "model_message_started",
+      "session_interrupted",
+      "session_settled",
+    ]);
+  });
+
+  test("does not retry a cancellation terminal transition after persistence fails", async () => {
+    let markModelStarted: (() => void) | undefined;
+    const modelStarted = new Promise<void>((resolve) => {
+      markModelStarted = resolve;
+    });
+    const model: ModelDriver = {
+      async *stream(request) {
+        markModelStarted?.();
+        await new Promise<void>((resolve) => {
+          request.signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+    };
+    const records: SessionEventRecord[] = [];
+    const store: SessionStore = {
+      async append(record) {
+        records.push(record);
+        if (record.event.type === "session_interrupted") {
+          throw new Error("The durable write completed before the adapter reported failure.");
+        }
+      },
+      async read() {
+        return records;
+      },
+    };
+    const session = createTestSession({ model, store });
+
+    const pendingResult = session.run({ text: "Cancel exactly once" });
+    await modelStarted;
+    session.abort();
+    const result = await pendingResult;
+
+    expect({
+      result,
+      interruptionCount: records.filter((record) => record.event.type === "session_interrupted")
+        .length,
+    }).toEqual({
+      result: {
+        status: "failed",
+        error: {
+          code: "session_persistence_failed",
+          message: "The session event could not be persisted.",
+        },
+      },
+      interruptionCount: 1,
+    });
+  });
+
+  test("a caller AbortSignal converges on the same cancelled terminal state", async () => {
+    let markModelStarted: (() => void) | undefined;
+    const modelStarted = new Promise<void>((resolve) => {
+      markModelStarted = resolve;
+    });
+    const model: ModelDriver = {
+      async *stream(request) {
+        markModelStarted?.();
+        await new Promise<void>((resolve) => {
+          request.signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+    };
+    const session = createTestSession({ model });
+    const controller = new AbortController();
+    const events: RuntimeEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const pendingResult = session.run(
+      { text: "Cancel from the caller" },
+      { signal: controller.signal },
+    );
+    await modelStarted;
+    controller.abort();
+    const result = await pendingResult;
+
+    expect({
+      result,
+      settledEvents: events.filter((event) => event.type === "session_settled"),
+    }).toEqual({
+      result: cancelledResult,
+      settledEvents: [{ type: "session_settled", result: cancelledResult }],
+    });
+  });
+
+  test("a pre-aborted caller signal never starts the model", async () => {
+    let modelCalls = 0;
+    const model = new FakeModelDriver(() => {
+      modelCalls += 1;
+      return [{ type: "finish", reason: "stop" }];
+    });
+    const controller = new AbortController();
+    controller.abort();
+    const session = createTestSession({ model });
+    const events: RuntimeEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const result = await session.run({ text: "Already cancelled" }, { signal: controller.signal });
+
+    expect({ result, modelCalls, events }).toEqual({
+      result: cancelledResult,
+      modelCalls: 0,
+      events: [
+        { type: "user_message", text: "Already cancelled" },
+        { type: "session_interrupted", reason: "cancelled" },
+        { type: "session_settled", result: cancelledResult },
+      ],
+    });
+  });
+
+  test("rejects a concurrent run without taking cancellation ownership from the active run", async () => {
+    let markModelStarted: (() => void) | undefined;
+    let releaseModel: (() => void) | undefined;
+    const modelStarted = new Promise<void>((resolve) => {
+      markModelStarted = resolve;
+    });
+    const modelReleased = new Promise<void>((resolve) => {
+      releaseModel = resolve;
+    });
+    const model: ModelDriver = {
+      async *stream() {
+        markModelStarted?.();
+        await modelReleased;
+        yield { type: "finish", reason: "stop" };
+      },
+    };
+    const store = createInMemorySessionStore();
+    const session = createTestSession({ model, store });
+    const events: RuntimeEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const activeRun = session.run({ text: "Keep this run active" });
+    await modelStarted;
+    const concurrentRun = session.run({ text: "Do not start this run" });
+    session.abort();
+    releaseModel?.();
+    const [concurrentResult, activeResult] = await Promise.all([concurrentRun, activeRun]);
+
+    expect({ concurrentResult, activeResult, events }).toEqual({
+      concurrentResult: {
+        status: "failed",
+        error: {
+          code: "run_already_active",
+          message: "The session already has an active run.",
+        },
+      },
+      activeResult: cancelledResult,
+      events: [
+        { type: "user_message", text: "Keep this run active" },
+        { type: "model_message_started" },
+        { type: "session_interrupted", reason: "cancelled" },
+        { type: "session_settled", result: cancelledResult },
+      ],
+    });
+  });
+
+  test("cancellation after one tool completes prevents later tool and model work", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-tool-cancellation-"));
+    await writeFile(join(workspaceRoot, "first.txt"), "first\n", "utf8");
+    await writeFile(join(workspaceRoot, "second.txt"), "second\n", "utf8");
+    let modelCalls = 0;
+    const model = new FakeModelDriver(() => {
+      modelCalls += 1;
+      return modelCalls === 1
+        ? [
+            { type: "tool_call_start", id: "call-first", name: "read_file" },
+            { type: "tool_call_delta", id: "call-first", json: '{"path":"first.txt"}' },
+            { type: "tool_call_end", id: "call-first" },
+            { type: "tool_call_start", id: "call-second", name: "read_file" },
+            { type: "tool_call_delta", id: "call-second", json: '{"path":"second.txt"}' },
+            { type: "tool_call_end", id: "call-second" },
+            { type: "finish", reason: "tool_calls" },
+          ]
+        : [
+            { type: "text_delta", text: "A later model turn started." },
+            { type: "finish", reason: "stop" },
+          ];
+    });
+    const session = createTestSession({
+      model,
+      tools: createReadToolRegistry({ workspaceRoot }),
+      permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    });
+    const events: RuntimeEvent[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+      if (event.type === "tool_completed" && event.callId === "call-first") {
+        session.abort();
+      }
+    });
+
+    try {
+      const result = await session.run({ text: "Read both files unless cancelled" });
+
+      expect({
+        result,
+        modelCalls,
+        secondToolEvents: events.filter(
+          (event) => "callId" in event && event.callId === "call-second",
+        ),
+      }).toEqual({
+        result: cancelledResult,
+        modelCalls: 1,
+        secondToolEvents: [],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("cancellation before terminal settlement cannot be overwritten by model success", async () => {
+    const model = new FakeModelDriver([
+      { type: "text_delta", text: "This answer was interrupted." },
+      { type: "finish", reason: "stop" },
+    ]);
+    const session = createTestSession({ model });
+    const events: RuntimeEvent[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+      if (event.type === "model_message_completed") {
+        session.abort();
+      }
+    });
+
+    const result = await session.run({ text: "Cancel before success settles" });
+
+    expect({ result, finalEvents: events.slice(-2) }).toEqual({
+      result: cancelledResult,
+      finalEvents: [
+        { type: "session_interrupted", reason: "cancelled" },
+        { type: "session_settled", result: cancelledResult },
+      ],
+    });
+  });
+
+  test("cancellation stops publishing buffered provider events", async () => {
+    const model = new FakeModelDriver([
+      { type: "text_delta", text: "first" },
+      { type: "text_delta", text: "second" },
+      { type: "finish", reason: "stop" },
+    ]);
+    const session = createTestSession({ model });
+    const events: RuntimeEvent[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+      if (event.type === "model_message_delta") {
+        session.abort();
+      }
+    });
+
+    const result = await session.run({ text: "Stop the buffered stream" });
+
+    expect({
+      result,
+      deltas: events
+        .filter((event) => event.type === "model_message_delta")
+        .map((event) => event.text),
+    }).toEqual({
+      result: cancelledResult,
+      deltas: ["first"],
+    });
+  });
+
+  test("turn limits stop before the next model invocation", async () => {
+    let modelCalls = 0;
+    const model = new FakeModelDriver(() => {
+      modelCalls += 1;
+      return [
+        { type: "tool_call_start", id: "call-limited", name: "missing_tool" },
+        { type: "tool_call_delta", id: "call-limited", json: "{}" },
+        { type: "tool_call_end", id: "call-limited" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    });
+    const session = createTestSession({ model });
+    const events: RuntimeEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const result = await session.run(
+      { text: "Do not exceed one model turn" },
+      { limits: { maxTurns: 1 } },
+    );
+
+    expect({ result, modelCalls, finalEvent: events.at(-1) }).toEqual({
+      result: {
+        status: "failed",
+        error: {
+          code: "turn_limit_exceeded",
+          message: "The run reached its model turn limit.",
+        },
+      },
+      modelCalls: 1,
+      finalEvent: {
+        type: "session_settled",
+        result: {
+          status: "failed",
+          error: {
+            code: "turn_limit_exceeded",
+            message: "The run reached its model turn limit.",
+          },
+        },
+      },
+    });
+  });
+
+  test.each([
+    ["NaN turn limit", { maxTurns: Number.NaN }],
+    ["infinite token limit", { maxTokens: Number.POSITIVE_INFINITY }],
+    ["negative turn limit", { maxTurns: -1 }],
+    ["fractional token limit", { maxTokens: 1.5 }],
+  ] as const)("rejects a %s before starting a run", async (_name, limits) => {
+    let modelCalls = 0;
+    const model = new FakeModelDriver(() => {
+      modelCalls += 1;
+      return [{ type: "finish", reason: "stop" }];
+    });
+    const session = createTestSession({ model });
+    const events: RuntimeEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const result = await session.run({ text: "Use a valid finite limit" }, { limits });
+
+    expect({ result, modelCalls, events }).toEqual({
+      result: {
+        status: "failed",
+        error: {
+          code: "invalid_run_limits",
+          message: "Run limits must be positive safe integers.",
+        },
+      },
+      modelCalls: 0,
+      events: [],
+    });
+  });
+
+  test("provider-reported token limits stop before a requested tool", async () => {
+    const model = new FakeModelDriver([
+      { type: "tool_call_start", id: "call-over-budget", name: "read_file" },
+      {
+        type: "tool_call_delta",
+        id: "call-over-budget",
+        json: '{"path":"README.md"}',
+      },
+      { type: "tool_call_end", id: "call-over-budget" },
+      { type: "usage", inputTokens: 6, outputTokens: 5 },
+      { type: "finish", reason: "tool_calls" },
+    ]);
+    const session = createTestSession({ model });
+    const events: RuntimeEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const result = await session.run(
+      { text: "Stop before the tool" },
+      { limits: { maxTokens: 10 } },
+    );
+
+    expect({
+      result,
+      usageEvents: events.filter((event) => event.type === "model_usage"),
+      toolEvents: events.filter((event) => event.type.startsWith("tool_")),
+    }).toEqual({
+      result: {
+        status: "failed",
+        error: {
+          code: "token_limit_exceeded",
+          message: "The run reached its provider-reported token limit.",
+        },
+      },
+      usageEvents: [{ type: "model_usage", inputTokens: 6, outputTokens: 5, totalTokens: 11 }],
+      toolEvents: [],
+    });
+  });
+
+  test("active token limits fail closed when provider usage is missing", async () => {
+    let modelCalls = 0;
+    const model = new FakeModelDriver(() => {
+      modelCalls += 1;
+      return modelCalls === 1
+        ? [
+            { type: "tool_call_start", id: "call-no-usage", name: "read_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-no-usage",
+              json: '{"path":"README.md"}',
+            },
+            { type: "tool_call_end", id: "call-no-usage" },
+            { type: "finish", reason: "tool_calls" },
+          ]
+        : [
+            { type: "text_delta", text: "This second turn must not run." },
+            { type: "finish", reason: "stop" },
+          ];
+    });
+    const session = createTestSession({ model });
+    const events: RuntimeEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const result = await session.run(
+      { text: "Require provider usage" },
+      { limits: { maxTokens: 100 } },
+    );
+
+    expect({
+      result,
+      modelCalls,
+      toolEvents: events.filter((event) => event.type.startsWith("tool_")),
+    }).toEqual({
+      result: {
+        status: "failed",
+        error: {
+          code: "token_usage_missing",
+          message: "The provider did not report token usage for an active token limit.",
+        },
+      },
+      modelCalls: 1,
+      toolEvents: [],
+    });
+  });
+
+  test("rejects invalid provider token usage before it can affect accounting", async () => {
+    const model = new FakeModelDriver([
+      { type: "text_delta", text: "Do not accept this answer." },
+      { type: "usage", inputTokens: -1, outputTokens: 2 },
+      { type: "finish", reason: "stop" },
+    ]);
+    const session = createTestSession({ model });
+    const events: RuntimeEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const result = await session.run({ text: "Report trustworthy usage" });
+
+    expect({
+      result,
+      usageEvents: events.filter((event) => event.type === "model_usage"),
+    }).toEqual({
+      result: {
+        status: "failed",
+        error: {
+          code: "model_protocol_invalid",
+          message: "The model reported invalid token usage.",
+        },
+      },
+      usageEvents: [],
+    });
+  });
+
   test("sends the user input to the model driver", async () => {
     const model = new FakeModelDriver((request) => {
       const firstMessage = request.messages[0];
@@ -50,7 +687,7 @@ describe("AgentSession", () => {
         { type: "finish", reason: "stop" },
       ];
     });
-    const session = new AgentSession({ model });
+    const session = createTestSession({ model });
 
     const result = await session.run({ text: "Explain this repository" });
 
@@ -62,7 +699,7 @@ describe("AgentSession", () => {
 
   test("reports a failed terminal result when the model stream ends without finishing", async () => {
     const model = new FakeModelDriver([{ type: "text_delta", text: "Partial answer" }]);
-    const session = new AgentSession({ model });
+    const session = createTestSession({ model });
     const events: RuntimeEvent[] = [];
     session.subscribe((event) => events.push(event));
 
@@ -114,7 +751,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -164,7 +801,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -232,7 +869,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -285,7 +922,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: [] }),
@@ -346,7 +983,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -441,7 +1078,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -506,7 +1143,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -556,7 +1193,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -610,7 +1247,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -647,7 +1284,7 @@ describe("AgentSession", () => {
         { type: "finish", reason: "stop" },
       ];
     });
-    const session = new AgentSession({ model });
+    const session = createTestSession({ model });
 
     const result = await session.run({ text: "Read the README" });
 
@@ -698,7 +1335,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -731,7 +1368,7 @@ describe("AgentSession", () => {
         { type: "tool_call_end", id: "call-stop" },
         { type: "finish", reason: "stop" },
       ]);
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -790,7 +1427,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -822,7 +1459,7 @@ describe("AgentSession", () => {
         { type: "tool_call_end", id: "call-conflict" },
         { type: "finish", reason: "tool_calls" },
       ]);
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -882,7 +1519,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -927,7 +1564,7 @@ describe("AgentSession", () => {
         },
         { type: "finish", reason: "tool_calls" },
       ]);
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -999,7 +1636,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -1030,7 +1667,7 @@ describe("AgentSession", () => {
         { type: "tool_call_end", id: "call-start" },
         { type: "finish", reason: "tool_calls" },
       ]);
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -1071,7 +1708,7 @@ describe("AgentSession", () => {
     },
   ])("rejects an orphaned tool-call $label event", async ({ event, message }) => {
     const model = new FakeModelDriver([event, { type: "finish", reason: "tool_calls" }]);
-    const session = new AgentSession({ model });
+    const session = createTestSession({ model });
     const events: RuntimeEvent[] = [];
     session.subscribe((runtimeEvent) => events.push(runtimeEvent));
 
@@ -1131,7 +1768,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -1184,7 +1821,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -1230,7 +1867,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -1288,7 +1925,7 @@ describe("AgentSession", () => {
           { type: "finish", reason: "stop" },
         ];
       });
-      const session = new AgentSession({
+      const session = createTestSession({
         model,
         tools: createReadToolRegistry({ workspaceRoot }),
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
@@ -1305,3 +1942,33 @@ describe("AgentSession", () => {
     }
   });
 });
+
+async function createAgentSessionStore(storeKind: "in-memory" | "JSONL") {
+  if (storeKind === "in-memory") {
+    return {
+      store: createInMemorySessionStore(),
+      cleanup: async () => {},
+    };
+  }
+
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-adapter-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  return {
+    store: await createJsonlSessionStore({
+      stateRoot: join(testRoot, "state"),
+      workspaceRoot,
+      sessionId: "session-adapter-contract",
+    }),
+    cleanup: () => rm(testRoot, { recursive: true, force: true }),
+  };
+}
+
+function createTestSession(
+  dependencies: Omit<AgentSessionDependencies, "store"> & { readonly store?: SessionStore },
+): AgentSession {
+  return new AgentSession({
+    ...dependencies,
+    store: dependencies.store ?? createInMemorySessionStore(),
+  });
+}

--- a/packages/testkit/src/session-store.test.ts
+++ b/packages/testkit/src/session-store.test.ts
@@ -1,0 +1,348 @@
+import { chmod, mkdir, mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createInMemorySessionStore,
+  createJsonlSessionStore,
+  type SessionEventRecord,
+  SessionStoreError,
+} from "@adam-agent/agent";
+import { expect, test } from "vitest";
+
+const runId = "123e4567-e89b-42d3-a456-426614174000";
+
+test("SessionStore adapters append and read versioned records in order", async () => {
+  const { testRoot, stores } = await createContractStores("adam-agent-session-store-", "session-1");
+  const records: readonly SessionEventRecord[] = [
+    {
+      schemaVersion: 1,
+      runId,
+      sequence: 1,
+      event: { type: "user_message", text: "Persist me" },
+    },
+    {
+      schemaVersion: 1,
+      runId,
+      sequence: 2,
+      event: {
+        type: "session_settled",
+        result: { status: "completed", answer: "Persisted." },
+      },
+    },
+  ];
+
+  try {
+    for (const [name, store] of stores) {
+      for (const record of records) {
+        await store.append(record);
+      }
+      expect(await store.read(), name).toEqual(records);
+    }
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("JSONL SessionStore rejects an existing session ID without modifying its history", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-collision-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const options = {
+    stateRoot,
+    workspaceRoot,
+    sessionId: "session-collision",
+  } as const;
+  const store = await createJsonlSessionStore(options);
+  const record: SessionEventRecord = {
+    schemaVersion: 1,
+    runId,
+    sequence: 1,
+    event: { type: "user_message", text: "Keep this history intact" },
+  };
+
+  try {
+    await store.append(record);
+
+    await expect(createJsonlSessionStore(options)).rejects.toMatchObject({
+      name: "SessionStoreError",
+      code: "session_log_exists",
+      message: "The session log already exists.",
+    });
+    expect(await store.read()).toEqual([record]);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("JSONL SessionStore rejects a non-canonical persisted event", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-invalid-session-store-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const store = await createJsonlSessionStore({
+    stateRoot,
+    workspaceRoot,
+    sessionId: "session-invalid",
+  });
+
+  try {
+    await store.append({
+      schemaVersion: 1,
+      runId,
+      sequence: 1,
+      event: { type: "user_message", text: "Create the log" },
+    });
+    const storedPaths = await readdir(stateRoot, { recursive: true });
+    const sessionRelativePath = storedPaths.find((path) => path.endsWith(".jsonl"));
+    if (sessionRelativePath === undefined) {
+      throw new Error("The JSONL session file was not created.");
+    }
+    await writeFile(
+      join(stateRoot, sessionRelativePath),
+      `{"schemaVersion":1,"runId":"${runId}","sequence":1,"event":{"type":"model_message_delta","text":"not durable"}}\n`,
+      "utf8",
+    );
+
+    const readPromise = store.read();
+
+    await expect(readPromise).rejects.toMatchObject({
+      name: "SessionStoreError",
+      code: "session_log_invalid",
+      message: "The session log contains an invalid record.",
+    });
+    await expect(readPromise).rejects.toBeInstanceOf(SessionStoreError);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("JSONL SessionStore rejects an oversized restored log before parsing records", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-oversized-session-store-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const store = await createJsonlSessionStore({
+    stateRoot,
+    workspaceRoot,
+    sessionId: "session-oversized",
+  });
+
+  try {
+    const storedPaths = await readdir(stateRoot, { recursive: true });
+    const sessionRelativePath = storedPaths.find((path) => path.endsWith(".jsonl"));
+    if (sessionRelativePath === undefined) {
+      throw new Error("The JSONL session file was not created.");
+    }
+    await writeFile(join(stateRoot, sessionRelativePath), "x".repeat(8 * 1024 * 1024 + 1), "utf8");
+
+    await expect(store.read()).rejects.toMatchObject({
+      name: "SessionStoreError",
+      code: "session_log_too_large",
+      message: "The session log exceeds its read limit.",
+    });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionStore adapters reject non-canonical records on append", async () => {
+  const { testRoot, stores } = await createContractStores(
+    "adam-agent-session-contract-",
+    "session-contract",
+  );
+  const invalidRecord = {
+    schemaVersion: 1,
+    runId,
+    sequence: 1,
+    event: { type: "model_message_delta", text: "not canonical" },
+  } as unknown as SessionEventRecord;
+
+  try {
+    for (const [name, store] of stores) {
+      await expect(store.append(invalidRecord), name).rejects.toMatchObject({
+        name: "SessionStoreError",
+        code: "session_log_invalid",
+      });
+    }
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionStore adapters reject an oversized canonical record before modifying history", async () => {
+  const { testRoot, stores } = await createContractStores(
+    "adam-agent-session-record-bound-",
+    "session-record-bound",
+  );
+  const oversizedRecord: SessionEventRecord = {
+    schemaVersion: 1,
+    runId,
+    sequence: 1,
+    event: { type: "model_message_completed", text: "x".repeat(1024 * 1024) },
+  };
+
+  try {
+    for (const [name, store] of stores) {
+      await expect(store.append(oversizedRecord), name).rejects.toMatchObject({
+        name: "SessionStoreError",
+        code: "session_log_too_large",
+      });
+      expect(await store.read(), name).toEqual([]);
+    }
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionStore adapters reject the first append beyond the readable log bound", async () => {
+  const { testRoot, stores } = await createContractStores(
+    "adam-agent-session-log-bound-",
+    "session-log-bound",
+  );
+  const boundedText = "x".repeat(920 * 1024);
+
+  try {
+    for (const [name, store] of stores) {
+      for (let sequence = 1; sequence <= 8; sequence += 1) {
+        await store.append({
+          schemaVersion: 1,
+          runId,
+          sequence,
+          event: { type: "model_message_completed", text: boundedText },
+        });
+      }
+      await expect(
+        store.append({
+          schemaVersion: 1,
+          runId,
+          sequence: 9,
+          event: { type: "model_message_completed", text: boundedText },
+        }),
+        name,
+      ).rejects.toMatchObject({
+        name: "SessionStoreError",
+        code: "session_log_too_large",
+      });
+      expect(await store.read(), name).toHaveLength(8);
+    }
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionStore adapters reject an out-of-sequence append before modifying history", async () => {
+  const { testRoot, stores } = await createContractStores(
+    "adam-agent-session-order-contract-",
+    "session-order-contract",
+  );
+
+  try {
+    for (const [name, store] of stores) {
+      await expect(
+        store.append({
+          schemaVersion: 1,
+          runId,
+          sequence: 2,
+          event: { type: "model_message_started" },
+        }),
+        name,
+      ).rejects.toMatchObject({
+        name: "SessionStoreError",
+        code: "session_log_invalid",
+      });
+      expect(await store.read(), name).toEqual([]);
+    }
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("JSONL SessionStore restores owner-only session file permissions", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-mode-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const store = await createJsonlSessionStore({
+    stateRoot,
+    workspaceRoot,
+    sessionId: "session-mode",
+  });
+
+  try {
+    await store.append({
+      schemaVersion: 1,
+      runId,
+      sequence: 1,
+      event: { type: "user_message", text: "First record" },
+    });
+    const storedPaths = await readdir(stateRoot, { recursive: true });
+    const sessionRelativePath = storedPaths.find((path) => path.endsWith(".jsonl"));
+    if (sessionRelativePath === undefined) {
+      throw new Error("The JSONL session file was not created.");
+    }
+    const sessionPath = join(stateRoot, sessionRelativePath);
+    await chmod(sessionPath, 0o644);
+
+    await store.append({
+      schemaVersion: 1,
+      runId,
+      sequence: 2,
+      event: { type: "model_message_started" },
+    });
+
+    expect((await stat(sessionPath)).mode & 0o777).toBe(0o600);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("JSONL SessionStore restores owner-only session directory permissions", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-directory-mode-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const options = {
+    stateRoot,
+    workspaceRoot,
+    sessionId: "session-directory-mode",
+  } as const;
+
+  try {
+    await createJsonlSessionStore({ ...options, sessionId: "session-directory-mode-repair" });
+    const storedPaths = await readdir(stateRoot, { recursive: true });
+    const sessionsRelativePath = storedPaths.find((path) => path.endsWith("sessions"));
+    if (sessionsRelativePath === undefined) {
+      throw new Error("The JSONL sessions directory was not created.");
+    }
+    const sessionsPath = join(stateRoot, sessionsRelativePath);
+    await chmod(sessionsPath, 0o755);
+
+    await createJsonlSessionStore(options);
+
+    expect((await stat(sessionsPath)).mode & 0o777).toBe(0o700);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+async function createContractStores(prefix: string, sessionId: string) {
+  const testRoot = await mkdtemp(join(tmpdir(), prefix));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  return {
+    testRoot,
+    stores: [
+      ["in-memory", createInMemorySessionStore()],
+      [
+        "JSONL",
+        await createJsonlSessionStore({
+          stateRoot: join(testRoot, "state"),
+          workspaceRoot,
+          sessionId,
+        }),
+      ],
+    ] as const,
+  };
+}


### PR DESCRIPTION
## Summary

- persist versioned canonical events through caller-supplied in-memory and project-scoped JSONL stores
- add stable run identity, cancellation/interruption lifecycle, single-active-run ownership, and persist-before-publish ordering
- add validated per-run turn/token limits and fail-closed provider usage accounting
- bound session records and logs, reject collisions and invalid append order before history is modified

## Verification

- `pnpm quality:check` — 3 files, 58 tests passed
- `pnpm --silent adam "What is this repository?"` — deterministic CLI smoke passed
- dual standards/spec review completed with no remaining A3a deviations

## Boundaries

Resume, branching, write/edit approval, shell, interactive CLI cancellation, and live providers remain out of A3a. Referenced artifact storage is reserved as an A3c prerequisite before shell overflow is introduced.