### PR TITLE
feat(tui): add minimum complete B9 TUI

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,51 @@
+# Third-Party Notices
+
+## `@earendil-works/pi-tui` 0.84.2
+
+Adam Agent uses the terminal mechanics package
+[`@earendil-works/pi-tui`](https://github.com/earendil-works/pi/tree/914cf1472e715297caa30db4b9535d534a9eb718/packages/tui),
+licensed under the MIT License.
+
+Copyright (c) Mario Zechner and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## `pi-catppuccin` Catppuccin Mocha theme
+
+Adam Agent's semantic terminal palette is adapted from
+[`sherif-fanous/pi-catppuccin`](https://github.com/sherif-fanous/pi-catppuccin/tree/cd09277df06621155d9c4c20e45309bce5341779),
+licensed under the MIT License.
+
+Copyright (c) Sherif Fanous and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@adam-agent/tui",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "adam-agent-tui": "./dist/main.js"
+  },
+  "dependencies": {
+    "@adam-agent/agent": "workspace:*",
+    "@adam-agent/presentation": "workspace:*",
+    "@earendil-works/pi-tui": "0.84.2"
+  }
+}

--- a/apps/tui/src/exit-policy.ts
+++ b/apps/tui/src/exit-policy.ts
@@ -1,0 +1,115 @@
+export type DeadlineHandle = { cancel(): void };
+
+export type DeadlineScheduler = {
+  schedule(delayMilliseconds: number, onDeadline: () => void): DeadlineHandle;
+};
+
+export type ClipboardAdapter = {
+  writeText(text: string): Promise<"copied" | "failed" | "unsupported">;
+};
+
+export const nodeDeadlineScheduler: DeadlineScheduler = {
+  schedule(delayMilliseconds, onDeadline) {
+    const timer = setTimeout(onDeadline, delayMilliseconds);
+    timer.unref();
+    return { cancel: () => clearTimeout(timer) };
+  },
+};
+
+export class ExitArm {
+  #armed = false;
+  #deadline: DeadlineHandle | undefined;
+  readonly #onExpired: () => void;
+  readonly #scheduler: DeadlineScheduler;
+
+  constructor(scheduler: DeadlineScheduler, onExpired: () => void) {
+    this.#scheduler = scheduler;
+    this.#onExpired = onExpired;
+  }
+
+  get armed(): boolean {
+    return this.#armed;
+  }
+
+  press(): "armed" | "confirmed" {
+    if (this.#armed) {
+      this.reset();
+      return "confirmed";
+    }
+    this.#armed = true;
+    this.#deadline = this.#scheduler.schedule(2_000, () => {
+      this.#armed = false;
+      this.#deadline = undefined;
+      this.#onExpired();
+    });
+    return "armed";
+  }
+
+  reset(): boolean {
+    const wasArmed = this.#armed;
+    this.#armed = false;
+    this.#deadline?.cancel();
+    this.#deadline = undefined;
+    return wasArmed;
+  }
+}
+
+export class LegacyDuplicateGuard {
+  #deadline: DeadlineHandle | undefined;
+  readonly #scheduler: DeadlineScheduler;
+
+  constructor(scheduler: DeadlineScheduler) {
+    this.#scheduler = scheduler;
+  }
+
+  admit(): boolean {
+    if (this.#deadline !== undefined) {
+      return false;
+    }
+    this.#deadline = this.#scheduler.schedule(50, () => {
+      this.#deadline = undefined;
+    });
+    return true;
+  }
+
+  reset(): void {
+    this.#deadline?.cancel();
+    this.#deadline = undefined;
+  }
+}
+
+export async function copyDraftToClipboard(
+  draft: string,
+  adapter: ClipboardAdapter | undefined,
+  scheduler: DeadlineScheduler,
+): Promise<"copied" | "failed" | "unsupported" | null> {
+  const text = boundedUtf8(draft, 64 * 1024);
+  if (text.length === 0) {
+    return null;
+  }
+  if (adapter === undefined) {
+    return "unsupported";
+  }
+  let guard: DeadlineHandle | undefined;
+  try {
+    return await Promise.race([
+      adapter.writeText(text).catch(() => "failed" as const),
+      new Promise<"failed">((resolve) => {
+        guard = scheduler.schedule(250, () => resolve("failed"));
+      }),
+    ]);
+  } finally {
+    guard?.cancel();
+  }
+}
+
+function boundedUtf8(value: string, maximumBytes: number): string {
+  let result = "";
+  for (const character of value) {
+    if (Buffer.byteLength(result + character, "utf8") > maximumBytes) {
+      break;
+    }
+    result += character;
+  }
+  return result;
+}

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -1,0 +1,747 @@
+import { spawn } from "node:child_process";
+import { access, mkdir, mkdtemp, readFile, rm as remove, watch, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, expect, test } from "vitest";
+
+const fixturePath = fileURLToPath(new URL("../dist/test-fixture.js", import.meta.url));
+const productionPath = fileURLToPath(new URL("../dist/main.js", import.meta.url));
+const fixtureFailureMilliseconds = 30_000;
+const activeFixtures = new Set<Fixture>();
+
+afterEach(async () => {
+  await cleanupActiveFixtures();
+});
+
+test("real TUI starts on an authoritative empty session and restores the terminal on exit", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-startup-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain("Adam · New session");
+    expect(result.stdout).toContain("fake.local · Certified");
+    expect(result.stdout).toContain("\u001b[?2004h");
+    expect(result.stdout).toContain("\u001b[?2004l");
+    expect(result.stdout).toContain("\u001b[?2026h");
+    expect(result.stdout).toContain("\u001b[?2026l");
+    expect(result.stdout).toContain("\u001b[?25h");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI entry exposes its usage contract", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-help-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      program: { arguments: ["--help"], cwd: workspaceRoot, entrypoint: productionPath },
+      stateRoot,
+      workspaceRoot,
+    });
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain(
+      "Usage: adam-agent-tui [--target <exact-target-id> | --resume <session-id>]",
+    );
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI entry rejects conflicting target and resume arguments", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-invalid-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      program: {
+        arguments: [
+          "--resume",
+          "session-id",
+          "--target",
+          "deepseek-v4-flash.direct",
+          "--state-root",
+          stateRoot,
+        ],
+        cwd: workspaceRoot,
+        entrypoint: productionPath,
+      },
+      stateRoot,
+      workspaceRoot,
+    });
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 1, signal: null, stderr: "" });
+    expect(result.stdout).toContain("--resume and --target cannot be combined.");
+    expect(result.stdout).toContain("Usage: adam-agent-tui");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI entry reaches a credentialed exact-target session without a model call", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-startup-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      program: {
+        arguments: ["--target", "deepseek-v4-flash.direct", "--state-root", stateRoot],
+        cwd: workspaceRoot,
+        entrypoint: productionPath,
+        environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
+      },
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    await fixture.waitFor("deepseek-v4-flash.direct · Certified");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("editor submission renders Working then a streamed Markdown answer from real Presentation truth", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-streaming-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "streaming",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Explain streaming\r");
+    await fixture.waitFor("Explain streaming");
+    await fixture.waitFor("Working");
+    await writeFile(join(controlRoot, "release-model"), "release\n", "utf8");
+    await fixture.waitFor("Streaming answer");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain("\u001b[48;2;49;50;68m");
+    expect(result.stdout).toContain("\u001b[38;2;243;139;168m");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a real read tool is rendered as a bounded Pi-style tool card", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-read-tool-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "README.md"), "# Fixture\n\nReadable content.\n", "utf8");
+
+  try {
+    const fixture = startFixture({ scenario: "read", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Read README\r");
+    await fixture.waitFor("read README.md");
+    await fixture.waitFor("29 bytes");
+    await fixture.waitFor("Read complete");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a shell tool card uses the accepted dollar-command grammar", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-shell-card-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ scenario: "shell", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Show shell card\r");
+    await fixture.waitFor("$ printf shell-card-fixture");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a mutation permission shows its canonical diff and Enter allows the exact call", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-mutation-permission-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "edit.txt"), "before\n", "utf8");
+
+  try {
+    const fixture = startFixture({ scenario: "mutation", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Edit the file\r");
+    await fixture.waitFor("Permission required");
+    await fixture.waitFor("-before");
+    await fixture.waitFor("+after");
+    fixture.write("\r");
+    await fixture.waitFor("Edit complete");
+    await expect(readFile(join(workspaceRoot, "edit.txt"), "utf8")).resolves.toBe("after\n");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("Enter cannot allow a mutation while its canonical preview is still loading", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-preview-loading-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+  await writeFile(join(workspaceRoot, "edit.txt"), "before\n", "utf8");
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "mutation-delayed-preview",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Edit before preview\r");
+    await fixture.waitFor("Loading canonical preview");
+    await fixture.waitFor("Allow unavailable");
+    fixture.write("\r");
+    await writeFile(join(controlRoot, "release-preview"), "release\n", "utf8");
+    await waitForPath(join(controlRoot, "preview-read-complete"));
+    await fixture.waitFor("denied");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    await expect(readFile(join(workspaceRoot, "edit.txt"), "utf8")).resolves.toBe("before\n");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("Ctrl+C cancels one active run and repeated input cannot arm exit while settling", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-cancel-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ scenario: "cancellation", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Cancel this run\r");
+    await fixture.waitFor("Working");
+    fixture.write("\u0003\u0003");
+    await fixture.waitFor("cancelled");
+    expect(fixture.output()).not.toContain("Press Ctrl+C again");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("idle Ctrl+C preserves a CJK draft and copies it only on the confirming press", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-retained-draft-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+  const draft = "保留草稿 🚀";
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "clipboard-success",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write(draft);
+    await fixture.waitFor(draft);
+    fixture.write("\u001b[99;5:1u");
+    await fixture.waitFor("Press Ctrl+C again within two seconds to exit · draft will be copied");
+    expect(fixture.output()).not.toContain("clipboard copied");
+    fixture.write("\u0003");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe(draft);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("Kitty Ctrl+C repeat and release phases cannot confirm an armed exit", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-kitty-phases-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "clipboard-success",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("草稿");
+    await fixture.waitFor("草稿");
+    fixture.write("\u001b[99;5:1u");
+    await fixture.waitFor("Press Ctrl+C again within two seconds to exit");
+    fixture.write("\u001b[99;5:2u\u001b[99;5:3ux");
+    await fixture.waitFor("草稿x");
+    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe("草稿x");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the injected deadline causally expires an idle Ctrl+C exit arm", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-exit-expiry-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({ controlRoot, scenario: "deadline", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("\u001b[99;5:1u");
+    await fixture.waitFor("Press Ctrl+C again within two seconds to exit");
+    await waitForPath(join(controlRoot, "scheduled-deadline-2000-1"));
+    const armedOutputEnd = fixture.output().length;
+    await writeFile(join(controlRoot, "deadline-2000-1"), "expire\n", "utf8");
+    await fixture.waitForAfter("fake.local · Certified", armedOutputEnd);
+    const expiredOutputEnd = fixture.output().length;
+    fixture.write("\u001b[99;5:1u");
+    await fixture.waitForAfter("Press Ctrl+C again within two seconds to exit", expiredOutputEnd);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the legacy duplicate guard consumes one immediate Ctrl+C duplicate", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-legacy-duplicate-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({ controlRoot, scenario: "deadline", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("保留");
+    await fixture.waitFor("保留");
+    fixture.write("\u0003\u0003");
+    await fixture.waitFor("Press Ctrl+C again within two seconds to exit");
+    await waitForPath(join(controlRoot, "scheduled-deadline-50-1"));
+    await writeFile(join(controlRoot, "deadline-50-1"), "expire\n", "utf8");
+    fixture.write("x");
+    await fixture.waitFor("保留x");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a pending clipboard adapter fails closed from the injected deadline", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-clipboard-timeout-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "clipboard-timeout",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("保留超时草稿");
+    await fixture.waitFor("保留超时草稿");
+    fixture.write("\u0011");
+    await waitForPath(join(controlRoot, "clipboard-started"));
+    await waitForPath(join(controlRoot, "scheduled-deadline-250-1"));
+    await writeFile(join(controlRoot, "deadline-250-1"), "expire\n", "utf8");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain("Clipboard copy failed; draft was not copied.");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("unsupported clipboard is reported after terminal restoration without blocking exit", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-clipboard-unsupported-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("draft without clipboard");
+    await fixture.waitFor("draft without clipboard");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain("Clipboard unavailable; draft was not copied.");
+    expect(result.stdout.indexOf("\u001b[?2004l")).toBeLessThan(
+      result.stdout.indexOf("Clipboard unavailable; draft was not copied."),
+    );
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a restarted TUI resumes an existing authoritative transcript", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-resume-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ scenario: "resume", stateRoot, workspaceRoot });
+    await fixture.waitFor("Resume transcript");
+    await fixture.waitFor("Previous answer");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("untrusted model terminal controls are rendered as inert text", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-terminal-controls-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      noColor: true,
+      scenario: "unsafe-output",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Render unsafe output\r");
+    await fixture.waitFor("Visible");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).not.toContain("\u001b]52;c;YXR0YWNr\u0007");
+    expect(result.stdout).not.toContain("\u001b[2Janswer");
+    expect(result.stdout).not.toContain("\u001b[38;2;");
+    expect(result.stdout).not.toContain("\u001b[48;2;");
+    expect(result.stdout).toContain("› Render unsafe output");
+    expect(result.stdout).toContain("Visible answer.");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+type FixtureResult = {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stderr: string;
+  readonly stdout: string;
+};
+
+type Fixture = {
+  readonly cleanup: () => Promise<void>;
+  readonly closed: Promise<FixtureResult>;
+  readonly output: () => string;
+  readonly waitFor: (text: string) => Promise<void>;
+  readonly waitForAfter: (text: string, offset: number) => Promise<void>;
+  readonly write: (text: string) => void;
+};
+
+function startFixture(input: {
+  readonly controlRoot?: string;
+  readonly noColor?: boolean;
+  readonly program?: {
+    readonly arguments: readonly string[];
+    readonly cwd: string;
+    readonly entrypoint: string;
+    readonly environment?: Readonly<Record<string, string>>;
+  };
+  readonly scenario?:
+    | "cancellation"
+    | "clipboard-timeout"
+    | "clipboard-success"
+    | "deadline"
+    | "mutation"
+    | "mutation-delayed-preview"
+    | "read"
+    | "resume"
+    | "shell"
+    | "streaming"
+    | "unsafe-output";
+  readonly stateRoot: string;
+  readonly workspaceRoot: string;
+}): Fixture {
+  const arguments_ =
+    input.program === undefined
+      ? [
+          process.execPath,
+          fixturePath,
+          "--state-root",
+          input.stateRoot,
+          "--workspace-root",
+          input.workspaceRoot,
+          ...(input.controlRoot === undefined ? [] : ["--control-root", input.controlRoot]),
+          ...(input.scenario === undefined ? [] : ["--scenario", input.scenario]),
+        ]
+      : [process.execPath, input.program.entrypoint, ...input.program.arguments];
+  const command = arguments_.map(shellQuote).join(" ");
+  const { NO_COLOR: _noColor, ...environment } = process.env;
+  const child = spawn("script", ["-qfec", command, "/dev/null"], {
+    ...(input.program === undefined ? {} : { cwd: input.program.cwd }),
+    detached: true,
+    env: {
+      ...environment,
+      ...input.program?.environment,
+      ...(input.noColor === true ? { NO_COLOR: "1" } : {}),
+      TERM: "xterm-256color",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  let stdout = "";
+  let stderr = "";
+  let processClosed = false;
+  const outputWaiters = new Set<{
+    readonly offset: number;
+    readonly text: string;
+    readonly resolve: () => void;
+    readonly reject: (error: Error) => void;
+    readonly guard: ReturnType<typeof setTimeout>;
+  }>();
+  let failureGuard: ReturnType<typeof setTimeout> | undefined;
+  const processResult = Promise.withResolvers<{
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+  }>();
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+    for (const waiter of outputWaiters) {
+      if (stdout.indexOf(waiter.text, waiter.offset) >= 0) {
+        clearTimeout(waiter.guard);
+        outputWaiters.delete(waiter);
+        waiter.resolve();
+      }
+    }
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  child.once("close", (code, signal) => {
+    processClosed = true;
+    processResult.resolve({ code, signal });
+  });
+  child.once("error", (error) => processResult.reject(error));
+
+  const signalProcessGroup = (signal: NodeJS.Signals): void => {
+    if (child.pid === undefined || processClosed) {
+      return;
+    }
+    try {
+      process.kill(-child.pid, signal);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+        child.kill(signal);
+      }
+    }
+  };
+  const awaitCloseWithGuard = async (milliseconds: number): Promise<boolean> => {
+    if (processClosed) {
+      return true;
+    }
+    const guard = Promise.withResolvers<boolean>();
+    const timeout = setTimeout(() => guard.resolve(false), milliseconds);
+    timeout.unref();
+    try {
+      return await Promise.race([processResult.promise.then(() => true), guard.promise]);
+    } finally {
+      clearTimeout(timeout);
+    }
+  };
+  const cleanup = async (): Promise<void> => {
+    if (!processClosed) {
+      signalProcessGroup("SIGTERM");
+      if (!(await awaitCloseWithGuard(1_000))) {
+        signalProcessGroup("SIGKILL");
+      }
+    }
+    await processResult.promise.catch(() => undefined);
+  };
+  let timedOut = false;
+  const result = new Promise<FixtureResult>((resolve, reject) => {
+    processResult.promise.then(
+      (settled) => {
+        if (timedOut) {
+          reject(new Error("The real TUI process did not reach startup and causal close."));
+        } else {
+          resolve({ ...settled, stderr, stdout });
+        }
+      },
+      (error: unknown) => reject(error),
+    );
+    failureGuard = setTimeout(() => {
+      timedOut = true;
+      void cleanup();
+    }, fixtureFailureMilliseconds);
+    failureGuard.unref();
+  });
+  void result.then(
+    () => {
+      activeFixtures.delete(fixture);
+    },
+    () => {
+      activeFixtures.delete(fixture);
+    },
+  );
+  const settleOutputWaiters = () => {
+    if (failureGuard !== undefined) {
+      clearTimeout(failureGuard);
+    }
+    for (const waiter of outputWaiters) {
+      clearTimeout(waiter.guard);
+      waiter.reject(new Error(`The TUI process closed before rendering ${waiter.text}.`));
+    }
+    outputWaiters.clear();
+  };
+  void processResult.promise.then(settleOutputWaiters, settleOutputWaiters);
+  const fixture: Fixture = {
+    cleanup,
+    closed: result,
+    output: () => stdout,
+    waitFor(text) {
+      return waitForAfter(text, 0);
+    },
+    waitForAfter,
+    write(text) {
+      child.stdin.write(text);
+    },
+  };
+  function waitForAfter(text: string, offset: number): Promise<void> {
+    if (stdout.indexOf(text, offset) >= 0) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve, reject) => {
+      const waiter = {
+        offset,
+        text,
+        resolve,
+        reject,
+        guard: setTimeout(() => {
+          outputWaiters.delete(waiter);
+          void cleanup().then(
+            () => reject(new Error(`The real TUI process did not render ${text}.`)),
+            () => reject(new Error(`The real TUI process did not render ${text}.`)),
+          );
+        }, fixtureFailureMilliseconds),
+      };
+      outputWaiters.add(waiter);
+    });
+  }
+  activeFixtures.add(fixture);
+  return fixture;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+async function cleanupActiveFixtures(): Promise<void> {
+  await Promise.all([...activeFixtures].map((fixture) => fixture.cleanup()));
+  activeFixtures.clear();
+}
+
+async function rm(path: string, options: { readonly force: boolean; readonly recursive: boolean }) {
+  await cleanupActiveFixtures();
+  await remove(path, options);
+}
+
+async function waitForPath(path: string): Promise<void> {
+  const directory = join(path, "..");
+  const filename = path.slice(directory.length + 1);
+  const watcher = watch(directory);
+  const failure = Promise.withResolvers<never>();
+  const guard = setTimeout(
+    () => failure.reject(new Error(`The fixture did not create ${filename}.`)),
+    fixtureFailureMilliseconds,
+  );
+  try {
+    if (
+      await access(path).then(
+        () => true,
+        () => false,
+      )
+    ) {
+      return;
+    }
+    await Promise.race([
+      (async () => {
+        for await (const event of watcher) {
+          if (
+            event.filename === filename &&
+            (await access(path).then(
+              () => true,
+              () => false,
+            ))
+          ) {
+            return;
+          }
+        }
+      })(),
+      failure.promise,
+    ]);
+  } finally {
+    clearTimeout(guard);
+    await watcher.return?.();
+  }
+}

--- a/apps/tui/src/main.ts
+++ b/apps/tui/src/main.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+
+import {
+  createModelTargets,
+  createPermissionPolicy,
+  createPresentationSession,
+  createSessionLifecycle,
+  ModelTargetError,
+  SessionLifecycleError,
+  selectModelTargetId,
+} from "@adam-agent/agent";
+
+import { runTui } from "./tui-app.js";
+
+class TuiConfigurationError extends Error {}
+
+try {
+  const command = parseCommand(process.argv.slice(2));
+  if (command.type === "help") {
+    process.stdout.write(`${usage()}\n`);
+  } else {
+    const startupSignal = new AbortController().signal;
+    const workspaceRoot = process.cwd();
+    const { ADAM_AGENT_STATE_ROOT: configuredStateRoot } = process.env;
+    const stateRoot =
+      command.stateRoot ?? configuredStateRoot ?? join(homedir(), ".local", "state", "adam-agent");
+    const modelTargets = createModelTargets({ environment: process.env });
+    const lifecycle = createSessionLifecycle({
+      modelTargets,
+      permissions: createPermissionPolicy({
+        allowedEffects: ["read"],
+        askedEffects: ["write", "execute", "network", "delegate", "administrative"],
+      }),
+      stateRoot,
+      workspaceRoot,
+    });
+    try {
+      if (command.resumeSessionId !== undefined && command.targetId !== undefined) {
+        throw new TuiConfigurationError("--resume and --target cannot be combined.");
+      }
+      if (command.resumeSessionId !== undefined) {
+        const snapshot = await lifecycle.inspect({ sessionId: command.resumeSessionId });
+        if (snapshot.schemaVersion !== 3) {
+          throw new TuiConfigurationError("The selected session cannot be opened by this TUI.");
+        }
+        const presentation = await createPresentationSession({
+          lifecycle,
+          projectLabel: basename(workspaceRoot),
+          sessionId: command.resumeSessionId,
+          stateRoot,
+          workspaceRoot,
+        });
+        await runTui({
+          presentation,
+          targetStatus: {
+            targetId: snapshot.targetIdentity.targetId,
+            certification:
+              snapshot.targetIdentity.certification === "certified" ? "Certified" : "Experimental",
+          },
+        });
+      } else {
+        const targetId = command.targetId ?? selectModelTargetId(process.env);
+        const targets = await modelTargets.snapshot({
+          discoverGateway: false,
+          signal: startupSignal,
+        });
+        const selected = targets.targets.find((target) => target.identity.targetId === targetId);
+        if (selected === undefined) {
+          throw new TuiConfigurationError(`The exact target ${targetId} is not available.`);
+        }
+        if (selected.readiness.status !== "available") {
+          throw new TuiConfigurationError(
+            `The exact target ${targetId} is missing its required credential.`,
+          );
+        }
+        const presentation = await createPresentationSession({
+          lifecycle,
+          projectLabel: basename(workspaceRoot),
+          stateRoot,
+          targetIdentity: selected.identity,
+          workspaceRoot,
+        });
+        await runTui({
+          presentation,
+          targetStatus: {
+            targetId: selected.identity.targetId,
+            certification:
+              selected.identity.certification === "certified" ? "Certified" : "Experimental",
+          },
+        });
+      }
+    } finally {
+      await lifecycle.close();
+    }
+  }
+} catch (error) {
+  const message =
+    error instanceof TuiConfigurationError ||
+    error instanceof ModelTargetError ||
+    error instanceof SessionLifecycleError
+      ? error.message
+      : "The Adam TUI could not start safely.";
+  process.stderr.write(`${message}\n${usage()}\n`);
+  process.exitCode = 1;
+}
+
+type TuiCommand =
+  | { readonly type: "help" }
+  | {
+      readonly type: "run";
+      readonly resumeSessionId?: string;
+      readonly stateRoot?: string;
+      readonly targetId?: string;
+    };
+
+function parseCommand(arguments_: readonly string[]): TuiCommand {
+  if (arguments_.length === 1 && (arguments_[0] === "--help" || arguments_[0] === "-h")) {
+    return { type: "help" };
+  }
+  const values = new Map<string, string>();
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const option = arguments_[index];
+    const value = arguments_[index + 1];
+    if (
+      option === undefined ||
+      value === undefined ||
+      (option !== "--resume" && option !== "--state-root" && option !== "--target") ||
+      values.has(option)
+    ) {
+      throw new TuiConfigurationError("The TUI arguments are invalid.");
+    }
+    values.set(option, value);
+  }
+  return {
+    type: "run",
+    ...(values.get("--resume") === undefined
+      ? {}
+      : { resumeSessionId: values.get("--resume") as string }),
+    ...(values.get("--state-root") === undefined
+      ? {}
+      : { stateRoot: values.get("--state-root") as string }),
+    ...(values.get("--target") === undefined ? {} : { targetId: values.get("--target") as string }),
+  };
+}
+
+function usage(): string {
+  return "Usage: adam-agent-tui [--target <exact-target-id> | --resume <session-id>] [--state-root <path>]";
+}

--- a/apps/tui/src/permission-overlay.ts
+++ b/apps/tui/src/permission-overlay.ts
@@ -1,0 +1,88 @@
+import type { PendingInteraction } from "@adam-agent/presentation";
+import {
+  type Component,
+  type Focusable,
+  Key,
+  matchesKey,
+  truncateToWidth,
+  visibleWidth,
+} from "@earendil-works/pi-tui";
+import { safeTerminalText } from "./safe-terminal-text.js";
+import type { AdamTuiTheme } from "./theme.js";
+
+export class PermissionOverlay implements Component, Focusable {
+  focused = false;
+  readonly #interaction: PendingInteraction;
+  readonly #onDecision: (decision: "allow" | "deny") => void;
+  readonly #theme: AdamTuiTheme;
+  #allowEnabled: boolean;
+  #preview = "Loading canonical preview…";
+  #selection: "allow" | "deny";
+
+  constructor(options: {
+    readonly interaction: PendingInteraction;
+    readonly onDecision: (decision: "allow" | "deny") => void;
+    readonly theme: AdamTuiTheme;
+  }) {
+    this.#interaction = options.interaction;
+    this.#onDecision = options.onDecision;
+    this.#theme = options.theme;
+    this.#allowEnabled = false;
+    this.#selection = "deny";
+  }
+
+  setPreview(input: { readonly readable: boolean; readonly text: string }): void {
+    this.#preview = safeTerminalText(input.text);
+    this.#allowEnabled = this.#interaction.canAllow && input.readable;
+    this.#selection = this.#allowEnabled ? "allow" : "deny";
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.left) || matchesKey(data, Key.right)) {
+      if (this.#allowEnabled) {
+        this.#selection = this.#selection === "allow" ? "deny" : "allow";
+      }
+      return;
+    }
+    if (matchesKey(data, Key.escape)) {
+      this.#onDecision("deny");
+      return;
+    }
+    if (matchesKey(data, Key.enter)) {
+      this.#onDecision(this.#selection);
+    }
+  }
+
+  invalidate(): void {}
+
+  render(width: number): string[] {
+    if (width < 4) {
+      return [truncateToWidth("Permission required", Math.max(0, width))];
+    }
+    const innerWidth = width - 4;
+    const subject = truncateToWidth(safeTerminalText(this.#interaction.subject.value), innerWidth);
+    const options = this.#allowEnabled
+      ? `${this.#selection === "allow" ? ">" : " "} Allow    ${
+          this.#selection === "deny" ? ">" : " "
+        } Deny`
+      : "  Allow unavailable    > Deny";
+    const content = [
+      this.#theme.toolTitle("Permission required"),
+      `${this.#interaction.effect} · ${subject}`,
+      "",
+      ...this.#preview.split("\n"),
+      "",
+      options,
+      "Enter confirm · ←/→ select · Esc deny · Ctrl+C abort",
+    ].map((line) => padLine(truncateToWidth(line, innerWidth), innerWidth));
+    return [
+      `┌${"─".repeat(Math.max(0, width - 2))}┐`,
+      ...content.map((line) => `│ ${line} │`),
+      `└${"─".repeat(Math.max(0, width - 2))}┘`,
+    ];
+  }
+}
+
+function padLine(line: string, width: number): string {
+  return `${line}${" ".repeat(Math.max(0, width - visibleWidth(line)))}`;
+}

--- a/apps/tui/src/safe-terminal-text.ts
+++ b/apps/tui/src/safe-terminal-text.ts
@@ -1,0 +1,36 @@
+/**
+ * Converts untrusted durable/runtime text into printable terminal content.
+ * Pi owns terminal control sequences; presented content never does.
+ */
+export function safeTerminalText(value: string): string {
+  let result = "";
+  for (const character of stripTerminalSequences(value)) {
+    const codePoint = character.codePointAt(0) as number;
+    if (character === "\n") {
+      result += character;
+    } else if (character === "\r") {
+      result += "\n";
+    } else if (character === "\t") {
+      result += "  ";
+    } else if (
+      codePoint >= 0x20 &&
+      !(codePoint >= 0x7f && codePoint <= 0x9f) &&
+      !isBidirectionalControl(codePoint)
+    ) {
+      result += character;
+    }
+  }
+  return result;
+}
+
+function isBidirectionalControl(codePoint: number): boolean {
+  return (
+    codePoint === 0x061c ||
+    codePoint === 0x200e ||
+    codePoint === 0x200f ||
+    (codePoint >= 0x202a && codePoint <= 0x202e) ||
+    (codePoint >= 0x2066 && codePoint <= 0x2069)
+  );
+}
+
+import { stripTerminalSequences } from "@earendil-works/pi-tui";

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -356,8 +356,8 @@ async function waitForFile(
     if (await fileExists(join(directory, filename))) {
       return true;
     }
-    for await (const event of watcher) {
-      if (event.filename === filename && (await fileExists(join(directory, filename)))) {
+    for await (const _event of watcher) {
+      if (await fileExists(join(directory, filename))) {
         return true;
       }
     }

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -1,0 +1,380 @@
+import { access, watch, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import {
+  type ContextProfile,
+  createPermissionPolicy,
+  createPresentationSession,
+  createSessionLifecycle,
+  type ModelDriver,
+  type ModelTargetIdentity,
+  type ModelTargets,
+} from "@adam-agent/agent";
+import {
+  type PresentationArtifactReadBarrier,
+  presentationArtifactReadBarrier,
+} from "@adam-agent/agent/internal-testing";
+
+import { type ClipboardAdapter, type DeadlineScheduler, runTui } from "./tui-app.js";
+
+const targetIdentity: ModelTargetIdentity = {
+  targetId: "fake.local",
+  vendor: "adam",
+  modelId: "fake-local",
+  route: "direct",
+  profileVersion: 1,
+  certification: "certified",
+};
+const contextProfile: ContextProfile = {
+  version: 1,
+  contextWindowTokens: 32_768,
+  maximumOutputTokens: 4_096,
+  compactAtTokens: 24_576,
+  postCompactTargetTokens: 8_192,
+  retainedTargetTokens: 4_096,
+  estimatorVersion: 1,
+};
+
+const options = parseArguments(process.argv.slice(2));
+const modelTargets = createFixtureModelTargets(options);
+const lifecycle = createSessionLifecycle({
+  ...(modelTargets === undefined ? {} : { modelTargets }),
+  permissions: createPermissionPolicy({ allowedEffects: ["read"], askedEffects: ["write"] }),
+  stateRoot: options.stateRoot,
+  workspaceRoot: options.workspaceRoot,
+});
+
+try {
+  const previewBarrier = previewReadBarrier(options);
+  const resumedSessionId =
+    options.scenario === "resume"
+      ? await lifecycle.create({ targetIdentity }).then(async (created) => {
+          await lifecycle.continue({
+            sessionId: created.sessionId,
+            input: { text: "Resume transcript" },
+          });
+          return created.sessionId;
+        })
+      : undefined;
+  const presentation = await createPresentationSession(
+    resumedSessionId === undefined
+      ? {
+          lifecycle,
+          projectLabel: "workspace",
+          stateRoot: options.stateRoot,
+          targetIdentity,
+          workspaceRoot: options.workspaceRoot,
+          ...(previewBarrier === undefined
+            ? {}
+            : { [presentationArtifactReadBarrier]: previewBarrier }),
+        }
+      : {
+          lifecycle,
+          projectLabel: "workspace",
+          sessionId: resumedSessionId,
+          stateRoot: options.stateRoot,
+          workspaceRoot: options.workspaceRoot,
+          ...(previewBarrier === undefined
+            ? {}
+            : { [presentationArtifactReadBarrier]: previewBarrier }),
+        },
+  );
+  const clipboard = clipboardAdapter(options);
+  const deadlineScheduler = controlledDeadlineScheduler(options);
+  await runTui({
+    ...(clipboard === undefined ? {} : { clipboard }),
+    ...(deadlineScheduler === undefined ? {} : { deadlineScheduler }),
+    presentation,
+    targetStatus: { targetId: targetIdentity.targetId, certification: "Certified" },
+  });
+} finally {
+  await lifecycle.close();
+}
+
+function parseArguments(arguments_: readonly string[]): {
+  readonly controlRoot?: string;
+  readonly scenario?:
+    | "cancellation"
+    | "clipboard-timeout"
+    | "clipboard-success"
+    | "deadline"
+    | "mutation"
+    | "mutation-delayed-preview"
+    | "read"
+    | "resume"
+    | "shell"
+    | "streaming"
+    | "unsafe-output";
+  readonly stateRoot: string;
+  readonly workspaceRoot: string;
+} {
+  const stateRoot = optionValue(arguments_, "--state-root");
+  const workspaceRoot = optionValue(arguments_, "--workspace-root");
+  if (stateRoot === undefined || workspaceRoot === undefined) {
+    throw new TypeError("The TUI fixture requires --state-root and --workspace-root.");
+  }
+  const scenario = optionValue(arguments_, "--scenario");
+  if (
+    scenario !== undefined &&
+    scenario !== "cancellation" &&
+    scenario !== "clipboard-timeout" &&
+    scenario !== "clipboard-success" &&
+    scenario !== "deadline" &&
+    scenario !== "mutation" &&
+    scenario !== "mutation-delayed-preview" &&
+    scenario !== "read" &&
+    scenario !== "resume" &&
+    scenario !== "shell" &&
+    scenario !== "streaming" &&
+    scenario !== "unsafe-output"
+  ) {
+    throw new TypeError("The TUI fixture scenario is invalid.");
+  }
+  const controlRoot = optionValue(arguments_, "--control-root");
+  return {
+    ...(controlRoot === undefined ? {} : { controlRoot }),
+    ...(scenario === undefined ? {} : { scenario }),
+    stateRoot,
+    workspaceRoot,
+  };
+}
+
+function optionValue(arguments_: readonly string[], option: string): string | undefined {
+  const index = arguments_.indexOf(option);
+  return index < 0 ? undefined : arguments_[index + 1];
+}
+
+function createFixtureModelTargets(options: {
+  readonly controlRoot?: string;
+  readonly scenario?:
+    | "cancellation"
+    | "clipboard-timeout"
+    | "clipboard-success"
+    | "deadline"
+    | "mutation"
+    | "mutation-delayed-preview"
+    | "read"
+    | "resume"
+    | "shell"
+    | "streaming"
+    | "unsafe-output";
+}): ModelTargets | undefined {
+  if (
+    options.scenario === undefined ||
+    options.scenario === "clipboard-success" ||
+    options.scenario === "clipboard-timeout" ||
+    options.scenario === "deadline"
+  ) {
+    return undefined;
+  }
+  if (options.scenario === "streaming" && options.controlRoot === undefined) {
+    throw new TypeError("The streaming fixture requires --control-root.");
+  }
+  const model: ModelDriver = {
+    async *stream(request) {
+      if (request.tools.length === 0) {
+        yield { type: "text_delta", text: "Streaming session" };
+        yield { type: "finish", reason: "stop" };
+        return;
+      }
+      if (options.scenario === "read") {
+        const latest = request.messages.at(-1);
+        if (latest?.role === "user") {
+          yield { type: "tool_call_start", id: "read-readme", name: "read_file" };
+          yield { type: "tool_call_delta", id: "read-readme", json: '{"path":"README.md"}' };
+          yield { type: "tool_call_end", id: "read-readme" };
+          yield { type: "finish", reason: "tool_calls" };
+          return;
+        }
+        yield { type: "text_delta", text: "Read complete." };
+      } else if (
+        options.scenario === "mutation" ||
+        options.scenario === "mutation-delayed-preview"
+      ) {
+        const latest = request.messages.at(-1);
+        if (latest?.role === "user") {
+          yield { type: "tool_call_start", id: "edit-file", name: "edit_file" };
+          yield {
+            type: "tool_call_delta",
+            id: "edit-file",
+            json: JSON.stringify({
+              operations: [
+                {
+                  kind: "update",
+                  path: "edit.txt",
+                  edits: [{ oldText: "before", newText: "after" }],
+                },
+              ],
+            }),
+          };
+          yield { type: "tool_call_end", id: "edit-file" };
+          yield { type: "finish", reason: "tool_calls" };
+          return;
+        }
+        yield { type: "text_delta", text: "Edit complete." };
+      } else if (options.scenario === "cancellation") {
+        await new Promise<void>((resolve) => {
+          if (request.signal.aborted) {
+            resolve();
+            return;
+          }
+          request.signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        throw request.signal.reason;
+      } else if (options.scenario === "resume") {
+        yield { type: "text_delta", text: "Previous answer." };
+      } else if (options.scenario === "shell") {
+        const latest = request.messages.at(-1);
+        if (latest?.role === "user") {
+          yield { type: "tool_call_start", id: "shell-card", name: "run_shell" };
+          yield {
+            type: "tool_call_delta",
+            id: "shell-card",
+            json: JSON.stringify({ command: "printf shell-card-fixture" }),
+          };
+          yield { type: "tool_call_end", id: "shell-card" };
+          yield { type: "finish", reason: "tool_calls" };
+          return;
+        }
+        yield { type: "text_delta", text: "Shell card complete." };
+      } else if (options.scenario === "unsafe-output") {
+        yield {
+          type: "text_delta",
+          text: "\u001b]52;c;YXR0YWNr\u0007Visible \u001b[2Janswer.",
+        };
+      } else {
+        await writeFile(join(options.controlRoot as string, "model-started"), "started\n", "utf8");
+        await waitForFile(options.controlRoot as string, "release-model");
+        yield { type: "text_delta", text: "# Streaming answer\n\n**Markdown ready.**" };
+      }
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  return {
+    async resolve() {
+      return { identity: targetIdentity, driver: model, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic TUI fixture" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+}
+
+function previewReadBarrier(options: {
+  readonly controlRoot?: string;
+  readonly scenario?: string;
+}): PresentationArtifactReadBarrier | undefined {
+  if (options.scenario !== "mutation-delayed-preview" || options.controlRoot === undefined) {
+    return undefined;
+  }
+  return {
+    async beforeRead() {
+      await writeFile(join(options.controlRoot as string, "preview-requested"), "requested\n");
+      await waitForFile(options.controlRoot as string, "release-preview");
+    },
+    async afterRead() {
+      await writeFile(join(options.controlRoot as string, "preview-read-complete"), "complete\n");
+    },
+  };
+}
+
+function clipboardAdapter(options: {
+  readonly controlRoot?: string;
+  readonly scenario?: string;
+}): ClipboardAdapter | undefined {
+  if (options.controlRoot === undefined) {
+    return undefined;
+  }
+  if (options.scenario === "clipboard-timeout") {
+    return {
+      async writeText() {
+        await writeFile(join(options.controlRoot as string, "clipboard-started"), "started\n");
+        return new Promise(() => undefined);
+      },
+    };
+  }
+  if (options.scenario !== "clipboard-success") {
+    return undefined;
+  }
+  return {
+    async writeText(text) {
+      await writeFile(join(options.controlRoot as string, "clipboard.txt"), text, "utf8");
+      return "copied";
+    },
+  };
+}
+
+function controlledDeadlineScheduler(options: {
+  readonly controlRoot?: string;
+  readonly scenario?: string;
+}): DeadlineScheduler | undefined {
+  if (
+    options.controlRoot === undefined ||
+    (options.scenario !== "deadline" && options.scenario !== "clipboard-timeout")
+  ) {
+    return undefined;
+  }
+  const ordinals = new Map<number, number>();
+  return {
+    schedule(delayMilliseconds, onDeadline) {
+      const ordinal = (ordinals.get(delayMilliseconds) ?? 0) + 1;
+      ordinals.set(delayMilliseconds, ordinal);
+      const controller = new AbortController();
+      const deadlineName = `deadline-${delayMilliseconds}-${ordinal}`;
+      void waitForFile(options.controlRoot as string, deadlineName, controller.signal).then(
+        (reached) => {
+          if (reached) {
+            onDeadline();
+          }
+        },
+      );
+      void writeFile(
+        join(options.controlRoot as string, `scheduled-${deadlineName}`),
+        "scheduled\n",
+        "utf8",
+      ).catch(() => undefined);
+      return { cancel: () => controller.abort() };
+    },
+  };
+}
+
+async function waitForFile(
+  directory: string,
+  filename: string,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  const watcher = watch(directory, { signal });
+  try {
+    if (await fileExists(join(directory, filename))) {
+      return true;
+    }
+    for await (const event of watcher) {
+      if (event.filename === filename && (await fileExists(join(directory, filename)))) {
+        return true;
+      }
+    }
+    return false;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).name === "AbortError") {
+      return false;
+    }
+    throw error;
+  } finally {
+    await watcher.return?.();
+  }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  return access(path).then(
+    () => true,
+    () => false,
+  );
+}

--- a/apps/tui/src/theme.ts
+++ b/apps/tui/src/theme.ts
@@ -1,0 +1,88 @@
+import type { EditorTheme, MarkdownTheme } from "@earendil-works/pi-tui";
+
+/**
+ * Catppuccin Mocha semantic projection adapted from sherif-fanous/pi-catppuccin
+ * commit cd09277df06621155d9c4c20e45309bce5341779 (MIT). See THIRD_PARTY_NOTICES.md.
+ */
+
+export type AdamTuiTheme = {
+  readonly editor: EditorTheme;
+  readonly markdown: MarkdownTheme;
+  readonly muted: (text: string) => string;
+  readonly primary: (text: string) => string;
+  readonly toolBackground: (text: string) => string;
+  readonly toolOutput: (text: string) => string;
+  readonly toolTitle: (text: string) => string;
+  readonly userBackground: (text: string) => string;
+  readonly userText: (text: string) => string;
+  readonly userMarker: string;
+};
+
+export function createAdamTuiTheme(noColor = noColorRequested()): AdamTuiTheme {
+  const color = (red: number, green: number, blue: number) =>
+    noColor ? identity : (text: string) => `\u001b[38;2;${red};${green};${blue}m${text}\u001b[39m`;
+  const background = (red: number, green: number, blue: number) =>
+    noColor ? identity : (text: string) => `\u001b[48;2;${red};${green};${blue}m${text}\u001b[49m`;
+  const bold = (style: (text: string) => string) => (text: string) =>
+    noColor ? text : `\u001b[1m${style(text)}\u001b[22m`;
+  const boldOnly = (text: string) => (noColor ? text : `\u001b[1m${text}\u001b[22m`);
+  const italic = (text: string) => (noColor ? text : `\u001b[3m${text}\u001b[23m`);
+  const strikethrough = (text: string) => (noColor ? text : `\u001b[9m${text}\u001b[29m`);
+  const underline = (text: string) => (noColor ? text : `\u001b[4m${text}\u001b[24m`);
+  const text = color(205, 214, 244);
+  const muted = color(166, 173, 200);
+  const mauve = color(203, 166, 247);
+  const red = color(243, 139, 168);
+  const green = color(166, 227, 161);
+  const blue = color(137, 180, 250);
+  const pink = color(245, 194, 231);
+  const teal = color(148, 226, 213);
+  const overlay = color(108, 112, 134);
+  const subtext = color(186, 194, 222);
+
+  return {
+    primary: text,
+    muted,
+    userText: text,
+    userBackground: background(49, 50, 68),
+    userMarker: noColor ? "› " : "",
+    toolBackground: background(24, 24, 37),
+    toolTitle: bold(mauve),
+    toolOutput: subtext,
+    editor: {
+      borderColor: overlay,
+      selectList: {
+        selectedPrefix: mauve,
+        selectedText: text,
+        description: muted,
+        scrollInfo: muted,
+        noMatch: muted,
+      },
+    },
+    markdown: {
+      heading: bold(red),
+      link: blue,
+      linkUrl: blue,
+      code: green,
+      codeBlock: green,
+      codeBlockBorder: muted,
+      quote: text,
+      quoteBorder: teal,
+      hr: pink,
+      listBullet: mauve,
+      bold: boldOnly,
+      italic,
+      strikethrough,
+      underline,
+    },
+  };
+}
+
+function identity(text: string): string {
+  return text;
+}
+
+function noColorRequested(): boolean {
+  const { NO_COLOR: noColor } = process.env;
+  return noColor !== undefined;
+}

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -1,0 +1,372 @@
+import type { PresentationSession } from "@adam-agent/presentation";
+import {
+  Box,
+  Container,
+  Editor,
+  isKeyRelease,
+  isKeyRepeat,
+  Key,
+  Loader,
+  Markdown,
+  matchesKey,
+  ProcessTerminal,
+  Spacer,
+  type Terminal,
+  Text,
+  type TUI,
+  TuiMainScreen,
+} from "@earendil-works/pi-tui";
+
+import {
+  type ClipboardAdapter,
+  copyDraftToClipboard,
+  type DeadlineScheduler,
+  ExitArm,
+  LegacyDuplicateGuard,
+  nodeDeadlineScheduler,
+} from "./exit-policy.js";
+import { PermissionOverlay } from "./permission-overlay.js";
+import { safeTerminalText } from "./safe-terminal-text.js";
+import { createAdamTuiTheme } from "./theme.js";
+
+export type { ClipboardAdapter, DeadlineScheduler } from "./exit-policy.js";
+
+export type TuiTargetStatus = {
+  readonly certification: "Certified" | "Experimental";
+  readonly targetId: string;
+};
+
+export type RunTuiOptions = {
+  readonly presentation: PresentationSession;
+  readonly targetStatus: TuiTargetStatus;
+  readonly terminal?: Terminal;
+  readonly clipboard?: ClipboardAdapter;
+  readonly deadlineScheduler?: DeadlineScheduler;
+};
+
+export async function runTui(options: RunTuiOptions): Promise<void> {
+  const terminal = options.terminal ?? new ProcessTerminal();
+  const deadlineScheduler = options.deadlineScheduler ?? nodeDeadlineScheduler;
+  const tui: TUI = new TuiMainScreen(terminal, true);
+  const theme = createAdamTuiTheme();
+  const root = new Container();
+  const header = new Text();
+  const transcript = new Container();
+  const editor = new Editor(tui, theme.editor, { paddingX: 1 });
+  const footer = new Text();
+  const working = new Loader(tui, theme.toolTitle, theme.muted, "Working", { intervalMs: 80 });
+  let workingVisible = false;
+  let cancelSettling = false;
+  let requestPolicyRender: () => void = () => undefined;
+  const exitArm = new ExitArm(deadlineScheduler, () => requestPolicyRender());
+  const legacyDuplicateGuard = new LegacyDuplicateGuard(deadlineScheduler);
+  let previousRunActive: boolean | undefined;
+  let permission:
+    | {
+        readonly overlay: PermissionOverlay;
+        readonly requestId: string;
+        readonly hide: () => void;
+      }
+    | undefined;
+  root.addChild(header);
+  root.addChild(new Spacer(1));
+  root.addChild(transcript);
+  root.addChild(editor);
+  root.addChild(footer);
+  tui.addChild(root);
+  tui.setFocus(editor);
+
+  const clearExitWindow = () => {
+    exitArm.reset();
+    legacyDuplicateGuard.reset();
+  };
+
+  const renderState = () => {
+    const state = options.presentation.getState();
+    const active = state.authoritative.active;
+    header.setText(
+      theme.primary(`Adam · ${safeTerminalText(active?.session.label ?? "No session")}`),
+    );
+    transcript.clear();
+    let previousWasAssistant = false;
+    for (const item of active?.transcript.items ?? []) {
+      if (item.type === "user_message") {
+        if (previousWasAssistant) {
+          transcript.addChild(new Spacer(1));
+        }
+        const user = new Box(1, 1, theme.userBackground);
+        user.addChild(
+          new Text(theme.userText(`${theme.userMarker}${safeTerminalText(item.text)}`)),
+        );
+        transcript.addChild(user);
+        previousWasAssistant = false;
+      } else if (item.type === "assistant_message" && item.text !== null) {
+        transcript.addChild(new Spacer(1));
+        transcript.addChild(new Markdown(safeTerminalText(item.text), 0, 0, theme.markdown));
+        previousWasAssistant = true;
+      } else if (item.type === "tool_call") {
+        const tool = new Box(1, 1, theme.toolBackground);
+        const subject = item.subject?.value;
+        const label = safeTerminalText(item.label);
+        const title =
+          item.kind === "shell"
+            ? subject === undefined
+              ? "$"
+              : `$ ${safeTerminalText(subject)}`
+            : subject === undefined
+              ? label
+              : `${label} ${safeTerminalText(subject)}`;
+        tool.addChild(new Text(theme.toolTitle(title)));
+        const detail = item.resultSummary ?? toolStatusText(item.status, item.outcome?.status);
+        if (detail !== null) {
+          tool.addChild(new Text(theme.toolOutput(safeTerminalText(detail))));
+        }
+        transcript.addChild(new Spacer(1));
+        transcript.addChild(tool);
+        previousWasAssistant = false;
+      } else if (item.type === "session_notice") {
+        const message =
+          item.status === "interrupted"
+            ? item.reason
+            : item.status === "incomplete"
+              ? item.reason
+              : `${item.code}: ${item.message}`;
+        transcript.addChild(new Spacer(1));
+        transcript.addChild(new Text(theme.muted(safeTerminalText(message))));
+        previousWasAssistant = false;
+      }
+    }
+    const transientAssistant = state.transient?.assistant?.text;
+    const showWorking = state.transient?.activity === "working";
+    if (showWorking) {
+      transcript.addChild(new Spacer(1));
+      transcript.addChild(working);
+    } else if (transientAssistant !== undefined && transientAssistant.length > 0) {
+      transcript.addChild(new Spacer(1));
+      transcript.addChild(new Markdown(safeTerminalText(transientAssistant), 0, 0, theme.markdown));
+    }
+    if (showWorking && !workingVisible) {
+      working.start();
+    } else if (!showWorking && workingVisible) {
+      working.stop();
+    }
+    workingVisible = showWorking;
+    const pending = active?.pendingInteractions[0];
+    if (
+      cancelSettling &&
+      state.transient === null &&
+      active?.pendingInteractions.length === 0 &&
+      active.session.status !== "idle"
+    ) {
+      cancelSettling = false;
+    }
+    const runActive = state.transient !== null || pending !== undefined || cancelSettling;
+    if (previousRunActive !== undefined && previousRunActive !== runActive) {
+      clearExitWindow();
+    }
+    previousRunActive = runActive;
+    if (pending === undefined && permission !== undefined) {
+      clearExitWindow();
+      permission.hide();
+      permission = undefined;
+      tui.setFocus(editor);
+    } else if (pending !== undefined && permission?.requestId !== pending.requestId) {
+      clearExitWindow();
+      permission?.hide();
+      const overlay = new PermissionOverlay({
+        interaction: pending,
+        theme,
+        onDecision(decision) {
+          void options.presentation.dispatch({
+            type: "decide_permission",
+            requestId: pending.requestId,
+            decision,
+          });
+        },
+      });
+      const handle = tui.showOverlay(overlay, {
+        width: "80%",
+        minWidth: 36,
+        maxHeight: "80%",
+        margin: 1,
+      });
+      permission = { overlay, requestId: pending.requestId, hide: () => handle.hide() };
+      if (pending.changePreviewRef === null) {
+        overlay.setPreview({ readable: pending.effect !== "write", text: "No preview available." });
+      } else {
+        void options.presentation
+          .dispatch({ type: "read_artifact", artifact: pending.changePreviewRef, range: null })
+          .then((receipt) => {
+            if (permission?.requestId !== pending.requestId) {
+              return;
+            }
+            overlay.setPreview(
+              receipt.status === "admitted" && receipt.resource !== null
+                ? { readable: true, text: receipt.resource.text }
+                : { readable: false, text: "Canonical preview unavailable." },
+            );
+            tui.requestRender();
+          });
+      }
+    }
+    if (runActive) {
+      editor.disableSubmit = true;
+    } else if (active?.session.status === "settled" || active?.session.status === "interrupted") {
+      editor.disableSubmit = false;
+    }
+    footer.setText(
+      exitArm.armed
+        ? theme.muted(
+            `Press Ctrl+C again within two seconds to exit${
+              editor.getExpandedText().length === 0 ? "" : " · draft will be copied"
+            }`,
+          )
+        : active === null
+          ? "No active session"
+          : theme.muted(
+              `${safeTerminalText(active.session.targetId)} · ${options.targetStatus.certification}`,
+            ),
+    );
+    tui.requestRender();
+  };
+  requestPolicyRender = renderState;
+  renderState();
+  const unsubscribe = options.presentation.subscribe(renderState);
+  editor.onChange = () => {
+    if (exitArm.armed) {
+      clearExitWindow();
+      renderState();
+    }
+  };
+  editor.onSubmit = (text) => {
+    const active = options.presentation.getState().authoritative.active;
+    if (active === null || text.trim().length === 0 || editor.disableSubmit) {
+      return;
+    }
+    clearExitWindow();
+    editor.disableSubmit = true;
+    void options.presentation
+      .dispatch({
+        type: "submit_prompt",
+        sessionId: active.session.id,
+        text,
+        skills: [],
+      })
+      .then((receipt) => {
+        if (receipt.status === "admitted") {
+          editor.addToHistory(text);
+          editor.setText("");
+        } else {
+          editor.disableSubmit = false;
+        }
+      })
+      .catch(() => {
+        editor.disableSubmit = false;
+      })
+      .finally(() => {
+        tui.requestRender();
+      });
+  };
+  const exited = Promise.withResolvers<void>();
+  let stopping = false;
+  const stop = async (copyDraft: boolean) => {
+    if (stopping) {
+      return;
+    }
+    stopping = true;
+    clearExitWindow();
+    unsubscribe();
+    permission?.hide();
+    working.stop();
+    tui.stop();
+    try {
+      if (copyDraft) {
+        const clipboardResult = await copyDraftToClipboard(
+          editor.getExpandedText(),
+          options.clipboard,
+          deadlineScheduler,
+        );
+        if (clipboardResult === "unsupported") {
+          terminal.write("\r\nClipboard unavailable; draft was not copied.\r\n");
+        } else if (clipboardResult === "failed") {
+          terminal.write("\r\nClipboard copy failed; draft was not copied.\r\n");
+        }
+      }
+      await options.presentation.close();
+      exited.resolve();
+    } catch (error) {
+      exited.reject(error);
+    }
+  };
+  tui.addInputListener((data) => {
+    if (matchesKey(data, Key.ctrl("q"))) {
+      void stop(true);
+      return { consume: true };
+    }
+    if (matchesKey(data, Key.ctrl("c"))) {
+      if (isKeyRepeat(data) || isKeyRelease(data)) {
+        return { consume: true };
+      }
+      if (data === "\u0003" && !legacyDuplicateGuard.admit()) {
+        return { consume: true };
+      }
+      const active = options.presentation.getState().authoritative.active;
+      const runActive =
+        options.presentation.getState().transient !== null ||
+        (active?.pendingInteractions.length ?? 0) > 0;
+      if (runActive || cancelSettling) {
+        if (!cancelSettling && active !== null) {
+          cancelSettling = true;
+          void options.presentation
+            .dispatch({ type: "cancel_run", sessionId: active.session.id })
+            .then((receipt) => {
+              const state = options.presentation.getState();
+              const current = state.authoritative.active;
+              if (
+                receipt.status === "rejected" ||
+                (state.transient === null &&
+                  current?.pendingInteractions.length === 0 &&
+                  current.session.status !== "idle")
+              ) {
+                cancelSettling = false;
+                renderState();
+              }
+            })
+            .catch(() => {
+              cancelSettling = false;
+              renderState();
+            });
+        }
+        return { consume: true };
+      }
+      if (exitArm.press() === "confirmed") {
+        void stop(true);
+        return { consume: true };
+      }
+      renderState();
+      return { consume: true };
+    }
+    return undefined;
+  });
+  tui.start();
+  await exited.promise;
+}
+
+function toolStatusText(
+  status: "completed" | "denied" | "failed" | "permission_required" | "requested" | "running",
+  outcome: "completed" | "denied" | "failed" | "indeterminate" | undefined,
+): string | null {
+  if (outcome === "indeterminate") {
+    return "indeterminate · inspect before retry";
+  }
+  if (status === "permission_required") {
+    return "permission required";
+  }
+  if (status === "denied") {
+    return "denied";
+  }
+  if (status === "failed") {
+    return "failed";
+  }
+  return status === "running" || status === "requested" ? status : null;
+}

--- a/apps/tui/tsconfig.json
+++ b/apps/tui/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../../packages/presentation" }, { "path": "../../packages/agent" }]
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "markdown:check": "markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#dist\" \"#coverage\"",
     "markdown:fix": "markdownlint-cli2 --fix \"**/*.md\" \"#node_modules\" \"#dist\" \"#coverage\"",
     "browser:check": "tsc -p packages/presentation/tsconfig.browser.json --pretty false",
+    "tui": "tsc -b --pretty false && node --env-file-if-exists=.env apps/tui/dist/main.js",
     "quality:check": "pnpm code:check && pnpm markdown:check && pnpm typecheck && pnpm browser:check && pnpm test",
     "quality:fix": "pnpm code:fix && pnpm markdown:fix",
     "test": "tsc -b && vitest run",

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -28,8 +28,10 @@ export {
 export { preparedDirectDeepSeekV2ContextProfile } from "./model-targets.js";
 export type { PatchFileSystem } from "./patch-transaction.js";
 export {
+  type PresentationArtifactReadBarrier,
   type PresentationHydrationBarrier,
   type PresentationRuntimeRefreshBarrier,
+  presentationArtifactReadBarrier,
   presentationCatalogPageSize,
   presentationHistoryPageSize,
   presentationHydrationBarrier,

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -31,6 +31,9 @@ export const presentationCatalogPageSize = Symbol("adam-agent.presentation-catal
 export const presentationRuntimeRefreshBarrier = Symbol(
   "adam-agent.presentation-runtime-refresh-barrier",
 );
+export const presentationArtifactReadBarrier = Symbol(
+  "adam-agent.presentation-artifact-read-barrier",
+);
 
 export type PresentationHydrationBarrier = {
   afterHydrate(input: {
@@ -43,6 +46,11 @@ export type PresentationRuntimeRefreshBarrier = {
   beforeRead(notification: SessionRuntimeNotification): Promise<void>;
 };
 
+export type PresentationArtifactReadBarrier = {
+  beforeRead(): Promise<void>;
+  afterRead?(): Promise<void>;
+};
+
 type PresentationSessionBaseOptions = {
   readonly lifecycle: SessionLifecycle;
   readonly projectLabel: string;
@@ -50,6 +58,7 @@ type PresentationSessionBaseOptions = {
   readonly workspaceRoot: string;
   readonly [presentationHydrationBarrier]?: PresentationHydrationBarrier;
   readonly [presentationRuntimeRefreshBarrier]?: PresentationRuntimeRefreshBarrier;
+  readonly [presentationArtifactReadBarrier]?: PresentationArtifactReadBarrier;
   readonly [presentationHistoryPageSize]?: number;
   readonly [presentationCatalogPageSize]?: number;
 };
@@ -306,6 +315,21 @@ export async function createPresentationSession(
               return;
             }
             const event = notification.event;
+            if (event.type === "user_message" || event.type === "model_message_started") {
+              state = {
+                revision: state.revision + 1,
+                authoritative: state.authoritative,
+                transient: { activity: "working", assistant: null },
+              };
+              publishStateChange();
+            } else if (event.type === "tool_requested" || event.type === "tool_started") {
+              state = {
+                revision: state.revision + 1,
+                authoritative: state.authoritative,
+                transient: { activity: "using_tool", assistant: null },
+              };
+              publishStateChange();
+            }
             if (isModelMessageDelta(event)) {
               const streamId = `${notification.sessionId}:${notification.runId}`;
               const existingText =
@@ -762,6 +786,58 @@ export async function createPresentationSession(
           };
         }
       }
+      if (command.type === "read_artifact") {
+        const active = state.authoritative.active;
+        if (
+          active === null ||
+          command.artifact.source !== "change_preview" ||
+          !isKnownArtifact(active, command.artifact)
+        ) {
+          return {
+            status: "rejected",
+            code: "stale_interaction",
+            message: "The requested artifact is no longer part of the active presentation.",
+          };
+        }
+        if (options.stateRoot === undefined || command.artifact.byteCount > 64 * 1024) {
+          return {
+            status: "rejected",
+            code: "not_available",
+            message: "The artifact is not available through this Presentation session.",
+          };
+        }
+        try {
+          await options[presentationArtifactReadBarrier]?.beforeRead();
+          const bytes = await readFileArtifact({
+            root: join(options.stateRoot, "artifacts"),
+            id: command.artifact.id,
+            maximumBytes: command.artifact.byteCount,
+          });
+          if (bytes === undefined || bytes.byteLength !== command.artifact.byteCount) {
+            throw new TypeError("The artifact bytes are unavailable.");
+          }
+          const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+          await options[presentationArtifactReadBarrier]?.afterRead?.();
+          return {
+            status: "admitted",
+            commandId: randomUUID(),
+            resource: {
+              mediaType: command.artifact.mediaType,
+              offset: 0,
+              byteCount: bytes.byteLength,
+              totalByteCount: bytes.byteLength,
+              eof: true,
+              text,
+            },
+          };
+        } catch {
+          return {
+            status: "rejected",
+            code: "not_available",
+            message: "The artifact could not be read safely.",
+          };
+        }
+      }
       if (command.type === "set_session_manual_name") {
         if (command.sessionId !== state.authoritative.active?.session.id) {
           return {
@@ -859,6 +935,36 @@ export async function createPresentationSession(
     unsubscribeMetadata();
     throw error;
   }
+}
+
+function isKnownArtifact(
+  active: import("@adam-agent/presentation").ActiveSessionDisplay,
+  artifact: import("@adam-agent/presentation").ArtifactReference,
+): boolean {
+  const candidates = [
+    ...active.pendingInteractions.flatMap((interaction) =>
+      interaction.changePreviewRef === null ? [] : [interaction.changePreviewRef],
+    ),
+    ...active.transcript.items.flatMap((item) => {
+      if (item.type === "assistant_message") {
+        return item.artifact === null ? [] : [item.artifact];
+      }
+      if (item.type === "tool_call") {
+        return [
+          ...item.artifacts,
+          ...(item.changePreviewRef === null ? [] : [item.changePreviewRef]),
+        ];
+      }
+      return [];
+    }),
+  ];
+  return candidates.some(
+    (candidate) =>
+      candidate.id === artifact.id &&
+      candidate.mediaType === artifact.mediaType &&
+      candidate.byteCount === artifact.byteCount &&
+      candidate.source === artifact.source,
+  );
 }
 
 function boundedHistoryPageSize(value: number | undefined): number {

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -62,6 +62,15 @@ export type ArtifactReference = {
   readonly source: "model_response" | "tool_output" | "change_preview" | "operation";
 };
 
+export type ArtifactChunk = {
+  readonly mediaType: string;
+  readonly offset: number;
+  readonly byteCount: number;
+  readonly totalByteCount: number;
+  readonly eof: boolean;
+  readonly text: string;
+};
+
 export type UserMessageDisplay = {
   readonly type: "user_message";
   readonly id: string;
@@ -203,6 +212,7 @@ export type AuthoritativePresentationSnapshot = {
 };
 
 export type PresentationTransientState = {
+  readonly activity: "working" | "replying" | "using_tool" | null;
   readonly assistant: {
     readonly streamId: string;
     readonly afterSequence: number;
@@ -229,7 +239,11 @@ export type PresentationUpdate =
     };
 
 export type CommandReceipt =
-  | { readonly status: "admitted"; readonly commandId: string; readonly resource: null }
+  | {
+      readonly status: "admitted";
+      readonly commandId: string;
+      readonly resource: ArtifactChunk | null;
+    }
   | {
       readonly status: "rejected";
       readonly code:
@@ -259,6 +273,11 @@ export type PresentationCommand =
   | {
       readonly type: "load_more_sessions";
       readonly after: string;
+    }
+  | {
+      readonly type: "read_artifact";
+      readonly artifact: ArtifactReference;
+      readonly range: null;
     }
   | {
       readonly type: "set_session_manual_name";
@@ -334,6 +353,7 @@ export function reconcilePresentationUpdate(
     revision: state.revision + 1,
     authoritative: state.authoritative,
     transient: {
+      activity: "replying",
       assistant: {
         streamId: update.streamId,
         afterSequence: update.afterSequence,

--- a/packages/presentation/src/presentation.test.ts
+++ b/packages/presentation/src/presentation.test.ts
@@ -69,6 +69,7 @@ describe("presentation reconciliation", () => {
       revision: 2,
       authoritative: emptySnapshot,
       transient: {
+        activity: "replying",
         assistant: {
           streamId: "stream-1",
           afterSequence: 0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/testkit
 
+  apps/tui:
+    dependencies:
+      '@adam-agent/agent':
+        specifier: workspace:*
+        version: link:../../packages/agent
+      '@adam-agent/presentation':
+        specifier: workspace:*
+        version: link:../../packages/presentation
+      '@earendil-works/pi-tui':
+        specifier: 0.84.2
+        version: 0.84.2
+
   packages/agent:
     dependencies:
       '@adam-agent/extension-api':
@@ -172,6 +184,10 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@earendil-works/pi-tui@0.84.2':
+    resolution: {integrity: sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg==}
+    engines: {node: '>=22.19.0'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -757,6 +773,11 @@ packages:
     resolution: {integrity: sha512-qHKeU2E1bdyNAT077go2FVTNXvYcktN5IHtF6XyeD1l0PClxzSp2tUApAV14ORI8DGX4H9bNKZEzelZp4qn8IA==}
     engines: {node: '>=22'}
 
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   mdurl@2.1.0:
     resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
 
@@ -1240,6 +1261,11 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.8':
     optional: true
 
+  '@earendil-works/pi-tui@0.84.2':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 18.0.5
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@modelcontextprotocol/client@2.0.0':
@@ -1684,6 +1710,8 @@ snapshots:
       string-width: 8.2.1
     transitivePeerDependencies:
       - supports-color
+
+  marked@18.0.5: {}
 
   mdurl@2.1.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
   "files": [],
   "references": [
     { "path": "./apps/cli" },
+    { "path": "./apps/tui" },
     { "path": "./packages/extension-api" },
     { "path": "./packages/presentation" },
     { "path": "./packages/agent" },


### PR DESCRIPTION
## Summary

- add the production Pi TUI entry with authoritative transcript, editor, streaming Markdown, Working state, Pi-style tool cards, permission/diff flow, cancellation, resume, target certification, and retained-draft exit
- extend the browser-safe Presentation contract with semantic activity and bounded canonical artifact reads
- sanitize untrusted terminal content, pin and attribute Pi/Catppuccin dependencies, and enforce fail-closed permission and clipboard deadline behavior
- cover the shipped entry and TUI behavior through causal real-process PTY tests

## Scope

- this is the minimum complete TUI slice only
- target/session pickers, narrow/responsive layouts, resize/paste/signal integration, MCP, Eve, and later capabilities remain deferred

## Verification

- `pnpm quality:check`
- 24 test files passed, 2 skipped; 737 tests passed, 10 explicit opt-in tests skipped
- focused Presentation/TUI suite: 71 passed
- independent Standards review: no hard findings
- independent Spec review: no hard findings