### PR TITLE
test: stabilize B9 lifecycle timing

### DIFF
--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -1165,6 +1165,7 @@ test("Enter cannot allow a mutation while its canonical preview is still loading
     fixture.write("Edit before preview\r");
     await fixture.waitFor("Loading canonical preview");
     await fixture.waitFor("Allow unavailable");
+    await waitForPath(join(controlRoot, "preview-requested"));
     fixture.write("\r");
     await writeFile(join(controlRoot, "release-preview"), "release\n", "utf8");
     await waitForPath(join(controlRoot, "preview-read-complete"));

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -1554,13 +1554,18 @@ test("PresentationSession catches up a durable settlement that arrives after hyd
       },
     });
 
-    expect(presentation.getState()).toMatchObject({
+    const caughtUp = presentation.getState();
+    expect(caughtUp).toMatchObject({
       authoritative: {
-        continuity: { status: "current", sessionThroughSequence: 9 },
+        continuity: { status: "current" },
         active: { session: { id: created.sessionId, status: "settled" } },
       },
       transient: null,
     });
+    if (caughtUp.authoritative.continuity.status !== "current") {
+      throw new Error("Expected current Presentation continuity after hydration catch-up.");
+    }
+    expect(caughtUp.authoritative.continuity.sessionThroughSequence).toBeGreaterThanOrEqual(9);
 
     await presentation.close();
   } finally {

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -1565,7 +1565,7 @@ test("PresentationSession catches up a durable settlement that arrives after hyd
     if (caughtUp.authoritative.continuity.status !== "current") {
       throw new Error("Expected current Presentation continuity after hydration catch-up.");
     }
-    expect(caughtUp.authoritative.continuity.sessionThroughSequence).toBeGreaterThanOrEqual(9);
+    expect([9, 10]).toContain(caughtUp.authoritative.continuity.sessionThroughSequence);
 
     await presentation.close();
   } finally {


### PR DESCRIPTION
## Summary

- bound hydration catch-up continuity to the two valid durable outcomes, sequence 9 before automatic naming metadata or sequence 10 after it
- synchronize the delayed-preview PTY Enter action on the existing `preview-requested` causal marker

## Why

Exact-merge Quality run [#74](https://github.com/DrEden33773/adam-agent/actions/runs/32489144427) failed because the catch-up test required sequence 9 even though authoritative automatic-title metadata had validly advanced the same current state to sequence 10. The preview PTY also showed a local parallel-run race because it sent input after rendered text without waiting for the artifact-read request marker.

## Verification

- `pnpm quality:check`
  - 24 test files passed, 2 skipped
  - 782 tests passed, 10 skipped
  - Biome, Markdown, TypeScript, and browser-safe checks passed
- focused hydration and preview PTY tracers passed
- Standards review: PASS
- Spec review: PASS
- pushed SHA verified: `632afd36a4bb91264aed7494549da7f1e1aa5c42`

## Scope

Test-only B9-L1 merge-Quality repair. No production behavior, E1/H1 work, or workspace gitlink update.
