### PR TITLE
test: add deterministic lifecycle harness

### DIFF
--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -37,6 +37,11 @@ export {
   presentationHydrationBarrier,
   presentationRuntimeRefreshBarrier,
 } from "./presentation-session.js";
+export type {
+  ProjectLifecycleOwner,
+  ProjectLifecycleOwnerLease,
+} from "./project-lifecycle-owner.js";
+export { ProjectLifecycleOwnerError } from "./project-lifecycle-owner.js";
 export { assemblePromptMessagesV1, digestPromptRequestV1 } from "./prompt-assembly.js";
 export {
   sessionDurableContext,
@@ -54,10 +59,14 @@ export {
   type SessionTitleDeadlineScheduler,
   sessionAutomaticTitlesEnabled,
   sessionLogicalRunStartedBarrier,
+  sessionProjectLifecycleOwner,
   sessionRuntimeNotificationTransform,
+  sessionStoreDirectory,
   sessionTitleDeadlineScheduler,
 } from "./session-lifecycle.js";
 export {
+  createInMemorySessionStoreDirectory,
+  createJsonlSessionStoreDirectory,
   openJsonlSessionStore,
   type SessionContextCompactionCommittedRecord,
   type SessionContextCompactionFailedRecord,
@@ -69,6 +78,7 @@ export {
   type SessionProviderAttemptStartedRecord,
   type SessionRecord,
   type SessionRuntimeEventRecord,
+  type SessionStoreDirectory,
   type SessionToolIntent,
   type SessionV3Record,
 } from "./session-store.js";

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { readdir, realpath } from "node:fs/promises";
+import { realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { isDeepStrictEqual } from "node:util";
@@ -74,6 +74,7 @@ import {
 } from "./model-targets.js";
 import {
   createProjectLifecycleOwner,
+  type ProjectLifecycleOwner,
   ProjectLifecycleOwnerError,
 } from "./project-lifecycle-owner.js";
 import {
@@ -106,9 +107,7 @@ import {
 } from "./session-durable-context.js";
 import { normalizedSessionTitle, sessionTitleFallback } from "./session-naming.js";
 import {
-  createJsonlSessionStore,
-  openJsonlSessionStore,
-  readJsonlSessionRecords,
+  createJsonlSessionStoreDirectory,
   type SessionContextCompactionCommittedRecord,
   type SessionContextCompactionFailedRecord,
   type SessionContextCompactionInterruptedRecord,
@@ -126,6 +125,7 @@ import {
   type SessionRecord,
   type SessionSkillActivationBatchCommittedRecord,
   type SessionStore,
+  type SessionStoreDirectory,
 } from "./session-store.js";
 import {
   createInitialSkillContextV1,
@@ -298,6 +298,12 @@ export type SessionLogicalRunStartedBarrier = {
 /** Tests only. Production lifecycle instances always default automatic titles on. */
 export const sessionAutomaticTitlesEnabled = Symbol("adam-agent.session-automatic-titles-enabled");
 
+/** Tests only. Production lifecycle instances use the OS-backed project owner. */
+export const sessionProjectLifecycleOwner = Symbol("adam-agent.session-project-lifecycle-owner");
+
+/** Tests only. Production lifecycle instances use the JSONL session directory. */
+export const sessionStoreDirectory = Symbol("adam-agent.session-store-directory");
+
 /** Tests only. Production publishes each exact runtime notification once. */
 export const sessionRuntimeNotificationTransform = Symbol(
   "adam-agent.session-runtime-notification-transform",
@@ -328,6 +334,8 @@ export type SessionLifecycleOptions = {
   readonly [sessionTitleDeadlineScheduler]?: SessionTitleDeadlineScheduler;
   readonly [sessionLogicalRunStartedBarrier]?: SessionLogicalRunStartedBarrier;
   readonly [sessionAutomaticTitlesEnabled]?: boolean;
+  readonly [sessionProjectLifecycleOwner]?: ProjectLifecycleOwner;
+  readonly [sessionStoreDirectory]?: SessionStoreDirectory<SessionRecord>;
   readonly [sessionRuntimeNotificationTransform]?: SessionRuntimeNotificationTransform;
 };
 
@@ -564,10 +572,6 @@ function decodeProjectSessionCatalogCursor(cursor: string | undefined): string |
   return sessionId;
 }
 
-function isNodeError(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && "code" in error;
-}
-
 const nodeMcpIdleScheduler: McpIdleScheduler = {
   schedule(delayMilliseconds, task) {
     const timer = setTimeout(() => {
@@ -587,8 +591,15 @@ const nodeSessionTitleDeadlineScheduler: SessionTitleDeadlineScheduler = {
 };
 
 export function createSessionLifecycle(providedOptions: SessionLifecycleOptions): SessionLifecycle {
+  const storeDirectory =
+    providedOptions[sessionStoreDirectory] ??
+    createJsonlSessionStoreDirectory<SessionRecord>({
+      workspaceRoot: providedOptions.workspaceRoot,
+      ...(providedOptions.stateRoot === undefined ? {} : { stateRoot: providedOptions.stateRoot }),
+    });
   const options: SessionLifecycleOptions = {
     ...providedOptions,
+    [sessionStoreDirectory]: storeDirectory,
     tools:
       providedOptions.tools ??
       createCodingToolRegistry({
@@ -616,7 +627,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         .catch(() => undefined);
     }
   };
-  const owner = createProjectLifecycleOwner(options);
+  const owner = options[sessionProjectLifecycleOwner] ?? createProjectLifecycleOwner(options);
   const pendingMcpCatalogChanges = new Map<
     string,
     {
@@ -744,11 +755,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     reason: "model_request_failed" | "invalid_title",
   ): Promise<void> => {
     await runTitleWithOwner(async () => {
-      const records = await readJsonlSessionRecords({
-        workspaceRoot: options.workspaceRoot,
-        sessionId: input.sessionId,
-        ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-      });
+      const records = await readSessionRecords(options, input.sessionId);
       if (
         records.some(
           (entry) =>
@@ -760,11 +767,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       ) {
         return;
       }
-      const store = await openJsonlSessionStore<SessionRecord>({
-        workspaceRoot: options.workspaceRoot,
-        sessionId: input.sessionId,
-        ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-      });
+      const store = await openSessionStore(options, input.sessionId);
       const sequence = (records.at(-1)?.sequence ?? 0) + 1;
       await store.append({
         schemaVersion: 3,
@@ -854,11 +857,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         return;
       }
       await runTitleWithOwner(async () => {
-        const records = await readJsonlSessionRecords({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: input.sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const records = await readSessionRecords(options, input.sessionId);
         const latestGeneration = records.findLast(
           (entry) =>
             entry.schemaVersion === 3 && entry.record.type === "session_title_generation_started",
@@ -877,11 +876,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         ) {
           return;
         }
-        const store = await openJsonlSessionStore<SessionRecord>({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: input.sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const store = await openSessionStore(options, input.sessionId);
         const sequence = (records.at(-1)?.sequence ?? 0) + 1;
         await store.append({
           schemaVersion: 3,
@@ -920,11 +915,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     }
     try {
       return await withOwner(async () => {
-        const records = await readJsonlSessionRecords({
-          workspaceRoot: options.workspaceRoot,
-          sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const records = await readSessionRecords(options, sessionId);
         if (
           records.some(
             (entry) =>
@@ -935,11 +926,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         ) {
           return;
         }
-        const store = await openJsonlSessionStore<SessionRecord>({
-          workspaceRoot: options.workspaceRoot,
-          sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const store = await openSessionStore(options, sessionId);
         let manualNameActive = false;
         for (const entry of records) {
           if (entry.schemaVersion !== 3) {
@@ -1028,16 +1015,8 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     if (changes.length === 0) {
       return;
     }
-    const records = await readJsonlSessionRecords({
-      workspaceRoot: options.workspaceRoot,
-      sessionId,
-      ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-    });
-    const store = await openJsonlSessionStore<SessionRecord>({
-      workspaceRoot: options.workspaceRoot,
-      sessionId,
-      ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-    });
+    const records = await readSessionRecords(options, sessionId);
+    const store = await openSessionStore(options, sessionId);
     let nextSequence = (records.at(-1)?.sequence ?? 0) + 1;
     for (const [key, change] of changes) {
       const existingClosedServers = new Set(
@@ -1148,16 +1127,8 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
   const closeIdleMcpGeneration = async (sessionId: string, generationId: string) => {
     await withOwner(async () => {
       const closed = await mcpHost.closeIdleSession({ sessionId, generationId });
-      const records = await readJsonlSessionRecords({
-        workspaceRoot: options.workspaceRoot,
-        sessionId,
-        ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-      });
-      const store = await openJsonlSessionStore<SessionRecord>({
-        workspaceRoot: options.workspaceRoot,
-        sessionId,
-        ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-      });
+      const records = await readSessionRecords(options, sessionId);
+      const store = await openSessionStore(options, sessionId);
       if (closed.status !== "closed") {
         for (const [index, server] of closed.servers.entries()) {
           await store.append({
@@ -1217,11 +1188,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     input: { readonly sessionId: string },
     artifactCache = createArtifactMaterializationCache(),
   ): Promise<SessionSnapshot> => {
-    const records = await readJsonlSessionRecords({
-      workspaceRoot: options.workspaceRoot,
-      sessionId: input.sessionId,
-      ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-    });
+    const records = await storeDirectory.open(input.sessionId).then((store) => store?.read() ?? []);
     const first = records[0];
     if (first === undefined) {
       throw new SessionLifecycleError("session_not_found");
@@ -1370,11 +1337,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       }
     }
     if (snapshot.schemaVersion === 3) {
-      const promptRecords = await readJsonlSessionRecords({
-        workspaceRoot: options.workspaceRoot,
-        sessionId: input.sessionId,
-        ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-      });
+      const promptRecords = await readSessionRecords(options, input.sessionId);
       const promptGenesis = promptRecords[0];
       const activePromptContext =
         promptGenesis !== undefined && isGenesisRecord(promptGenesis)
@@ -1496,11 +1459,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         if (parent.degradation !== undefined) {
           throw new SessionLifecycleError("session_invalid");
         }
-        let parentRecords = await readJsonlSessionRecords({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: input.parentSessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        let parentRecords = await readSessionRecords(options, input.parentSessionId);
         const requestedCurrentTail =
           input.sourceBoundary === undefined && input.atSequence === parentRecords.length;
         let normalizedCurrentTail = false;
@@ -1553,11 +1512,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             indeterminateEffect
           ) {
             normalizedCurrentTail = true;
-            parentRecords = await readJsonlSessionRecords({
-              workspaceRoot: options.workspaceRoot,
-              sessionId: input.parentSessionId,
-              ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-            });
+            parentRecords = await readSessionRecords(options, input.parentSessionId);
           }
         }
         const sourceSessionId = input.sourceBoundary?.sessionId ?? input.parentSessionId;
@@ -1584,11 +1539,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         const sourceRecords =
           sourceSessionId === input.parentSessionId
             ? parentRecords
-            : await readJsonlSessionRecords({
-                workspaceRoot: options.workspaceRoot,
-                sessionId: sourceSessionId,
-                ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-              });
+            : await readSessionRecords(options, sourceSessionId);
         if (sourceEventPosition > sourceRecords.length) {
           throw new SessionLifecycleError("session_branch_boundary_invalid");
         }
@@ -1632,11 +1583,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           targetIdentity = target.identity;
         }
         const sessionId = randomUUID();
-        const store = await createJsonlSessionStore<SessionRecord>({
-          workspaceRoot: options.workspaceRoot,
-          sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const store = await sessionStoreDirectoryFrom(options).create(sessionId);
         const prefix = `${parentPrefix.map((record) => JSON.stringify(record)).join("\n")}\n`;
         const branchFallback = sessionTitleFallback(
           `Branch of ${sessionDisplayLabelFromRecords(parentRecords)}`,
@@ -1745,11 +1692,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           await runWithOwner(async () => {
             for (const closedSession of hostResult.closedSessions) {
               await flushPendingMcpCatalogChanges(closedSession.sessionId);
-              const records = await readJsonlSessionRecords({
-                workspaceRoot: options.workspaceRoot,
-                sessionId: closedSession.sessionId,
-                ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-              });
+              const records = await readSessionRecords(options, closedSession.sessionId);
               const existing = new Set(
                 records.flatMap((entry) =>
                   entry.schemaVersion === 3 &&
@@ -1765,11 +1708,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
               if (missing.length === 0) {
                 continue;
               }
-              const store = await openJsonlSessionStore<SessionRecord>({
-                workspaceRoot: options.workspaceRoot,
-                sessionId: closedSession.sessionId,
-                ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-              });
+              const store = await openSessionStore(options, closedSession.sessionId);
               for (const [index, server] of missing.entries()) {
                 await store.append({
                   schemaVersion: 3,
@@ -1790,11 +1729,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
               if (unconfirmed.catalogDigest === undefined || unconfirmed.servers.length === 0) {
                 continue;
               }
-              const records = await readJsonlSessionRecords({
-                workspaceRoot: options.workspaceRoot,
-                sessionId: unconfirmed.sessionId,
-                ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-              });
+              const records = await readSessionRecords(options, unconfirmed.sessionId);
               const existing = new Set(
                 records.flatMap((entry) =>
                   entry.schemaVersion === 3 &&
@@ -1811,11 +1746,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
               if (missing.length === 0) {
                 continue;
               }
-              const store = await openJsonlSessionStore<SessionRecord>({
-                workspaceRoot: options.workspaceRoot,
-                sessionId: unconfirmed.sessionId,
-                ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-              });
+              const store = await openSessionStore(options, unconfirmed.sessionId);
               for (const [index, server] of missing.entries()) {
                 await store.append({
                   schemaVersion: 3,
@@ -1861,11 +1792,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         const repository = await loadInitialRepositoryInstructions({
           workspaceRoot: options.workspaceRoot,
         });
-        const store = await createJsonlSessionStore<SessionRecord>({
-          workspaceRoot: options.workspaceRoot,
-          sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const store = await storeDirectory.create(sessionId);
         const skillBudgetContext = await resolveSkillBudgetContext(options, input.targetIdentity);
         const extensionSources = await resolveExtensionSkillSources(options);
         const skillContext = await createInitialSkillContextV1({
@@ -1955,11 +1882,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         ) {
           throw new SessionLifecycleError("session_model_target_incompatible");
         }
-        let records = await readJsonlSessionRecords({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: input.sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        let records = await readSessionRecords(options, input.sessionId);
         const first = records[0];
         if (first === undefined || !isGenesisRecord(first)) {
           throw new SessionLifecycleError("session_invalid");
@@ -1998,11 +1921,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
                     : maximum,
                 0,
               ) + 1;
-            const reactivationStore = await openJsonlSessionStore<SessionRecord>({
-              workspaceRoot: options.workspaceRoot,
-              sessionId: input.sessionId,
-              ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-            });
+            const reactivationStore = await openSessionStore(options, input.sessionId);
             const nextSequence = (records.at(-1)?.sequence ?? 0) + 1;
             await reactivationStore.append({
               schemaVersion: 3,
@@ -2112,11 +2031,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
               });
               throw new SessionLifecycleError(failure.code);
             }
-            records = await readJsonlSessionRecords({
-              workspaceRoot: options.workspaceRoot,
-              sessionId: input.sessionId,
-              ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-            });
+            records = await readSessionRecords(options, input.sessionId);
           }
         }
         const artifactInspection = await materializeModelResponseArtifacts(
@@ -2140,11 +2055,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
               activePromptContext,
               reconciled.context,
             );
-            const reconciliationStore = await openJsonlSessionStore<SessionRecord>({
-              workspaceRoot: options.workspaceRoot,
-              sessionId: input.sessionId,
-              ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-            });
+            const reconciliationStore = await openSessionStore(options, input.sessionId);
             let nextSequence = (records.at(-1)?.sequence ?? 0) + 1;
             const catalogRecord: SessionRecord = {
               schemaVersion: 3,
@@ -2238,11 +2149,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         if (resumeState === undefined && input.input === undefined) {
           throw new SessionLifecycleError("session_invalid");
         }
-        const store = await openJsonlSessionStore<SessionRecord>({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: input.sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const store = await openSessionStore(options, input.sessionId);
         const durableOutputLimits = (
           options as SessionLifecycleOptions & {
             readonly [sessionDurableOutputLimits]?: AgentSessionDurableOutputLimits;
@@ -2445,11 +2352,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             throw new SessionLifecycleError("session_invalid");
           }
           if (closed.servers.length > 0) {
-            const store = await openJsonlSessionStore<SessionRecord>({
-              workspaceRoot: options.workspaceRoot,
-              sessionId: command.sessionId,
-              ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-            });
+            const store = await openSessionStore(options, command.sessionId);
             for (const [index, server] of closed.servers.entries()) {
               await store.append({
                 schemaVersion: 3,
@@ -2487,11 +2390,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         ) {
           throw new SessionLifecycleError("session_invalid");
         }
-        const store = await openJsonlSessionStore<SessionRecord>({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: command.sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const store = await openSessionStore(options, command.sessionId);
         if (command.type === "confirm_workspace") {
           if (
             inspected.mcp === undefined ||
@@ -2561,11 +2460,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           let reactivationProfile: McpToolProfileV1 | undefined;
           let activationRecords: readonly SessionRecord[] = [];
           if (reactivating) {
-            activationRecords = await readJsonlSessionRecords({
-              workspaceRoot: options.workspaceRoot,
-              sessionId: command.sessionId,
-              ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-            });
+            activationRecords = await readSessionRecords(options, command.sessionId);
             const genesis = activationRecords[0];
             if (genesis === undefined || !isGenesisRecord(genesis)) {
               throw new SessionLifecycleError("session_invalid");
@@ -2756,11 +2651,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           ) {
             throw new SessionLifecycleError("session_invalid");
           }
-          const records = await readJsonlSessionRecords({
-            workspaceRoot: options.workspaceRoot,
-            sessionId: command.sessionId,
-            ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-          });
+          const records = await readSessionRecords(options, command.sessionId);
           const failedStart = records.findLast(
             (entry) =>
               entry.schemaVersion === 3 &&
@@ -2932,11 +2823,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           ) {
             throw new SessionLifecycleError("session_invalid");
           }
-          const records = await readJsonlSessionRecords({
-            workspaceRoot: options.workspaceRoot,
-            sessionId: command.sessionId,
-            ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-          });
+          const records = await readSessionRecords(options, command.sessionId);
           const genesis = records[0];
           if (genesis === undefined || !isGenesisRecord(genesis)) {
             throw new SessionLifecycleError("session_invalid");
@@ -3011,11 +2898,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           } catch {
             throw new SessionLifecycleError("mcp_catalog_invalid");
           }
-          const records = await readJsonlSessionRecords({
-            workspaceRoot: options.workspaceRoot,
-            sessionId: command.sessionId,
-            ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-          });
+          const records = await readSessionRecords(options, command.sessionId);
           const genesis = records[0];
           if (genesis === undefined || !isGenesisRecord(genesis)) {
             throw new SessionLifecycleError("session_invalid");
@@ -3069,11 +2952,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       if (snapshot.schemaVersion !== 3) {
         throw new SessionLifecycleError("session_invalid");
       }
-      const records = await readJsonlSessionRecords({
-        workspaceRoot: options.workspaceRoot,
-        sessionId: input.sessionId,
-        ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-      });
+      const records = await readSessionRecords(options, input.sessionId);
       const titleSnapshot = await startAutomaticTitle(
         input.sessionId,
         snapshot,
@@ -3102,24 +2981,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       }
       const afterSessionId = decodeProjectSessionCatalogCursor(input.cursor);
       const projectId = await canonicalProjectId(options.workspaceRoot);
-      const sessionsDirectory = join(
-        effectiveSessionStateRoot(options.stateRoot),
-        "projects",
-        projectId.replace(/^sha256:/u, ""),
-        "sessions",
-      );
-      let sessionIds: string[];
-      try {
-        sessionIds = (await readdir(sessionsDirectory, { withFileTypes: true }))
-          .filter((entry) => entry.isFile() && /^[0-9a-f-]{36}\.jsonl$/u.test(entry.name))
-          .map((entry) => entry.name.slice(0, -".jsonl".length))
-          .sort();
-      } catch (error) {
-        if (isNodeError(error) && error.code === "ENOENT") {
-          return { projectId, items: [], nextCursor: null };
-        }
-        throw error;
-      }
+      const sessionIds = [...(await storeDirectory.listSessionIds())].sort();
       const afterIndex =
         afterSessionId === undefined
           ? 0
@@ -3152,11 +3014,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         ) {
           throw new SessionLifecycleError("session_invalid");
         }
-        const records = await readJsonlSessionRecords({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: input.sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const records = await readSessionRecords(options, input.sessionId);
         const genesis = records[0];
         if (genesis === undefined || !isGenesisRecord(genesis)) {
           throw new SessionLifecycleError("session_invalid");
@@ -3165,11 +3023,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         if (context === undefined) {
           throw new SessionLifecycleError("session_invalid");
         }
-        const store = await openJsonlSessionStore<SessionRecord>({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: input.sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const store = await openSessionStore(options, input.sessionId);
         let repository: PromptContextRecordV1["repository"];
         try {
           repository = await loadRepositoryInstructions({
@@ -3255,11 +3109,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             },
           };
         }
-        const records = await readJsonlSessionRecords({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: input.sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const records = await readSessionRecords(options, input.sessionId);
         const genesis = records[0];
         if (genesis === undefined || !isGenesisRecord(genesis)) {
           throw new SessionLifecycleError("session_invalid");
@@ -3283,11 +3133,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             extensionSources: await resolveExtensionSkillSources(options),
           });
         } catch {
-          const store = await openJsonlSessionStore<SessionRecord>({
-            workspaceRoot: options.workspaceRoot,
-            sessionId: input.sessionId,
-            ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-          });
+          const store = await openSessionStore(options, input.sessionId);
           await store.append({
             schemaVersion: 3,
             sequence: records.length + 1,
@@ -3316,11 +3162,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           return { status: "unchanged", snapshot: inspected };
         }
         const nextPromptContext = replacePromptSkillsV2(promptContext, nextSkillContext);
-        const store = await openJsonlSessionStore<SessionRecord>({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: input.sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const store = await openSessionStore(options, input.sessionId);
         await store.append({
           schemaVersion: 3,
           sequence: records.length + 1,
@@ -3349,11 +3191,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         if (inspected.schemaVersion !== 3 || options.modelTargets === undefined) {
           throw new SessionLifecycleError("session_invalid");
         }
-        const records = await readJsonlSessionRecords({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: input.sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const records = await readSessionRecords(options, input.sessionId);
         const firstRun = records.find(
           (entry) => entry.schemaVersion === 3 && entry.record.type === "logical_run_started",
         );
@@ -3381,11 +3219,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           }
         }
         const generationId = randomUUID();
-        const store = await openJsonlSessionStore<SessionRecord>({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: input.sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const store = await openSessionStore(options, input.sessionId);
         const sequence = (records.at(-1)?.sequence ?? 0) + 1;
         await store.append({
           schemaVersion: 3,
@@ -3447,11 +3281,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         if (resumed.status === "rejected") {
           return resumed;
         }
-        const records = await readJsonlSessionRecords({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: input.sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const records = await readSessionRecords(options, input.sessionId);
         const started = records.findLast(
           (entry) =>
             entry.schemaVersion === 3 && entry.record.type === "session_title_generation_started",
@@ -3471,11 +3301,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           if (terminalExists) {
             return resumed;
           }
-          const store = await openJsonlSessionStore<SessionRecord>({
-            workspaceRoot: options.workspaceRoot,
-            sessionId: input.sessionId,
-            ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-          });
+          const store = await openSessionStore(options, input.sessionId);
           const sequence = (records.at(-1)?.sequence ?? 0) + 1;
           await store.append({
             schemaVersion: 3,
@@ -3510,16 +3336,8 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         if (inspected.schemaVersion !== 3) {
           throw new SessionLifecycleError("session_invalid");
         }
-        const records = await readJsonlSessionRecords({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: input.sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
-        const store = await openJsonlSessionStore<SessionRecord>({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: input.sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const records = await readSessionRecords(options, input.sessionId);
+        const store = await openSessionStore(options, input.sessionId);
         const sequence = (records.at(-1)?.sequence ?? 0) + 1;
         await store.append({
           schemaVersion: 3,
@@ -3551,16 +3369,8 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         if (inspected.schemaVersion !== 3) {
           throw new SessionLifecycleError("session_invalid");
         }
-        const records = await readJsonlSessionRecords({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: input.sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
-        const store = await openJsonlSessionStore<SessionRecord>({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: input.sessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+        const records = await readSessionRecords(options, input.sessionId);
+        const store = await openSessionStore(options, input.sessionId);
         const sequence = (records.at(-1)?.sequence ?? 0) + 1;
         await store.append({
           schemaVersion: 3,
@@ -5603,11 +5413,7 @@ async function validateSessionLineage(
   }
   await validateInheritedContextEvidence(options, parentGenesis, prefixRecords);
   if ("recordVersion" in lineage) {
-    const declaredParentRecords = await readJsonlSessionRecords({
-      workspaceRoot: options.workspaceRoot,
-      sessionId: lineage.parentSessionId,
-      ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-    });
+    const declaredParentRecords = await readSessionRecords(options, lineage.parentSessionId);
     const declaredParentGenesis = declaredParentRecords[0];
     if (declaredParentGenesis === undefined || !isGenesisRecord(declaredParentGenesis)) {
       throw new SessionLifecycleError("session_invalid");
@@ -5637,11 +5443,7 @@ async function sessionInheritsSourceBoundary(
     return false;
   }
   if (sessionGenesis.record.sessionId === sourceSessionId) {
-    const ownRecords = await readJsonlSessionRecords({
-      workspaceRoot: options.workspaceRoot,
-      sessionId: sourceSessionId,
-      ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-    });
+    const ownRecords = await readSessionRecords(options, sourceSessionId);
     return sourceEventPosition <= ownRecords.length;
   }
   const lineage = sessionGenesis.record.lineage;
@@ -5655,11 +5457,7 @@ async function sessionInheritsSourceBoundary(
   if (sourceSessionId === inheritedSessionId) {
     return sourceEventPosition <= inheritedEventPosition;
   }
-  const inheritedRecords = await readJsonlSessionRecords({
-    workspaceRoot: options.workspaceRoot,
-    sessionId: inheritedSessionId,
-    ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-  });
+  const inheritedRecords = await readSessionRecords(options, inheritedSessionId);
   const inheritedGenesis = inheritedRecords[0];
   if (inheritedGenesis === undefined || !isGenesisRecord(inheritedGenesis)) {
     return false;
@@ -5896,11 +5694,7 @@ async function readValidatedLineagePrefix(
   }
   let declaredParentRecords: readonly SessionRecord[];
   try {
-    declaredParentRecords = await readJsonlSessionRecords({
-      workspaceRoot: options.workspaceRoot,
-      sessionId: lineage.parentSessionId,
-      ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-    });
+    declaredParentRecords = await readSessionRecords(options, lineage.parentSessionId);
   } catch {
     throw new SessionLifecycleError("session_invalid");
   }
@@ -5931,11 +5725,7 @@ async function readValidatedLineagePrefix(
   const parentRecords =
     sourceSessionId === lineage.parentSessionId
       ? declaredParentRecords
-      : await readJsonlSessionRecords({
-          workspaceRoot: options.workspaceRoot,
-          sessionId: sourceSessionId,
-          ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-        });
+      : await readSessionRecords(options, sourceSessionId);
   const parentGenesis = parentRecords[0];
   if (
     parentGenesis === undefined ||
@@ -6824,11 +6614,7 @@ async function appendDanglingAttemptInterruption(
   options: SessionLifecycleOptions,
   snapshot: CurrentSessionSnapshot,
 ): Promise<boolean> {
-  const records = await readJsonlSessionRecords({
-    workspaceRoot: options.workspaceRoot,
-    sessionId: snapshot.sessionId,
-    ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-  });
+  const records = await readSessionRecords(options, snapshot.sessionId);
   const currentRecords = records.filter((record) => record.schemaVersion === 3);
   const latestRun = currentRecords.findLast(
     (record) => record.record.type === "logical_run_started",
@@ -6846,11 +6632,7 @@ async function appendDanglingAttemptInterruption(
   ) {
     return false;
   }
-  const store = await openJsonlSessionStore<SessionRecord>({
-    workspaceRoot: options.workspaceRoot,
-    sessionId: snapshot.sessionId,
-    ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-  });
+  const store = await openSessionStore(options, snapshot.sessionId);
   await store.append({
     schemaVersion: 3,
     sequence: records.length + 1,
@@ -6869,11 +6651,7 @@ async function appendDanglingContextCompactionInterruption(
   options: SessionLifecycleOptions,
   snapshot: CurrentSessionSnapshot,
 ): Promise<boolean> {
-  const records = await readJsonlSessionRecords({
-    workspaceRoot: options.workspaceRoot,
-    sessionId: snapshot.sessionId,
-    ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-  });
+  const records = await readSessionRecords(options, snapshot.sessionId);
   const started = records.findLast(
     (record) => record.schemaVersion === 3 && record.record.type === "context_compaction_started",
   );
@@ -6893,11 +6671,7 @@ async function appendDanglingContextCompactionInterruption(
   if (hasTerminal) {
     return false;
   }
-  const store = await openJsonlSessionStore<SessionRecord>({
-    workspaceRoot: options.workspaceRoot,
-    sessionId: snapshot.sessionId,
-    ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-  });
+  const store = await openSessionStore(options, snapshot.sessionId);
   await store.append({
     schemaVersion: 3,
     sequence: records.length + 1,
@@ -6921,11 +6695,7 @@ async function appendMissingUserMessage(
   options: SessionLifecycleOptions,
   snapshot: CurrentSessionSnapshot,
 ): Promise<boolean> {
-  const records = await readJsonlSessionRecords({
-    workspaceRoot: options.workspaceRoot,
-    sessionId: snapshot.sessionId,
-    ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-  });
+  const records = await readSessionRecords(options, snapshot.sessionId);
   const currentRecords = records.filter((record) => record.schemaVersion === 3);
   const run = currentRecords.findLast((record) => record.record.type === "logical_run_started");
   if (run?.record.type !== "logical_run_started") {
@@ -6941,11 +6711,7 @@ async function appendMissingUserMessage(
   if (hasUserMessage) {
     return false;
   }
-  const store = await openJsonlSessionStore<SessionRecord>({
-    workspaceRoot: options.workspaceRoot,
-    sessionId: snapshot.sessionId,
-    ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-  });
+  const store = await openSessionStore(options, snapshot.sessionId);
   await store.append({
     schemaVersion: 3,
     sequence: records.length + 1,
@@ -6962,11 +6728,7 @@ async function settleRunTerminalIntent(
   options: SessionLifecycleOptions,
   snapshot: CurrentSessionSnapshot,
 ): Promise<boolean> {
-  const records = await readJsonlSessionRecords({
-    workspaceRoot: options.workspaceRoot,
-    sessionId: snapshot.sessionId,
-    ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-  });
+  const records = await readSessionRecords(options, snapshot.sessionId);
   const currentRecords = records.filter((record) => record.schemaVersion === 3);
   const run = currentRecords.findLast((record) => record.record.type === "logical_run_started");
   if (run?.record.type !== "logical_run_started") {
@@ -6991,11 +6753,7 @@ async function settleRunTerminalIntent(
   ) {
     return false;
   }
-  const store = await openJsonlSessionStore<SessionRecord>({
-    workspaceRoot: options.workspaceRoot,
-    sessionId: snapshot.sessionId,
-    ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-  });
+  const store = await openSessionStore(options, snapshot.sessionId);
   let nextSequence = records.length + 1;
   const hasCancellationEvent = currentRecords.some(
     (record) =>
@@ -7031,11 +6789,7 @@ async function settleIndeterminateToolEffects(
   options: SessionLifecycleOptions,
   snapshot: CurrentSessionSnapshot,
 ): Promise<boolean> {
-  const records = await readJsonlSessionRecords({
-    workspaceRoot: options.workspaceRoot,
-    sessionId: snapshot.sessionId,
-    ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-  });
+  const records = await readSessionRecords(options, snapshot.sessionId);
   const currentRecords = records.filter((record) => record.schemaVersion === 3);
   const latestRun = currentRecords.findLast(
     (record) => record.record.type === "logical_run_started",
@@ -7095,11 +6849,7 @@ async function settleIndeterminateToolEffects(
   if (first === undefined) {
     return false;
   }
-  const store = await openJsonlSessionStore<SessionRecord>({
-    workspaceRoot: options.workspaceRoot,
-    sessionId: snapshot.sessionId,
-    ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-  });
+  const store = await openSessionStore(options, snapshot.sessionId);
   let nextSequence = records.length + 1;
   for (const call of indeterminateCalls) {
     if (!call.requested) {
@@ -7161,11 +6911,7 @@ async function settleInterruptedCancellation(
   options: SessionLifecycleOptions,
   snapshot: CurrentSessionSnapshot,
 ): Promise<boolean> {
-  const records = await readJsonlSessionRecords({
-    workspaceRoot: options.workspaceRoot,
-    sessionId: snapshot.sessionId,
-    ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-  });
+  const records = await readSessionRecords(options, snapshot.sessionId);
   const currentRecords = records.filter((record) => record.schemaVersion === 3);
   const run = currentRecords.findLast((record) => record.record.type === "logical_run_started");
   if (run?.record.type !== "logical_run_started") {
@@ -7188,11 +6934,7 @@ async function settleInterruptedCancellation(
   if (cancellation === undefined || settled) {
     return false;
   }
-  const store = await openJsonlSessionStore<SessionRecord>({
-    workspaceRoot: options.workspaceRoot,
-    sessionId: snapshot.sessionId,
-    ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-  });
+  const store = await openSessionStore(options, snapshot.sessionId);
   await store.append({
     schemaVersion: 3,
     sequence: records.length + 1,
@@ -7216,11 +6958,7 @@ async function settleCompletedResponseTerminal(
   snapshot: CurrentSessionSnapshot,
   artifactCache: ModelResponseArtifactCache,
 ): Promise<boolean> {
-  const records = await readJsonlSessionRecords({
-    workspaceRoot: options.workspaceRoot,
-    sessionId: snapshot.sessionId,
-    ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-  });
+  const records = await readSessionRecords(options, snapshot.sessionId);
   const currentRecords = records.filter((record) => record.schemaVersion === 3);
   const run = currentRecords.findLast((record) => record.record.type === "logical_run_started");
   if (run?.record.type !== "logical_run_started") {
@@ -7336,11 +7074,7 @@ async function settleCompletedResponseTerminal(
             },
           }
         : { status: "completed", answer: responseText };
-  const store = await openJsonlSessionStore<SessionRecord>({
-    workspaceRoot: options.workspaceRoot,
-    sessionId: snapshot.sessionId,
-    ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-  });
+  const store = await openSessionStore(options, snapshot.sessionId);
   let nextSequence = records.length + 1;
   const responseWasPublished = currentRecords.some(
     (record) =>
@@ -8256,6 +7990,35 @@ function effectiveSessionStateRoot(configured: string | undefined): string {
   return xdgStateHome === undefined || xdgStateHome.length === 0
     ? join(homedir(), ".local", "state", "adam-agent")
     : join(xdgStateHome, "adam-agent");
+}
+
+function sessionStoreDirectoryFrom(
+  options: SessionLifecycleOptions,
+): SessionStoreDirectory<SessionRecord> {
+  const directory = options[sessionStoreDirectory];
+  if (directory === undefined) {
+    throw new TypeError("The normalized Session Lifecycle requires a session store directory.");
+  }
+  return directory;
+}
+
+async function readSessionRecords(
+  options: SessionLifecycleOptions,
+  sessionId: string,
+): Promise<readonly SessionRecord[]> {
+  const store = await sessionStoreDirectoryFrom(options).open(sessionId);
+  return store?.read() ?? [];
+}
+
+async function openSessionStore(
+  options: SessionLifecycleOptions,
+  sessionId: string,
+): Promise<SessionStore<SessionRecord>> {
+  const store = await sessionStoreDirectoryFrom(options).open(sessionId);
+  if (store === undefined) {
+    throw new SessionLifecycleError("session_not_found");
+  }
+  return store;
 }
 
 function inlineModelResponseField(field: string | SessionModelResponseField): string {

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { chmod, type FileHandle, mkdir, open, realpath } from "node:fs/promises";
+import { chmod, type FileHandle, mkdir, open, readdir, realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -765,6 +765,12 @@ export type SessionRecord = SessionEventRecord | SessionV3Record;
 export interface SessionStore<RecordType extends SessionRecord = SessionEventRecord> {
   append(record: RecordType): Promise<void>;
   read(): Promise<readonly RecordType[]>;
+}
+
+export interface SessionStoreDirectory<RecordType extends SessionRecord = SessionRecord> {
+  create(sessionId: string): Promise<SessionStore<RecordType>>;
+  listSessionIds(): Promise<readonly string[]>;
+  open(sessionId: string): Promise<SessionStore<RecordType> | undefined>;
 }
 
 export class SessionStoreError extends Error {
@@ -2040,6 +2046,67 @@ export function createInMemorySessionStore<
   };
 }
 
+export function createInMemorySessionStoreDirectory<
+  RecordType extends SessionRecord = SessionRecord,
+>(): SessionStoreDirectory<RecordType> {
+  const stores = new Map<string, SessionStore<RecordType>>();
+  return {
+    async create(sessionId) {
+      validateSessionId(sessionId);
+      if (stores.has(sessionId)) {
+        throw new SessionStoreError("session_log_exists");
+      }
+      const store = createInMemorySessionStore<RecordType>();
+      stores.set(sessionId, store);
+      return store;
+    },
+    async listSessionIds() {
+      return [...stores.keys()].sort();
+    },
+    async open(sessionId) {
+      validateSessionId(sessionId);
+      const store = stores.get(sessionId);
+      return store !== undefined && (await store.read()).length > 0 ? store : undefined;
+    },
+  };
+}
+
+export function createJsonlSessionStoreDirectory<
+  RecordType extends SessionRecord = SessionRecord,
+>(options: {
+  readonly workspaceRoot: string;
+  readonly stateRoot?: string;
+}): SessionStoreDirectory<RecordType> {
+  return {
+    create(sessionId) {
+      return createJsonlSessionStore<RecordType>({ ...options, sessionId });
+    },
+    async listSessionIds() {
+      const { sessionsDirectory } = await resolveProjectSessionDirectories(options);
+      try {
+        return (await readdir(sessionsDirectory, { withFileTypes: true }))
+          .filter((entry) => entry.isFile() && /^[0-9a-f-]{36}\.jsonl$/u.test(entry.name))
+          .map((entry) => entry.name.slice(0, -".jsonl".length))
+          .sort();
+      } catch (error) {
+        if (isNodeError(error) && error.code === "ENOENT") {
+          return [];
+        }
+        throw error;
+      }
+    },
+    async open(sessionId) {
+      validateSessionId(sessionId);
+      const sessionPath = await resolveSessionPath({ ...options, sessionId });
+      const log = await readBoundedSessionLog(sessionPath);
+      if (log === undefined || log.records.length === 0) {
+        return undefined;
+      }
+      return createJsonlStore<RecordType>(sessionPath, log.records.length + 1, log.storedBytes);
+    },
+  };
+}
+
 export async function createJsonlSessionStore<
   RecordType extends SessionRecord = SessionEventRecord,
 >(options: {
@@ -2049,12 +2116,8 @@ export async function createJsonlSessionStore<
 }): Promise<SessionStore<RecordType>> {
   validateSessionId(options.sessionId);
 
-  const canonicalWorkspaceRoot = await realpath(options.workspaceRoot);
-  const projectId = createHash("sha256").update(canonicalWorkspaceRoot).digest("hex");
-  const stateRoot = options.stateRoot ?? defaultStateRoot();
-  const projectsDirectory = join(stateRoot, "projects");
-  const projectDirectory = join(projectsDirectory, projectId);
-  const sessionsDirectory = join(projectDirectory, "sessions");
+  const { projectDirectory, projectsDirectory, sessionsDirectory } =
+    await resolveProjectSessionDirectories(options);
   for (const directory of [projectsDirectory, projectDirectory, sessionsDirectory]) {
     await mkdir(directory, { recursive: true, mode: 0o700 });
     await chmod(directory, 0o700);
@@ -2154,10 +2217,27 @@ async function resolveSessionPath(options: {
   readonly stateRoot?: string;
 }): Promise<string> {
   validateSessionId(options.sessionId);
+  const { sessionsDirectory } = await resolveProjectSessionDirectories(options);
+  return join(sessionsDirectory, `${options.sessionId}.jsonl`);
+}
+
+async function resolveProjectSessionDirectories(options: {
+  readonly workspaceRoot: string;
+  readonly stateRoot?: string;
+}): Promise<{
+  readonly projectDirectory: string;
+  readonly projectsDirectory: string;
+  readonly sessionsDirectory: string;
+}> {
   const canonicalWorkspaceRoot = await realpath(options.workspaceRoot);
   const projectId = createHash("sha256").update(canonicalWorkspaceRoot).digest("hex");
-  const stateRoot = options.stateRoot ?? defaultStateRoot();
-  return join(stateRoot, "projects", projectId, "sessions", `${options.sessionId}.jsonl`);
+  const projectsDirectory = join(options.stateRoot ?? defaultStateRoot(), "projects");
+  const projectDirectory = join(projectsDirectory, projectId);
+  return {
+    projectDirectory,
+    projectsDirectory,
+    sessionsDirectory: join(projectDirectory, "sessions"),
+  };
 }
 
 function defaultStateRoot(): string {

--- a/packages/testkit/src/index.ts
+++ b/packages/testkit/src/index.ts
@@ -1,3 +1,5 @@
+import { realpathSync } from "node:fs";
+
 import {
   createSessionLifecycle,
   type ModelDriver,
@@ -6,13 +8,81 @@ import {
   type SessionLifecycle,
   type SessionLifecycleOptions,
 } from "@adam-agent/agent";
-import { sessionAutomaticTitlesEnabled } from "@adam-agent/agent/internal-testing";
+import {
+  createInMemorySessionStoreDirectory,
+  type ProjectLifecycleOwner,
+  ProjectLifecycleOwnerError,
+  type ProjectLifecycleOwnerLease,
+  type SessionRecord,
+  type SessionStoreDirectory,
+  sessionAutomaticTitlesEnabled,
+  sessionProjectLifecycleOwner,
+  sessionStoreDirectory,
+} from "@adam-agent/agent/internal-testing";
 
 /** Keeps pre-B9 fixtures focused on their original provider/session contract. */
 export function createSessionLifecycleForTesting(
   options: SessionLifecycleOptions,
 ): SessionLifecycle {
   return createSessionLifecycle({ ...options, [sessionAutomaticTitlesEnabled]: false });
+}
+
+export function createInMemorySessionLifecycleHarness(): {
+  readonly acquireOwner: () => Promise<ProjectLifecycleOwnerLease>;
+  readonly createLifecycle: (options: SessionLifecycleOptions) => SessionLifecycle;
+  readonly sessions: SessionStoreDirectory<SessionRecord>;
+} {
+  const directory = createInMemorySessionStoreDirectory<SessionRecord>();
+  const owner = createInMemoryProjectLifecycleOwner();
+  let canonicalWorkspaceRoot: string | undefined;
+  return {
+    acquireOwner: () => owner.acquire(),
+    createLifecycle(options) {
+      const requestedCanonicalRoot = realpathSync(options.workspaceRoot);
+      canonicalWorkspaceRoot ??= requestedCanonicalRoot;
+      if (canonicalWorkspaceRoot !== requestedCanonicalRoot) {
+        throw new TypeError("One in-memory lifecycle harness may own only one workspace root.");
+      }
+      return createSessionLifecycle({
+        ...options,
+        [sessionAutomaticTitlesEnabled]: false,
+        [sessionProjectLifecycleOwner]: owner,
+        [sessionStoreDirectory]: directory,
+      });
+    },
+    sessions: directory,
+  };
+}
+
+function createInMemoryProjectLifecycleOwner(): ProjectLifecycleOwner {
+  let held = false;
+  const acquire = async (): Promise<ProjectLifecycleOwnerLease> => {
+    if (held) {
+      throw new ProjectLifecycleOwnerError("project_in_use");
+    }
+    held = true;
+    let released = false;
+    return {
+      async release() {
+        if (released) {
+          return;
+        }
+        released = true;
+        held = false;
+      },
+    };
+  };
+  return {
+    acquire,
+    async run(operation) {
+      const lease = await acquire();
+      try {
+        return await operation();
+      } finally {
+        await lease.release();
+      }
+    },
+  };
 }
 
 export type FakeModelScript =

--- a/packages/testkit/src/session-lifecycle.test.ts
+++ b/packages/testkit/src/session-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,7 +8,6 @@ import { fileURLToPath } from "node:url";
 import {
   type ContextProfile,
   createCodingToolRegistry,
-  createJsonlSessionStore,
   createModelTargets,
   createMutationToolRegistry,
   createPermissionPolicy,
@@ -29,7 +28,7 @@ import {
   sessionAutomaticTitlesEnabled,
 } from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
-import { FakeModelDriver } from "./index.js";
+import { createInMemorySessionLifecycleHarness, FakeModelDriver } from "./index.js";
 
 const targetIdentity: ModelTargetIdentity = {
   targetId: "deepseek-v4-flash.direct",
@@ -121,7 +120,10 @@ test("session metadata observers cannot overturn a durable naming mutation", asy
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
-  const lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    stateRoot,
+    workspaceRoot,
+  });
   const releaseObserver = Promise.withResolvers<void>();
   const unsubscribeFailure = lifecycle.subscribeMetadata(() => {
     throw new Error("observer failed");
@@ -205,19 +207,51 @@ const lifecycleOwnerFixturePath = fileURLToPath(
   new URL("../dist/session-lifecycle-owner.fixture.js", import.meta.url),
 );
 
+test("SessionLifecycle rejects a deterministic competing owner and proceeds after release", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-lifecycle-memory-owner-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const workspaceAlias = join(testRoot, "workspace-alias");
+  await mkdir(workspaceRoot);
+  await symlink(workspaceRoot, workspaceAlias, "dir");
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ workspaceRoot });
+  const aliasLifecycle = harness.createLifecycle({ workspaceRoot: workspaceAlias });
+  const competingOwner = await harness.acquireOwner();
+
+  try {
+    await expect(aliasLifecycle.create({ targetIdentity })).rejects.toMatchObject({
+      code: "project_in_use",
+    });
+    await competingOwner.release();
+
+    await expect(aliasLifecycle.create({ targetIdentity })).resolves.toMatchObject({
+      status: "idle",
+      targetIdentity,
+    });
+  } finally {
+    await competingOwner.release();
+    await aliasLifecycle.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("SessionLifecycle creates durable new-schema genesis for an exact project and target", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-lifecycle-create-"));
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
 
+  const harness = createInMemorySessionLifecycleHarness();
+  const first = harness.createLifecycle({ stateRoot, workspaceRoot });
+  let cold: ReturnType<typeof createSessionLifecycle> | undefined;
+
   try {
-    const created = await createSessionLifecycle({ stateRoot, workspaceRoot }).create({
-      targetIdentity,
-    });
-    const inspected = await createSessionLifecycle({ stateRoot, workspaceRoot }).inspect({
-      sessionId: created.sessionId,
-    });
+    const created = await first.create({ targetIdentity });
+    await expect(first.close()).resolves.toEqual({ status: "closed" });
+    const coldLifecycle = harness.createLifecycle({ stateRoot, workspaceRoot });
+    cold = coldLifecycle;
+    const inspected = await coldLifecycle.inspect({ sessionId: created.sessionId });
 
     const expected = {
       schemaVersion: 3,
@@ -234,6 +268,42 @@ test("SessionLifecycle creates durable new-schema genesis for an exact project a
     expect({ created, inspected }).toEqual({ created: expected, inspected: expected });
     await expect(stat(join(stateRoot, "artifacts"))).rejects.toMatchObject({ code: "ENOENT" });
   } finally {
+    await first.close();
+    await cold?.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle catalogs shared in-memory sessions through public pagination", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-lifecycle-memory-catalog-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ workspaceRoot });
+
+  try {
+    const created = [
+      await lifecycle.create({ targetIdentity }),
+      await lifecycle.create({ targetIdentity }),
+    ];
+    const firstPage = await lifecycle.listProjectSessions({ limit: 1 });
+    if (firstPage.nextCursor === null) {
+      throw new Error("The first in-memory catalog page requires a continuation cursor.");
+    }
+    const secondPage = await lifecycle.listProjectSessions({
+      cursor: firstPage.nextCursor,
+      limit: 1,
+    });
+
+    expect([...firstPage.items, ...secondPage.items].map((item) => item.sessionId)).toEqual(
+      created.map((item) => item.sessionId).sort(),
+    );
+    expect({ first: firstPage.nextCursor, second: secondPage.nextCursor }).toEqual({
+      first: expect.any(String),
+      second: null,
+    });
+  } finally {
+    await lifecycle.close();
     await rm(testRoot, { recursive: true, force: true });
   }
 });
@@ -243,10 +313,11 @@ test("SessionLifecycle creates a prompt-v3 genesis with an empty bounded Skill s
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
+  const harness = createInMemorySessionLifecycleHarness();
 
   try {
     const tools = createCodingToolRegistry({ stateRoot, workspaceRoot });
-    const lifecycle = createSessionLifecycle({ stateRoot, tools, workspaceRoot });
+    const lifecycle = harness.createLifecycle({ stateRoot, tools, workspaceRoot });
     const created = await lifecycle.create({ targetIdentity });
     const inspected = await lifecycle.inspect({ sessionId: created.sessionId });
 
@@ -292,7 +363,8 @@ test("SessionLifecycle restores an uncompacted v1 session after the current targ
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
-  const created = await createSessionLifecycle({ stateRoot, workspaceRoot }).create({
+  const harness = createInMemorySessionLifecycleHarness();
+  const created = await harness.createLifecycle({ stateRoot, workspaceRoot }).create({
     targetIdentity,
   });
   const v2Identity: ModelTargetIdentity = { ...targetIdentity, profileVersion: 2 };
@@ -339,14 +411,16 @@ test("SessionLifecycle restores an uncompacted v1 session after the current targ
   };
 
   try {
-    const continued = await createSessionLifecycle({
-      modelTargets: upgradedTargets,
-      stateRoot,
-      workspaceRoot,
-    }).continue({
-      sessionId: created.sessionId,
-      input: { text: "Continue with the historical profile." },
-    });
+    const continued = await harness
+      .createLifecycle({
+        modelTargets: upgradedTargets,
+        stateRoot,
+        workspaceRoot,
+      })
+      .continue({
+        sessionId: created.sessionId,
+        input: { text: "Continue with the historical profile." },
+      });
 
     expect({ result: continued.result, observedBudgets, v2DriverCalls }).toEqual({
       result: { status: "completed", answer: "Historical v1 restored." },
@@ -395,11 +469,12 @@ test("SessionLifecycle rejects an unsupported historical profile before model re
   };
 
   try {
-    const created = await createSessionLifecycle({ stateRoot, workspaceRoot }).create({
+    const harness = createInMemorySessionLifecycleHarness();
+    const created = await harness.createLifecycle({ stateRoot, workspaceRoot }).create({
       targetIdentity: unsupportedIdentity,
     });
     await expect(
-      createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot }).resume({
+      harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot }).resume({
         sessionId: created.sessionId,
       }),
     ).resolves.toMatchObject({
@@ -407,7 +482,7 @@ test("SessionLifecycle rejects an unsupported historical profile before model re
       error: { code: "model_target_incompatible" },
     });
     await expect(
-      createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot }).continue({
+      harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot }).continue({
         sessionId: created.sessionId,
         input: { text: "This request must not reach the model." },
       }),
@@ -425,13 +500,13 @@ test("SessionLifecycle rejects restored v3 records that violate session causalit
   await mkdir(workspaceRoot);
 
   try {
-    const lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ stateRoot, workspaceRoot });
     const created = await lifecycle.create({ targetIdentity });
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
     await store.append({
       schemaVersion: 3,
       sequence: 2,
@@ -459,14 +534,14 @@ test("SessionLifecycle rejects a fabricated completed settlement without a provi
   await mkdir(workspaceRoot);
 
   try {
-    const lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ stateRoot, workspaceRoot });
     const created = await lifecycle.create({ targetIdentity });
     const runId = "123e4567-e89b-42d3-a456-426614174098";
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
     await store.append({
       schemaVersion: 3,
       sequence: 2,
@@ -508,7 +583,8 @@ test("SessionLifecycle keeps legacy history inspectable but rejects model resume
   const workspaceRoot = join(testRoot, "workspace");
   const sessionId = "legacy-session";
   await mkdir(workspaceRoot);
-  const store = await createJsonlSessionStore({ stateRoot, workspaceRoot, sessionId });
+  const harness = createInMemorySessionLifecycleHarness();
+  const store = await harness.sessions.create(sessionId);
   await store.append({
     schemaVersion: 1,
     runId: "123e4567-e89b-42d3-a456-426614174000",
@@ -526,7 +602,7 @@ test("SessionLifecycle keeps legacy history inspectable but rejects model resume
   });
 
   try {
-    const lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+    const lifecycle = harness.createLifecycle({ stateRoot, workspaceRoot });
     const inspected = await lifecycle.inspect({ sessionId });
     const resumed = await lifecycle.resume({ sessionId });
 
@@ -559,9 +635,10 @@ test("SessionLifecycle hydrate-only resume validates the exact target without mo
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
   let providerWasCalled = false;
+  const harness = createInMemorySessionLifecycleHarness();
 
   try {
-    const created = await createSessionLifecycle({ stateRoot, workspaceRoot }).create({
+    const created = await harness.createLifecycle({ stateRoot, workspaceRoot }).create({
       targetIdentity,
     });
     const modelTargets = createModelTargets({
@@ -571,7 +648,7 @@ test("SessionLifecycle hydrate-only resume validates the exact target without mo
         throw new Error("hydrate-only resume must not call the provider");
       },
     });
-    const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
     const before = await lifecycle.inspect({ sessionId: created.sessionId });
 
     const resumed = await lifecycle.resume({ sessionId: created.sessionId });
@@ -592,9 +669,10 @@ test("SessionLifecycle branches a complete boundary by reference without changin
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
+  const harness = createInMemorySessionLifecycleHarness();
 
   try {
-    const lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+    const lifecycle = harness.createLifecycle({ stateRoot, workspaceRoot });
     const parent = await lifecycle.create({ targetIdentity });
     const parentBefore = await lifecycle.inspect({ sessionId: parent.sessionId });
 
@@ -663,28 +741,19 @@ test("SessionLifecycle continues a branch from its referenced parent context", a
       };
     },
   };
+  const harness = createInMemorySessionLifecycleHarness();
 
   try {
-    const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
     const parent = await lifecycle.create({ targetIdentity });
-    await lifecycle.continue({
+    const parentRun = await lifecycle.continue({
       sessionId: parent.sessionId,
       input: { text: "Parent prompt" },
     });
-    const parentRecords = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: parent.sessionId,
-    }).then((store) => store.read());
-    const responseBoundary = parentRecords.find(
-      (record) => record.schemaVersion === 3 && record.record.type === "model_response_completed",
-    )?.sequence;
-    if (responseBoundary === undefined) {
-      throw new Error("Expected a complete parent response boundary.");
-    }
+    const branchBoundary = parentRun.snapshot.lastSequence;
     const child = await lifecycle.branch({
       parentSessionId: parent.sessionId,
-      atSequence: responseBoundary,
+      atSequence: branchBoundary,
     });
 
     const childRun = await lifecycle.continue({
@@ -705,7 +774,7 @@ test("SessionLifecycle continues a branch from its referenced parent context", a
         { role: "assistant", content: "Parent answer", toolCalls: [] },
         { role: "user", content: "Child prompt" },
       ],
-      childLineage: expect.objectContaining({ parentEventPosition: responseBoundary }),
+      childLineage: expect.objectContaining({ parentEventPosition: branchBoundary }),
     });
   } finally {
     await rm(testRoot, { recursive: true, force: true });
@@ -744,7 +813,8 @@ test("SessionLifecycle retains inherited branch context across a cold continuati
   };
 
   try {
-    const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
     const root = await lifecycle.create({ targetIdentity });
     const rootRun = await lifecycle.continue({
       sessionId: root.sessionId,
@@ -755,11 +825,10 @@ test("SessionLifecycle retains inherited branch context across a cold continuati
       atSequence: rootRun.snapshot.lastSequence,
     });
     const runId = "123e4567-e89b-42d3-a456-426614174097";
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: child.sessionId,
-    });
+    const store = await harness.sessions.open(child.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the child session store.");
+    }
     const records: readonly Omit<
       Extract<SessionRecord, { readonly schemaVersion: 3 }>,
       "sequence"
@@ -831,9 +900,10 @@ test("SessionLifecycle branches to an explicit compatible exact target only when
       }),
   });
   const currentTargetIdentity = { ...targetIdentity, profileVersion: 2 };
+  const harness = createInMemorySessionLifecycleHarness();
 
   try {
-    const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
     const parent = await lifecycle.create({ targetIdentity: currentTargetIdentity });
     const parentRun = await lifecycle.continue({
       sessionId: parent.sessionId,
@@ -908,7 +978,8 @@ test("SessionLifecycle rejects an incompatible retarget hidden behind an empty b
   };
 
   try {
-    const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
     const root = await lifecycle.create({ targetIdentity });
     const rootRun = await lifecycle.continue({
       sessionId: root.sessionId,
@@ -938,14 +1009,14 @@ test("SessionLifecycle normalizes an active provider attempt before branching it
   await mkdir(workspaceRoot);
 
   try {
-    const lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ stateRoot, workspaceRoot });
     const parent = await lifecycle.create({ targetIdentity });
     const runId = "123e4567-e89b-42d3-a456-426614174050";
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: parent.sessionId,
-    });
+    const store = await harness.sessions.open(parent.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the parent session store.");
+    }
     await store.append({
       schemaVersion: 3,
       sequence: 2,
@@ -1065,7 +1136,8 @@ test("SessionLifecycle branches completed failed and cancelled runs without reop
         throw new Error("provider offline");
       },
     });
-    const failedLifecycle = createSessionLifecycle({
+    const failedHarness = createInMemorySessionLifecycleHarness();
+    const failedLifecycle = failedHarness.createLifecycle({
       modelTargets: failingTargets,
       stateRoot,
       workspaceRoot: failedWorkspace,
@@ -1116,7 +1188,8 @@ test("SessionLifecycle branches completed failed and cancelled runs without reop
         };
       },
     };
-    const cancelledLifecycle = createSessionLifecycle({
+    const cancelledHarness = createInMemorySessionLifecycleHarness();
+    const cancelledLifecycle = cancelledHarness.createLifecycle({
       modelTargets: cancellingTargets,
       stateRoot,
       workspaceRoot: cancelledWorkspace,
@@ -1227,7 +1300,8 @@ test("SessionLifecycle durably completes a canonical provider response while kee
   });
 
   try {
-    const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
     const created = await lifecycle.create({ targetIdentity });
     const events: RuntimeEvent[] = [];
     lifecycle.subscribe((event) => events.push(event));
@@ -1237,7 +1311,7 @@ test("SessionLifecycle durably completes a canonical provider response while kee
       input: { text: "Introduce yourself" },
       limits: { maxTurns: 2, maxTokens: 100 },
     });
-    const inspected = await createSessionLifecycle({ stateRoot, workspaceRoot }).inspect({
+    const inspected = await harness.createLifecycle({ stateRoot, workspaceRoot }).inspect({
       sessionId: created.sessionId,
     });
 
@@ -1319,14 +1393,14 @@ test("SessionLifecycle continues a run that crashed before its first provider at
   });
 
   try {
-    const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
     const created = await lifecycle.create({ targetIdentity });
     const runId = "123e4567-e89b-42d3-a456-426614174097";
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
     await store.append({
       schemaVersion: 3,
       sequence: 2,
@@ -1403,14 +1477,14 @@ test("SessionLifecycle restores the canonical user event after a pre-event crash
   });
 
   try {
-    const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
     const created = await lifecycle.create({ targetIdentity });
     const runId = "123e4567-e89b-42d3-a456-426614174095";
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
     await store.append({
       schemaVersion: 3,
       sequence: 2,
@@ -1469,14 +1543,14 @@ test("SessionLifecycle terminalizes a durable cancellation instead of reopening 
   });
 
   try {
-    const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
     const created = await lifecycle.create({ targetIdentity });
     const runId = "123e4567-e89b-42d3-a456-426614174096";
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
     const records: readonly Omit<
       Extract<SessionRecord, { readonly schemaVersion: 3 }>,
       "sequence"
@@ -1593,7 +1667,8 @@ test("SessionLifecycle completes a durable run-terminal intent instead of starti
   });
 
   try {
-    const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
     const created = await lifecycle.create({ targetIdentity });
     const runId = "123e4567-e89b-42d3-a456-426614174094";
     const terminalResult = {
@@ -1603,11 +1678,10 @@ test("SessionLifecycle completes a durable run-terminal intent instead of starti
         message: "The model stream ended without a finish event.",
       },
     } as const;
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
     const records: readonly Omit<
       Extract<SessionRecord, { readonly schemaVersion: 3 }>,
       "sequence"
@@ -1717,21 +1791,23 @@ test("SessionLifecycle artifactizes replay-critical reasoning instead of truncat
   };
 
   try {
-    const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
     const created = await lifecycle.create({ targetIdentity });
     const continued = await lifecycle.continue({
       sessionId: created.sessionId,
       input: { text: "Think too much" },
     });
-    const completedResponses = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    }).then(async (store) =>
-      (await store.read()).filter(
-        (record) => record.schemaVersion === 3 && record.record.type === "model_response_completed",
-      ),
-    );
+    const completedResponses = await harness.sessions
+      .open(created.sessionId)
+      .then(async (store) =>
+        store === undefined
+          ? []
+          : (await store.read()).filter(
+              (record) =>
+                record.schemaVersion === 3 && record.record.type === "model_response_completed",
+            ),
+      );
 
     expect(continued).toMatchObject({
       result: { status: "completed", answer: "" },
@@ -1790,7 +1866,8 @@ test("SessionLifecycle classifies an oversized complete response batch as replay
   };
 
   try {
-    const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
     const created = await lifecycle.create({ targetIdentity });
     const continued = await lifecycle.continue({
       sessionId: created.sessionId,
@@ -1843,7 +1920,8 @@ test("SessionLifecycle commits a complete tool response before permission resolu
     if (readTool === undefined) {
       throw new Error("Expected the read_file tool.");
     }
-    const lifecycle = createSessionLifecycle({
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({
       modelTargets,
       stateRoot,
       workspaceRoot,
@@ -1872,11 +1950,9 @@ test("SessionLifecycle commits a complete tool response before permission resolu
     });
     const permission = await permissionRequested;
     const beforeDecision = await lifecycle.inspect({ sessionId: created.sessionId });
-    const durableRecords = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    }).then((store) => store.read());
+    const durableRecords = await harness.sessions
+      .open(created.sessionId)
+      .then((store) => store?.read() ?? []);
     const completedResponse = durableRecords.find(
       (record) => record.schemaVersion === 3 && record.record.type === "model_response_completed",
     );
@@ -1956,14 +2032,14 @@ test("SessionLifecycle cold continuation interrupts the old attempt and reuses i
   });
 
   try {
-    const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
     const created = await lifecycle.create({ targetIdentity });
     const runId = "123e4567-e89b-42d3-a456-426614174100";
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
     await store.append({
       schemaVersion: 3,
       sequence: 2,
@@ -2121,14 +2197,14 @@ test("SessionLifecycle retains reported token usage from an interrupted provider
   };
 
   try {
-    const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
     const created = await lifecycle.create({ targetIdentity });
     const runId = "123e4567-e89b-42d3-a456-426614174101";
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
     const records: readonly Omit<
       Extract<SessionRecord, { readonly schemaVersion: 3 }>,
       "sequence"
@@ -2223,7 +2299,8 @@ test("SessionLifecycle settles an exhausted durable tool response before replayi
     if (readTool === undefined) {
       throw new Error("Expected the read_file tool.");
     }
-    const lifecycle = createSessionLifecycle({
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({
       modelTargets,
       permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
       stateRoot,
@@ -2237,11 +2314,10 @@ test("SessionLifecycle settles an exhausted durable tool response before replayi
       name: "read_file",
       argumentsJson: '{"path":"README.md"}',
     } as const;
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
     const records: readonly Omit<
       Extract<SessionRecord, { readonly schemaVersion: 3 }>,
       "sequence"
@@ -2389,14 +2465,14 @@ test("SessionLifecycle settles a durable stop response with aggregate usage afte
   });
 
   try {
-    const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
     const created = await lifecycle.create({ targetIdentity });
     const runId = "123e4567-e89b-42d3-a456-426614174150";
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
     const records: readonly Omit<
       Extract<SessionRecord, { readonly schemaVersion: 3 }>,
       "sequence"
@@ -2529,7 +2605,8 @@ test("SessionLifecycle cold continuation replays a completed safe read as contex
     if (readTool === undefined) {
       throw new Error("Expected the read_file tool.");
     }
-    const lifecycle = createSessionLifecycle({
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({
       modelTargets,
       stateRoot,
       workspaceRoot,
@@ -2538,11 +2615,10 @@ test("SessionLifecycle cold continuation replays a completed safe read as contex
     });
     const created = await lifecycle.create({ targetIdentity });
     const runId = "123e4567-e89b-42d3-a456-426614174200";
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
     const records: readonly Omit<
       Extract<SessionRecord, { readonly schemaVersion: 3 }>,
       "sequence"
@@ -2791,7 +2867,8 @@ test("SessionLifecycle settles a started unsafe tool effect as indeterminate wit
     if (writeTool === undefined) {
       throw new Error("Expected the write_file tool.");
     }
-    const lifecycle = createSessionLifecycle({
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({
       modelTargets,
       permissions: createPermissionPolicy({ allowedEffects: ["write"] }),
       stateRoot,
@@ -2805,11 +2882,10 @@ test("SessionLifecycle settles a started unsafe tool effect as indeterminate wit
       name: "write_file",
       argumentsJson: '{"path":"unsafe.txt","content":"x"}',
     } as const;
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
     const records: readonly Omit<
       Extract<SessionRecord, { readonly schemaVersion: 3 }>,
       "sequence"
@@ -2981,7 +3057,8 @@ test("SessionLifecycle explicitly replays one exact safe read after revalidating
     if (readTool === undefined) {
       throw new Error("Expected the read_file tool.");
     }
-    const lifecycle = createSessionLifecycle({
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({
       modelTargets,
       permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
       stateRoot,
@@ -2995,11 +3072,10 @@ test("SessionLifecycle explicitly replays one exact safe read after revalidating
       name: "read_file",
       argumentsJson: '{"path":"README.md"}',
     } as const;
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
     const records: readonly Omit<
       Extract<SessionRecord, { readonly schemaVersion: 3 }>,
       "sequence"
@@ -3106,11 +3182,7 @@ test("SessionLifecycle explicitly replays one exact safe read after revalidating
 
     const hydrated = await lifecycle.resume({ sessionId: created.sessionId });
     const continued = await lifecycle.continue({ sessionId: created.sessionId });
-    const persisted = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    }).then((sessionStore) => sessionStore.read());
+    const persisted = await store.read();
     const publicToolEvents = persisted.flatMap((record) =>
       record.schemaVersion === 3 &&
       record.record.type === "runtime_event" &&
@@ -3197,7 +3269,8 @@ test("SessionLifecycle asks again after restart instead of restoring a pending p
     if (readTool === undefined) {
       throw new Error("Expected the read_file tool.");
     }
-    const lifecycle = createSessionLifecycle({
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({
       modelTargets,
       permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["read"] }),
       stateRoot,
@@ -3212,11 +3285,10 @@ test("SessionLifecycle asks again after restart instead of restoring a pending p
       argumentsJson: '{"path":"README.md"}',
     } as const;
     const requestId = `${runId}:${call.id}`;
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
     const records: readonly Omit<
       Extract<SessionRecord, { readonly schemaVersion: 3 }>,
       "sequence"
@@ -3398,7 +3470,8 @@ test.each([
       if (readTool === undefined) {
         throw new Error("Expected the read_file tool.");
       }
-      const lifecycle = createSessionLifecycle({
+      const harness = createInMemorySessionLifecycleHarness();
+      const lifecycle = harness.createLifecycle({
         modelTargets,
         permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
         stateRoot,
@@ -3412,11 +3485,10 @@ test.each([
         name: "read_file",
         argumentsJson: '{"path":"README.md"}',
       } as const;
-      const store = await openJsonlSessionStore<SessionRecord>({
-        stateRoot,
-        workspaceRoot,
-        sessionId: created.sessionId,
-      });
+      const store = await harness.sessions.open(created.sessionId);
+      if (store === undefined) {
+        throw new Error("Expected the created session store.");
+      }
       const records: readonly Omit<
         Extract<SessionRecord, { readonly schemaVersion: 3 }>,
         "sequence"
@@ -3663,13 +3735,13 @@ test("SessionLifecycle rejects a title terminal record without its matching dura
   await mkdir(workspaceRoot);
 
   try {
-    const lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ stateRoot, workspaceRoot });
     const created = await lifecycle.create({ targetIdentity });
-    const store = await openJsonlSessionStore<SessionRecord>({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
     await store.append({
       schemaVersion: 3,
       sequence: 2,

--- a/packages/testkit/src/session-store.test.ts
+++ b/packages/testkit/src/session-store.test.ts
@@ -8,7 +8,12 @@ import {
   type SessionEventRecord,
   SessionStoreError,
 } from "@adam-agent/agent";
-import type { ContextProfile, SessionRecord } from "@adam-agent/agent/internal-testing";
+import {
+  type ContextProfile,
+  createInMemorySessionStoreDirectory,
+  createJsonlSessionStoreDirectory,
+  type SessionRecord,
+} from "@adam-agent/agent/internal-testing";
 import { expect, expectTypeOf, test } from "vitest";
 
 const runId = "123e4567-e89b-42d3-a456-426614174000";
@@ -35,6 +40,56 @@ type InvalidV1PatchRecord = {
 
 test("SessionEventRecord type pairs each schema version with its event contract", () => {
   expectTypeOf<InvalidV1PatchRecord>().not.toMatchTypeOf<SessionEventRecord>();
+});
+
+test("SessionStoreDirectory adapters create open and list isolated session stores", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-directory-contract-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const sessionId = "10000000-0000-4000-8000-000000000001";
+  const secondSessionId = "10000000-0000-4000-8000-000000000002";
+  const directories = [
+    ["in-memory", createInMemorySessionStoreDirectory<SessionEventRecord>()],
+    [
+      "JSONL",
+      createJsonlSessionStoreDirectory<SessionEventRecord>({
+        stateRoot: join(testRoot, "state"),
+        workspaceRoot,
+      }),
+    ],
+  ] as const;
+  const record: SessionEventRecord = {
+    schemaVersion: 1,
+    runId,
+    sequence: 1,
+    event: { type: "user_message", text: "Directory contract" },
+  };
+
+  try {
+    for (const [name, directory] of directories) {
+      expect(await directory.listSessionIds(), name).toEqual([]);
+      expect(await directory.open(sessionId), name).toBeUndefined();
+      const created = await directory.create(sessionId);
+      await created.append(record);
+      const second = await directory.create(secondSessionId);
+      expect(await second.read(), name).toEqual([]);
+
+      await expect(directory.create(sessionId), name).rejects.toMatchObject({
+        code: "session_log_exists",
+      });
+      expect(await directory.listSessionIds(), name).toEqual([sessionId, secondSessionId]);
+      await expect(
+        directory.open(sessionId).then((store) => store?.read()),
+        name,
+      ).resolves.toEqual([record]);
+      await expect(
+        directory.open(secondSessionId).then((store) => store?.read()),
+        name,
+      ).resolves.toBeUndefined();
+    }
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
 });
 
 test("SessionStore adapters append and read versioned records in order", async () => {


### PR DESCRIPTION
## Summary

- inject the existing ProjectLifecycleOwner and a narrow SessionStoreDirectory through internal testing exports
- add a harness-scoped in-memory lifecycle owner and store directory with canonical-project exclusion, nonblocking contention, and explicit release
- migrate lifecycle semantic tests to the deterministic harness while retaining raw JSONL corruption, cross-project copying, and real-process boundaries
- keep production Session Lifecycle behavior and public exports unchanged

## Evidence

- pnpm quality:check: 24 test files passed, 2 opt-in files skipped; 823 tests passed, 10 opt-in tests skipped
- complete Session Lifecycle file: 43/43 passed, including retained real-process cases
- SessionStoreDirectory parity contract passed for in-memory and JSONL adapters
- final Standards review: zero findings
- final Spec review: zero findings

Test duration is telemetry only. Success is determined by causal observables, assertions, and process completion; this change adds no sleep, polling, duration gate, worker cap, or timeout expansion.

## Scope

This is Test Architecture Hardening H1 only. H2 scripted MCP transport, H3 VirtualTerminal and OS test structure, and B9-R1 PR3 remain out of scope.