### PR TITLE
feat: add local mutations and approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Adam Agent is a lightweight, inspectable TypeScript coding agent for local software-engineering work.
 
-The repository contains a provider-neutral Agent kernel with root-confined read, recursive list, and literal text-search tools, canonical event persistence through caller-supplied in-memory and durable project-scoped JSONL stores, cancellation, and per-run turn/token limits, backed by a deterministic fake model. Write and execute tools, approval prompts, resume, interactive terminal support, and live model providers have not been added yet. The accepted runtime is Node.js 24 LTS with pnpm 11; Bun is reserved for a later compatibility-tested distribution experiment.
+The repository contains a provider-neutral Agent kernel with workspace-confined reads, create-only UTF-8 writes, exact multi-edit mutations, call-scoped permission requests, canonical event persistence through caller-supplied in-memory and durable project-scoped JSONL stores, cancellation, and per-run turn/token limits, backed by a deterministic fake model. Path confinement rejects traversal and symlink escape but is not an OS sandbox and does not claim protection from hostile concurrent filesystem mutation. The current one-shot CLI remains read-only; execute tools, resume, interactive terminal support, and live model providers have not been added yet. The accepted runtime is Node.js 24 LTS with pnpm 11; Bun is reserved for a later compatibility-tested distribution experiment.
 
 ## Development
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -4,7 +4,10 @@ import type { CanonicalRuntimeEvent, SessionStore } from "./session-store.js";
 import type {
   ModelToolDefinition,
   PermissionPolicy,
+  PermissionPolicyInput,
+  PermissionSubject,
   ToolCall,
+  ToolEffect,
   ToolRegistry,
   ToolResult,
 } from "./tool-runtime.js";
@@ -19,12 +22,15 @@ export {
 } from "./session-store.js";
 
 export {
+  createMutationToolRegistry,
   createPermissionPolicy,
   createReadToolRegistry,
   type JsonValue,
   type ModelToolDefinition,
   type PermissionDecision,
   type PermissionPolicy,
+  type PermissionPolicyInput,
+  type PermissionSubject,
   type ToolCall,
   type ToolEffect,
   type ToolRegistry,
@@ -107,6 +113,21 @@ export type RunResult =
       };
     };
 
+export type PermissionDecisionCommand = {
+  readonly requestId: string;
+  readonly decision: "allow" | "deny";
+};
+
+export type PermissionDecisionCommandResult =
+  | { readonly status: "accepted" }
+  | {
+      readonly status: "rejected";
+      readonly error: {
+        readonly code: "permission_request_not_pending" | "invalid_permission_decision";
+        readonly message: string;
+      };
+    };
+
 export type RuntimeEvent =
   | { readonly type: "user_message"; readonly text: string }
   | { readonly type: "model_message_started" }
@@ -120,10 +141,23 @@ export type RuntimeEvent =
     }
   | { readonly type: "tool_requested"; readonly callId: string; readonly name: string }
   | {
+      readonly type: "tool_permission_requested";
+      readonly requestId: string;
+      readonly callId: string;
+      readonly name: string;
+      readonly effect: ToolEffect;
+      readonly scope: "call";
+      readonly subject: PermissionSubject;
+    }
+  | {
       readonly type: "tool_permission_decided";
       readonly callId: string;
       readonly name: string;
       readonly decision: "allow" | "deny";
+      readonly requestId?: string | undefined;
+      readonly effect?: ToolEffect | undefined;
+      readonly scope?: "call" | undefined;
+      readonly subject?: PermissionSubject | undefined;
     }
   | { readonly type: "tool_started"; readonly callId: string; readonly name: string }
   | {
@@ -162,6 +196,12 @@ export class AgentSession {
   #activeRunId: string | undefined;
   #nextSequence = 1;
   #terminalResult: RunResult | undefined;
+  #pendingPermission:
+    | {
+        readonly requestId: string;
+        readonly resolve: (decision: "allow" | "deny") => void;
+      }
+    | undefined;
 
   constructor(dependencies: AgentSessionDependencies) {
     this.#model = dependencies.model;
@@ -179,6 +219,30 @@ export class AgentSession {
 
   abort(): void {
     this.#activeAbortController?.abort();
+  }
+
+  decidePermission(command: PermissionDecisionCommand): PermissionDecisionCommandResult {
+    if (command.decision !== "allow" && command.decision !== "deny") {
+      return {
+        status: "rejected",
+        error: {
+          code: "invalid_permission_decision",
+          message: "The permission decision must be allow or deny.",
+        },
+      };
+    }
+    const pendingPermission = this.#pendingPermission;
+    if (pendingPermission === undefined || pendingPermission.requestId !== command.requestId) {
+      return {
+        status: "rejected",
+        error: {
+          code: "permission_request_not_pending",
+          message: "The permission request is not pending.",
+        },
+      };
+    }
+    pendingPermission.resolve(command.decision);
+    return { status: "accepted" };
   }
 
   async run(input: UserInput, options: RunOptions = {}): Promise<RunResult> {
@@ -455,13 +519,53 @@ export class AgentSession {
           await this.#appendToolResult(messages, call, preparedCall);
           continue;
         }
-        const decision = this.#permissions?.decide(adapter.effect) ?? "deny";
-        await this.#emit({
-          type: "tool_permission_decided",
+        const permissionInput: PermissionPolicyInput = {
           callId: call.id,
           name: call.name,
-          decision,
-        });
+          effect: adapter.effect,
+          scope: "call",
+          subject: preparedCall.permissionSubject,
+        };
+        const policyDecision = this.#permissions?.decide(permissionInput) ?? "deny";
+        if (signal.aborted) {
+          return this.#settleCancelled();
+        }
+        let decision: "allow" | "deny";
+        if (policyDecision === "ask") {
+          const runId = this.#activeRunId;
+          if (runId === undefined) {
+            throw new Error("Cannot request permission without an active run ID.");
+          }
+          const requestId = `${runId}:${call.id}`;
+          const pendingDecision = this.#createPendingPermissionDecision(requestId, signal);
+          try {
+            await this.#emit({
+              type: "tool_permission_requested",
+              requestId,
+              ...permissionInput,
+            });
+            const userDecision = await pendingDecision.promise;
+            if (userDecision === undefined) {
+              return this.#settleCancelled();
+            }
+            decision = userDecision;
+            await this.#emit({
+              type: "tool_permission_decided",
+              requestId,
+              decision,
+              ...permissionInput,
+            });
+          } finally {
+            pendingDecision.cancel();
+          }
+        } else {
+          decision = policyDecision;
+          await this.#emit({
+            type: "tool_permission_decided",
+            decision,
+            ...permissionInput,
+          });
+        }
         if (signal.aborted) {
           return this.#settleCancelled();
         }
@@ -584,6 +688,42 @@ export class AgentSession {
       });
     }
     messages.push({ role: "tool", callId: call.id, name: call.name, result });
+  }
+
+  #createPendingPermissionDecision(
+    requestId: string,
+    signal: AbortSignal,
+  ): {
+    readonly promise: Promise<"allow" | "deny" | undefined>;
+    readonly cancel: () => void;
+  } {
+    let settle: (decision: "allow" | "deny" | undefined) => void = () => {};
+    const promise = new Promise<"allow" | "deny" | undefined>((resolve) => {
+      let settled = false;
+      const finish = (decision: "allow" | "deny" | undefined) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        signal.removeEventListener("abort", abortPending);
+        if (this.#pendingPermission?.requestId === requestId) {
+          this.#pendingPermission = undefined;
+        }
+        resolve(decision);
+      };
+      const abortPending = () => finish(undefined);
+      settle = finish;
+      this.#pendingPermission = {
+        requestId,
+        resolve: (decision) => finish(decision),
+      };
+      if (signal.aborted) {
+        abortPending();
+      } else {
+        signal.addEventListener("abort", abortPending, { once: true });
+      }
+    });
+    return { promise, cancel: () => settle(undefined) };
   }
 
   async #emit(event: RuntimeEvent): Promise<void> {

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -73,10 +73,20 @@ const toolErrorSchema = z.strictObject({
     "permission_denied",
     "outside_workspace",
     "not_found",
+    "already_exists",
+    "ambiguous_match",
+    "binary_file",
+    "file_too_large",
+    "no_match",
+    "overlapping_edits",
     "tool_io_failed",
   ]),
   message: z.string(),
 });
