### PR TITLE
Add OpenAI-compatible DeepSeek provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Adam Agent is a lightweight, inspectable TypeScript coding agent for local software-engineering work.
 
-The repository contains a provider-neutral Agent kernel with four model-facing coding tools (`read_file`, `write_file`, `edit_file`, and `run_shell`), call-scoped permission requests, canonical event persistence through caller-supplied in-memory and durable project-scoped JSONL stores, cancellation, bounded shell output with durable content-addressed overflow artifacts, and per-run turn/token limits, backed by a deterministic fake model. Filesystem path confinement rejects traversal and symlink escape, while approved shell commands run from the project root with a minimal environment and mandatory timeout/process-group cleanup. Neither mechanism is an OS sandbox or network isolation boundary, and the shell must only be used for trusted local work after reviewing each command. Resume, an interactive terminal UI, and live model providers have not been added yet. The accepted runtime is Node.js 24 LTS with pnpm 11; Bun is reserved for a later compatibility-tested distribution experiment.
+The repository contains a provider-neutral Agent kernel with four model-facing coding tools (`read_file`, `write_file`, `edit_file`, and `run_shell`), call-scoped permission requests, canonical event persistence through caller-supplied in-memory and durable project-scoped JSONL stores, cancellation, bounded shell output with durable content-addressed overflow artifacts, and per-run turn/token limits. A deterministic fake model remains the default, while an environment-selected OpenAI-compatible Adapter provides the first live DeepSeek path. Filesystem path confinement rejects traversal and symlink escape, while approved shell commands run from the project root with a minimal environment and mandatory timeout/process-group cleanup. Neither mechanism is an OS sandbox or network isolation boundary, and the shell must only be used for trusted local work after reviewing each command. Resume and an interactive terminal UI have not been added yet. The accepted runtime is Node.js 24 LTS with pnpm 11; Bun is reserved for a later compatibility-tested distribution experiment.
 
 ## Development
 
@@ -14,7 +14,22 @@ pnpm quality:check
 pnpm --silent adam "What is this repository?"
 ```
 
-The `adam` command currently exercises deterministic read, edit, and shell scenarios through the fake provider; it asks on stderr before write or execute effects and does not call a live model. Session JSONL and overflow artifacts are written under `ADAM_AGENT_STATE_ROOT` when set, otherwise under `~/.local/state/adam-agent`.
+With no provider environment variable, the `adam` command exercises deterministic read, edit, and shell scenarios through the fake provider. It asks on stderr before write or execute effects. Session JSONL and overflow artifacts are written under `ADAM_AGENT_STATE_ROOT` when set, otherwise under `~/.local/state/adam-agent`.
+
+To use the live DeepSeek Adapter, supply the credential from the environment and select the provider explicitly:
+
+```bash
+export DEEPSEEK_API_KEY="..."
+ADAM_AGENT_PROVIDER=deepseek pnpm --silent adam "Summarize this repository"
+```
+
+The default live model is `deepseek-v4-pro`; set `ADAM_AGENT_MODEL` to override it, for example `deepseek-v4-flash`. Adam sends requests only to `https://api.deepseek.com` in this slice and does not persist credentials, raw provider responses, or reasoning content. Provider failures are reduced to bounded Adam-owned metadata before session persistence. The live model can request the same four tools as the fake path, and write or execute effects still require the existing call-scoped approval.
+
+With `DEEPSEEK_API_KEY` already present, the opt-in live smoke gate runs one answer-only turn and one real read-tool round trip:
+
+```bash
+ADAM_AGENT_LIVE_TESTS=1 pnpm exec vitest run packages/testkit/src/openai-compatible-model-driver.live.test.ts
+```
 
 Use `pnpm quality:fix` only when an intentional formatting rewrite is desired. The pre-commit hook is check-only.
 

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -44,6 +44,182 @@ describe("one-shot CLI", () => {
     }
   });
 
