### PR TITLE
Stabilize Biome stdout limit enforcement

### DIFF
--- a/packages/agent/src/biome-execution.ts
+++ b/packages/agent/src/biome-execution.ts
@@ -136,7 +136,12 @@ async function runBiomeProcess(options: {
     let stderrBytes = 0;
     let failure: Error | undefined;
     let closed = false;
-    const terminate = () => signalProcessGroup(child.pid, "SIGKILL");
+    const terminate = () => {
+      signalProcessGroup(child.pid, "SIGKILL");
+      if (!child.killed) {
+        child.kill("SIGKILL");
+      }
+    };
     const fail = (error: Error) => {
       failure ??= error;
       terminate();

--- a/packages/testkit/src/extension-capabilities.test.ts
+++ b/packages/testkit/src/extension-capabilities.test.ts
@@ -1528,12 +1528,12 @@ async function writeNoisyBiomeExtension(packageRoot: string): Promise<void> {
     "adam.analyzer-execution.biome@1",
     `const biome = operation.capabilities["adam.analyzer-execution.biome@1"];
       const content = Array.from(
-        { length: 4500 },
+        { length: 3000 },
         (_, index) => \`export const value\${index} = candidate == \${index};\`,
       ).join("\\n");
       const analysis = await biome.analyze({
         profile: "adam-biome-recommended-v1",
-        files: [{ path: "src/noisy.ts", content }],
+        files: [{ path: "src/" + "n".repeat(120) + ".ts", content }],
       });
       return { analysis };`,
   );


### PR DESCRIPTION
## Summary

- terminate both the detached Biome process group and the directly tracked child when execution fails
- keep the real-Biome stdout-limit test above 1 MiB with fewer diagnostics and a longer valid path
- reduce CI contention sensitivity without increasing the test timeout

## Verification

- `pnpm quality:check`
- 17 test files passed, 1 skipped; 474 tests passed, 8 skipped
- focused stdout-limit and cancellation tests passed