+const permissionSubjectSchema = z.discriminatedUnion("type", [
+  z.strictObject({ type: z.literal("file"), path: z.string() }),
+  z.strictObject({ type: z.literal("workspace_path"), path: z.string() }),
+]);
 const canonicalRuntimeEventSchema: z.ZodType<CanonicalRuntimeEvent> = z.discriminatedUnion("type", [
   z.strictObject({ type: z.literal("user_message"), text: z.string() }),
   z.strictObject({ type: z.literal("model_message_started") }),
@@ -95,10 +105,25 @@ const canonicalRuntimeEventSchema: z.ZodType<CanonicalRuntimeEvent> = z.discrimi
     name: z.string(),
   }),
   z.strictObject({
+    type: z.literal("tool_permission_requested"),
+    requestId: z.string(),
+    callId: z.string(),
+    name: z.string(),
+    effect: z.enum(["read", "write", "execute", "network", "delegate", "administrative"]),
+    scope: z.literal("call"),
+    subject: permissionSubjectSchema,
+  }),
+  z.strictObject({
     type: z.literal("tool_permission_decided"),
     callId: z.string(),
     name: z.string(),
     decision: z.enum(["allow", "deny"]),
+    requestId: z.string().optional(),
+    effect: z
+      .enum(["read", "write", "execute", "network", "delegate", "administrative"])
+      .optional(),
+    scope: z.literal("call").optional(),
+    subject: permissionSubjectSchema.optional(),
   }),
   z.strictObject({
     type: z.literal("tool_started"),

--- a/packages/agent/src/tool-runtime.ts
+++ b/packages/agent/src/tool-runtime.ts
@@ -1,4 +1,5 @@
-import { open, opendir, realpath } from "node:fs/promises";
+import { constants } from "node:fs";
+import { type FileHandle, mkdir, open, opendir, realpath } from "node:fs/promises";
 import { isAbsolute, relative, resolve, sep } from "node:path";
 
 import { z } from "zod";
@@ -36,6 +37,12 @@ export type ToolResult =
           | "permission_denied"
           | "outside_workspace"
           | "not_found"
+          | "already_exists"
+          | "ambiguous_match"
+          | "binary_file"
+          | "file_too_large"
+          | "no_match"
+          | "overlapping_edits"
           | "tool_io_failed";
         readonly message: string;
       };
@@ -64,6 +71,7 @@ type FailedToolResult = Extract<ToolResult, { readonly status: "failed" }>;
 
 type PreparedToolCall = {
   readonly status: "ready";
+  readonly permissionSubject: PermissionSubject;
   execute(): Promise<ToolResult>;
 };
 
@@ -81,25 +89,72 @@ export type ToolRegistry = {
   resolve(name: string): ToolAdapter | undefined;
 };
 
-export type PermissionDecision = "allow" | "deny";
+export type PermissionDecision = "allow" | "ask" | "deny";
+
+export type PermissionSubject =
+  | { readonly type: "file"; readonly path: string }
+  | { readonly type: "workspace_path"; readonly path: string };
+
+export type PermissionPolicyInput = {
+  readonly callId: string;
+  readonly name: string;
+  readonly effect: ToolEffect;
+  readonly scope: "call";
+  readonly subject: PermissionSubject;
+};
 
 export type PermissionPolicy = {
-  decide(effect: ToolEffect): PermissionDecision;
+  decide(input: PermissionPolicyInput): PermissionDecision;
 };
 
 export function createPermissionPolicy(options: {
   readonly allowedEffects: readonly ToolEffect[];
+  readonly askedEffects?: readonly ToolEffect[];
 }): PermissionPolicy {
   const allowedEffects = new Set(options.allowedEffects);
+  const askedEffects = new Set(options.askedEffects ?? []);
   return {
-    decide(effect) {
-      return allowedEffects.has(effect) ? "allow" : "deny";
+    decide(input) {
+      if (allowedEffects.has(input.effect)) {
+        return "allow";
+      }
+      return askedEffects.has(input.effect) ? "ask" : "deny";
     },
   };
 }
 
 const readFileInputSchema = z.strictObject({ path: z.string().min(1) });
 const listFilesInputSchema = z.strictObject({ path: z.string().min(1) });
+const maximumMutationFileBytes = 1024 * 1024;
+const maximumEditArgumentsBytes = 1024 * 1024;
+const textMutationContentSchema = z
+  .string()
+  .refine((content) => !content.includes("\0"))
+  .refine((content) => Buffer.byteLength(content, "utf8") <= maximumMutationFileBytes);
+const writeFileInputSchema = z.strictObject({
+  path: z.string().min(1),
+  content: textMutationContentSchema,
+});
+const editFileInputSchema = z
+  .strictObject({
+    path: z.string().min(1),
+    edits: z
+      .array(
+        z.strictObject({
+          oldText: textMutationContentSchema.refine((text) => text.length > 0),
+          newText: textMutationContentSchema,
+        }),
+      )
+      .min(1),
+  })
+  .refine(
+    (input) =>
+      input.edits.reduce(
+        (total, edit) =>
+          total + Buffer.byteLength(edit.oldText, "utf8") + Buffer.byteLength(edit.newText, "utf8"),
+        0,
+      ) <= maximumEditArgumentsBytes,
+  );
 const readFileMaximumResult = { maximumBytes: 64 * 1024 } as const;
 const listFilesMaximumResult = { maximumEntries: 200 } as const;
 const searchTextMaximumResult = {
@@ -153,6 +208,15 @@ const searchTextOutputSchema = z.strictObject({
   matches: z.array(searchMatchSchema).max(searchTextMaximumResult.maximumMatches),
   truncated: z.boolean(),
 });
+const writeFileOutputSchema = z.strictObject({
+  path: z.string(),
+  bytesWritten: z.number().int().nonnegative(),
+});
+const editFileOutputSchema = z.strictObject({
+  path: z.string(),
+  replacements: z.number().int().positive(),
+  bytesWritten: z.number().int().nonnegative(),
+});
 
 export function createReadToolRegistry(options: { readonly workspaceRoot: string }): ToolRegistry {
   const workspaceRoot = resolve(options.workspaceRoot);
@@ -171,8 +235,17 @@ export function createReadToolRegistry(options: { readonly workspaceRoot: string
       if (!parsedArguments.success) {
         return invalidToolInput();
       }
+      const permissionSubject = preparePermissionSubject(
+        workspaceRoot,
+        parsedArguments.data.path,
+        "file",
+      );
+      if ("status" in permissionSubject) {
+        return permissionSubject;
+      }
       return {
         status: "ready",
+        permissionSubject,
         async execute() {
           return executeSafely(readFileOutputSchema, async () => {
             const targetPath = await resolveConfinedPath(workspaceRoot, parsedArguments.data.path);
@@ -201,8 +274,17 @@ export function createReadToolRegistry(options: { readonly workspaceRoot: string
       if (!parsedArguments.success) {
         return invalidToolInput();
       }
+      const permissionSubject = preparePermissionSubject(
+        workspaceRoot,
+        parsedArguments.data.path,
+        "workspace_path",
+      );
+      if ("status" in permissionSubject) {
+        return permissionSubject;
+      }
       return {
         status: "ready",
+        permissionSubject,
         async execute() {
           return executeSafely(listFilesOutputSchema, async () => {
             const targetPath = await resolveConfinedPath(workspaceRoot, parsedArguments.data.path);
@@ -236,8 +318,17 @@ export function createReadToolRegistry(options: { readonly workspaceRoot: string
       if (!parsedArguments.success) {
         return invalidToolInput();
       }
+      const permissionSubject = preparePermissionSubject(
+        workspaceRoot,
+        parsedArguments.data.path,
+        "workspace_path",
+      );
+      if ("status" in permissionSubject) {
+        return permissionSubject;
+      }
       return {
         status: "ready",
+        permissionSubject,
         async execute() {
           return executeSafely(searchTextOutputSchema, async () => {
             const targetPath = await resolveConfinedPath(workspaceRoot, parsedArguments.data.path);
@@ -309,6 +400,218 @@ export function createReadToolRegistry(options: { readonly workspaceRoot: string
   };
 }
 
+export function createMutationToolRegistry(options: {
+  readonly workspaceRoot: string;
+}): ToolRegistry {
+  const workspaceRoot = resolve(options.workspaceRoot);
+  const writeFileAdapter: ToolAdapter = {
+    definition: {
+      name: "write_file",
+      description: "Create a UTF-8 text file inside the workspace, including missing parents.",
+      inputSchema: z.toJSONSchema(writeFileInputSchema),
+    },
+    outputSchema: writeFileOutputSchema,
+    effect: "write",
+    cancellation: "unsupported",
+    maximumResult: {},
+    prepare(argumentsJson) {
+      const parsedArguments = parseInput(writeFileInputSchema, argumentsJson);
+      if (!parsedArguments.success) {
+        return invalidToolInput();
+      }
+      const permissionSubject = preparePermissionSubject(
+        workspaceRoot,
+        parsedArguments.data.path,
+        "file",
+      );
+      if ("status" in permissionSubject) {
+        return permissionSubject;
+      }
+      return {
+        status: "ready",
+        permissionSubject,
+        async execute() {
+          return executeSafely(writeFileOutputSchema, async () => {
+            const target = await openConfinedMutationTarget(
+              workspaceRoot,
+              parsedArguments.data.path,
+              true,
+            );
+            try {
+              await rejectEscapingExistingTarget(target);
+              const file = await open(
+                target.path,
+                constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+                0o666,
+              );
+              try {
+                await file.writeFile(parsedArguments.data.content, "utf8");
+              } finally {
+                await file.close();
+              }
+            } finally {
+              await target.parent.close();
+            }
+            return {
+              path: parsedArguments.data.path,
+              bytesWritten: Buffer.byteLength(parsedArguments.data.content, "utf8"),
+            };
+          });
+        },
+      };
+    },
+  };
+  const editFileAdapter: ToolAdapter = {
+    definition: {
+      name: "edit_file",
+      description: "Apply exact text replacements to one existing workspace file.",
+      inputSchema: z.toJSONSchema(editFileInputSchema),
+    },
+    outputSchema: editFileOutputSchema,
+    effect: "write",
+    cancellation: "unsupported",
+    maximumResult: {},
+    prepare(argumentsJson) {
+      const parsedArguments = parseInput(editFileInputSchema, argumentsJson);
+      if (!parsedArguments.success) {
+        return invalidToolInput();
+      }
+      const permissionSubject = preparePermissionSubject(
+        workspaceRoot,
+        parsedArguments.data.path,
+        "file",
+      );
+      if ("status" in permissionSubject) {
+        return permissionSubject;
+      }
+      return {
+        status: "ready",
+        permissionSubject,
+        async execute() {
+          return executeSafely(editFileOutputSchema, async () => {
+            const target = await openConfinedMutationTarget(
+              workspaceRoot,
+              parsedArguments.data.path,
+              false,
+            );
+            try {
+              const file = await open(target.path, constants.O_RDWR);
+              try {
+                await assertOpenedHandleIsConfined(target.canonicalRoot, file);
+                const originalBytes = await readBytesFromHandleBounded(
+                  file,
+                  maximumMutationFileBytes + 1,
+                );
+                if (originalBytes.byteLength > maximumMutationFileBytes) {
+                  throw new ToolExecutionError(
+                    "file_too_large",
+                    "The requested file exceeds the one MiB edit limit.",
+                  );
+                }
+                if (originalBytes.includes(0)) {
+                  throw new ToolExecutionError(
+                    "binary_file",
+                    "The requested file is not supported UTF-8 text.",
+                  );
+                }
+                let originalContent: string;
+                try {
+                  originalContent = new TextDecoder("utf-8", { fatal: true }).decode(originalBytes);
+                  if (
+                    originalBytes[0] === 0xef &&
+                    originalBytes[1] === 0xbb &&
+                    originalBytes[2] === 0xbf
+                  ) {
+                    originalContent = `\uFEFF${originalContent}`;
+                  }
+                } catch {
+                  throw new ToolExecutionError(
+                    "binary_file",
+                    "The requested file is not supported UTF-8 text.",
+                  );
+                }
+                const lineEnding = detectLineEnding(originalContent);
+                const replacements = parsedArguments.data.edits.map((edit) => {
+                  const firstMatch = originalContent.indexOf(edit.oldText);
+                  if (firstMatch === -1) {
+                    throw new ToolExecutionError(
+                      "no_match",
+                      "The edit text was not found in the file.",
+                    );
+                  }
+                  if (originalContent.indexOf(edit.oldText, firstMatch + 1) !== -1) {
+                    throw new ToolExecutionError(
+                      "ambiguous_match",
+                      "The edit text matched more than one location.",
+                    );
+                  }
+                  return {
+                    start: firstMatch,
+                    end: firstMatch + edit.oldText.length,
+                    newText:
+                      lineEnding === undefined
+                        ? edit.newText
+                        : edit.newText.replace(/\r\n|\r|\n/gu, lineEnding),
+                  };
+                });
+                replacements.sort((left, right) => left.start - right.start);
+                for (let index = 1; index < replacements.length; index += 1) {
+                  const prior = replacements[index - 1];
+                  const current = replacements[index];
+                  if (prior !== undefined && current !== undefined && current.start < prior.end) {
+                    throw new ToolExecutionError(
+                      "overlapping_edits",
+                      "The requested edits overlap in the original file.",
+                    );
+                  }
+                }
+                let updatedContent = "";
+                let originalOffset = 0;
+                for (const replacement of replacements) {
+                  updatedContent += originalContent.slice(originalOffset, replacement.start);
+                  updatedContent += replacement.newText;
+                  originalOffset = replacement.end;
+                }
+                updatedContent += originalContent.slice(originalOffset);
+                if (Buffer.byteLength(updatedContent, "utf8") > maximumMutationFileBytes) {
+                  throw new ToolExecutionError(
+                    "file_too_large",
+                    "The updated file exceeds the one MiB edit limit.",
+                  );
+                }
+                const updatedBytes = Buffer.from(updatedContent, "utf8");
+                await file.truncate(0);
+                await writeBytesFully(file, updatedBytes);
+                return {
+                  path: parsedArguments.data.path,
+                  replacements: parsedArguments.data.edits.length,
+                  bytesWritten: updatedBytes.byteLength,
+                };
+              } finally {
+                await file.close();
+              }
+            } finally {
+              await target.parent.close();
+            }
+          });
+        },
+      };
+    },
+  };
+  const adapters = new Map(
+    [writeFileAdapter, editFileAdapter].map((adapter) => [adapter.definition.name, adapter]),
+  );
+
+  return {
+    definitions() {
+      return [...adapters.values()].map((adapter) => adapter.definition);
+    },
+    resolve(name) {
+      return adapters.get(name);
+    },
+  };
+}
+
 async function readTextFileBounded(
   path: string,
   maximumBytes: number,
@@ -323,6 +626,40 @@ async function readTextFileBounded(
     };
   } finally {
     await file.close();
+  }
+}
+
+async function readBytesFromHandleBounded(file: FileHandle, maximumBytes: number): Promise<Buffer> {
+  const buffer = Buffer.alloc(maximumBytes);
+  let totalBytesRead = 0;
+  while (totalBytesRead < buffer.length) {
+    const { bytesRead } = await file.read(
+      buffer,
+      totalBytesRead,
+      buffer.length - totalBytesRead,
+      totalBytesRead,
+    );
+    if (bytesRead === 0) {
+      break;
+    }
+    totalBytesRead += bytesRead;
+  }
+  return buffer.subarray(0, totalBytesRead);
+}
+
+async function writeBytesFully(file: FileHandle, content: Buffer): Promise<void> {
+  let totalBytesWritten = 0;
+  while (totalBytesWritten < content.byteLength) {
+    const { bytesWritten } = await file.write(
+      content,
+      totalBytesWritten,
+      content.byteLength - totalBytesWritten,
+      totalBytesWritten,
+    );
+    if (bytesWritten === 0) {
+      throw new Error("The filesystem made no progress while writing.");
+    }
+    totalBytesWritten += bytesWritten;
   }
 }
 
@@ -342,6 +679,18 @@ async function executeSafely(
   } catch (error) {
     if (error instanceof ToolExecutionError) {
       return { status: "failed", error: { code: error.code, message: error.message } };
+    }
+    if (isNodeError(error) && error.code === "EEXIST") {
+      return {
+        status: "failed",
+        error: { code: "already_exists", message: "The requested file already exists." },
+      };
+    }
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return {
+        status: "failed",
+        error: { code: "not_found", message: "The requested path does not exist." },
+      };
     }
     return {
       status: "failed",
@@ -440,6 +789,18 @@ function collectTextMatches(
   return truncated;
 }
 
+function detectLineEnding(content: string): "\n" | "\r" | "\r\n" | undefined {
+  const firstCarriageReturn = content.indexOf("\r");
+  const firstLineFeed = content.indexOf("\n");
+  if (firstCarriageReturn === -1 && firstLineFeed === -1) {
+    return undefined;
+  }
+  if (firstCarriageReturn !== -1 && (firstLineFeed === -1 || firstCarriageReturn < firstLineFeed)) {
+    return content[firstCarriageReturn + 1] === "\n" ? "\r\n" : "\r";
+  }
+  return "\n";
+}
+
 function parseInput<T>(
   schema: z.ZodType<T>,
   argumentsJson: string,
@@ -463,6 +824,25 @@ function invalidToolInput(): FailedToolResult {
       message: "The tool input did not match its schema.",
     },
   };
+}
+
+function preparePermissionSubject(
+  workspaceRoot: string,
+  requestedPath: string,
+  type: PermissionSubject["type"],
+): PermissionSubject | FailedToolResult {
+  try {
+    const lexicalPath = resolveLexicallyConfinedPath(workspaceRoot, requestedPath);
+    return {
+      type,
+      path: relative(workspaceRoot, lexicalPath).split(sep).join("/"),
+    };
+  } catch (error) {
+    if (error instanceof ToolExecutionError) {
+      return { status: "failed", error: { code: error.code, message: error.message } };
+    }
+    throw error;
+  }
 }
 
 async function resolveConfinedPath(workspaceRoot: string, requestedPath: string): Promise<string> {
@@ -492,6 +872,119 @@ async function resolveConfinedPath(workspaceRoot: string, requestedPath: string)
     );
   }
   return canonicalPath;
+}
+
+type ConfinedMutationTarget = {
+  readonly canonicalRoot: string;
+  readonly parent: FileHandle;
+  readonly path: string;
+};
+
+async function openConfinedMutationTarget(
+  workspaceRoot: string,
+  requestedPath: string,
+  createParents: boolean,
+): Promise<ConfinedMutationTarget> {
+  const lexicalPath = resolveLexicallyConfinedPath(workspaceRoot, requestedPath);
+  const canonicalRoot = await realpath(workspaceRoot);
+  const relativePath = relative(workspaceRoot, lexicalPath);
+  const segments = relativePath === "" ? ["."] : relativePath.split(sep);
+  const targetName = segments.pop() ?? ".";
+  let currentDirectory = await open(
+    canonicalRoot,
+    constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+  );
+  try {
+    for (const segment of segments) {
+      const childPath = pathFromDirectoryHandle(currentDirectory, segment);
+      if (createParents) {
+        try {
+          await mkdir(childPath);
+        } catch (error) {
+          if (!isNodeError(error) || error.code !== "EEXIST") {
+            throw error;
+          }
+        }
+      }
+      const childDirectory = await open(childPath, constants.O_RDONLY | constants.O_DIRECTORY);
+      try {
+        await assertOpenedHandleIsConfined(canonicalRoot, childDirectory);
+      } catch (error) {
+        await childDirectory.close();
+        throw error;
+      }
+      await currentDirectory.close();
+      currentDirectory = childDirectory;
+    }
+    return {
+      canonicalRoot,
+      parent: currentDirectory,
+      path: pathFromDirectoryHandle(currentDirectory, targetName),
+    };
+  } catch (error) {
+    await currentDirectory.close();
+    if (isNodeError(error) && (error.code === "ELOOP" || error.code === "ENOTDIR")) {
+      throw new ToolExecutionError(
+        "outside_workspace",
+        "The requested path resolves through an unsupported symbolic link.",
+      );
+    }
+    throw error;
+  }
+}
+
+function pathFromDirectoryHandle(directory: FileHandle, name: string): string {
+  return `/proc/self/fd/${directory.fd}/${name}`;
+}
+
+async function rejectEscapingExistingTarget(target: ConfinedMutationTarget): Promise<void> {
+  try {
+    const canonicalTarget = await realpath(target.path);
+    if (isOutside(target.canonicalRoot, canonicalTarget)) {
+      throw new ToolExecutionError(
+        "outside_workspace",
+        "The requested path resolves outside the workspace root.",
+      );
+    }
+  } catch (error) {
+    if (!isNodeError(error) || error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+async function assertOpenedHandleIsConfined(
+  canonicalRoot: string,
+  file: FileHandle,
+): Promise<void> {
+  const canonicalTarget = await realpath(`/proc/self/fd/${file.fd}`);
+  if (isOutside(canonicalRoot, canonicalTarget)) {
+    throw new ToolExecutionError(
+      "outside_workspace",
+      "The requested path resolves outside the workspace root.",
+    );
+  }
+}
+
+function resolveLexicallyConfinedPath(workspaceRoot: string, requestedPath: string): string {
+  if (isAbsolute(requestedPath)) {
+    throw new ToolExecutionError(
+      "outside_workspace",
+      "The requested path must be relative to the workspace root.",
+    );
+  }
+  const lexicalPath = resolve(workspaceRoot, requestedPath);
+  if (isOutside(workspaceRoot, lexicalPath)) {
+    throw new ToolExecutionError(
+      "outside_workspace",
+      "The requested path is outside the workspace root.",
+    );
+  }
+  return lexicalPath;
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
 }
 
 function isOutside(root: string, target: string): boolean {

--- a/packages/testkit/src/agent-session.test.ts
+++ b/packages/testkit/src/agent-session.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -7,6 +7,7 @@ import {
   type AgentSessionDependencies,
   createInMemorySessionStore,
   createJsonlSessionStore,
+  createMutationToolRegistry,
   createPermissionPolicy,
   createReadToolRegistry,
   type ModelDriver,
@@ -769,6 +770,1409 @@ describe("AgentSession", () => {
     }
   });
 
+  test("creates a nested UTF-8 file after write policy allows the call", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-write-"));
+    const targetPath = join(workspaceRoot, "src", "new", "module.ts");
+
+    try {
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-write", name: "write_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-write",
+              json: '{"path":"src/new/module.ts","content":"export const fruit = \\"pear\\";\\n"}',
+            },
+            { type: "tool_call_end", id: "call-write" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedWriteResult =
+          latestMessage?.role === "tool" &&
+          latestMessage.callId === "call-write" &&
+          latestMessage.name === "write_file" &&
+          latestMessage.result.status === "completed" &&
+          JSON.stringify(latestMessage.result.output) ===
+            JSON.stringify({ path: "src/new/module.ts", bytesWritten: 29 });
+
+        return [
+          {
+            type: "text_delta",
+            text: receivedWriteResult
+              ? "The module was created."
+              : "The write result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
+      });
+      const events: RuntimeEvent[] = [];
+      session.subscribe((event) => events.push(event));
+
+      const result = await session.run({ text: "Create a nested module" });
+
+      expect({
+        result,
+        content: await readFile(targetPath, "utf8"),
+        toolEvents: events.filter((event) => event.type.startsWith("tool_")),
+      }).toEqual({
+        result: { status: "completed", answer: "The module was created." },
+        content: 'export const fruit = "pear";\n',
+        toolEvents: [
+          { type: "tool_requested", callId: "call-write", name: "write_file" },
+          {
+            type: "tool_permission_decided",
+            callId: "call-write",
+            name: "write_file",
+            decision: "allow",
+            effect: "write",
+            scope: "call",
+            subject: { type: "file", path: "src/new/module.ts" },
+          },
+          { type: "tool_started", callId: "call-write", name: "write_file" },
+          {
+            type: "tool_completed",
+            callId: "call-write",
+            name: "write_file",
+            output: { path: "src/new/module.ts", bytesWritten: 29 },
+          },
+        ],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("write_file rejects an existing path without changing its content", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-write-existing-"));
+    const targetPath = join(workspaceRoot, "notes.txt");
+    const originalContent = "keep this version\n";
+
+    try {
+      await writeFile(targetPath, originalContent, "utf8");
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-existing", name: "write_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-existing",
+              json: '{"path":"notes.txt","content":"replace it\\n"}',
+            },
+            { type: "tool_call_end", id: "call-existing" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedCreateOnlyFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "already_exists";
+        return [
+          {
+            type: "text_delta",
+            text: receivedCreateOnlyFailure
+              ? "The existing file was preserved."
+              : "The create-only failure was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
+      });
+      const events: RuntimeEvent[] = [];
+      session.subscribe((event) => events.push(event));
+
+      const result = await session.run({ text: "Create notes.txt" });
+
+      expect({
+        result,
+        content: await readFile(targetPath, "utf8"),
+        finalToolEvent: events.filter((event) => event.type.startsWith("tool_")).at(-1),
+      }).toEqual({
+        result: { status: "completed", answer: "The existing file was preserved." },
+        content: originalContent,
+        finalToolEvent: {
+          type: "tool_failed",
+          callId: "call-existing",
+          name: "write_file",
+          error: {
+            code: "already_exists",
+            message: "The requested file already exists.",
+          },
+        },
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
+    { label: "NUL-containing", content: "before\0after" },
+    { label: "larger-than-one-MiB", content: "x".repeat(1024 * 1024 + 1) },
+  ])("write_file rejects $label content before permission or creation", async ({ content }) => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-write-invalid-content-"));
+    const targetPath = join(workspaceRoot, "nested", "invalid.txt");
+
+    try {
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-invalid-content", name: "write_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-invalid-content",
+              json: JSON.stringify({ path: "nested/invalid.txt", content }),
+            },
+            { type: "tool_call_end", id: "call-invalid-content" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedInputFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "invalid_tool_input";
+        return [
+          {
+            type: "text_delta",
+            text: receivedInputFailure
+              ? "The invalid write content was rejected."
+              : "The invalid write result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["write"] }),
+      });
+      const toolEvents: RuntimeEvent[] = [];
+      session.subscribe((event) => {
+        if (event.type.startsWith("tool_")) {
+          toolEvents.push(event);
+        }
+      });
+
+      const result = await session.run({ text: "Write invalid content" });
+
+      expect({
+        result,
+        exists: await readFile(targetPath).then(
+          () => true,
+          () => false,
+        ),
+        toolEvents,
+      }).toEqual({
+        result: { status: "completed", answer: "The invalid write content was rejected." },
+        exists: false,
+        toolEvents: [
+          { type: "tool_requested", callId: "call-invalid-content", name: "write_file" },
+          {
+            type: "tool_failed",
+            callId: "call-invalid-content",
+            name: "write_file",
+            error: {
+              code: "invalid_tool_input",
+              message: "The tool input did not match its schema.",
+            },
+          },
+        ],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("an asked write waits for one call-scoped decision before starting", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-write-ask-"));
+    const targetPath = join(workspaceRoot, "approved.txt");
+    const store = createInMemorySessionStore();
+
+    try {
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-ask", name: "write_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-ask",
+              json: '{"path":"approved.txt","content":"approved\\n"}',
+            },
+            { type: "tool_call_end", id: "call-ask" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        return [
+          { type: "text_delta", text: "The approved file was created." },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        store,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["write"] }),
+      });
+      let commandResult: ReturnType<AgentSession["decidePermission"]> | undefined;
+      let mismatchedResult: ReturnType<AgentSession["decidePermission"]> | undefined;
+      let requestId: string | undefined;
+      session.subscribe((event) => {
+        if (event.type === "tool_permission_requested") {
+          requestId = event.requestId;
+          mismatchedResult = session.decidePermission({
+            requestId: `${event.requestId}:stale`,
+            decision: "allow",
+          });
+          commandResult = session.decidePermission({
+            requestId: event.requestId,
+            decision: "allow",
+          });
+        }
+      });
+
+      const result = await session.run({ text: "Create approved.txt" });
+      const duplicateResult = session.decidePermission({
+        requestId: requestId ?? "missing-request",
+        decision: "allow",
+      });
+      const persistedToolEvents = (await store.read())
+        .map((record) => record.event)
+        .filter((event) => event.type.startsWith("tool_"));
+      const permissionRequest = persistedToolEvents.find(
+        (event) => event.type === "tool_permission_requested",
+      );
+      const permissionDecision = persistedToolEvents.find(
+        (event) => event.type === "tool_permission_decided",
+      );
+
+      expect({
+        result,
+        content: await readFile(targetPath, "utf8").catch(() => undefined),
+        commandResult,
+        mismatchedResult,
+        duplicateResult,
+        persistedToolEvents,
+        correlated:
+          permissionRequest?.type === "tool_permission_requested" &&
+          permissionDecision?.type === "tool_permission_decided" &&
+          permissionDecision.requestId === permissionRequest.requestId,
+      }).toEqual({
+        result: { status: "completed", answer: "The approved file was created." },
+        content: "approved\n",
+        commandResult: { status: "accepted" },
+        mismatchedResult: {
+          status: "rejected",
+          error: {
+            code: "permission_request_not_pending",
+            message: "The permission request is not pending.",
+          },
+        },
+        duplicateResult: {
+          status: "rejected",
+          error: {
+            code: "permission_request_not_pending",
+            message: "The permission request is not pending.",
+          },
+        },
+        persistedToolEvents: [
+          { type: "tool_requested", callId: "call-ask", name: "write_file" },
+          {
+            type: "tool_permission_requested",
+            requestId: expect.any(String),
+            callId: "call-ask",
+            name: "write_file",
+            effect: "write",
+            scope: "call",
+            subject: { type: "file", path: "approved.txt" },
+          },
+          {
+            type: "tool_permission_decided",
+            requestId: expect.any(String),
+            callId: "call-ask",
+            name: "write_file",
+            decision: "allow",
+            effect: "write",
+            scope: "call",
+            subject: { type: "file", path: "approved.txt" },
+          },
+          { type: "tool_started", callId: "call-ask", name: "write_file" },
+          {
+            type: "tool_completed",
+            callId: "call-ask",
+            name: "write_file",
+            output: { path: "approved.txt", bytesWritten: 9 },
+          },
+        ],
+        correlated: true,
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("an invalid permission decision is rejected without consuming the request", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-write-invalid-decision-"));
+    const targetPath = join(workspaceRoot, "denied.txt");
+
+    try {
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-invalid-decision", name: "write_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-invalid-decision",
+              json: '{"path":"denied.txt","content":"not written\\n"}',
+            },
+            { type: "tool_call_end", id: "call-invalid-decision" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedDenial =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "permission_denied";
+        return [
+          {
+            type: "text_delta",
+            text: receivedDenial ? "The write remained denied." : "The denial was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["write"] }),
+      });
+      let invalidResult: unknown;
+      let validResult: unknown;
+      session.subscribe((event) => {
+        if (event.type === "tool_permission_requested") {
+          invalidResult = session.decidePermission({
+            requestId: event.requestId,
+            decision: "always",
+          } as never);
+          validResult = session.decidePermission({
+            requestId: event.requestId,
+            decision: "deny",
+          });
+        }
+      });
+
+      const result = await session.run({ text: "Try an invalid permission response" });
+
+      expect({
+        result,
+        invalidResult,
+        validResult,
+        exists: await readFile(targetPath).then(
+          () => true,
+          () => false,
+        ),
+      }).toEqual({
+        result: { status: "completed", answer: "The write remained denied." },
+        invalidResult: {
+          status: "rejected",
+          error: {
+            code: "invalid_permission_decision",
+            message: "The permission decision must be allow or deny.",
+          },
+        },
+        validResult: { status: "accepted" },
+        exists: false,
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("abort clears a pending permission request without starting the mutation", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-write-ask-abort-"));
+    const targetPath = join(workspaceRoot, "cancelled.txt");
+    let releasePermissionRequest: ((requestId: string) => void) | undefined;
+    const permissionRequested = new Promise<string>((resolve) => {
+      releasePermissionRequest = resolve;
+    });
+
+    try {
+      const model = new FakeModelDriver([
+        { type: "tool_call_start", id: "call-ask-abort", name: "write_file" },
+        {
+          type: "tool_call_delta",
+          id: "call-ask-abort",
+          json: '{"path":"cancelled.txt","content":"not written\\n"}',
+        },
+        { type: "tool_call_end", id: "call-ask-abort" },
+        { type: "finish", reason: "tool_calls" },
+      ]);
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["write"] }),
+      });
+      const toolEvents: RuntimeEvent[] = [];
+      session.subscribe((event) => {
+        if (event.type.startsWith("tool_")) {
+          toolEvents.push(event);
+        }
+        if (event.type === "tool_permission_requested") {
+          releasePermissionRequest?.(event.requestId);
+        }
+      });
+
+      const pendingResult = session.run({ text: "Create cancelled.txt" });
+      const requestId = await permissionRequested;
+      session.abort();
+      const result = await pendingResult;
+      const lateResult = session.decidePermission({ requestId, decision: "allow" });
+
+      expect({
+        result,
+        lateResult,
+        exists: await readFile(targetPath).then(
+          () => true,
+          () => false,
+        ),
+        toolEvents,
+      }).toEqual({
+        result: cancelledResult,
+        lateResult: {
+          status: "rejected",
+          error: {
+            code: "permission_request_not_pending",
+            message: "The permission request is not pending.",
+          },
+        },
+        exists: false,
+        toolEvents: [
+          { type: "tool_requested", callId: "call-ask-abort", name: "write_file" },
+          {
+            type: "tool_permission_requested",
+            requestId,
+            callId: "call-ask-abort",
+            name: "write_file",
+            effect: "write",
+            scope: "call",
+            subject: { type: "file", path: "cancelled.txt" },
+          },
+        ],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("abort during policy evaluation prevents an orphan permission request", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-policy-abort-"));
+    let session: AgentSession;
+
+    try {
+      const model = new FakeModelDriver([
+        { type: "tool_call_start", id: "call-policy-abort", name: "write_file" },
+        {
+          type: "tool_call_delta",
+          id: "call-policy-abort",
+          json: '{"path":"cancelled.txt","content":"not written\\n"}',
+        },
+        { type: "tool_call_end", id: "call-policy-abort" },
+        { type: "finish", reason: "tool_calls" },
+      ]);
+      session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: {
+          decide() {
+            session.abort();
+            return "ask";
+          },
+        },
+      });
+      const toolEvents: RuntimeEvent[] = [];
+      session.subscribe((event) => {
+        if (event.type.startsWith("tool_")) {
+          toolEvents.push(event);
+        }
+      });
+
+      const result = await session.run({ text: "Cancel while policy evaluates" });
+
+      expect({ result, toolEvents }).toEqual({
+        result: cancelledResult,
+        toolEvents: [{ type: "tool_requested", callId: "call-policy-abort", name: "write_file" }],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("write_file rejects lexical traversal before requesting permission", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-write-traversal-"));
+
+    try {
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-write-traversal", name: "write_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-write-traversal",
+              json: '{"path":"../outside.txt","content":"escape\\n"}',
+            },
+            { type: "tool_call_end", id: "call-write-traversal" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedConfinementFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "outside_workspace";
+        return [
+          {
+            type: "text_delta",
+            text: receivedConfinementFailure
+              ? "The traversal was rejected."
+              : "The traversal result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["write"] }),
+      });
+      const toolEvents: RuntimeEvent[] = [];
+      session.subscribe((event) => {
+        if (event.type.startsWith("tool_")) {
+          toolEvents.push(event);
+        }
+        if (event.type === "tool_permission_requested") {
+          session.decidePermission({ requestId: event.requestId, decision: "deny" });
+        }
+      });
+
+      const result = await session.run({ text: "Write outside the workspace" });
+
+      expect({ result, toolEvents }).toEqual({
+        result: { status: "completed", answer: "The traversal was rejected." },
+        toolEvents: [
+          {
+            type: "tool_requested",
+            callId: "call-write-traversal",
+            name: "write_file",
+          },
+          {
+            type: "tool_failed",
+            callId: "call-write-traversal",
+            name: "write_file",
+            error: {
+              code: "outside_workspace",
+              message: "The requested path is outside the workspace root.",
+            },
+          },
+        ],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("write_file rejects a target symlink that resolves outside the workspace", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-write-symlink-"));
+    const workspaceRoot = join(testRoot, "workspace");
+    const outsidePath = join(testRoot, "outside.txt");
+    const originalContent = "outside stays unchanged\n";
+
+    try {
+      await mkdir(workspaceRoot);
+      await writeFile(outsidePath, originalContent, "utf8");
+      await symlink(outsidePath, join(workspaceRoot, "linked.txt"));
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-write-symlink", name: "write_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-write-symlink",
+              json: '{"path":"linked.txt","content":"do not write\\n"}',
+            },
+            { type: "tool_call_end", id: "call-write-symlink" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedConfinementFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "outside_workspace";
+        return [
+          {
+            type: "text_delta",
+            text: receivedConfinementFailure
+              ? "The escaping symlink was rejected."
+              : "The symlink result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
+      });
+
+      const result = await session.run({ text: "Write through the symlink" });
+
+      expect({ result, outsideContent: await readFile(outsidePath, "utf8") }).toEqual({
+        result: { status: "completed", answer: "The escaping symlink was rejected." },
+        outsideContent: originalContent,
+      });
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("edit_file rejects a target symlink outside the workspace before mutation", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-edit-symlink-"));
+    const workspaceRoot = join(testRoot, "workspace");
+    const outsidePath = join(testRoot, "outside.txt");
+    const originalContent = "outside stays unchanged\n";
+
+    try {
+      await mkdir(workspaceRoot);
+      await writeFile(outsidePath, originalContent, "utf8");
+      await symlink(outsidePath, join(workspaceRoot, "linked.txt"));
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-edit-symlink", name: "edit_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-edit-symlink",
+              json: JSON.stringify({
+                path: "linked.txt",
+                edits: [{ oldText: "unchanged", newText: "changed" }],
+              }),
+            },
+            { type: "tool_call_end", id: "call-edit-symlink" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedConfinementFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "outside_workspace";
+        return [
+          {
+            type: "text_delta",
+            text: receivedConfinementFailure
+              ? "The escaping edit symlink was rejected."
+              : "The edit symlink result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
+      });
+
+      const result = await session.run({ text: "Edit through the symlink" });
+
+      expect({ result, outsideContent: await readFile(outsidePath, "utf8") }).toEqual({
+        result: { status: "completed", answer: "The escaping edit symlink was rejected." },
+        outsideContent: originalContent,
+      });
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("edit_file applies exact multi-replacements against one original file", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-edit-"));
+    const targetPath = join(workspaceRoot, "fruit.ts");
+
+    try {
+      await writeFile(targetPath, 'const fruit = "apple";\nconst color = "green";\n', "utf8");
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-edit", name: "edit_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-edit",
+              json: '{"path":"fruit.ts","edits":[{"oldText":"apple","newText":"pear"},{"oldText":"green","newText":"gold"}]}',
+            },
+            { type: "tool_call_end", id: "call-edit" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedEditResult =
+          latestMessage?.role === "tool" &&
+          latestMessage.callId === "call-edit" &&
+          latestMessage.name === "edit_file" &&
+          latestMessage.result.status === "completed" &&
+          JSON.stringify(latestMessage.result.output) ===
+            JSON.stringify({ path: "fruit.ts", replacements: 2, bytesWritten: 44 });
+        return [
+          {
+            type: "text_delta",
+            text: receivedEditResult
+              ? "Both edits were applied."
+              : "The edit result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
+      });
+
+      const result = await session.run({ text: "Update the fruit module" });
+
+      expect({ result, content: await readFile(targetPath, "utf8") }).toEqual({
+        result: { status: "completed", answer: "Both edits were applied." },
+        content: 'const fruit = "pear";\nconst color = "gold";\n',
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("edit_file rejects an ambiguous match without applying any replacement", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-edit-ambiguous-"));
+    const targetPath = join(workspaceRoot, "fruit.txt");
+    const originalContent = "apple apple\ncolor green\n";
+
+    try {
+      await writeFile(targetPath, originalContent, "utf8");
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-ambiguous", name: "edit_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-ambiguous",
+              json: '{"path":"fruit.txt","edits":[{"oldText":"apple","newText":"pear"},{"oldText":"green","newText":"gold"}]}',
+            },
+            { type: "tool_call_end", id: "call-ambiguous" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedAmbiguousFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "ambiguous_match";
+        return [
+          {
+            type: "text_delta",
+            text: receivedAmbiguousFailure
+              ? "The ambiguous edit was rejected."
+              : "The ambiguous edit result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
+      });
+
+      const result = await session.run({ text: "Update fruit.txt exactly" });
+
+      expect({ result, content: await readFile(targetPath, "utf8") }).toEqual({
+        result: { status: "completed", answer: "The ambiguous edit was rejected." },
+        content: originalContent,
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("edit_file treats overlapping occurrences of one oldText as ambiguous", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-edit-overlapping-match-"));
+    const targetPath = join(workspaceRoot, "letters.txt");
+    const originalContent = "aaa";
+
+    try {
+      await writeFile(targetPath, originalContent, "utf8");
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-overlapping-match", name: "edit_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-overlapping-match",
+              json: '{"path":"letters.txt","edits":[{"oldText":"aa","newText":"x"}]}',
+            },
+            { type: "tool_call_end", id: "call-overlapping-match" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedAmbiguousFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "ambiguous_match";
+        return [
+          {
+            type: "text_delta",
+            text: receivedAmbiguousFailure
+              ? "The overlapping occurrence was rejected."
+              : "The overlapping occurrence result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
+      });
+
+      const result = await session.run({ text: "Replace aa exactly once" });
+
+      expect({ result, content: await readFile(targetPath, "utf8") }).toEqual({
+        result: { status: "completed", answer: "The overlapping occurrence was rejected." },
+        content: originalContent,
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("edit_file rejects overlapping original ranges without changing the file", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-edit-overlap-"));
+    const targetPath = join(workspaceRoot, "letters.txt");
+    const originalContent = "abcdef\n";
+
+    try {
+      await writeFile(targetPath, originalContent, "utf8");
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-overlap", name: "edit_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-overlap",
+              json: '{"path":"letters.txt","edits":[{"oldText":"abc","newText":"X"},{"oldText":"bcd","newText":"Y"}]}',
+            },
+            { type: "tool_call_end", id: "call-overlap" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedOverlapFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "overlapping_edits";
+        return [
+          {
+            type: "text_delta",
+            text: receivedOverlapFailure
+              ? "The overlapping edits were rejected."
+              : "The overlap result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
+      });
+
+      const result = await session.run({ text: "Apply overlapping edits" });
+
+      expect({ result, content: await readFile(targetPath, "utf8") }).toEqual({
+        result: { status: "completed", answer: "The overlapping edits were rejected." },
+        content: originalContent,
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("edit_file reports a missing exact match without changing the file", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-edit-missing-match-"));
+    const targetPath = join(workspaceRoot, "fruit.txt");
+    const originalContent = "apple\n";
+
+    try {
+      await writeFile(targetPath, originalContent, "utf8");
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-no-match", name: "edit_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-no-match",
+              json: '{"path":"fruit.txt","edits":[{"oldText":"orange","newText":"pear"}]}',
+            },
+            { type: "tool_call_end", id: "call-no-match" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedNoMatchFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "no_match";
+        return [
+          {
+            type: "text_delta",
+            text: receivedNoMatchFailure
+              ? "The missing match was reported."
+              : "The no-match result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
+      });
+
+      const result = await session.run({ text: "Replace orange with pear" });
+
+      expect({ result, content: await readFile(targetPath, "utf8") }).toEqual({
+        result: { status: "completed", answer: "The missing match was reported." },
+        content: originalContent,
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("edit_file preserves UTF-8 BOM, CRLF style, and the existing file mode", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-edit-format-"));
+    const targetPath = join(workspaceRoot, "formatted.txt");
+
+    try {
+      await writeFile(targetPath, Buffer.from("\uFEFFone\r\ntwo\r\n", "utf8"));
+      await chmod(targetPath, 0o744);
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-format", name: "edit_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-format",
+              json: '{"path":"formatted.txt","edits":[{"oldText":"one\\r\\ntwo","newText":"one\\nchanged"}]}',
+            },
+            { type: "tool_call_end", id: "call-format" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedFormatPreservingResult =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "completed" &&
+          JSON.stringify(latestMessage.result.output) ===
+            JSON.stringify({ path: "formatted.txt", replacements: 1, bytesWritten: 17 });
+        return [
+          {
+            type: "text_delta",
+            text: receivedFormatPreservingResult
+              ? "The formatted file was updated."
+              : "The formatted edit result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
+      });
+
+      const result = await session.run({ text: "Update the formatted file" });
+      const fileStats = await stat(targetPath);
+
+      expect({
+        result,
+        bytes: [...(await readFile(targetPath))],
+        mode: fileStats.mode & 0o777,
+      }).toEqual({
+        result: { status: "completed", answer: "The formatted file was updated." },
+        bytes: [...Buffer.from("\uFEFFone\r\nchanged\r\n", "utf8")],
+        mode: 0o744,
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("edit_file preserves CR-only line endings in replacement text", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-edit-cr-format-"));
+    const targetPath = join(workspaceRoot, "classic-mac.txt");
+    const originalContent = "one\rtwo\r";
+
+    try {
+      await writeFile(targetPath, originalContent, "utf8");
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-cr-format", name: "edit_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-cr-format",
+              json: JSON.stringify({
+                path: "classic-mac.txt",
+                edits: [{ oldText: "one", newText: "first\nsecond" }],
+              }),
+            },
+            { type: "tool_call_end", id: "call-cr-format" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const editCompleted =
+          latestMessage?.role === "tool" && latestMessage.result.status === "completed";
+        return [
+          {
+            type: "text_delta",
+            text: editCompleted ? "The CR file was updated." : "The CR edit failed.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
+      });
+
+      const result = await session.run({ text: "Update the CR-only file" });
+
+      expect({ result, content: await readFile(targetPath, "utf8") }).toEqual({
+        result: { status: "completed", answer: "The CR file was updated." },
+        content: "first\rsecond\rtwo\r",
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("edit_file rejects a NUL-containing target without changing its bytes", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-edit-binary-"));
+    const targetPath = join(workspaceRoot, "binary.dat");
+    const originalBytes = Buffer.from([0x61, 0x00, 0x62]);
+
+    try {
+      await writeFile(targetPath, originalBytes);
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-binary", name: "edit_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-binary",
+              json: '{"path":"binary.dat","edits":[{"oldText":"a","newText":"x"}]}',
+            },
+            { type: "tool_call_end", id: "call-binary" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedBinaryFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "binary_file";
+        return [
+          {
+            type: "text_delta",
+            text: receivedBinaryFailure
+              ? "The binary target was rejected."
+              : "The binary-file result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
+      });
+
+      const result = await session.run({ text: "Edit the binary target" });
+
+      expect({ result, bytes: [...(await readFile(targetPath))] }).toEqual({
+        result: { status: "completed", answer: "The binary target was rejected." },
+        bytes: [...originalBytes],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("edit_file rejects a target larger than one MiB before matching", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-edit-large-"));
+    const targetPath = join(workspaceRoot, "large.txt");
+    const originalContent = `${"a".repeat(1024 * 1024)}b`;
+
+    try {
+      await writeFile(targetPath, originalContent, "utf8");
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-large", name: "edit_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-large",
+              json: '{"path":"large.txt","edits":[{"oldText":"b","newText":"c"}]}',
+            },
+            { type: "tool_call_end", id: "call-large" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedSizeFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "file_too_large";
+        return [
+          {
+            type: "text_delta",
+            text: receivedSizeFailure
+              ? "The oversized target was rejected."
+              : "The file-size result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
+      });
+
+      const result = await session.run({ text: "Edit the oversized target" });
+
+      expect({ result, size: (await stat(targetPath)).size }).toEqual({
+        result: { status: "completed", answer: "The oversized target was rejected." },
+        size: 1024 * 1024 + 1,
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("edit_file rejects combined replacement input larger than one MiB", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-edit-input-large-"));
+    const targetPath = join(workspaceRoot, "words.txt");
+    const originalContent = "left right\n";
+    const largeLeft = "a".repeat(600 * 1024);
+    const largeRight = "b".repeat(600 * 1024);
+
+    try {
+      await writeFile(targetPath, originalContent, "utf8");
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-large-input", name: "edit_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-large-input",
+              json: JSON.stringify({
+                path: "words.txt",
+                edits: [
+                  { oldText: "left", newText: largeLeft },
+                  { oldText: "right", newText: largeRight },
+                ],
+              }),
+            },
+            { type: "tool_call_end", id: "call-large-input" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedInputFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "invalid_tool_input";
+        return [
+          {
+            type: "text_delta",
+            text: receivedInputFailure
+              ? "The oversized edit input was rejected."
+              : "The edit-input result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
+      });
+
+      const result = await session.run({ text: "Apply oversized replacement input" });
+
+      expect({ result, content: await readFile(targetPath, "utf8") }).toEqual({
+        result: { status: "completed", answer: "The oversized edit input was rejected." },
+        content: originalContent,
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("edit_file rejects an updated result larger than one MiB before writing", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-edit-output-large-"));
+    const targetPath = join(workspaceRoot, "growing.txt");
+    const originalContent = `${"a".repeat(800 * 1024)}marker`;
+    const largeReplacement = "b".repeat(400 * 1024);
+
+    try {
+      await writeFile(targetPath, originalContent, "utf8");
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-large-output", name: "edit_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-large-output",
+              json: JSON.stringify({
+                path: "growing.txt",
+                edits: [{ oldText: "marker", newText: largeReplacement }],
+              }),
+            },
+            { type: "tool_call_end", id: "call-large-output" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedSizeFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "file_too_large";
+        return [
+          {
+            type: "text_delta",
+            text: receivedSizeFailure
+              ? "The oversized edit result was rejected."
+              : "The edit-result size was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
+      });
+
+      const result = await session.run({ text: "Grow the file beyond its limit" });
+
+      expect({ result, size: (await stat(targetPath)).size }).toEqual({
+        result: { status: "completed", answer: "The oversized edit result was rejected." },
+        size: Buffer.byteLength(originalContent, "utf8"),
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("edit_file reports a missing target without creating it", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-edit-missing-file-"));
+    const targetPath = join(workspaceRoot, "missing.txt");
+
+    try {
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return [
+            { type: "tool_call_start", id: "call-missing-file", name: "edit_file" },
+            {
+              type: "tool_call_delta",
+              id: "call-missing-file",
+              json: '{"path":"missing.txt","edits":[{"oldText":"before","newText":"after"}]}',
+            },
+            { type: "tool_call_end", id: "call-missing-file" },
+            { type: "finish", reason: "tool_calls" },
+          ];
+        }
+
+        const receivedMissingFileFailure =
+          latestMessage?.role === "tool" &&
+          latestMessage.result.status === "failed" &&
+          latestMessage.result.error.code === "not_found";
+        return [
+          {
+            type: "text_delta",
+            text: receivedMissingFileFailure
+              ? "The missing file was reported."
+              : "The missing-file result was unexpected.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createMutationToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
+      });
+
+      const result = await session.run({ text: "Edit the missing file" });
+
+      expect({
+        result,
+        exists: await readFile(targetPath).then(
+          () => true,
+          () => false,
+        ),
+      }).toEqual({
+        result: { status: "completed", answer: "The missing file was reported." },
+        exists: false,
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
   test("feeds one typed validation failure back for malformed tool input", async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-invalid-"));
 
@@ -1008,6 +2412,9 @@ describe("AgentSession", () => {
             callId: "call-first",
             name: "read_file",
             decision: "allow",
+            effect: "read",
+            scope: "call",
+            subject: { type: "file", path: "first.txt" },
           },
           { type: "tool_started", callId: "call-first", name: "read_file" },
           {
@@ -1022,6 +2429,9 @@ describe("AgentSession", () => {
             callId: "call-second",
             name: "read_file",
             decision: "allow",
+            effect: "read",
+            scope: "call",
+            subject: { type: "file", path: "second.txt" },
           },
           { type: "tool_started", callId: "call-second", name: "read_file" },
           {


### PR DESCRIPTION
## Summary

- add bounded create-only UTF-8 write and exact multi-edit tools
- add call-scoped allow, ask, and deny permission flow with durable request and decision events
- preserve BOM, line endings, and file modes while rejecting traversal, symlink escape, binary input, ambiguity, overlap, and oversized mutations
- document the local-workspace confinement boundary without claiming an OS sandbox

## Verification

- pnpm code:check
- pnpm markdown:check
- pnpm typecheck
- pnpm vitest run packages (80 passed)
- pnpm --silent adam "What is this repository?"
- dual standards and specification review: no remaining HIGH or MEDIUM findings

Hosted Quality is required before Owner merge. The local managed environment has a known Node child-process pipe-stdout anomaly in the existing CLI integration test; direct CLI execution succeeds, and hosted Ubuntu CI remains the authoritative full-suite gate.