### PR TITLE
Replace wall-clock test synchronization with causal signals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ Build a lightweight, inspectable local coding agent. Make the core coding path r
 - Before writing a behavior test, name the public interface and observable result under test. Work one failing behavior test and the minimum implementation to pass it at a time.
 - Do not pre-write a horizontal test suite, test private internals, or mock Adam-owned modules. Fake external providers, clocks, processes, filesystems, MCP servers, and Web sources only at their real seams.
 - Test through module interfaces and observable runtime events rather than private implementation state.
+- Synchronize concurrent and process tests on causal observables such as events, IPC, filesystem notifications, stream output, or child closure. Never use polling intervals, arbitrary sleeps, elapsed-time assertions, or wait-then-assert-absence as success criteria; timeouts are failure and cleanup guards only.
+- Test deadline and backoff policy with a fake clock. Use real time only when timer or OS-process integration is itself under test and no causal fake-clock seam exists; block fixtures on events or open streams instead of finite sleeps.
 - Use deterministic provider streams for tool ordering, rejection, cancellation, malformed output, compaction, and retry tests.
 - Add real-process tests for shell cancellation, MCP lifecycle, path confinement, and signal handling when the corresponding adapters exist.
 - Add PTY or real-terminal coverage for resize, bracketed paste, wide-character input, permission prompts, interrupt, and cleanup when the interactive terminal exists.

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -1,8 +1,18 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, open, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  open,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  watch,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -462,23 +472,17 @@ describe("one-shot CLI", () => {
         stdinPath: join(testRoot, "stdin"),
       });
 
