### PR TITLE
Optimize structural Provider V4 stream parts

### DIFF
--- a/packages/agent/src/ai-sdk-model-driver.ts
+++ b/packages/agent/src/ai-sdk-model-driver.ts
@@ -96,6 +96,9 @@ export class AiSdkModelDriver implements ModelDriver {
       for await (const part of result.stream) {
         normalization.streamPartCount += 1;
         assertWithinLimit(normalization.streamPartCount, maximumStreamPartCount);
+        if (isIgnoredStructuralPart(part)) {
+          continue;
+        }
         const events = [...mapStreamPart(part, normalization)];
         if (part.type === "finish") {
           if (deadlineTimer !== undefined) {
@@ -133,6 +136,19 @@ export class AiSdkModelDriver implements ModelDriver {
       }
       request.signal.removeEventListener("abort", abortFromCaller);
     }
+  }
+}
+
+function isIgnoredStructuralPart(part: LanguageModelV4StreamPart): boolean {
+  switch (part.type) {
+    case "response-metadata":
+    case "text-start":
+    case "text-end":
+    case "reasoning-start":
+    case "reasoning-end":
+      return true;
+    default:
+      return false;
   }
 }
 


### PR DESCRIPTION
## Summary

- keep counting every low-level Provider V4 part before any mapping decision
- skip generator and array allocation for structural parts that produce no Adam event and do not reset inactivity
- preserve warning validation, progress semantics, byte/tool limits, and the exact 2,000,001-part rejection boundary

## Why

The B5.5b PR head passed hosted Quality, but the exact merge run exposed repeatable CPU contention: the 2,000,000-part tracer passed while a parallel real-Biome stdout test reached its pre-existing 20-second guard. The structural fast path halves the focused tracer runtime locally without weakening the boundary.

## Verification

- `pnpm quality:check` — 474 passed, 8 skipped
- focused 2,000,001-part tracer — passed in approximately 0.5 seconds of test time locally