+  test("rejects explicit DeepSeek selection when its credential is missing", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-deepseek-missing-key-"));
+    const workspaceRoot = join(testRoot, "workspace");
+    await mkdir(workspaceRoot);
+
+    try {
+      const result = await runCli({
+        cwd: workspaceRoot,
+        stateRoot: join(testRoot, "state"),
+        prompt: "Hello",
+        stdin: "",
+        env: { ADAM_AGENT_PROVIDER: "deepseek" },
+      });
+
+      expect(result).toEqual({
+        stdout: "",
+        stderr: "DEEPSEEK_API_KEY is required when ADAM_AGENT_PROVIDER=deepseek.\n",
+        exitCode: 1,
+        signal: null,
+      });
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("does not echo an unsupported provider value", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-provider-invalid-"));
+    const workspaceRoot = join(testRoot, "workspace");
+    await mkdir(workspaceRoot);
+
+    try {
+      const result = await runCli({
+        cwd: workspaceRoot,
+        stateRoot: join(testRoot, "state"),
+        prompt: "Hello",
+        stdin: "",
+        env: { ADAM_AGENT_PROVIDER: "invalid\u001b[31m" },
+      });
+
+      expect(result).toEqual({
+        stdout: "",
+        stderr: "ADAM_AGENT_PROVIDER must be unset or deepseek.\n",
+        exitCode: 1,
+        signal: null,
+      });
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("selects DeepSeek with the current default model", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-deepseek-selection-"));
+    const workspaceRoot = join(testRoot, "workspace");
+    const fetchHookPath = join(testRoot, "fetch-hook.mjs");
+    await mkdir(workspaceRoot);
+    await writeFile(
+      fetchHookPath,
+      `globalThis.fetch = async (_input, init) => {
+  const request = JSON.parse(String(init?.body));
+  const chunks = [
+    {
+      id: "selection-1",
+      choices: [{ index: 0, delta: { content: "Selected " + request.model + "." }, finish_reason: null }],
+      created: 1,
+      model: request.model,
+      object: "chat.completion.chunk",
+      usage: null,
+    },
+    {
+      id: "selection-1",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      created: 1,
+      model: request.model,
+      object: "chat.completion.chunk",
+      usage: null,
+    },
+  ];
+  return new Response(chunks.map((chunk) => "data: " + JSON.stringify(chunk) + "\\n\\n").join("") + "data: [DONE]\\n\\n", {
+    headers: { "content-type": "text/event-stream" },
+    status: 200,
+  });
+
+};
+`,
+      "utf8",
+    );
+
+    try {
+      const defaultResult = await runCli({
+        cwd: workspaceRoot,
+        stateRoot: join(testRoot, "default-state"),
+        prompt: "Hello",
+        stdin: "",
+        env: {
+          ADAM_AGENT_PROVIDER: "deepseek",
+          DEEPSEEK_API_KEY: "test-deepseek-key",
+          NODE_OPTIONS: `--import=${fetchHookPath}`,
+        },
+      });
+      const overrideResult = await runCli({
+        cwd: workspaceRoot,
+        stateRoot: join(testRoot, "override-state"),
+        prompt: "Hello",
+        stdin: "",
+        env: {
+          ADAM_AGENT_PROVIDER: "deepseek",
+          DEEPSEEK_API_KEY: "test-deepseek-key",
+          ADAM_AGENT_MODEL: "deepseek-v4-flash",
+          NODE_OPTIONS: `--import=${fetchHookPath}`,
+        },
+      });
+
+      expect({ defaultResult, overrideResult }).toEqual({
+        defaultResult: {
+          stdout: "Selected deepseek-v4-pro.\n",
+          stderr: "",
+          exitCode: 0,
+          signal: null,
+        },
+        overrideResult: {
+          stdout: "Selected deepseek-v4-flash.\n",
+          stderr: "",
+          exitCode: 0,
+          signal: null,
+        },
+      });
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("reports a sanitized DeepSeek failure with exit code 1", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-deepseek-failure-"));
+    const workspaceRoot = join(testRoot, "workspace");
+    const fetchHookPath = join(testRoot, "fetch-hook.mjs");
+    await mkdir(workspaceRoot);
+    await writeFile(
+      fetchHookPath,
+      `globalThis.fetch = async () => new Response(JSON.stringify({
+  error: {
+    message: "Authentication failed for test-deepseek-key",
+    type: "authentication_error",
+    code: "invalid_api_key",
+  },
+}), {
+  headers: { "content-type": "application/json", "x-request-id": "cli-auth-1" },
+  status: 401,
+});
+`,
+      "utf8",
+    );
+
+    try {
+      const result = await runCli({
+        cwd: workspaceRoot,
+        stateRoot: join(testRoot, "state"),
+        prompt: "Hello",
+        stdin: "",
+        env: {
+          ADAM_AGENT_PROVIDER: "deepseek",
+          DEEPSEEK_API_KEY: "test-deepseek-key",
+          NODE_OPTIONS: `--import=${fetchHookPath}`,
+        },
+      });
+
+      expect(result).toEqual({
+        stdout: "",
+        stderr: "The model provider rejected authentication.\n",
+        exitCode: 1,
+        signal: null,
+      });
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+
   test("asks on stderr and accepts a piped y before running a shell command", async () => {
     const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-shell-"));
     const workspaceRoot = join(testRoot, "workspace");
@@ -251,7 +427,7 @@ async function interruptCliDuringShell(options: {
   const input = await open(options.stdinPath, "r");
   const child = spawn(process.execPath, [cliPath, "Run the long repository verification command"], {
     cwd: options.cwd,
-    env: { ...process.env, ADAM_AGENT_STATE_ROOT: options.stateRoot },
+    env: cliEnvironment(options.stateRoot),
     stdio: [input.fd, "pipe", "pipe"],
   });
   await input.close();
@@ -296,7 +472,7 @@ async function interruptCliAtPermission(options: {
   return new Promise((resolvePromise, rejectPromise) => {
     const child = spawn(process.execPath, [cliPath, "Run the repository verification command"], {
       cwd: options.cwd,
-      env: { ...process.env, ADAM_AGENT_STATE_ROOT: options.stateRoot },
+      env: cliEnvironment(options.stateRoot),
       stdio: ["pipe", "pipe", "pipe"],
     });
     let stdout = "";
@@ -338,6 +514,7 @@ async function runCli(options: {
   readonly stateRoot: string;
   readonly prompt: string;
   readonly stdin: string;
+  readonly env?: Readonly<Record<string, string>>;
 }): Promise<{
   readonly stdout: string;
   readonly stderr: string;
@@ -357,11 +534,10 @@ async function runCli(options: {
       ],
       {
         cwd: options.cwd,
-        env: {
-          ...process.env,
+        env: cliEnvironment(options.stateRoot, {
           ADAM_AGENT_CLI_TEST_STDIN: options.stdin,
-          ADAM_AGENT_STATE_ROOT: options.stateRoot,
-        },
+          ...options.env,
+        }),
         stdio: ["ignore", "pipe", "pipe"],
       },
     );
@@ -380,6 +556,21 @@ async function runCli(options: {
       resolvePromise({ stdout, stderr, exitCode, signal });
     });
   });
+}
+
+function cliEnvironment(
+  stateRoot: string,
+  additional: Readonly<Record<string, string>> = {},
+): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = { ...process.env };
+  for (const name of ["ADAM_AGENT_PROVIDER", "DEEPSEEK_API_KEY", "ADAM_AGENT_MODEL"] as const) {
+    delete environment[name];
+  }
+  return {
+    ...environment,
+    ADAM_AGENT_STATE_ROOT: stateRoot,
+    ...additional,
+  };
 }
 
 async function waitForFile(path: string): Promise<void> {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -12,7 +12,9 @@ import {
   createJsonlSessionStore,
   createPermissionPolicy,
   type JsonValue,
+  type ModelDriver,
   type ModelMessage,
+  OpenAICompatibleModelDriver,
   type RuntimeEvent,
 } from "@adam-agent/agent";
 import { FakeModelDriver } from "@adam-agent/testkit";
@@ -30,7 +32,7 @@ const longVerificationCommand =
   "trap '' TERM; printf started > started.txt; sleep 5; printf survived > survived.txt";
 const codingTaskPrompt = "Update the demo file and verify it";
 const codingTaskVerificationCommand = 'test "$(cat demo.txt)" = after && printf verified';
-const model = new FakeModelDriver((request) => {
+const fakeModel = new FakeModelDriver((request) => {
   const latestMessage = request.messages.at(-1);
   if (latestMessage?.role === "user") {
     if (prompt === codingTaskPrompt) {
@@ -110,6 +112,7 @@ const model = new FakeModelDriver((request) => {
     { type: "finish", reason: "stop" },
   ];
 });
+const model: ModelDriver = selectModel();
 const store = await createJsonlSessionStore({
   stateRoot,
   workspaceRoot,
@@ -319,4 +322,36 @@ function jsonProperty(object: { readonly [key: string]: JsonValue }, name: strin
 
 function writeText(fileDescriptor: number, text: string): void {
   writeSync(fileDescriptor, text);
+}
+
+function selectModel(): ModelDriver {
+  const {
+    ADAM_AGENT_PROVIDER: provider,
+    DEEPSEEK_API_KEY: apiKey,
+    ADAM_AGENT_MODEL: configuredModel,
+  } = process.env;
+  if (provider === undefined) {
+    return fakeModel;
+  }
+  if (provider !== "deepseek") {
+    return failConfiguration("ADAM_AGENT_PROVIDER must be unset or deepseek.");
+  }
+  if (apiKey === undefined || apiKey.trim().length === 0) {
+    return failConfiguration("DEEPSEEK_API_KEY is required when ADAM_AGENT_PROVIDER=deepseek.");
+  }
+  if (configuredModel !== undefined && configuredModel.trim().length === 0) {
+    return failConfiguration("ADAM_AGENT_MODEL must be non-empty when set.");
+  }
+  return new OpenAICompatibleModelDriver({
+    profile: "deepseek",
+    apiKey,
+    baseURL: "https://api.deepseek.com",
+    model: configuredModel ?? "deepseek-v4-pro",
+    maximumOutputTokens: 32_768,
+  });
+}
+
+function failConfiguration(message: string): never {
+  writeText(2, `${message}\n`);
+  process.exit(1);
 }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -10,6 +10,7 @@
     }
   },
   "dependencies": {
+    "openai": "7.4.0",
     "zod": "4.4.3"
   }
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,11 +1,18 @@
 import { randomUUID } from "node:crypto";
 
+import { ModelDriverError, type ModelDriverErrorCategory } from "./model-driver-error.js";
+
 export {
   type ArtifactReference,
   type ArtifactSource,
   type ArtifactStore,
   createFileArtifactStore,
 } from "./artifact-store.js";
+export { ModelDriverError, type ModelDriverErrorCategory } from "./model-driver-error.js";
+export {
+  OpenAICompatibleModelDriver,
+  type OpenAICompatibleModelDriverOptions,
+} from "./openai-compatible-model-driver.js";
 
 import type { CanonicalRuntimeEvent, SessionStore } from "./session-store.js";
 import type {
@@ -59,10 +66,13 @@ export type RunOptions = {
 };
 
 export type ModelMessage =
+  | { readonly role: "system"; readonly content: string }
+  | { readonly role: "developer"; readonly content: string }
   | { readonly role: "user"; readonly content: string }
   | {
       readonly role: "assistant";
       readonly content: string;
+      readonly reasoning?: string;
       readonly toolCalls: readonly ToolCall[];
     }
   | {
@@ -80,6 +90,7 @@ export type ModelRequest = {
 
 export type ModelEvent =
   | { readonly type: "text_delta"; readonly text: string }
+  | { readonly type: "reasoning_delta"; readonly text: string }
   | { readonly type: "tool_call_start"; readonly id: string; readonly name: string }
   | { readonly type: "tool_call_delta"; readonly id: string; readonly json: string }
   | { readonly type: "tool_call_end"; readonly id: string }
@@ -87,8 +98,21 @@ export type ModelEvent =
       readonly type: "usage";
       readonly inputTokens: number;
       readonly outputTokens: number;
+      readonly reasoningTokens?: number | undefined;
+      readonly cachedInputTokens?: number | undefined;
+      readonly cacheMissInputTokens?: number | undefined;
     }
-  | { readonly type: "finish"; readonly reason: "stop" | "tool_calls" };
+  | {
+      readonly type: "finish";
+      readonly reason:
+        | "stop"
+        | "tool_calls"
+        | "length"
+        | "content_filter"
+        | "resource_exhausted"
+        | "unknown";
+      readonly rawReason?: string | undefined;
+    };
 
 export interface ModelDriver {
   stream(request: ModelRequest): AsyncIterable<ModelEvent>;
@@ -108,18 +132,34 @@ export type RunResult =
     }
   | {
       readonly status: "failed";
-      readonly error: {
-        readonly code:
-          | "model_stream_incomplete"
-          | "model_protocol_invalid"
-          | "invalid_run_limits"
-          | "run_already_active"
-          | "session_persistence_failed"
-          | "turn_limit_exceeded"
-          | "token_limit_exceeded"
-          | "token_usage_missing";
-        readonly message: string;
-      };
+      readonly error:
+        | {
+            readonly code:
+              | "model_stream_incomplete"
+              | "model_protocol_invalid"
+              | "model_output_truncated"
+              | "model_content_filtered"
+              | "invalid_run_limits"
+              | "run_already_active"
+              | "session_persistence_failed"
+              | "turn_limit_exceeded"
+              | "token_limit_exceeded"
+              | "token_usage_missing";
+            readonly message: string;
+          }
+        | {
+            readonly code: "model_resource_exhausted" | "model_finish_unknown";
+            readonly message: string;
+            readonly providerReason?: string | undefined;
+          }
+        | {
+            readonly code: "model_request_failed";
+            readonly message: string;
+            readonly category: ModelDriverErrorCategory;
+            readonly status?: number | undefined;
+            readonly providerCode?: string | undefined;
+            readonly requestId?: string | undefined;
+          };
     };
 
 export type PermissionDecisionCommand = {
@@ -147,6 +187,9 @@ export type RuntimeEvent =
       readonly inputTokens: number;
       readonly outputTokens: number;
       readonly totalTokens: number;
+      readonly reasoningTokens?: number | undefined;
+      readonly cachedInputTokens?: number | undefined;
+      readonly cacheMissInputTokens?: number | undefined;
     }
   | { readonly type: "tool_requested"; readonly callId: string; readonly name: string }
   | {
@@ -290,6 +333,9 @@ export class AgentSession {
         if (abortController.signal.aborted && this.#terminalResult === undefined) {
           return await this.#settleCancelled();
         }
+        if (error instanceof ModelDriverError) {
+          return await this.#settleModelRequestFailed(error);
+        }
         throw error;
       }
     } catch (error) {
@@ -342,7 +388,16 @@ export class AgentSession {
         return this.#settleCancelled();
       }
       let answer = "";
-      let finishReason: "stop" | "tool_calls" | undefined;
+      let reasoning = "";
+      let finishReason:
+        | "stop"
+        | "tool_calls"
+        | "length"
+        | "content_filter"
+        | "resource_exhausted"
+        | "unknown"
+        | undefined;
+      let rawFinishReason: string | undefined;
       let protocolError: string | undefined;
       let usageWasReported = false;
       const assemblingCalls = new Map<string, ToolCall>();
@@ -360,6 +415,9 @@ export class AgentSession {
           case "text_delta":
             answer += event.text;
             await this.#emit({ type: "model_message_delta", text: event.text });
+            break;
+          case "reasoning_delta":
+            reasoning += event.text;
             break;
           case "tool_call_start":
             if (assemblingCalls.has(event.id)) {
@@ -400,6 +458,7 @@ export class AgentSession {
             if (
               !isNonnegativeSafeInteger(event.inputTokens) ||
               !isNonnegativeSafeInteger(event.outputTokens) ||
+              !areOptionalUsageDetailsValid(event) ||
               !Number.isSafeInteger(totalTokens) ||
               !Number.isSafeInteger(nextReportedTokens)
             ) {
@@ -413,11 +472,21 @@ export class AgentSession {
               inputTokens: event.inputTokens,
               outputTokens: event.outputTokens,
               totalTokens,
+              ...(event.reasoningTokens === undefined
+                ? {}
+                : { reasoningTokens: event.reasoningTokens }),
+              ...(event.cachedInputTokens === undefined
+                ? {}
+                : { cachedInputTokens: event.cachedInputTokens }),
+              ...(event.cacheMissInputTokens === undefined
+                ? {}
+                : { cacheMissInputTokens: event.cacheMissInputTokens }),
             });
             break;
           }
           case "finish":
             finishReason = event.reason;
+            rawFinishReason = event.rawReason;
             break;
         }
         if (signal.aborted || finishReason !== undefined) {
@@ -435,6 +504,19 @@ export class AgentSession {
 
       if (protocolError !== undefined) {
         return this.#settleProtocolInvalid(protocolError);
+      }
+
+      if (finishReason === "length") {
+        return this.#settleOutputTruncated();
+      }
+      if (finishReason === "content_filter") {
+        return this.#settleContentFiltered();
+      }
+      if (finishReason === "resource_exhausted") {
+        return this.#settleResourceExhausted(rawFinishReason);
+      }
+      if (finishReason === "unknown") {
+        return this.#settleUnknownFinish(rawFinishReason);
       }
 
       await this.#emit({ type: "model_message_completed", text: answer });
@@ -487,7 +569,12 @@ export class AgentSession {
         uniqueCalls.set(call.id, call);
       }
 
-      messages.push({ role: "assistant", content: answer, toolCalls: completedCalls });
+      messages.push({
+        role: "assistant",
+        content: answer,
+        ...(reasoning.length === 0 ? {} : { reasoning }),
+        toolCalls: completedCalls,
+      });
       for (const call of uniqueCalls.values()) {
         if (signal.aborted) {
           return this.#settleCancelled();
@@ -612,10 +699,72 @@ export class AgentSession {
     return this.#settle(result);
   }
 
+  async #settleModelRequestFailed(error: ModelDriverError): Promise<RunResult> {
+    const result: RunResult = {
+      status: "failed",
+      error: {
+        code: "model_request_failed",
+        message: error.message,
+        category: error.category,
+        ...(error.status === undefined ? {} : { status: error.status }),
+        ...(error.providerCode === undefined ? {} : { providerCode: error.providerCode }),
+        ...(error.requestId === undefined ? {} : { requestId: error.requestId }),
+      },
+    };
+    return this.#settle(result);
+  }
+
   async #settleProtocolInvalid(message: string): Promise<RunResult> {
     const result: RunResult = {
       status: "failed",
       error: { code: "model_protocol_invalid", message },
+    };
+    return this.#settle(result);
+  }
+
+  async #settleOutputTruncated(): Promise<RunResult> {
+    const result: RunResult = {
+      status: "failed",
+      error: {
+        code: "model_output_truncated",
+        message: "The model response reached its output-token limit.",
+      },
+    };
+    return this.#settle(result);
+  }
+
+  async #settleContentFiltered(): Promise<RunResult> {
+    const result: RunResult = {
+      status: "failed",
+      error: {
+        code: "model_content_filtered",
+        message: "The provider filtered the model response.",
+      },
+    };
+    return this.#settle(result);
+  }
+
+  async #settleResourceExhausted(providerReason: string | undefined): Promise<RunResult> {
+    const result: RunResult = {
+      status: "failed",
+      error: {
+        code: "model_resource_exhausted",
+        message:
+          "The provider could not complete the model response because resources were unavailable.",
+        ...(providerReason === undefined ? {} : { providerReason }),
+      },
+    };
+    return this.#settle(result);
+  }
+
+  async #settleUnknownFinish(providerReason: string | undefined): Promise<RunResult> {
+    const result: RunResult = {
+      status: "failed",
+      error: {
+        code: "model_finish_unknown",
+        message: "The provider ended the model response for an unknown reason.",
+        ...(providerReason === undefined ? {} : { providerReason }),
+      },
     };
     return this.#settle(result);
   }
@@ -762,6 +911,14 @@ export class AgentSession {
 
 function isNonnegativeSafeInteger(value: number): boolean {
   return Number.isSafeInteger(value) && value >= 0;
+}
+
+function areOptionalUsageDetailsValid(
+  usage: Extract<ModelEvent, { readonly type: "usage" }>,
+): boolean {
+  return [usage.reasoningTokens, usage.cachedInputTokens, usage.cacheMissInputTokens].every(
+    (value) => value === undefined || isNonnegativeSafeInteger(value),
+  );
 }
 
 function areRunLimitsValid(limits: RunOptions["limits"]): boolean {

--- a/packages/agent/src/model-driver-error.ts
+++ b/packages/agent/src/model-driver-error.ts
@@ -1,0 +1,42 @@
+export const modelDriverErrorCategories = [
+  "authentication",
+  "authorization",
+  "rate_limit",
+  "invalid_request",
+  "provider",
+  "transport",
+  "protocol_incompatibility",
+  "timeout",
+  "aborted",
+  "unknown",
+] as const;
+
+export type ModelDriverErrorCategory = (typeof modelDriverErrorCategories)[number];
+
+export class ModelDriverError extends Error {
+  readonly category: ModelDriverErrorCategory;
+  readonly status: number | undefined;
+  readonly providerCode: string | undefined;
+  readonly requestId: string | undefined;
+  readonly responseSummary: string | undefined;
+
+  constructor(
+    category: ModelDriverErrorCategory,
+    message: string,
+    options: {
+      readonly cause: unknown;
+      readonly status?: number | undefined;
+      readonly providerCode?: string | undefined;
+      readonly requestId?: string | undefined;
+      readonly responseSummary?: string | undefined;
+    },
+  ) {
+    super(message, { cause: options.cause });
+    this.name = "ModelDriverError";
+    this.category = category;
+    this.status = options.status;
+    this.providerCode = options.providerCode;
+    this.requestId = options.requestId;
+    this.responseSummary = options.responseSummary;
+  }
+}

--- a/packages/agent/src/openai-compatible-model-driver.ts
+++ b/packages/agent/src/openai-compatible-model-driver.ts
@@ -1,0 +1,508 @@
+import OpenAI, {
+  APIConnectionError,
+  APIError,
+  APIUserAbortError,
+  AuthenticationError,
+} from "openai";
+import type {
+  ChatCompletionMessageParam,
+  ChatCompletionTool,
+} from "openai/resources/chat/completions";
+
+import type { ModelDriver, ModelEvent, ModelMessage, ModelRequest } from "./index.js";
+import { ModelDriverError } from "./model-driver-error.js";
+
+const maximumNormalizedTextBytes = 512 * 1024;
+const maximumNormalizedReasoningBytes = 512 * 1024;
+const maximumToolArgumentBytes = 512 * 1024;
+const maximumToolCallCount = 128;
+const maximumToolCallIdBytes = 1_024;
+const maximumToolNameBytes = 256;
+const maximumStreamChunkCount = 100_000;
+
+export type OpenAICompatibleModelDriverOptions = {
+  readonly profile: "deepseek";
+  readonly apiKey: string;
+  readonly baseURL: string;
+  readonly model: string;
+  readonly maximumOutputTokens: number;
+  readonly deadlineMs?: number;
+  readonly fetch?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+};
+
+export class OpenAICompatibleModelDriver implements ModelDriver {
+  readonly #client: OpenAI;
+  readonly #deadlineMs: number;
+  readonly #maximumOutputTokens: number;
+  readonly #model: string;
+  readonly #sensitiveValues: readonly string[];
+
+  constructor(options: OpenAICompatibleModelDriverOptions) {
+    if (options.profile !== "deepseek") {
+      throw new RangeError("The OpenAI-compatible provider profile is not supported.");
+    }
+    const deadlineMs = options.deadlineMs ?? 120_000;
+    if (!Number.isSafeInteger(deadlineMs) || deadlineMs <= 0) {
+      throw new RangeError("The model request deadline must be a positive safe integer.");
+    }
+    this.#client = new OpenAI({
+      apiKey: options.apiKey,
+      baseURL: options.baseURL,
+      fetch: options.fetch,
+      logLevel: "off",
+      maxRetries: 0,
+      timeout: deadlineMs,
+    });
+    this.#deadlineMs = deadlineMs;
+    this.#maximumOutputTokens = options.maximumOutputTokens;
+    this.#model = options.model;
+    this.#sensitiveValues = [options.apiKey];
+  }
+
+  async *stream(request: ModelRequest): AsyncIterable<ModelEvent> {
+    const attemptController = new AbortController();
+    let deadlineExpired = false;
+    const abortFromCaller = () => attemptController.abort(request.signal.reason);
+    if (request.signal.aborted) {
+      abortFromCaller();
+    } else {
+      request.signal.addEventListener("abort", abortFromCaller, { once: true });
+    }
+    const deadlineTimer = setTimeout(() => {
+      deadlineExpired = true;
+      attemptController.abort(new Error("The model provider request reached its deadline."));
+    }, this.#deadlineMs);
+    try {
+      yield* this.#stream({ ...request, signal: attemptController.signal });
+      if (deadlineExpired) {
+        throw createDeadlineError();
+      }
+      if (request.signal.aborted) {
+        throw createAbortedError();
+      }
+    } catch (error) {
+      if (deadlineExpired) {
+        throw createDeadlineError(error);
+      }
+      if (request.signal.aborted) {
+        throw createAbortedError(error);
+      }
+      if (error instanceof ModelDriverError) {
+        throw error;
+      }
+      throw classifyModelDriverError(error, this.#sensitiveValues);
+    } finally {
+      clearTimeout(deadlineTimer);
+      request.signal.removeEventListener("abort", abortFromCaller);
+    }
+  }
+
+  async *#stream(request: ModelRequest): AsyncIterable<ModelEvent> {
+    const messages = request.messages.map(mapMessage);
+    const tools: ChatCompletionTool[] = request.tools.map((tool) => ({
+      type: "function",
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.inputSchema,
+      },
+    }));
+    const stream = await this.#client.chat.completions.create(
+      {
+        messages,
+        model: this.#model,
+        stream: true,
+        stream_options: { include_usage: true },
+        max_tokens: this.#maximumOutputTokens,
+        ...(tools.length === 0 ? {} : { tools }),
+      },
+      { signal: request.signal },
+    );
+    let finishReason:
+      | "stop"
+      | "tool_calls"
+      | "length"
+      | "content_filter"
+      | "resource_exhausted"
+      | "unknown"
+      | undefined;
+    let rawFinishReason: string | undefined;
+    let usage: { readonly inputTokens: number; readonly outputTokens: number } | undefined;
+    let chunkCount = 0;
+    let normalizedTextBytes = 0;
+    let normalizedReasoningBytes = 0;
+    let toolArgumentBytes = 0;
+    const toolCalls = new Map<
+      number,
+      {
+        id: string;
+        name: string;
+        readonly argumentFragments: string[];
+      }
+    >();
+
+    for await (const chunk of stream) {
+      chunkCount += 1;
+      assertWithinLimit(chunkCount, maximumStreamChunkCount);
+      assertCanonicalChoicePayload(chunk);
+      if (chunk.usage !== null && chunk.usage !== undefined) {
+        const detailedUsage = chunk.usage as typeof chunk.usage & {
+          readonly prompt_cache_hit_tokens?: unknown;
+          readonly prompt_cache_miss_tokens?: unknown;
+          readonly completion_tokens_details?: { readonly reasoning_tokens?: unknown };
+        };
+        usage = {
+          inputTokens: chunk.usage.prompt_tokens,
+          outputTokens: chunk.usage.completion_tokens,
+          ...(typeof detailedUsage.completion_tokens_details?.reasoning_tokens === "number"
+            ? { reasoningTokens: detailedUsage.completion_tokens_details.reasoning_tokens }
+            : {}),
+          ...(typeof detailedUsage.prompt_cache_hit_tokens === "number"
+            ? { cachedInputTokens: detailedUsage.prompt_cache_hit_tokens }
+            : {}),
+          ...(typeof detailedUsage.prompt_cache_miss_tokens === "number"
+            ? { cacheMissInputTokens: detailedUsage.prompt_cache_miss_tokens }
+            : {}),
+        };
+      }
+      for (const choice of chunk.choices) {
+        const reasoningContent = (
+          choice.delta as typeof choice.delta & { readonly reasoning_content?: unknown }
+        ).reasoning_content;
+        if (typeof reasoningContent === "string") {
+          normalizedReasoningBytes = addBytesWithinLimit(
+            normalizedReasoningBytes,
+            reasoningContent,
+            maximumNormalizedReasoningBytes,
+          );
+          yield { type: "reasoning_delta", text: reasoningContent };
+        }
+        if (choice.delta.content !== null && choice.delta.content !== undefined) {
+          normalizedTextBytes = addBytesWithinLimit(
+            normalizedTextBytes,
+            choice.delta.content,
+            maximumNormalizedTextBytes,
+          );
+          yield { type: "text_delta", text: choice.delta.content };
+        }
+        const providerFinishReason = choice.finish_reason as string | null;
+        if (
+          providerFinishReason === "stop" ||
+          providerFinishReason === "tool_calls" ||
+          providerFinishReason === "length" ||
+          providerFinishReason === "content_filter"
+        ) {
+          finishReason = providerFinishReason;
+          rawFinishReason = providerFinishReason.slice(0, 128);
+        } else if (providerFinishReason === "insufficient_system_resource") {
+          finishReason = "resource_exhausted";
+          rawFinishReason = providerFinishReason.slice(0, 128);
+        } else if (providerFinishReason !== null) {
+          finishReason = "unknown";
+          rawFinishReason = providerFinishReason.slice(0, 128);
+        }
+        for (const fragment of choice.delta.tool_calls ?? []) {
+          if (!toolCalls.has(fragment.index)) {
+            assertWithinLimit(toolCalls.size + 1, maximumToolCallCount);
+          }
+          const call = toolCalls.get(fragment.index) ?? {
+            id: "",
+            name: "",
+            argumentFragments: [],
+          };
+          call.id += fragment.id ?? "";
+          call.name += fragment.function?.name ?? "";
+          assertWithinLimit(Buffer.byteLength(call.id, "utf8"), maximumToolCallIdBytes);
+          assertWithinLimit(Buffer.byteLength(call.name, "utf8"), maximumToolNameBytes);
+          if (fragment.function?.arguments !== undefined) {
+            toolArgumentBytes = addBytesWithinLimit(
+              toolArgumentBytes,
+              fragment.function.arguments,
+              maximumToolArgumentBytes,
+            );
+            call.argumentFragments.push(fragment.function.arguments);
+          }
+          toolCalls.set(fragment.index, call);
+        }
+      }
+    }
+
+    const orderedToolCalls = [...toolCalls].sort(([left], [right]) => left - right);
+    if (orderedToolCalls.some(([, call]) => call.id.length === 0 || call.name.length === 0)) {
+      throw new ModelDriverError(
+        "protocol_incompatibility",
+        "The model provider returned an incomplete tool call.",
+        { cause: undefined },
+      );
+    }
+    for (const [, call] of orderedToolCalls) {
+      yield { type: "tool_call_start", id: call.id, name: call.name };
+      for (const json of call.argumentFragments) {
+        yield { type: "tool_call_delta", id: call.id, json };
+      }
+      yield { type: "tool_call_end", id: call.id };
+    }
+    if (usage !== undefined) {
+      yield { type: "usage", ...usage };
+    }
+    if (finishReason !== undefined) {
+      yield { type: "finish", reason: finishReason, rawReason: rawFinishReason };
+    }
+  }
+}
+
+function addBytesWithinLimit(currentBytes: number, value: string, maximumBytes: number): number {
+  const nextBytes = currentBytes + Buffer.byteLength(value, "utf8");
+  assertWithinLimit(nextBytes, maximumBytes);
+  return nextBytes;
+}
+
+function assertWithinLimit(value: number, maximum: number): void {
+  if (value > maximum) {
+    throw new ModelDriverError(
+      "protocol_incompatibility",
+      "The model provider response exceeded Adam's stream limit.",
+      { cause: undefined },
+    );
+  }
+}
+
+function assertCanonicalChoicePayload(chunk: unknown): void {
+  if (typeof chunk !== "object" || chunk === null || !("choices" in chunk)) {
+    throw invalidChoicePayloadError();
+  }
+  const choices = chunk.choices;
+  if (!Array.isArray(choices) || choices.length > 1) {
+    throw invalidChoicePayloadError();
+  }
+  const choice = choices[0];
+  if (choice === undefined) {
+    return;
+  }
+  if (
+    typeof choice !== "object" ||
+    choice === null ||
+    !("index" in choice) ||
+    choice.index !== 0 ||
+    !("delta" in choice) ||
+    typeof choice.delta !== "object" ||
+    choice.delta === null ||
+    !("finish_reason" in choice) ||
+    (choice.finish_reason !== null && typeof choice.finish_reason !== "string")
+  ) {
+    throw invalidChoicePayloadError();
+  }
+  const delta = choice.delta as {
+    readonly content?: unknown;
+    readonly reasoning_content?: unknown;
+    readonly tool_calls?: unknown;
+  };
+  if (
+    !isOptionalNullableString(delta.content) ||
+    !isOptionalNullableString(delta.reasoning_content)
+  ) {
+    throw invalidChoicePayloadError();
+  }
+  const toolCallFragments = delta.tool_calls;
+  if (toolCallFragments !== undefined && toolCallFragments !== null) {
+    if (!Array.isArray(toolCallFragments) || !toolCallFragments.every(isToolCallFragment)) {
+      throw invalidChoicePayloadError();
+    }
+  }
+}
+
+function isOptionalNullableString(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === "string";
+}
+
+function isToolCallFragment(value: unknown): boolean {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("index" in value) ||
+    !Number.isSafeInteger(value.index) ||
+    (value.index as number) < 0 ||
+    !("id" in value ? isOptionalNullableString(value.id) : true)
+  ) {
+    return false;
+  }
+  if (!("function" in value) || value.function === undefined || value.function === null) {
+    return true;
+  }
+  if (typeof value.function !== "object") {
+    return false;
+  }
+  return (
+    (!("name" in value.function) || isOptionalNullableString(value.function.name)) &&
+    (!("arguments" in value.function) || isOptionalNullableString(value.function.arguments))
+  );
+}
+
+function invalidChoicePayloadError(): ModelDriverError {
+  return new ModelDriverError(
+    "protocol_incompatibility",
+    "The model provider returned an invalid choice payload.",
+    { cause: undefined },
+  );
+}
+
+function classifyModelDriverError(
+  error: unknown,
+  sensitiveValues: readonly string[],
+): ModelDriverError {
+  if (error instanceof APIUserAbortError) {
+    return new ModelDriverError("aborted", "The model provider request was aborted.", {
+      cause: error,
+    });
+  }
+  if (error instanceof AuthenticationError) {
+    return new ModelDriverError(
+      "authentication",
+      "The model provider rejected authentication.",
+      apiErrorOptions(error, sensitiveValues),
+    );
+  }
+  if (error instanceof APIError && error.status === 403) {
+    return new ModelDriverError(
+      "authorization",
+      "The model provider denied access to the request.",
+      apiErrorOptions(error, sensitiveValues),
+    );
+  }
+  if (error instanceof APIError && error.status === 429) {
+    return new ModelDriverError(
+      "rate_limit",
+      "The model provider rate limit was reached.",
+      apiErrorOptions(error, sensitiveValues),
+    );
+  }
+  if (error instanceof APIError && error.status === 400) {
+    return new ModelDriverError(
+      "invalid_request",
+      "The model provider rejected the request as invalid.",
+      apiErrorOptions(error, sensitiveValues),
+    );
+  }
+  if (error instanceof APIError && error.status !== undefined && error.status >= 500) {
+    return new ModelDriverError(
+      "provider",
+      "The model provider failed to complete the request.",
+      apiErrorOptions(error, sensitiveValues),
+    );
+  }
+  if (error instanceof APIConnectionError) {
+    return new ModelDriverError("transport", "The model provider connection failed.", {
+      cause: error,
+    });
+  }
+  if (error instanceof APIError) {
+    return new ModelDriverError(
+      "unknown",
+      "The model provider returned an unrecognized error response.",
+      apiErrorOptions(error, sensitiveValues),
+    );
+  }
+  if (error instanceof SyntaxError || error instanceof TypeError) {
+    return new ModelDriverError(
+      "protocol_incompatibility",
+      "The model provider returned an invalid streaming response.",
+      { cause: error },
+    );
+  }
+  return new ModelDriverError("unknown", "The model provider request failed.", {
+    cause: error,
+  });
+}
+
+function createDeadlineError(cause?: unknown): ModelDriverError {
+  return new ModelDriverError("timeout", "The model provider request reached its deadline.", {
+    cause,
+  });
+}
+
+function createAbortedError(cause?: unknown): ModelDriverError {
+  return new ModelDriverError("aborted", "The model provider request was aborted.", {
+    cause,
+  });
+}
+
+function apiErrorOptions(
+  error: APIError,
+  sensitiveValues: readonly string[],
+): {
+  readonly cause: unknown;
+  readonly status?: number | undefined;
+  readonly providerCode?: string | undefined;
+  readonly requestId?: string | undefined;
+  readonly responseSummary?: string | undefined;
+} {
+  return {
+    cause: error,
+    ...(error.status === undefined ? {} : { status: error.status }),
+    ...(error.code === null || error.code === undefined
+      ? {}
+      : { providerCode: redactSensitiveValues(error.code, sensitiveValues).slice(0, 128) }),
+    ...(error.requestID === null || error.requestID === undefined
+      ? {}
+      : { requestId: redactSensitiveValues(error.requestID, sensitiveValues).slice(0, 128) }),
+    ...summarizeApiError(error, sensitiveValues),
+  };
+}
+
+function summarizeApiError(
+  error: APIError,
+  sensitiveValues: readonly string[],
+): { readonly responseSummary?: string } {
+  if (
+    typeof error.error === "object" &&
+    error.error !== null &&
+    "message" in error.error &&
+    typeof error.error.message === "string"
+  ) {
+    return {
+      responseSummary: redactSensitiveValues(error.error.message, sensitiveValues).slice(0, 512),
+    };
+  }
+  return {};
+}
+
+function redactSensitiveValues(value: string, sensitiveValues: readonly string[]): string {
+  return sensitiveValues
+    .filter((sensitiveValue) => sensitiveValue.length > 0)
+    .reduce((redacted, sensitiveValue) => redacted.split(sensitiveValue).join("[REDACTED]"), value);
+}
+
+function mapMessage(message: ModelMessage): ChatCompletionMessageParam {
+  switch (message.role) {
+    case "system":
+      return { role: "system", content: message.content };
+    case "developer":
+      return {
+        role: "system",
+        content: `Developer instruction:\n${message.content}`,
+      };
+    case "user":
+      return { role: "user", content: message.content };
+    case "assistant":
+      return {
+        role: "assistant",
+        content: message.content,
+        ...(message.reasoning === undefined ? {} : { reasoning_content: message.reasoning }),
+        ...(message.toolCalls.length === 0
+          ? {}
+          : {
+              tool_calls: message.toolCalls.map((call) => ({
+                id: call.id,
+                type: "function" as const,
+                function: { name: call.name, arguments: call.argumentsJson },
+              })),
+            }),
+      };
+    case "tool":
+      return {
+        role: "tool",
+        tool_call_id: message.callId,
+        content: JSON.stringify(message.result),
+      };
+  }
+}

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -4,8 +4,8 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { z } from "zod";
-
 import type { RunResult, RuntimeEvent } from "./index.js";
+import { modelDriverErrorCategories } from "./model-driver-error.js";
 
 export type CanonicalRuntimeEvent = Exclude<RuntimeEvent, { readonly type: "model_message_delta" }>;
 
@@ -42,15 +42,37 @@ export class SessionStoreError extends Error {
   }
 }
 
-const runErrorCodeSchema = z.enum([
+const ordinaryRunErrorCodeSchema = z.enum([
   "model_stream_incomplete",
   "model_protocol_invalid",
+  "model_output_truncated",
+  "model_content_filtered",
   "invalid_run_limits",
   "run_already_active",
   "session_persistence_failed",
   "turn_limit_exceeded",
   "token_limit_exceeded",
   "token_usage_missing",
+]);
+type RunFailure = Extract<RunResult, { readonly status: "failed" }>["error"];
+const runFailureSchema: z.ZodType<RunFailure> = z.discriminatedUnion("code", [
+  z.strictObject({
+    code: ordinaryRunErrorCodeSchema,
+    message: z.string(),
+  }),
+  z.strictObject({
+    code: z.enum(["model_resource_exhausted", "model_finish_unknown"]),
+    message: z.string(),
+    providerReason: z.string().max(128).optional(),
+  }),
+  z.strictObject({
+    code: z.literal("model_request_failed"),
+    message: z.string(),
+    category: z.enum(modelDriverErrorCategories),
+    status: z.number().int().min(100).max(599).optional(),
+    providerCode: z.string().max(128).optional(),
+    requestId: z.string().max(128).optional(),
+  }),
 ]);
 const runResultSchema: z.ZodType<RunResult> = z.discriminatedUnion("status", [
   z.strictObject({ status: z.literal("completed"), answer: z.string() }),
@@ -63,7 +85,7 @@ const runResultSchema: z.ZodType<RunResult> = z.discriminatedUnion("status", [
   }),
   z.strictObject({
     status: z.literal("failed"),
-    error: z.strictObject({ code: runErrorCodeSchema, message: z.string() }),
+    error: runFailureSchema,
   }),
 ]);
 const toolErrorSchema = z.strictObject({
@@ -104,6 +126,9 @@ const canonicalRuntimeEventSchema: z.ZodType<CanonicalRuntimeEvent> = z.discrimi
       inputTokens: z.number().int().nonnegative(),
       outputTokens: z.number().int().nonnegative(),
       totalTokens: z.number().int().nonnegative(),
+      reasoningTokens: z.number().int().nonnegative().optional(),
+      cachedInputTokens: z.number().int().nonnegative().optional(),
+      cacheMissInputTokens: z.number().int().nonnegative().optional(),
     })
     .refine((usage) => usage.totalTokens === usage.inputTokens + usage.outputTokens),
   z.strictObject({

--- a/packages/testkit/src/openai-compatible-model-driver.live.test.ts
+++ b/packages/testkit/src/openai-compatible-model-driver.live.test.ts
@@ -1,0 +1,91 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  AgentSession,
+  createInMemorySessionStore,
+  createPermissionPolicy,
+  createReadToolRegistry,
+  OpenAICompatibleModelDriver,
+  type RuntimeEvent,
+} from "@adam-agent/agent";
+import { expect, test } from "vitest";
+
+const {
+  DEEPSEEK_API_KEY: apiKey,
+  ADAM_AGENT_LIVE_TESTS: liveTestSelection,
+  ADAM_AGENT_MODEL: configuredModel,
+} = process.env;
+const liveTestsEnabled = liveTestSelection === "1";
+const liveTest = test.skipIf(!liveTestsEnabled || apiKey === undefined || apiKey.length === 0);
+const liveApiKey = apiKey ?? "";
+const model = configuredModel ?? "deepseek-v4-pro";
+
+test.skipIf(!liveTestsEnabled)("requires DEEPSEEK_API_KEY for the live gate", () => {
+  expect(liveApiKey.length).toBeGreaterThan(0);
+});
+
+liveTest(
+  "completes one answer-only DeepSeek turn",
+  async () => {
+    const session = new AgentSession({
+      model: createLiveDriver(liveApiKey),
+      store: createInMemorySessionStore(),
+    });
+
+    const result = await session.run({ text: "Reply with exactly: adam-live-ok" });
+
+    expect(result.status).toBe("completed");
+    if (result.status === "completed") {
+      expect(result.answer.trim()).toBe("adam-live-ok");
+    }
+  },
+  120_000,
+);
+
+liveTest(
+  "completes one real read-tool DeepSeek round trip",
+  async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-live-deepseek-"));
+    const events: RuntimeEvent[] = [];
+    try {
+      await writeFile(join(workspaceRoot, "README.md"), "# Nebula Orchard\n", "utf8");
+      const session = new AgentSession({
+        model: createLiveDriver(liveApiKey),
+        store: createInMemorySessionStore(),
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+      session.subscribe((event) => events.push(event));
+
+      const result = await session.run({
+        text: "Use the read_file tool to read README.md, then reply with only the H1 project name.",
+      });
+
+      expect(result.status).toBe("completed");
+      if (result.status === "completed") {
+        expect(result.answer).toContain("Nebula Orchard");
+      }
+      expect(events).toContainEqual({
+        type: "tool_requested",
+        callId: expect.any(String),
+        name: "read_file",
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  },
+  120_000,
+);
+
+function createLiveDriver(liveApiKey: string): OpenAICompatibleModelDriver {
+  return new OpenAICompatibleModelDriver({
+    profile: "deepseek",
+    apiKey: liveApiKey,
+    baseURL: "https://api.deepseek.com",
+    model,
+    maximumOutputTokens: 2_048,
+    deadlineMs: 90_000,
+  });
+}

--- a/packages/testkit/src/openai-compatible-model-driver.test.ts
+++ b/packages/testkit/src/openai-compatible-model-driver.test.ts
@@ -1,0 +1,1208 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  AgentSession,
+  createInMemorySessionStore,
+  createPermissionPolicy,
+  createReadToolRegistry,
+  ModelDriverError,
+  type ModelEvent,
+  OpenAICompatibleModelDriver,
+} from "@adam-agent/agent";
+import { describe, expect, test, vi } from "vitest";
+
+describe("OpenAICompatibleModelDriver", () => {
+  test("normalizes one answer-only DeepSeek SSE stream", async () => {
+    const requests: Array<{ readonly url: string; readonly body: unknown }> = [];
+    const driver = new OpenAICompatibleModelDriver({
+      profile: "deepseek",
+      apiKey: "test-deepseek-key",
+      baseURL: "https://deepseek.invalid",
+      model: "deepseek-test",
+      maximumOutputTokens: 4_096,
+      fetch: async (input, init) => {
+        requests.push({
+          url: input instanceof Request ? input.url : String(input),
+          body: JSON.parse(String(init?.body)),
+        });
+        return new Response(answerOnlyStream, {
+          headers: { "content-type": "text/event-stream" },
+          status: 200,
+        });
+      },
+    });
+
+    const events = await collect(
+      driver.stream({
+        messages: [{ role: "user", content: "Introduce yourself" }],
+        tools: [],
+        signal: new AbortController().signal,
+      }),
+    );
+
+    expect({ requests, events }).toEqual({
+      requests: [
+        {
+          url: "https://deepseek.invalid/chat/completions",
+          body: {
+            messages: [{ role: "user", content: "Introduce yourself" }],
+            model: "deepseek-test",
+            stream: true,
+            stream_options: { include_usage: true },
+            max_tokens: 4_096,
+          },
+        },
+      ],
+      events: [
+        { type: "text_delta", text: "Hello, " },
+        { type: "text_delta", text: "Adam." },
+        {
+          type: "usage",
+          inputTokens: 7,
+          outputTokens: 3,
+          reasoningTokens: 1,
+          cachedInputTokens: 2,
+          cacheMissInputTokens: 5,
+        },
+        { type: "finish", reason: "stop", rawReason: "stop" },
+      ],
+    });
+  });
+
+  test("settles explicitly when DeepSeek reaches its output limit", async () => {
+    const store = createInMemorySessionStore();
+    const session = new AgentSession({
+      model: new OpenAICompatibleModelDriver({
+        profile: "deepseek",
+        apiKey: "test-deepseek-key",
+        baseURL: "https://deepseek.invalid",
+        model: "deepseek-test",
+        maximumOutputTokens: 4_096,
+        fetch: async () =>
+          new Response(lengthLimitedStream, {
+            headers: { "content-type": "text/event-stream" },
+            status: 200,
+          }),
+      }),
+      store,
+    });
+
+    const result = await session.run({ text: "Write a long answer" });
+    const records = await store.read();
+
+    expect({ result, settled: records.at(-1)?.event }).toEqual({
+      result: {
+        status: "failed",
+        error: {
+          code: "model_output_truncated",
+          message: "The model response reached its output-token limit.",
+        },
+      },
+      settled: {
+        type: "session_settled",
+        result: {
+          status: "failed",
+          error: {
+            code: "model_output_truncated",
+            message: "The model response reached its output-token limit.",
+          },
+        },
+      },
+    });
+  });
+
+  test("settles explicitly when DeepSeek filters the response", async () => {
+    const store = createInMemorySessionStore();
+    const session = new AgentSession({
+      model: new OpenAICompatibleModelDriver({
+        profile: "deepseek",
+        apiKey: "test-deepseek-key",
+        baseURL: "https://deepseek.invalid",
+        model: "deepseek-test",
+        maximumOutputTokens: 4_096,
+        fetch: async () =>
+          new Response(contentFilteredStream, {
+            headers: { "content-type": "text/event-stream" },
+            status: 200,
+          }),
+      }),
+      store,
+    });
+
+    const result = await session.run({ text: "Answer the request" });
+
+    expect(result).toEqual({
+      status: "failed",
+      error: {
+        code: "model_content_filtered",
+        message: "The provider filtered the model response.",
+      },
+    });
+  });
+
+  test("settles explicitly when DeepSeek reports insufficient system resources", async () => {
+    const store = createInMemorySessionStore();
+    const session = new AgentSession({
+      model: new OpenAICompatibleModelDriver({
+        profile: "deepseek",
+        apiKey: "test-deepseek-key",
+        baseURL: "https://deepseek.invalid",
+        model: "deepseek-test",
+        maximumOutputTokens: 4_096,
+        fetch: async () =>
+          new Response(resourceExhaustedStream, {
+            headers: { "content-type": "text/event-stream" },
+            status: 200,
+          }),
+      }),
+      store,
+    });
+
+    const result = await session.run({ text: "Answer the request" });
+
+    expect(result).toEqual({
+      status: "failed",
+      error: {
+        code: "model_resource_exhausted",
+        message:
+          "The provider could not complete the model response because resources were unavailable.",
+        providerReason: "insufficient_system_resource",
+      },
+    });
+  });
+
+  test("settles explicitly and retains an unknown provider finish reason", async () => {
+    const store = createInMemorySessionStore();
+    const session = new AgentSession({
+      model: new OpenAICompatibleModelDriver({
+        profile: "deepseek",
+        apiKey: "test-deepseek-key",
+        baseURL: "https://deepseek.invalid",
+        model: "deepseek-test",
+        maximumOutputTokens: 4_096,
+        fetch: async () =>
+          new Response(unknownFinishStream, {
+            headers: { "content-type": "text/event-stream" },
+            status: 200,
+          }),
+      }),
+      store,
+    });
+
+    const result = await session.run({ text: "Answer the request" });
+
+    expect(result).toEqual({
+      status: "failed",
+      error: {
+        code: "model_finish_unknown",
+        message: "The provider ended the model response for an unknown reason.",
+        providerReason: "future_provider_reason",
+      },
+    });
+  });
+
+  test("bounds an unknown provider finish reason before persistence", async () => {
+    const rawReason = "x".repeat(200);
+    const store = createInMemorySessionStore();
+    const session = new AgentSession({
+      model: new OpenAICompatibleModelDriver({
+        profile: "deepseek",
+        apiKey: "test-key",
+        baseURL: "https://deepseek.invalid",
+        model: "deepseek-test",
+        maximumOutputTokens: 4_096,
+        fetch: async () =>
+          new Response(
+            `data: ${JSON.stringify({
+              id: "bounded-finish-1",
+              choices: [{ index: 0, delta: {}, finish_reason: rawReason }],
+              created: 1,
+              model: "deepseek-test",
+              object: "chat.completion.chunk",
+            })}\n\ndata: [DONE]\n\n`,
+            {
+              headers: { "content-type": "text/event-stream" },
+              status: 200,
+            },
+          ),
+      }),
+      store,
+    });
+
+    const result = await session.run({ text: "Answer" });
+
+    expect(result).toMatchObject({
+      status: "failed",
+      error: {
+        code: "model_finish_unknown",
+        providerReason: "x".repeat(128),
+      },
+    });
+  });
+
+  test("rejects invalid detailed usage as a model protocol failure", async () => {
+    const session = new AgentSession({
+      model: new OpenAICompatibleModelDriver({
+        profile: "deepseek",
+        apiKey: "test-key",
+        baseURL: "https://deepseek.invalid",
+        model: "deepseek-test",
+        maximumOutputTokens: 4_096,
+        fetch: async () =>
+          new Response(invalidDetailedUsageStream, {
+            headers: { "content-type": "text/event-stream" },
+            status: 200,
+          }),
+      }),
+      store: createInMemorySessionStore(),
+    });
+
+    const result = await session.run({ text: "Answer" });
+
+    expect(result).toEqual({
+      status: "failed",
+      error: {
+        code: "model_protocol_invalid",
+        message: "The model reported invalid token usage.",
+      },
+    });
+  });
+
+  test("classifies a DeepSeek authentication response as an Adam-owned error", async () => {
+    const driver = new OpenAICompatibleModelDriver({
+      profile: "deepseek",
+      apiKey: "invalid-test-key",
+      baseURL: "https://deepseek.invalid",
+      model: "deepseek-test",
+      maximumOutputTokens: 4_096,
+      fetch: async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              message: "Authentication failed",
+              type: "authentication_error",
+              code: "invalid_api_key",
+            },
+          }),
+          {
+            headers: {
+              "content-type": "application/json",
+              "x-request-id": "request-auth-1",
+            },
+            status: 401,
+          },
+        ),
+    });
+
+    let thrown: unknown;
+    try {
+      await collect(
+        driver.stream({
+          messages: [{ role: "user", content: "Hello" }],
+          tools: [],
+          signal: new AbortController().signal,
+        }),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ModelDriverError);
+    expect(thrown).toMatchObject({
+      category: "authentication",
+      status: 401,
+      providerCode: "invalid_api_key",
+      requestId: "request-auth-1",
+      responseSummary: "Authentication failed",
+    });
+  });
+
+  test("persists only bounded Adam metadata for a provider failure", async () => {
+    const store = createInMemorySessionStore();
+    const session = new AgentSession({
+      model: new OpenAICompatibleModelDriver({
+        profile: "deepseek",
+        apiKey: "never-persist-this-test-key",
+        baseURL: "https://deepseek.invalid",
+        model: "deepseek-test",
+        maximumOutputTokens: 4_096,
+        fetch: async () =>
+          new Response(
+            JSON.stringify({
+              error: {
+                message:
+                  "Authentication failed for never-persist-this-test-key; repository token is private-repository-token",
+                type: "authentication_error",
+                code: "invalid-never-persist-this-test-key",
+              },
+            }),
+            {
+              headers: {
+                "content-type": "application/json",
+                "x-request-id": "request-never-persist-this-test-key",
+              },
+              status: 401,
+            },
+          ),
+      }),
+      store,
+    });
+
+    const result = await session.run({ text: "Hello" });
+    const persisted = JSON.stringify(await store.read());
+
+    expect(result).toEqual({
+      status: "failed",
+      error: {
+        code: "model_request_failed",
+        message: "The model provider rejected authentication.",
+        category: "authentication",
+        status: 401,
+        providerCode: "invalid-[REDACTED]",
+        requestId: "request-[REDACTED]",
+      },
+    });
+    expect(persisted).not.toContain("never-persist-this-test-key");
+    expect(persisted).not.toContain("private-repository-token");
+    expect(persisted).not.toContain("AuthenticationError");
+  });
+
+  test("classifies a DeepSeek authorization response", async () => {
+    const error = await collectDriverError(403, {
+      message: "Access denied",
+      type: "permission_error",
+      code: "permission_denied",
+    });
+
+    expect(error).toMatchObject({
+      category: "authorization",
+      status: 403,
+      providerCode: "permission_denied",
+      responseSummary: "Access denied",
+    });
+  });
+
+  test("classifies a DeepSeek rate-limit response", async () => {
+    const error = await collectDriverError(429, {
+      message: "Too many requests",
+      type: "rate_limit_error",
+      code: "rate_limit_exceeded",
+    });
+
+    expect(error).toMatchObject({
+      category: "rate_limit",
+      status: 429,
+      providerCode: "rate_limit_exceeded",
+      responseSummary: "Too many requests",
+    });
+  });
+
+  test("classifies a DeepSeek invalid-request response", async () => {
+    const error = await collectDriverError(400, {
+      message: "Invalid request",
+      type: "invalid_request_error",
+      code: "invalid_request",
+    });
+
+    expect(error).toMatchObject({
+      category: "invalid_request",
+      status: 400,
+      providerCode: "invalid_request",
+      responseSummary: "Invalid request",
+    });
+  });
+
+  test("classifies a DeepSeek server response", async () => {
+    const error = await collectDriverError(503, {
+      message: "Service unavailable",
+      type: "server_error",
+      code: "service_unavailable",
+    });
+
+    expect(error).toMatchObject({
+      category: "provider",
+      status: 503,
+      providerCode: "service_unavailable",
+      responseSummary: "Service unavailable",
+    });
+  });
+
+  test("retains bounded metadata for an unrecognized provider response", async () => {
+    const error = await collectDriverError(418, {
+      message: "Unexpected provider response",
+      type: "future_error",
+      code: "future_error_code",
+    });
+
+    expect(error).toMatchObject({
+      category: "unknown",
+      status: 418,
+      providerCode: "future_error_code",
+      responseSummary: "Unexpected provider response",
+    });
+  });
+
+  test("classifies one transport failure without a hidden retry", async () => {
+    let attempts = 0;
+    const driver = new OpenAICompatibleModelDriver({
+      profile: "deepseek",
+      apiKey: "test-key",
+      baseURL: "https://deepseek.invalid",
+      model: "deepseek-test",
+      maximumOutputTokens: 4_096,
+      fetch: async () => {
+        attempts += 1;
+        throw new TypeError("socket disconnected");
+      },
+    });
+
+    const error = await captureDriverError(driver);
+
+    expect({ error, attempts }).toMatchObject({
+      error: { category: "transport" },
+      attempts: 1,
+    });
+  });
+
+  test("classifies malformed provider SSE as a protocol incompatibility", async () => {
+    const driver = new OpenAICompatibleModelDriver({
+      profile: "deepseek",
+      apiKey: "test-key",
+      baseURL: "https://deepseek.invalid",
+      model: "deepseek-test",
+      maximumOutputTokens: 4_096,
+      fetch: async () =>
+        new Response('data: {"invalid":\n\n', {
+          headers: { "content-type": "text/event-stream" },
+          status: 200,
+        }),
+    });
+
+    const error = await captureDriverError(driver);
+
+    expect(error).toMatchObject({ category: "protocol_incompatibility" });
+  });
+
+  test("classifies an invalid provider chunk shape as a protocol incompatibility", async () => {
+    const driver = new OpenAICompatibleModelDriver({
+      profile: "deepseek",
+      apiKey: "test-key",
+      baseURL: "https://deepseek.invalid",
+      model: "deepseek-test",
+      maximumOutputTokens: 4_096,
+      fetch: async () =>
+        new Response(
+          'data: {"id":"invalid-1","choices":null,"created":1,"model":"deepseek-test","object":"chat.completion.chunk"}\n\n',
+          {
+            headers: { "content-type": "text/event-stream" },
+            status: 200,
+          },
+        ),
+    });
+
+    const error = await captureDriverError(driver);
+
+    expect(error).toMatchObject({ category: "protocol_incompatibility" });
+  });
+
+  test("rejects multiple provider choices instead of merging them", async () => {
+    const driver = new OpenAICompatibleModelDriver({
+      profile: "deepseek",
+      apiKey: "test-key",
+      baseURL: "https://deepseek.invalid",
+      model: "deepseek-test",
+      maximumOutputTokens: 4_096,
+      fetch: async () =>
+        new Response(
+          'data: {"id":"multiple-choices-1","choices":[{"index":0,"delta":{"content":"First"},"finish_reason":"stop"},{"index":1,"delta":{"content":"Second"},"finish_reason":"stop"}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk"}\n\n',
+          {
+            headers: { "content-type": "text/event-stream" },
+            status: 200,
+          },
+        ),
+    });
+
+    const error = await captureDriverError(driver);
+
+    expect(error).toMatchObject({
+      category: "protocol_incompatibility",
+      message: "The model provider returned an invalid choice payload.",
+    });
+  });
+
+  test("rejects a non-string provider content delta", async () => {
+    const driver = new OpenAICompatibleModelDriver({
+      profile: "deepseek",
+      apiKey: "test-key",
+      baseURL: "https://deepseek.invalid",
+      model: "deepseek-test",
+      maximumOutputTokens: 4_096,
+      fetch: async () =>
+        new Response(
+          'data: {"id":"invalid-content-1","choices":[{"index":0,"delta":{"content":42},"finish_reason":"stop"}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk"}\n\n',
+          {
+            headers: { "content-type": "text/event-stream" },
+            status: 200,
+          },
+        ),
+    });
+
+    const error = await captureDriverError(driver);
+
+    expect(error).toMatchObject({
+      category: "protocol_incompatibility",
+      message: "The model provider returned an invalid choice payload.",
+    });
+  });
+
+  test("rejects normalized text that exceeds Adam's stream limit", async () => {
+    const oversizedText = "x".repeat(512 * 1024 + 1);
+    const driver = new OpenAICompatibleModelDriver({
+      profile: "deepseek",
+      apiKey: "test-key",
+      baseURL: "https://deepseek.invalid",
+      model: "deepseek-test",
+      maximumOutputTokens: 4_096,
+      fetch: async () =>
+        new Response(
+          `data: ${JSON.stringify({
+            id: "oversized-text-1",
+            choices: [{ index: 0, delta: { content: oversizedText }, finish_reason: "stop" }],
+            created: 1,
+            model: "deepseek-test",
+            object: "chat.completion.chunk",
+          })}\n\n`,
+          {
+            headers: { "content-type": "text/event-stream" },
+            status: 200,
+          },
+        ),
+    });
+
+    const error = await captureDriverError(driver);
+
+    expect(error).toMatchObject({
+      category: "protocol_incompatibility",
+      message: "The model provider response exceeded Adam's stream limit.",
+    });
+  });
+
+  test("settles a truncated provider stream without completing partial text", async () => {
+    const store = createInMemorySessionStore();
+    const session = new AgentSession({
+      model: new OpenAICompatibleModelDriver({
+        profile: "deepseek",
+        apiKey: "test-key",
+        baseURL: "https://deepseek.invalid",
+        model: "deepseek-test",
+        maximumOutputTokens: 4_096,
+        fetch: async () =>
+          new Response(
+            'data: {"id":"truncated-1","choices":[{"index":0,"delta":{"content":"Partial"},"finish_reason":null}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk"}\n\n',
+            {
+              headers: { "content-type": "text/event-stream" },
+              status: 200,
+            },
+          ),
+      }),
+      store,
+    });
+
+    const result = await session.run({ text: "Answer" });
+    const events = (await store.read()).map((record) => record.event);
+
+    expect({
+      result,
+      completed: events.some((event) => event.type === "model_message_completed"),
+    }).toEqual({
+      result: {
+        status: "failed",
+        error: {
+          code: "model_stream_incomplete",
+          message: "The model stream ended without a finish event.",
+        },
+      },
+      completed: false,
+    });
+  });
+
+  test("classifies an already-aborted provider request", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const driver = new OpenAICompatibleModelDriver({
+      profile: "deepseek",
+      apiKey: "test-key",
+      baseURL: "https://deepseek.invalid",
+      model: "deepseek-test",
+      maximumOutputTokens: 4_096,
+      fetch: async () => {
+        throw new Error("The transport must not start for an aborted request.");
+      },
+    });
+
+    const error = await captureDriverError(driver, controller.signal);
+
+    expect(error).toMatchObject({ category: "aborted" });
+  });
+
+  test("caller cancellation wins during a live provider stream and settles once", async () => {
+    const caller = new AbortController();
+    const store = createInMemorySessionStore();
+    const session = new AgentSession({
+      model: new OpenAICompatibleModelDriver({
+        profile: "deepseek",
+        apiKey: "test-key",
+        baseURL: "https://deepseek.invalid",
+        model: "deepseek-test",
+        maximumOutputTokens: 4_096,
+        fetch: async (_input, init) =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(streamController) {
+                streamController.enqueue(
+                  new TextEncoder().encode(
+                    'data: {"id":"cancel-1","choices":[{"index":0,"delta":{"content":"Partial"},"finish_reason":null}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk"}\n\n',
+                  ),
+                );
+                init?.signal?.addEventListener(
+                  "abort",
+                  () => streamController.error(init.signal?.reason),
+                  { once: true },
+                );
+              },
+            }),
+            {
+              headers: { "content-type": "text/event-stream" },
+              status: 200,
+            },
+          ),
+      }),
+      store,
+    });
+    const events: Array<{ readonly type: string }> = [];
+    let resolveDelta: (() => void) | undefined;
+    const sawDelta = new Promise<void>((resolve) => {
+      resolveDelta = resolve;
+    });
+    session.subscribe((event) => {
+      events.push(event);
+      if (event.type === "model_message_delta") {
+        resolveDelta?.();
+      }
+    });
+
+    const running = session.run({ text: "Answer" }, { signal: caller.signal });
+    await sawDelta;
+    caller.abort();
+    const result = await running;
+
+    expect({
+      result,
+      settled: events.filter((event) => event.type === "session_settled").length,
+      completed: events.some((event) => event.type === "model_message_completed"),
+    }).toEqual({
+      result: {
+        status: "cancelled",
+        error: { code: "session_cancelled", message: "The session was cancelled." },
+      },
+      settled: 1,
+      completed: false,
+    });
+  });
+
+  test("a full-stream deadline settles as timeout and cannot later publish success", async () => {
+    vi.useFakeTimers();
+    const cleanup = new AbortController();
+    const store = createInMemorySessionStore();
+    const events: Array<{ readonly type: string }> = [];
+    let bodyWasAborted = false;
+    let resolveDelta: (() => void) | undefined;
+    const sawDelta = new Promise<void>((resolve) => {
+      resolveDelta = resolve;
+    });
+    const session = new AgentSession({
+      model: new OpenAICompatibleModelDriver({
+        profile: "deepseek",
+        apiKey: "test-key",
+        baseURL: "https://deepseek.invalid",
+        model: "deepseek-test",
+        maximumOutputTokens: 4_096,
+        deadlineMs: 50,
+        fetch: async (_input, init) =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(streamController) {
+                streamController.enqueue(
+                  new TextEncoder().encode(
+                    'data: {"id":"deadline-1","choices":[{"index":0,"delta":{"content":"Partial"},"finish_reason":null}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk"}\n\n',
+                  ),
+                );
+                init?.signal?.addEventListener(
+                  "abort",
+                  () => {
+                    bodyWasAborted = true;
+                    streamController.error(init.signal?.reason);
+                  },
+                  { once: true },
+                );
+              },
+            }),
+            {
+              headers: { "content-type": "text/event-stream" },
+              status: 200,
+            },
+          ),
+      }),
+      store,
+    });
+    session.subscribe((event) => {
+      events.push(event);
+      if (event.type === "model_message_delta") {
+        resolveDelta?.();
+      }
+    });
+
+    try {
+      const running = session.run({ text: "Answer" }, { signal: cleanup.signal });
+      await sawDelta;
+      await vi.advanceTimersByTimeAsync(50);
+      const result = await Promise.race([running, Promise.resolve("deadline-did-not-settle")]);
+      if (result === "deadline-did-not-settle") {
+        cleanup.abort();
+        await running;
+      }
+
+      expect({
+        result,
+        bodyWasAborted,
+        settled: events.filter((event) => event.type === "session_settled").length,
+        completed: events.some((event) => event.type === "model_message_completed"),
+      }).toEqual({
+        result: {
+          status: "failed",
+          error: {
+            code: "model_request_failed",
+            message: "The model provider request reached its deadline.",
+            category: "timeout",
+          },
+        },
+        bodyWasAborted: true,
+        settled: 1,
+        completed: false,
+      });
+    } finally {
+      cleanup.abort();
+      vi.useRealTimers();
+    }
+  });
+
+  test("maps Adam messages and tools into one DeepSeek request", async () => {
+    const requests: unknown[] = [];
+    const driver = new OpenAICompatibleModelDriver({
+      profile: "deepseek",
+      apiKey: "test-deepseek-key",
+      baseURL: "https://deepseek.invalid",
+      model: "deepseek-test",
+      maximumOutputTokens: 4_096,
+      fetch: async (_input, init) => {
+        requests.push(JSON.parse(String(init?.body)));
+        return new Response(answerOnlyStream, {
+          headers: { "content-type": "text/event-stream" },
+          status: 200,
+        });
+      },
+    });
+
+    await collect(
+      driver.stream({
+        messages: [
+          { role: "system", content: "Follow the platform rules." },
+          { role: "developer", content: "Work only inside the repository." },
+          { role: "user", content: "Read the project name." },
+          {
+            role: "assistant",
+            content: "I will read it.",
+            toolCalls: [
+              { id: "read-project", name: "read_file", argumentsJson: '{"path":"README.md"}' },
+            ],
+          },
+          {
+            role: "tool",
+            callId: "read-project",
+            name: "read_file",
+            result: {
+              status: "completed",
+              output: { path: "README.md", content: "# Adam Agent\n", truncated: false },
+            },
+          },
+        ],
+        tools: [
+          {
+            name: "read_file",
+            description: "Read a UTF-8 text file inside the workspace.",
+            inputSchema: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+              additionalProperties: false,
+            },
+          },
+        ],
+        signal: new AbortController().signal,
+      }),
+    );
+
+    expect(requests).toEqual([
+      {
+        messages: [
+          { role: "system", content: "Follow the platform rules." },
+          {
+            role: "system",
+            content: "Developer instruction:\nWork only inside the repository.",
+          },
+          { role: "user", content: "Read the project name." },
+          {
+            role: "assistant",
+            content: "I will read it.",
+            tool_calls: [
+              {
+                id: "read-project",
+                type: "function",
+                function: { name: "read_file", arguments: '{"path":"README.md"}' },
+              },
+            ],
+          },
+          {
+            role: "tool",
+            tool_call_id: "read-project",
+            content:
+              '{"status":"completed","output":{"path":"README.md","content":"# Adam Agent\\n","truncated":false}}',
+          },
+        ],
+        model: "deepseek-test",
+        stream: true,
+        stream_options: { include_usage: true },
+        max_tokens: 4_096,
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "read_file",
+              description: "Read a UTF-8 text file inside the workspace.",
+              parameters: {
+                type: "object",
+                properties: { path: { type: "string" } },
+                required: ["path"],
+                additionalProperties: false,
+              },
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("normalizes interleaved fragmented tool calls in stable index order", async () => {
+    const driver = new OpenAICompatibleModelDriver({
+      profile: "deepseek",
+      apiKey: "test-deepseek-key",
+      baseURL: "https://deepseek.invalid",
+      model: "deepseek-test",
+      maximumOutputTokens: 4_096,
+      fetch: async () =>
+        new Response(interleavedToolStream, {
+          headers: { "content-type": "text/event-stream" },
+          status: 200,
+        }),
+    });
+
+    const events = await collect(
+      driver.stream({
+        messages: [{ role: "user", content: "Read the README and print the directory." }],
+        tools: [],
+        signal: new AbortController().signal,
+      }),
+    );
+
+    expect(events).toEqual([
+      { type: "tool_call_start", id: "read-project", name: "read_file" },
+      { type: "tool_call_delta", id: "read-project", json: '{"pa' },
+      { type: "tool_call_delta", id: "read-project", json: 'th":"README.md"}' },
+      { type: "tool_call_end", id: "read-project" },
+      { type: "tool_call_start", id: "run-directory", name: "run_shell" },
+      { type: "tool_call_delta", id: "run-directory", json: '{"com' },
+      { type: "tool_call_delta", id: "run-directory", json: 'mand":"pwd"}' },
+      { type: "tool_call_end", id: "run-directory" },
+      { type: "usage", inputTokens: 11, outputTokens: 8 },
+      { type: "finish", reason: "tool_calls", rawReason: "tool_calls" },
+    ]);
+  });
+
+  test("rejects one incomplete parallel tool call before any valid call executes", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-provider-incomplete-tool-"));
+    const events: Array<{ readonly type: string }> = [];
+    try {
+      await writeFile(join(workspaceRoot, "README.md"), "# Adam Agent\n", "utf8");
+      const session = new AgentSession({
+        model: new OpenAICompatibleModelDriver({
+          profile: "deepseek",
+          apiKey: "test-key",
+          baseURL: "https://deepseek.invalid",
+          model: "deepseek-test",
+          maximumOutputTokens: 4_096,
+          fetch: async () =>
+            new Response(incompleteParallelToolStream, {
+              headers: { "content-type": "text/event-stream" },
+              status: 200,
+            }),
+        }),
+        store: createInMemorySessionStore(),
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+      session.subscribe((event) => events.push(event));
+
+      const result = await session.run({ text: "Read the README" }, { limits: { maxTurns: 1 } });
+
+      expect({
+        result,
+        toolStarted: events.some((event) => event.type === "tool_started"),
+      }).toEqual({
+        result: {
+          status: "failed",
+          error: {
+            code: "model_request_failed",
+            message: "The model provider returned an incomplete tool call.",
+            category: "protocol_incompatibility",
+          },
+        },
+        toolStarted: false,
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("replays reasoning across one real read tool turn without persisting it", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-provider-reasoning-"));
+    const responses = [reasoningToolStream, finalAnswerStream];
+    const requests: Array<{ readonly messages: readonly unknown[] }> = [];
+    const store = createInMemorySessionStore();
+
+    try {
+      await writeFile(join(workspaceRoot, "README.md"), "# Adam Agent\n", "utf8");
+      const driver = new OpenAICompatibleModelDriver({
+        profile: "deepseek",
+        apiKey: "test-deepseek-key",
+        baseURL: "https://deepseek.invalid",
+        model: "deepseek-test",
+        maximumOutputTokens: 4_096,
+        fetch: async (_input, init) => {
+          const body = JSON.parse(String(init?.body)) as {
+            readonly messages: readonly unknown[];
+          };
+          requests.push({ messages: body.messages });
+          const response = responses.shift();
+          if (response === undefined) {
+            throw new Error("The provider received an unexpected request.");
+          }
+          return new Response(response, {
+            headers: { "content-type": "text/event-stream" },
+            status: 200,
+          });
+        },
+      });
+      const session = new AgentSession({
+        model: driver,
+        store,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      const result = await session.run({ text: "What is the project name?" });
+      const records = await store.read();
+
+      expect({
+        result,
+        secondRequestMessages: requests[1]?.messages,
+        persistedReasoning: JSON.stringify(records).includes("I need the README."),
+      }).toEqual({
+        result: { status: "completed", answer: "The project is Adam Agent." },
+        secondRequestMessages: [
+          { role: "user", content: "What is the project name?" },
+          {
+            role: "assistant",
+            content: "",
+            reasoning_content: "I need the README.",
+            tool_calls: [
+              {
+                id: "read-project",
+                type: "function",
+                function: { name: "read_file", arguments: '{"path":"README.md"}' },
+              },
+            ],
+          },
+          {
+            role: "tool",
+            tool_call_id: "read-project",
+            content:
+              '{"status":"completed","output":{"path":"README.md","content":"# Adam Agent\\n","truncated":false}}',
+          },
+        ],
+        persistedReasoning: false,
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+async function collect(events: AsyncIterable<ModelEvent>): Promise<readonly ModelEvent[]> {
+  const collected: ModelEvent[] = [];
+  for await (const event of events) {
+    collected.push(event);
+  }
+  return collected;
+}
+
+async function collectDriverError(
+  status: number,
+  providerError: { readonly message: string; readonly type: string; readonly code: string },
+): Promise<ModelDriverError> {
+  const driver = new OpenAICompatibleModelDriver({
+    profile: "deepseek",
+    apiKey: "test-key",
+    baseURL: "https://deepseek.invalid",
+    model: "deepseek-test",
+    maximumOutputTokens: 4_096,
+    fetch: async () =>
+      new Response(JSON.stringify({ error: providerError }), {
+        headers: { "content-type": "application/json" },
+        status,
+      }),
+  });
+  return captureDriverError(driver);
+}
+
+async function captureDriverError(
+  driver: OpenAICompatibleModelDriver,
+  signal = new AbortController().signal,
+): Promise<ModelDriverError> {
+  try {
+    await collect(
+      driver.stream({
+        messages: [{ role: "user", content: "Hello" }],
+        tools: [],
+        signal,
+      }),
+    );
+  } catch (error) {
+    if (error instanceof ModelDriverError) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error("Expected the model driver to fail.");
+}
+
+const answerOnlyStream = [
+  'data: {"id":"answer-1","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello, "},"finish_reason":null}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  'data: {"id":"answer-1","choices":[{"index":0,"delta":{"content":"Adam."},"finish_reason":null}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  'data: {"id":"answer-1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  'data: {"id":"answer-1","choices":[],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":{"prompt_tokens":7,"completion_tokens":3,"total_tokens":10,"prompt_cache_hit_tokens":2,"prompt_cache_miss_tokens":5,"completion_tokens_details":{"reasoning_tokens":1}}}',
+  "",
+  "data: [DONE]",
+  "",
+].join("\n");
+
+const lengthLimitedStream = [
+  'data: {"id":"length-1","choices":[{"index":0,"delta":{"role":"assistant","content":"Partial"},"finish_reason":null}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  'data: {"id":"length-1","choices":[{"index":0,"delta":{},"finish_reason":"length"}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  "data: [DONE]",
+  "",
+].join("\n");
+
+const contentFilteredStream = [
+  'data: {"id":"filter-1","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":"content_filter"}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  "data: [DONE]",
+  "",
+].join("\n");
+
+const resourceExhaustedStream = [
+  'data: {"id":"resource-1","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":"insufficient_system_resource"}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  "data: [DONE]",
+  "",
+].join("\n");
+
+const unknownFinishStream = [
+  'data: {"id":"unknown-1","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":"future_provider_reason"}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  "data: [DONE]",
+  "",
+].join("\n");
+
+const invalidDetailedUsageStream = [
+  'data: {"id":"usage-invalid-1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  'data: {"id":"usage-invalid-1","choices":[],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2,"completion_tokens_details":{"reasoning_tokens":-1}}}',
+  "",
+  "data: [DONE]",
+  "",
+].join("\n");
+
+const interleavedToolStream = [
+  'data: {"id":"tools-1","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"read-project","type":"function","function":{"name":"read_","arguments":"{\\"pa"}},{"index":1,"id":"run-directory","type":"function","function":{"name":"run_","arguments":"{\\"com"}}]},"finish_reason":null}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  'data: {"id":"tools-1","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"name":"shell","arguments":"mand\\":\\"pwd\\"}"}},{"index":0,"function":{"name":"file","arguments":"th\\":\\"README.md\\"}"}}]},"finish_reason":null}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  'data: {"id":"tools-1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  'data: {"id":"tools-1","choices":[],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":{"prompt_tokens":11,"completion_tokens":8,"total_tokens":19}}',
+  "",
+  "data: [DONE]",
+  "",
+].join("\n");
+
+const incompleteParallelToolStream = [
+  'data: {"id":"incomplete-tool-1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"read-project","type":"function","function":{"name":"read_file","arguments":"{\\"path\\":\\"README.md\\"}"}},{"index":1,"type":"function","function":{"arguments":"{}"}}]},"finish_reason":null}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  'data: {"id":"incomplete-tool-1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  "data: [DONE]",
+  "",
+].join("\n");
+
+const reasoningToolStream = [
+  'data: {"id":"reasoning-1","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"I need "},"finish_reason":null}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  'data: {"id":"reasoning-1","choices":[{"index":0,"delta":{"reasoning_content":"the README."},"finish_reason":null}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  'data: {"id":"reasoning-1","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"read-project","type":"function","function":{"name":"read_file","arguments":"{\\"path\\":\\"README.md\\"}"}}]},"finish_reason":null}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  'data: {"id":"reasoning-1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  'data: {"id":"reasoning-1","choices":[],"created":1,"model":"deepseek-test","object":"chat.completion.chunk","usage":{"prompt_tokens":13,"completion_tokens":9,"total_tokens":22}}',
+  "",
+  "data: [DONE]",
+  "",
+].join("\n");
+
+const finalAnswerStream = [
+  'data: {"id":"answer-2","choices":[{"index":0,"delta":{"role":"assistant","content":"The project is Adam Agent."},"finish_reason":null}],"created":2,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  'data: {"id":"answer-2","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"created":2,"model":"deepseek-test","object":"chat.completion.chunk","usage":null}',
+  "",
+  'data: {"id":"answer-2","choices":[],"created":2,"model":"deepseek-test","object":"chat.completion.chunk","usage":{"prompt_tokens":21,"completion_tokens":6,"total_tokens":27}}',
+  "",
+  "data: [DONE]",
+  "",
+].join("\n");

--- a/packages/testkit/src/session-store.test.ts
+++ b/packages/testkit/src/session-store.test.ts
@@ -171,6 +171,36 @@ test("SessionStore adapters reject non-canonical records on append", async () =>
   }
 });
 
+test("SessionStore adapters require a category for model request failures", async () => {
+  const { testRoot, stores } = await createContractStores(
+    "adam-agent-session-model-failure-",
+    "session-model-failure",
+  );
+  const invalidRecord = {
+    schemaVersion: 1,
+    runId,
+    sequence: 1,
+    event: {
+      type: "session_settled",
+      result: {
+        status: "failed",
+        error: { code: "model_request_failed", message: "Missing category" },
+      },
+    },
+  } as unknown as SessionEventRecord;
+
+  try {
+    for (const [name, store] of stores) {
+      await expect(store.append(invalidRecord), name).rejects.toMatchObject({
+        name: "SessionStoreError",
+        code: "session_log_invalid",
+      });
+    }
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("SessionStore adapters reject an oversized canonical record before modifying history", async () => {
   const { testRoot, stores } = await createContractStores(
     "adam-agent-session-record-bound-",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
 
   packages/agent:
     dependencies:
+      openai:
+        specifier: 7.4.0
+        version: 7.4.0(zod@4.4.3)
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -746,6 +749,27 @@ packages:
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
+
+  openai@7.4.0:
+    resolution: {integrity: sha512-+C9Muit5x8j9R8ej8ZzVgKcrVDtqFqTy9gxFdov0EItLgU68zrJtF9ZeT0cyqJQW9S3PCJkdFgADtRGquRBtew==}
+    engines: {node: '>=22.0.0'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -1572,6 +1596,10 @@ snapshots:
   nanoid@3.3.18: {}
 
   obug@2.1.4: {}
+
+  openai@7.4.0(zod@4.4.3):
+    optionalDependencies:
+      zod: 4.4.3
 
   parse-entities@4.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

- add an Adam-owned OpenAI-compatible model driver with an explicit DeepSeek profile and the official OpenAI client as transport
- normalize streamed text, reasoning replay, tool calls, usage, finish reasons, cancellation, deadlines, and typed failures behind ModelDriver
- add environment-only CLI selection plus deterministic raw-SSE, process-boundary, persistence, and opt-in live tests

## Verification

- pnpm quality:check
- 130 tests passed; 3 opt-in live tests skipped because DEEPSEEK_API_KEY is absent
- specification review: PASS
- standards review: PASS

## Remaining live gate

Credentialed DeepSeek answer-only and read-tool smoke tests are skipped by the owner environment, not completed. No credentials or raw sessions are committed.