-      expect({
-        ...result,
-        survived: await readFile(join(workspaceRoot, "survived.txt"), "utf8").catch(
-          () => undefined,
-        ),
-      }).toEqual({
+      expect(result).toEqual({
         stdout: "",
         stderr:
-          'Allow run_shell at ".": "trap \'\' TERM; printf started > started.txt; sleep 5; printf survived > survived.txt" [y/N] The session was cancelled.\n',
+          'Allow run_shell at ".": "trap \'\' TERM; printf started > started.txt; tail -f /dev/null" [y/N] The session was cancelled.\n',
         exitCode: 130,
         signal: null,
-        survived: undefined,
       });
     } finally {
       await rm(testRoot, { recursive: true, force: true });
     }
-  });
+  }, 15_000);
 
   test("edits, verifies, and persists one approved coding task", async () => {
     const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-coding-task-"));
@@ -1201,16 +1205,41 @@ function cliEnvironment(
 }
 
 async function waitForFile(path: string): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    if (
-      await readFile(path).then(
-        () => true,
-        () => false,
-      )
-    ) {
+  const controller = new AbortController();
+  const guard = setTimeout(() => controller.abort(), 10_000);
+  const changes = watch(dirname(path), { signal: controller.signal });
+  try {
+    if (await pathExists(path)) {
       return;
     }
-    await new Promise((resolvePromise) => setTimeout(resolvePromise, 5));
+    for await (const _change of changes) {
+      if (await pathExists(path)) {
+        return;
+      }
+    }
+  } catch (error) {
+    if (!controller.signal.aborted) {
+      throw error;
+    }
+  } finally {
+    clearTimeout(guard);
+    controller.abort();
   }
   throw new Error(`Timed out waiting for ${path}`);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
 }

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -47,8 +47,7 @@ const verificationCommand = "printf cli-verified";
 const promptEscapingPrompt = "Run the prompt escaping command";
 const promptEscapingCommand = "printf first\n\u001b[31m\u202ecommand\u009b\u2028forged";
 const longVerificationPrompt = "Run the long repository verification command";
-const longVerificationCommand =
-  "trap '' TERM; printf started > started.txt; sleep 5; printf survived > survived.txt";
+const longVerificationCommand = "trap '' TERM; printf started > started.txt; tail -f /dev/null";
 const codingTaskPrompt = "Update the demo file and verify it";
 const multiFilePatchPrompt = "Apply the demo multi-file patch";
 const truncatedAnswerPrompt = "Return a deliberately truncated answer";

--- a/packages/testkit/src/extension-capabilities.test.ts
+++ b/packages/testkit/src/extension-capabilities.test.ts
@@ -1528,12 +1528,15 @@ async function writeNoisyBiomeExtension(packageRoot: string): Promise<void> {
     "adam.analyzer-execution.biome@1",
     `const biome = operation.capabilities["adam.analyzer-execution.biome@1"];
       const content = Array.from(
-        { length: 3000 },
+        { length: 2000 },
         (_, index) => \`export const value\${index} = candidate == \${index};\`,
       ).join("\\n");
       const analysis = await biome.analyze({
         profile: "adam-biome-recommended-v1",
-        files: [{ path: "src/" + "n".repeat(120) + ".ts", content }],
+        files: [{
+          path: ["src", "a".repeat(120), "b".repeat(120), "n".repeat(120) + ".ts"].join("/"),
+          content,
+        }],
       });
       return { analysis };`,
   );
@@ -1671,13 +1674,20 @@ async function findChildWithWorkingDirectory(expected: string): Promise<number |
 }
 
 async function waitForValue<T>(read: () => Promise<T | undefined>, message: string): Promise<T> {
-  const deadline = Date.now() + 5_000;
-  while (Date.now() < deadline) {
-    const value = await read();
-    if (value !== undefined) {
-      return value;
+  let guardExpired = false;
+  const guard = setTimeout(() => {
+    guardExpired = true;
+  }, 10_000);
+  try {
+    while (!guardExpired) {
+      const value = await read();
+      if (value !== undefined) {
+        return value;
+      }
+      await new Promise<void>((resolve) => setImmediate(resolve));
     }
-    await new Promise<void>((resolve) => setImmediate(resolve));
+  } finally {
+    clearTimeout(guard);
   }
   throw new Error(message);
 }

--- a/packages/testkit/src/operation-host.test.ts
+++ b/packages/testkit/src/operation-host.test.ts
@@ -9,7 +9,7 @@ import {
   createJsonlOperationStore,
   type OperationStore,
 } from "@adam-agent/agent";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 
 test("ExtensionHost starts one durable operation and reuses it for the same idempotent input", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-operation-host-"));
@@ -518,9 +518,16 @@ test("ExtensionHost settles a progress persistence failure without waiting for t
 });
 
 test("ExtensionHost reports recovery-required when terminal persistence fails", async () => {
+  vi.useFakeTimers();
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-operation-terminal-persistence-"));
   const workspaceRoot = join(testRoot, "workspace");
   const packageRoot = join(testRoot, "extension");
+  const executeEnteredKey = `__adamOperationTerminalExecute${Date.now()}${Math.random()}`;
+  let signalExecuteEntered = (): void => undefined;
+  const executeEntered = new Promise<void>((resolve) => {
+    signalExecuteEntered = resolve;
+  });
+  (globalThis as Record<string, unknown>)[executeEnteredKey] = signalExecuteEntered;
   const durableStore = createInMemoryOperationStore();
   const store: OperationStore = {
     append(record) {
@@ -535,7 +542,10 @@ test("ExtensionHost reports recovery-required when terminal persistence fails", 
 
   try {
     await mkdir(workspaceRoot);
-    await writeOperationExtension(packageRoot, "await new Promise(() => {});");
+    await writeOperationExtension(
+      packageRoot,
+      `globalThis[${JSON.stringify(executeEnteredKey)}](); await new Promise(() => {});`,
+    );
     const host = createExtensionHost({
       capabilities: [],
       extensions: [
@@ -559,6 +569,8 @@ test("ExtensionHost reports recovery-required when terminal persistence fails", 
       idempotencyKey: "review-terminal-persistence-1",
       input: { revision: "recovery" },
     });
+    await executeEntered;
+    await vi.advanceTimersByTimeAsync(1);
     const records = [];
     for await (const record of host.operations.events({ operationId: started.operationId })) {
       records.push(record);
@@ -570,6 +582,8 @@ test("ExtensionHost reports recovery-required when terminal persistence fails", 
       status: "recovery_required",
     });
   } finally {
+    vi.useRealTimers();
+    delete (globalThis as Record<string, unknown>)[executeEnteredKey];
     await rm(testRoot, { recursive: true, force: true });
   }
 });
@@ -1358,11 +1372,21 @@ test.each([
 );
 
 test("ExtensionHost bounds an uncooperative reconciliation hook", async () => {
+  vi.useFakeTimers();
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-operation-recovery-deadline-"));
   const workspaceRoot = join(testRoot, "workspace");
   const packageRoot = join(testRoot, "extension");
   const controlKey = `__adamOperationRecoveryDeadline${Date.now()}${Math.random()}`;
-  const control = { executeCalls: 0, hangReconcile: true, reconcileCalls: 0 };
+  let signalReconcileEntered = (): void => undefined;
+  const reconcileEntered = new Promise<void>((resolve) => {
+    signalReconcileEntered = resolve;
+  });
+  const control = {
+    executeCalls: 0,
+    hangReconcile: true,
+    reconcileCalls: 0,
+    reconcileEntered: signalReconcileEntered,
+  };
   (globalThis as Record<string, unknown>)[controlKey] = control;
 
   try {
@@ -1416,19 +1440,24 @@ test("ExtensionHost bounds an uncooperative reconciliation hook", async () => {
     });
     await recoveredHost.loadConfiguredExtensions();
 
-    await expect(recoveredHost.operations.recover(started.operationId)).rejects.toMatchObject({
+    const recovery = recoveredHost.operations.recover(started.operationId);
+    const recoveryExpectation = expect(recovery).rejects.toMatchObject({
       code: "operation_reconciliation_failed",
       name: "OperationHostError",
     });
+    await reconcileEntered;
+    await vi.advanceTimersByTimeAsync(10);
+    await recoveryExpectation;
     expect(control).toMatchObject({ executeCalls: 1, reconcileCalls: 1 });
     expect(
       (await durableStore.read(started.operationId)).map((record) => record.event.type),
     ).toEqual(["operation_started", "operation_reconciliation_started"]);
   } finally {
+    vi.useRealTimers();
     delete (globalThis as Record<string, unknown>)[controlKey];
     await rm(testRoot, { recursive: true, force: true });
   }
-}, 1_000);
+});
 
 test("ExtensionHost rereads a durable recovery terminal after an ambiguous append failure", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-operation-recovery-ambiguous-"));
@@ -2012,15 +2041,23 @@ test("ExtensionHost persists one idempotent cancel request and one cancelled ter
 });
 
 test("ExtensionHost enforces a caller-tightened deadline as one failed terminal fact", async () => {
+  vi.useFakeTimers();
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-operation-deadline-"));
   const workspaceRoot = join(testRoot, "workspace");
   const packageRoot = join(testRoot, "extension");
+  const executeEnteredKey = `__adamOperationDeadlineExecute${Date.now()}${Math.random()}`;
+  let signalExecuteEntered = (): void => undefined;
+  const executeEntered = new Promise<void>((resolve) => {
+    signalExecuteEntered = resolve;
+  });
+  (globalThis as Record<string, unknown>)[executeEnteredKey] = signalExecuteEntered;
 
   try {
     await mkdir(workspaceRoot);
     await writeOperationExtension(
       packageRoot,
-      `if (!context.signal.aborted) {
+      `globalThis[${JSON.stringify(executeEnteredKey)}]();
+      if (!context.signal.aborted) {
         await new Promise((resolve) => context.signal.addEventListener("abort", resolve, { once: true }));
       }
       return { accepted: true, revision: input.revision };`,
@@ -2048,6 +2085,8 @@ test("ExtensionHost enforces a caller-tightened deadline as one failed terminal 
       idempotencyKey: "review-deadline-1",
       input: { revision: "mno345" },
     });
+    await executeEntered;
+    await vi.advanceTimersByTimeAsync(1);
     const records = [];
     for await (const record of host.operations.events({ operationId: started.operationId })) {
       records.push(record);
@@ -2061,6 +2100,8 @@ test("ExtensionHost enforces a caller-tightened deadline as one failed terminal 
       },
     });
   } finally {
+    vi.useRealTimers();
+    delete (globalThis as Record<string, unknown>)[executeEnteredKey];
     await rm(testRoot, { recursive: true, force: true });
   }
 });
@@ -2492,13 +2533,23 @@ test("ExtensionHost disables new work but reports a non-settling active operatio
 });
 
 test("ExtensionHost retains a deadline-failed extension while its handler is still running", async () => {
+  vi.useFakeTimers();
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-operation-disable-deadline-"));
   const workspaceRoot = join(testRoot, "workspace");
   const packageRoot = join(testRoot, "extension");
+  const executeEnteredKey = `__adamOperationDisableExecute${Date.now()}${Math.random()}`;
+  let signalExecuteEntered = (): void => undefined;
+  const executeEntered = new Promise<void>((resolve) => {
+    signalExecuteEntered = resolve;
+  });
+  (globalThis as Record<string, unknown>)[executeEnteredKey] = signalExecuteEntered;
 
   try {
     await mkdir(workspaceRoot);
-    await writeOperationExtension(packageRoot, "await new Promise(() => {});");
+    await writeOperationExtension(
+      packageRoot,
+      `globalThis[${JSON.stringify(executeEnteredKey)}](); await new Promise(() => {});`,
+    );
     const host = createExtensionHost({
       capabilities: [],
       extensions: [
@@ -2523,11 +2574,15 @@ test("ExtensionHost retains a deadline-failed extension while its handler is sti
       idempotencyKey: "review-disable-deadline-1",
       input: { revision: "deadline-pending" },
     });
+    await executeEntered;
+    await vi.advanceTimersByTimeAsync(1);
     for await (const _record of host.operations.events({ operationId: started.operationId })) {
       // The durable deadline terminal fact is the synchronization point.
     }
 
-    await expect(host.disableExtension("fixture.extension")).resolves.toMatchObject({
+    vi.useRealTimers();
+    const disabling = host.disableExtension("fixture.extension");
+    await expect(disabling).resolves.toMatchObject({
       extensionId: "fixture.extension",
       status: "disabled_with_pending_operations",
     });
@@ -2536,6 +2591,8 @@ test("ExtensionHost retains a deadline-failed extension while its handler is sti
       status: "failed",
     });
   } finally {
+    vi.useRealTimers();
+    delete (globalThis as Record<string, unknown>)[executeEnteredKey];
     await rm(testRoot, { recursive: true, force: true });
   }
 });
@@ -3100,6 +3157,7 @@ async function writeGrantSensitiveRecoveryExtension(
     reconcile(input) {
       const control = globalThis[${JSON.stringify(controlKey)}];
       control.reconcileCalls += 1;
+      control.reconcileEntered?.();
       if (control.hangReconcile === true) {
         return new Promise(() => {});
       }

--- a/packages/testkit/src/shell-session.test.ts
+++ b/packages/testkit/src/shell-session.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
-import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, stat, watch, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import {
   AgentSession,
@@ -364,8 +364,7 @@ test("a shell process that cannot start returns a typed failure", async () => {
 
 test("a timed-out shell command cannot outlive the process-group termination grace", async () => {
   const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-shell-timeout-"));
-  const command =
-    "printf 'before timeout\\n'; trap '' TERM; sleep 0.4; printf survived > survived.txt";
+  const command = "printf 'before timeout\\n'; trap '' TERM; tail -f /dev/null";
 
   try {
     const model = new FakeModelDriver((request) => {
@@ -405,13 +404,7 @@ test("a timed-out shell command cannot outlive the process-group termination gra
 
     const result = await session.run({ text: "Run a command with a short timeout" });
 
-    expect({
-      result,
-      survived: await readFile(join(workspaceRoot, "survived.txt"), "utf8").catch(() => undefined),
-    }).toEqual({
-      result: { status: "completed", answer: "The command timed out." },
-      survived: undefined,
-    });
+    expect(result).toEqual({ status: "completed", answer: "The command timed out." });
   } finally {
     await rm(workspaceRoot, { recursive: true, force: true });
   }
@@ -419,8 +412,7 @@ test("a timed-out shell command cannot outlive the process-group termination gra
 
 test("timeout cleanup kills a detached descendant after the shell leader exits", async () => {
   const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-shell-descendant-timeout-"));
-  const command =
-    '(trap "" TERM; sleep 0.5; printf survived > survived.txt) </dev/null >/dev/null 2>/dev/null & wait';
+  const command = '(trap "" TERM; tail -f /dev/null) & wait';
 
   try {
     const model = new FakeModelDriver((request) => {
@@ -449,15 +441,11 @@ test("timeout cleanup kills a detached descendant after the shell leader exits",
       store: createInMemorySessionStore(),
     });
 
-    const result = await session.run({ text: "Time out a shell with a detached descendant" });
-    await new Promise((resolvePromise) => setTimeout(resolvePromise, 650));
-
-    expect({
-      result,
-      survived: await readFile(join(workspaceRoot, "survived.txt"), "utf8").catch(() => undefined),
-    }).toEqual({
-      result: { status: "completed", answer: "The descendant process was cleaned up." },
-      survived: undefined,
+    await expect(
+      session.run({ text: "Time out a shell with a detached descendant" }),
+    ).resolves.toEqual({
+      status: "completed",
+      answer: "The descendant process was cleaned up.",
     });
   } finally {
     await rm(workspaceRoot, { recursive: true, force: true });
@@ -467,7 +455,7 @@ test("timeout cleanup kills a detached descendant after the shell leader exits",
 test("the first timeout remains the shell outcome when caller cancellation races afterward", async () => {
   const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-shell-timeout-race-"));
   const store = createInMemorySessionStore();
-  const command = "trap 'printf timeout > timeout.txt' TERM; while :; do sleep 1; done";
+  const command = "trap 'printf timeout > timeout.txt' TERM; tail -f /dev/null";
 
   try {
     const model = new FakeModelDriver((request) => {
@@ -519,13 +507,12 @@ test("the first timeout remains the shell outcome when caller cancellation races
   } finally {
     await rm(workspaceRoot, { recursive: true, force: true });
   }
-});
+}, 15_000);
 
 test("aborting an active shell command records interruption and removes its process group", async () => {
   const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-shell-abort-"));
   const store = createInMemorySessionStore();
-  const command =
-    "trap '' TERM; printf started > started.txt; sleep 0.4; printf survived > survived.txt";
+  const command = "trap '' TERM; printf started > started.txt; tail -f /dev/null";
 
   try {
     const model = new FakeModelDriver((request) => {
@@ -569,7 +556,6 @@ test("aborting an active shell command records interruption and removes its proc
     expect({
       result,
       termination: jsonProperty(completedOutput, "termination"),
-      survived: await readFile(join(workspaceRoot, "survived.txt"), "utf8").catch(() => undefined),
       terminalEvents: persisted.filter(
         (event) => event.type === "session_interrupted" || event.type === "session_settled",
       ),
@@ -579,7 +565,6 @@ test("aborting an active shell command records interruption and removes its proc
         error: { code: "session_cancelled", message: "The session was cancelled." },
       },
       termination: { type: "interrupted" },
-      survived: undefined,
       terminalEvents: [
         { type: "session_interrupted", reason: "cancelled" },
         {
@@ -594,7 +579,7 @@ test("aborting an active shell command records interruption and removes its proc
   } finally {
     await rm(workspaceRoot, { recursive: true, force: true });
   }
-});
+}, 15_000);
 
 test("overflowing shell output is durably referenced before its bounded result is persisted", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-shell-artifact-"));
@@ -956,16 +941,41 @@ function jsonProperty(object: Record<string, unknown>, name: string): unknown {
 }
 
 async function waitForFile(path: string): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    if (
-      await readFile(path).then(
-        () => true,
-        () => false,
-      )
-    ) {
+  const controller = new AbortController();
+  const guard = setTimeout(() => controller.abort(), 10_000);
+  const changes = watch(dirname(path), { signal: controller.signal });
+  try {
+    if (await pathExists(path)) {
       return;
     }
-    await new Promise((resolvePromise) => setTimeout(resolvePromise, 5));
+    for await (const _change of changes) {
+      if (await pathExists(path)) {
+        return;
+      }
+    }
+  } catch (error) {
+    if (!controller.signal.aborted) {
+      throw error;
+    }
+  } finally {
+    clearTimeout(guard);
+    controller.abort();
   }
   throw new Error(`Timed out waiting for ${path}`);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
 }


### PR DESCRIPTION
## Root cause

The main-only failures were test-harness defects. Concurrent CI work delayed process startup beyond a fixed 500 ms polling window, and earlier coverage also used finite sleeps and wait-then-assert-absence checks. Those mechanisms measured runner scheduling rather than Adam behavior.

## Changes

- replace fixed file polling with filesystem notifications and state checks
- replace finite shell sleeps and delayed negative assertions with open-stream/process-closure evidence
- drive operation deadlines with fake timers after explicit handler-entry signals
- keep the real Biome stdout-limit integration above 1 MiB while reducing diagnostic work
- record the causal-synchronization rule in product `AGENTS.md`

## Audit result

Ordinary tests contain no finite `sleep`, fixed polling loop, elapsed-time assertion, or wait-then-assert-absence success criterion. Remaining timeouts are failure/cleanup guards or behavior-essential real process timer coverage.

## Verification

- focused concurrency/process suite: 112 passed
- `pnpm quality:check`: 17 files passed, 1 skipped; 474 tests passed, 8 skipped