### PR TITLE
Load local provider environment file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+ADAM_AGENT_PROVIDER=deepseek
+DEEPSEEK_API_KEY=
+# ADAM_AGENT_MODEL=deepseek-v4-pro

--- a/README.md
+++ b/README.md
@@ -16,12 +16,16 @@ pnpm --silent adam "What is this repository?"
 
 With no provider environment variable, the `adam` command exercises deterministic read, edit, and shell scenarios through the fake provider. It asks on stderr before write or execute effects. Session JSONL and overflow artifacts are written under `ADAM_AGENT_STATE_ROOT` when set, otherwise under `~/.local/state/adam-agent`.
 
-To use the live DeepSeek Adapter, supply the credential from the environment and select the provider explicitly:
+To use the live DeepSeek Adapter locally, copy the tracked placeholder file, restrict its permissions, and add the credential to the ignored project-root `.env`:
 
 ```bash
-export DEEPSEEK_API_KEY="..."
-ADAM_AGENT_PROVIDER=deepseek pnpm --silent adam "Summarize this repository"
+cp .env.example .env
+chmod 600 .env
+# Edit .env and set DEEPSEEK_API_KEY, then run:
+pnpm --silent adam "Summarize this repository"
 ```
+
+Adam loads only `.env` from the current project root and ignores it through the repository's committed `.gitignore`; `.env.example` contains names and non-secret defaults only. Values already present in the process environment take precedence, so CI or a shell export can override the local file. The file is still plaintext local credential material: do not share it, print it, pass it to the model, or rely on `.gitignore` as protection from other local processes or backups.
 
 The default live model is `deepseek-v4-pro`; set `ADAM_AGENT_MODEL` to override it, for example `deepseek-v4-flash`. Adam sends requests only to `https://api.deepseek.com` in this slice and does not persist credentials, raw provider responses, or reasoning content. Provider failures are reduced to bounded Adam-owned metadata before session persistence. The live model can request the same four tools as the fake path, and write or execute effects still require the existing call-scoped approval.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The default live model is `deepseek-v4-pro`; set `ADAM_AGENT_MODEL` to override 
 With `DEEPSEEK_API_KEY` already present, the opt-in live smoke gate runs one answer-only turn and one real read-tool round trip:
 
 ```bash
-ADAM_AGENT_LIVE_TESTS=1 pnpm exec vitest run packages/testkit/src/openai-compatible-model-driver.live.test.ts
+ADAM_AGENT_LIVE_TESTS=1 pnpm test:live:deepseek
 ```
 
 Use `pnpm quality:fix` only when an intentional formatting rewrite is desired. The pre-commit hook is check-only.

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -69,6 +69,70 @@ describe("one-shot CLI", () => {
     }
   });
 
+  test("loads DeepSeek from project .env without overriding the process environment", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-dotenv-"));
+    const workspaceRoot = join(testRoot, "workspace");
+    const fetchHookPath = join(testRoot, "fetch-hook.mjs");
+    await mkdir(workspaceRoot);
+    await writeFile(
+      join(workspaceRoot, ".env"),
+      "ADAM_AGENT_PROVIDER=deepseek\nDEEPSEEK_API_KEY=test-dotenv-key\nADAM_AGENT_MODEL=deepseek-dotenv-model\n",
+      "utf8",
+    );
+    await writeFile(
+      fetchHookPath,
+      `globalThis.fetch = async (_input, init) => {
+  const request = JSON.parse(String(init?.body));
+  const chunks = [
+    {
+      id: "dotenv-1",
+      choices: [{ index: 0, delta: { content: "Selected " + request.model + "." }, finish_reason: null }],
+      created: 1,
+      model: request.model,
+      object: "chat.completion.chunk",
+      usage: null,
+    },
+    {
+      id: "dotenv-1",
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      created: 1,
+      model: request.model,
+      object: "chat.completion.chunk",
+      usage: null,
+    },
+  ];
+  return new Response(chunks.map((chunk) => "data: " + JSON.stringify(chunk) + "\\n\\n").join("") + "data: [DONE]\\n\\n", {
+    headers: { "content-type": "text/event-stream" },
+    status: 200,
+  });
+};
+`,
+      "utf8",
+    );
+
+    try {
+      const result = await runCli({
+        cwd: workspaceRoot,
+        stateRoot: join(testRoot, "state"),
+        prompt: "Hello",
+        stdin: "",
+        env: {
+          ADAM_AGENT_MODEL: "deepseek-process-model",
+          NODE_OPTIONS: `--import=${fetchHookPath}`,
+        },
+      });
+
+      expect(result).toEqual({
+        stdout: "Selected deepseek-process-model.\n",
+        stderr: "",
+        exitCode: 0,
+        signal: null,
+      });
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+
   test("does not echo an unsupported provider value", async () => {
     const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-provider-invalid-"));
     const workspaceRoot = join(testRoot, "workspace");

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -19,6 +19,7 @@ import {
 } from "@adam-agent/agent";
 import { FakeModelDriver } from "@adam-agent/testkit";
 
+loadProjectEnvironment();
 const prompt = process.argv.slice(2).join(" ");
 const workspaceRoot = process.cwd();
 const { ADAM_AGENT_STATE_ROOT: configuredStateRoot } = process.env;
@@ -354,4 +355,15 @@ function selectModel(): ModelDriver {
 function failConfiguration(message: string): never {
   writeText(2, `${message}\n`);
   process.exit(1);
+}
+
+function loadProjectEnvironment(): void {
+  try {
+    process.loadEnvFile(join(process.cwd(), ".env"));
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return;
+    }
+    failConfiguration("Adam Agent could not load the project .env file.");
+  }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "quality:check": "pnpm code:check && pnpm markdown:check && pnpm typecheck && pnpm test",
     "quality:fix": "pnpm code:fix && pnpm markdown:fix",
     "test": "tsc -b && vitest run",
+    "test:live:deepseek": "node --env-file-if-exists=.env ./node_modules/vitest/vitest.mjs run packages/testkit/src/openai-compatible-model-driver.live.test.ts",
     "typecheck": "tsc -b --pretty false"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- load an optional project-root .env through the Node 24 built-in environment-file API
- preserve explicit process-environment precedence and the existing no-file fake-provider behavior
- add a tracked non-secret .env.example and document chmod 600 plus the remaining plaintext-local-file risks

## Verification

- pnpm quality:check
- 131 tests passed; 3 opt-in credentialed live tests skipped
- CLI subprocess tracer proves .env provider/key loading while an explicit process model value wins
- .env and .env.* are ignored; .env.example remains tracked

## Security boundary

The ignored .env is developer-owned plaintext input, not Adam-managed secret storage. Git ignore reduces accidental commits but does not protect against local processes, permissive file modes, or backups. No real credential is included.