### PR TITLE
Recommend DeepSeek V4 Flash when target is missing

### DIFF
--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -61,7 +61,7 @@ describe("one-shot CLI", () => {
       expect(result).toEqual({
         stdout: "",
         stderr:
-          "No model target selected. Set ADAM_AGENT_TARGET=deepseek-v4-pro.direct or ADAM_AGENT_TARGET=fake.local.\n",
+          "No model target selected. Set ADAM_AGENT_TARGET=deepseek-v4-flash.direct or ADAM_AGENT_TARGET=fake.local.\n",
         exitCode: 1,
         signal: null,
       });

--- a/packages/agent/src/model-targets.ts
+++ b/packages/agent/src/model-targets.ts
@@ -98,7 +98,7 @@ export function selectModelTargetId(
   }
   throw new ModelTargetError(
     "target_not_selected",
-    "No model target selected. Set ADAM_AGENT_TARGET=deepseek-v4-pro.direct or ADAM_AGENT_TARGET=fake.local.",
+    "No model target selected. Set ADAM_AGENT_TARGET=deepseek-v4-flash.direct or ADAM_AGENT_TARGET=fake.local.",
   );
 }
 

--- a/packages/testkit/src/model-targets.test.ts
+++ b/packages/testkit/src/model-targets.test.ts
@@ -904,7 +904,7 @@ test("credentials never imply a target when no explicit or legacy selector exist
       name: "ModelTargetError",
       code: "target_not_selected",
       message:
-        "No model target selected. Set ADAM_AGENT_TARGET=deepseek-v4-pro.direct or ADAM_AGENT_TARGET=fake.local.",
+        "No model target selected. Set ADAM_AGENT_TARGET=deepseek-v4-flash.direct or ADAM_AGENT_TARGET=fake.local.",
     }),
   );
 });


### PR DESCRIPTION
## Summary

- recommend `deepseek-v4-flash.direct` when no model target is selected
- keep the public selector and one-shot CLI expectations aligned
- leave target parsing, legacy compatibility, routing, and fallback behavior unchanged

## TDD evidence

- RED: focused `selectModelTargetId()` expectation failed against the previous Pro guidance
- GREEN: focused selector and real CLI process checks passed 2/2
- `pnpm quality:check`: 333 passed, 7 skipped
- `git diff --check`

No credentialed inference or Gateway request was performed.