### PR TITLE
test: harden TUI harness boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ The synthetic approximately 46.875 MiB model-response durability path is intenti
 pnpm test:large-output
 ```
 
+## Test topology
+
+TUI semantic behavior runs in-process through real Presentation, real `runTui`, and a harness-owned `VirtualTerminal`; `apps/tui/src/main.os.test.ts` retains only distinct Linux process, MCP stdio, PTY, signal, resize, paste, and terminal-restoration contracts. Both layers remain part of the single required `pnpm quality:check` regression gate with no changed-path skip; the split changes fixture ownership, not coverage authority. Run them separately while diagnosing with:
+
+```bash
+pnpm test:tui:behavior
+pnpm test:tui:os
+```
+
+Tests synchronize success on rendered output, lifecycle events, filesystem notification, and process closure. Direct timeouts live only in centralized failure or cleanup guards, and test duration is diagnostic telemetry rather than a correctness threshold.
+
 Use `pnpm quality:fix` only when an intentional formatting rewrite is desired. The pre-commit hook is check-only.
 
 See [`AGENTS.md`](AGENTS.md) for the authoritative engineering contract.

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -1,0 +1,500 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, expect, test } from "vitest";
+import { removeTuiFixtureRoot as rm, waitForPath } from "./tui-filesystem.test-support.js";
+import {
+  cleanupActiveTuiFixtures,
+  startTuiFixture as startFixture,
+} from "./tui-fixture.test-support.js";
+
+const productionPath = fileURLToPath(new URL("../dist/main.js", import.meta.url));
+const mcpFixturePath = fileURLToPath(
+  new URL("../../../packages/testkit/dist/mcp-stdio-server.fixture.js", import.meta.url),
+);
+afterEach(async () => {
+  await cleanupActiveTuiFixtures();
+});
+
+test("real TUI starts on an authoritative empty session and restores the terminal on exit", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-startup-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ external: true, stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain("Adam · New session");
+    expect(result.stdout).toContain("fake.local · Certified");
+    expect(result.stdout).toContain("\u001b[?2004h");
+    expect(result.stdout).toContain("\u001b[?2004l");
+    expect(result.stdout).toContain("\u001b[?2026h");
+    expect(result.stdout).toContain("\u001b[?2026l");
+    expect(result.stdout).toContain("\u001b[?25h");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI entry exposes its usage contract", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-help-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      program: { arguments: ["--help"], cwd: workspaceRoot, entrypoint: productionPath },
+      stateRoot,
+      workspaceRoot,
+    });
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain(
+      "Usage: adam-agent-tui [--target <exact-target-id> | --resume <session-id>]",
+    );
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI entry rejects conflicting target and resume arguments", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-invalid-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      program: {
+        arguments: [
+          "--resume",
+          "session-id",
+          "--target",
+          "deepseek-v4-flash.direct",
+          "--state-root",
+          stateRoot,
+        ],
+        cwd: workspaceRoot,
+        entrypoint: productionPath,
+      },
+      stateRoot,
+      workspaceRoot,
+    });
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 1, signal: null, stderr: "" });
+    expect(result.stdout).toContain("--resume and --target cannot be combined.");
+    expect(result.stdout).toContain("Usage: adam-agent-tui");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI entry reaches a credentialed exact-target session without a model call", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-startup-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      program: {
+        arguments: ["--target", "deepseek-v4-flash.direct", "--state-root", stateRoot],
+        cwd: workspaceRoot,
+        entrypoint: productionPath,
+        environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
+      },
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    await fixture.waitFor("deepseek-v4-flash.direct · Certified");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the real TUI MCP wizard preserves every separate B8 authority step", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-mcp-wizard-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  const spawnMarker = join(testRoot, "mcp-spawned");
+  const closeMarker = join(testRoot, "mcp-closed");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+  await writeFile(
+    join(workspaceRoot, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        fixture: {
+          command: process.execPath,
+          args: [mcpFixturePath, spawnMarker, closeMarker],
+        },
+      },
+    }),
+    "utf8",
+  );
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      external: true,
+      scenario: "streaming",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("/mc");
+    await fixture.waitFor("/mc");
+    fixture.write("\t");
+    await fixture.waitFor("/mcp");
+    const afterTyping = fixture.output().length;
+    fixture.write("\r");
+    const outcome = await Promise.race([
+      fixture
+        .waitForAfter("MCP authority · workspace confirmation required", afterTyping)
+        .then(() => "wizard" as const),
+      fixture.waitForAfter("Working", afterTyping).then(() => "prompt" as const),
+    ]);
+    expect(outcome).toBe("wizard");
+    fixture.write("\r");
+    await fixture.waitFor("MCP authority · server approval required");
+    fixture.write("\r");
+    await fixture.waitFor("MCP authority · activation required");
+    fixture.write("\r");
+    await fixture.waitFor("MCP authority · tool selection required");
+    await waitForPath(spawnMarker);
+    fixture.write("1");
+    fixture.write("\u001b[B");
+    fixture.write("c");
+    await fixture.waitFor("MCP authority · profile committed");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    await waitForPath(closeMarker);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI resumes and explicitly reactivates one committed MCP profile", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-mcp-reactivation-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const spawnMarker = join(testRoot, "mcp-spawned");
+  const closeMarker = join(testRoot, "mcp-closed");
+  await mkdir(workspaceRoot);
+  await writeFile(
+    join(workspaceRoot, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        fixture: {
+          command: process.execPath,
+          args: [mcpFixturePath, spawnMarker, closeMarker],
+        },
+      },
+    }),
+    "utf8",
+  );
+  const program = {
+    arguments: ["--state-root", stateRoot],
+    cwd: workspaceRoot,
+    entrypoint: productionPath,
+    environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
+  } as const;
+
+  try {
+    const seed = startFixture({ program, stateRoot, workspaceRoot });
+    await seed.waitFor("Select an exact model target");
+    seed.write("\r");
+    await seed.waitFor("Adam · New session");
+    seed.write("/mc");
+    await seed.waitFor("/mc");
+    seed.write("\t");
+    await seed.waitFor("/mcp");
+    seed.write("\r");
+    await seed.waitFor("MCP authority · workspace confirmation required");
+    seed.write("\r");
+    await seed.waitFor("MCP authority · server approval required");
+    seed.write("\r");
+    await seed.waitFor("MCP authority · activation required");
+    seed.write("\r");
+    await seed.waitFor("MCP authority · tool selection required");
+    seed.write("1");
+    seed.write("\u001b[B");
+    seed.write("c");
+    await seed.waitFor("MCP authority · profile committed");
+    seed.write("\u0011");
+    await expect(seed.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+
+    const resumed = startFixture({ program, stateRoot, workspaceRoot });
+    await resumed.waitFor("Select a project session");
+    resumed.write("\r");
+    await resumed.waitFor("Adam · New session");
+    resumed.write("/mc");
+    await resumed.waitFor("/mc");
+    resumed.write("\t");
+    await resumed.waitFor("/mcp");
+    resumed.write("\r");
+    await resumed.waitFor("MCP authority · profile reactivation required");
+    resumed.write("\r");
+    await resumed.waitFor("MCP authority · profile committed");
+    resumed.write("\u0011");
+    await expect(resumed.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the TUI process fails visibly when MCP shutdown cannot be confirmed", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-mcp-close-unconfirmed-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const spawnMarker = join(testRoot, "mcp-spawned");
+  const closeMarker = join(testRoot, "mcp-closed");
+  await mkdir(workspaceRoot);
+  await writeFile(
+    join(workspaceRoot, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        fixture: {
+          command: process.execPath,
+          args: [mcpFixturePath, spawnMarker, closeMarker],
+        },
+      },
+    }),
+    "utf8",
+  );
+
+  try {
+    const fixture = startFixture({
+      external: true,
+      scenario: "mcp-close-unconfirmed",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("/mc");
+    await fixture.waitFor("/mc");
+    fixture.write("\t");
+    await fixture.waitFor("/mcp");
+    fixture.write("\r");
+    await fixture.waitFor("MCP authority · workspace confirmation required");
+    fixture.write("\r");
+    await fixture.waitFor("MCP authority · server approval required");
+    fixture.write("\r");
+    await fixture.waitFor("MCP authority · activation required");
+    fixture.write("\r");
+    await fixture.waitFor("MCP authority · tool selection required");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 1, signal: null });
+    expect(`${result.stdout}${result.stderr}`).toContain("MCP shutdown could not be confirmed.");
+    await waitForPath(closeMarker);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("idle Ctrl+C preserves a CJK draft and copies it only on the confirming press", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-retained-draft-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+  const draft = "保留草稿 🚀";
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      external: true,
+      scenario: "clipboard-success",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write(draft);
+    await fixture.waitFor(draft);
+    fixture.write("\u001b[99;5:1u");
+    await fixture.waitFor("Press Ctrl+C again within two seconds to exit · draft will be copied");
+    expect(fixture.output()).not.toContain("clipboard copied");
+    fixture.write("\u0003");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe(draft);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("Kitty Ctrl+C repeat and release phases cannot confirm an armed exit", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-kitty-phases-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      external: true,
+      scenario: "clipboard-success",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("草稿");
+    await fixture.waitFor("草稿");
+    fixture.write("\u001b[99;5:1u");
+    await fixture.waitFor("Press Ctrl+C again within two seconds to exit");
+    fixture.write("\u001b[99;5:2u\u001b[99;5:3ux");
+    await fixture.waitFor("草稿x");
+    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe("草稿x");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("unsupported clipboard is reported after terminal restoration without blocking exit", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-clipboard-unsupported-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ external: true, stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("draft without clipboard");
+    await fixture.waitFor("draft without clipboard");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain("Clipboard unavailable; draft was not copied.");
+    expect(result.stdout.indexOf("\u001b[?2004l")).toBeLessThan(
+      result.stdout.indexOf("Clipboard unavailable; draft was not copied."),
+    );
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+test("the real terminal admits a mutation permission with Enter", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-mutation-permission-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "edit.txt"), "before\n", "utf8");
+
+  try {
+    const fixture = startFixture({
+      external: true,
+      scenario: "mutation",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Edit the file\r");
+    await fixture.waitFor("Permission required");
+    await fixture.waitFor("-before");
+    await fixture.waitFor("+after");
+    fixture.write("\r");
+    await fixture.waitFor("Edit complete");
+    await expect(readFile(join(workspaceRoot, "edit.txt"), "utf8")).resolves.toBe("after\n");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the real terminal delivers Ctrl+C interruption without arming exit", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-cancel-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      external: true,
+      scenario: "cancellation",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Cancel this run\r");
+    await fixture.waitFor("Working");
+    fixture.write("\u0003\u0003");
+    await fixture.waitFor("cancelled");
+    expect(fixture.output()).not.toContain("Press Ctrl+C again");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+test("the real terminal preserves one bracketed multiline paste as editor input", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-bracketed-paste-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      external: true,
+      scenario: "clipboard-success",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("\u001b[200~first pasted line\n第二行\u001b[201~");
+    await fixture.waitFor("第二行");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe(
+      "first pasted line\n第二行",
+    );
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the real terminal redraws after a pseudo-terminal resize", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-resize-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const terminalProcessMarker = join(testRoot, "terminal-process");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      external: true,
+      stateRoot,
+      terminalProcessMarker,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    const beforeResize = fixture.output().length;
+    await fixture.resize(52, 18);
+    await fixture.waitForAfter("Adam · New session", beforeResize);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -1104,11 +1104,8 @@ test("editor submission renders Working then a streamed Markdown answer from rea
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
   const controlRoot = join(testRoot, "control");
-  const testEnvironment = process.env as NodeJS.ProcessEnv & { NO_COLOR?: string };
-  const inheritedNoColor = testEnvironment.NO_COLOR;
   await mkdir(workspaceRoot);
   await mkdir(controlRoot);
-  Reflect.deleteProperty(testEnvironment, "NO_COLOR");
 
   try {
     const fixture = startFixture({ controlRoot, scenario: "streaming", stateRoot, workspaceRoot });
@@ -1124,11 +1121,6 @@ test("editor submission renders Working then a streamed Markdown answer from rea
     expect(result.stdout).toContain("\u001b[48;2;49;50;68m");
     expect(result.stdout).toContain("\u001b[38;2;243;139;168m");
   } finally {
-    if (inheritedNoColor === undefined) {
-      Reflect.deleteProperty(testEnvironment, "NO_COLOR");
-    } else {
-      testEnvironment.NO_COLOR = inheritedNoColor;
-    }
     await rm(testRoot, { recursive: true, force: true });
   }
 });

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -1,36 +1,246 @@
-import { spawn } from "node:child_process";
-import {
-  access,
-  mkdir,
-  mkdtemp,
-  readdir,
-  readFile,
-  rm as remove,
-  watch,
-  writeFile,
-} from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { afterEach, expect, test } from "vitest";
-
-import type { FixtureScenario } from "./fixture-scenario.js";
-
-const fixturePath = fileURLToPath(new URL("../dist/test-fixture.js", import.meta.url));
-const productionPath = fileURLToPath(new URL("../dist/main.js", import.meta.url));
-const mcpFixturePath = fileURLToPath(
-  new URL("../../../packages/testkit/dist/mcp-stdio-server.fixture.js", import.meta.url),
-);
-const fixtureFailureMilliseconds = 30_000;
-const activeFixtures = new Set<Fixture>();
+import {
+  readFilesRecursively,
+  removeTuiFixtureRoot as rm,
+  waitForPath,
+} from "./tui-filesystem.test-support.js";
+import {
+  cleanupActiveTuiFixtures,
+  startTuiFixture as startFixture,
+} from "./tui-fixture.test-support.js";
 
 afterEach(async () => {
-  await cleanupActiveFixtures();
+  await cleanupActiveTuiFixtures();
 });
 
-test("real TUI starts on an authoritative empty session and restores the terminal on exit", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-startup-"));
+test("the production TUI selects an exact available target before creating an empty-project session", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-target-picker-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ launch: {}, stateRoot, workspaceRoot });
+    await fixture.waitFor("Select an exact model target");
+    await fixture.waitFor("deepseek-v4-flash.direct");
+    await fixture.waitFor("deepseek-v4-pro.direct");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    await fixture.waitFor("deepseek-v4-flash.direct · Certified");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("Escape closes the target picker before idle Ctrl+C can arm exit", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-target-picker-escape-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ launch: {}, stateRoot, workspaceRoot });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\u001b[27;1;27~");
+    fixture.write("\u0003");
+    await fixture.waitFor("Press Ctrl+C again within two seconds to exit");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI creates from one valid saved exact default without opening the target picker", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-default-target-"));
+  const configRoot = join(testRoot, "config");
+  const configDirectory = join(configRoot, "adam-agent");
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(configDirectory, { recursive: true, mode: 0o700 });
+  await mkdir(workspaceRoot);
+  await writeFile(
+    join(configDirectory, "config.json"),
+    JSON.stringify({ schemaVersion: 1, defaultTargetId: "deepseek-v4-flash.direct" }),
+    { encoding: "utf8", mode: 0o600 },
+  );
+
+  try {
+    const fixture = startFixture({ launch: { configRoot }, stateRoot, workspaceRoot });
+    await fixture.waitFor("deepseek-v4-flash.direct · Certified");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain("Adam · New session");
+    expect(result.stdout).not.toContain("Select an exact model target");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production target picker saves its focused exact target separately from session creation", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-save-target-"));
+  const configRoot = join(testRoot, "config");
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ launch: { configRoot }, stateRoot, workspaceRoot });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\u0013");
+    await fixture.waitFor("Saved deepseek-v4-flash.direct as the default");
+    const configurationPath = join(configRoot, "adam-agent", "config.json");
+    await waitForPath(configurationPath);
+    expect(await readFile(configurationPath, "utf8")).toBe(
+      `${JSON.stringify({
+        schemaVersion: 1,
+        defaultTargetId: "deepseek-v4-flash.direct",
+      })}\n`,
+    );
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).not.toContain("Adam · New session");
+    expect(await readFilesRecursively(stateRoot)).not.toContain('"type":"session_genesis"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production target picker shows malformed configuration diagnostics without losing direct targets", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-invalid-target-config-"));
+  const configRoot = join(testRoot, "config");
+  const configDirectory = join(configRoot, "adam-agent");
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(configDirectory, { recursive: true, mode: 0o700 });
+  await mkdir(workspaceRoot);
+  await writeFile(join(configDirectory, "config.json"), "{not-json\n", {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+
+  try {
+    const fixture = startFixture({ launch: { configRoot }, stateRoot, workspaceRoot });
+    await fixture.waitFor("deepseek-v4-flash.direct");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain("The saved default target configuration is invalid.");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI shows the project session picker before any target resolution", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-session-picker-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      launch: { seedTargetIds: ["deepseek-v4-flash.direct"] },
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("deepseek-v4-flash.direct");
+    await fixture.waitFor("Select a project session");
+    fixture.write("\u001b[27;1;27~");
+    fixture.write("\u0003");
+    await fixture.waitFor("Press Ctrl+C again within two seconds to exit");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain("Select a project session");
+    expect(result.stdout).toContain("New Session");
+    expect(result.stdout).not.toContain("Select an exact model target");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("an explicit target still waits for explicit New Session when project sessions exist", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-explicit-target-session-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      launch: {
+        seedTargetIds: ["deepseek-v4-flash.direct"],
+        startupTargetId: "deepseek-v4-pro.direct",
+      },
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("deepseek-v4-");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result.stdout).toContain("Select a project session");
+    expect(result.stdout).not.toContain("Adam · New session");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production session picker opens the exact focused existing session", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-select-session-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      launch: { seedTargetIds: ["deepseek-v4-flash.direct"] },
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Select a project session");
+    const beforeSelection = fixture.output().length;
+    fixture.write("\r");
+    await fixture.waitForAfter("Adam · New session", beforeSelection);
+    await fixture.waitForAfter("deepseek-v4-flash.direct · Certified", beforeSelection);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production session picker requires explicit New Session before target selection", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-new-session-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      launch: { seedTargetIds: ["deepseek-v4-flash.direct"] },
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Select a project session");
+    const beforeNewSession = fixture.output().length;
+    fixture.write("\u001b[B\r");
+    await fixture.waitForAfter("Select an exact model target", beforeNewSession);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production editor renames the active session through canonical Presentation truth", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-name-session-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
   await mkdir(workspaceRoot);
@@ -38,38 +248,13 @@ test("real TUI starts on an authoritative empty session and restores the termina
   try {
     const fixture = startFixture({ stateRoot, workspaceRoot });
     await fixture.waitFor("Adam · New session");
+    const beforeRename = fixture.output().length;
+    fixture.write("/name Release triage\r");
+    await fixture.waitForAfter("Release triage", beforeRename);
     fixture.write("\u0011");
     const result = await fixture.closed;
     expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
-    expect(result.stdout).toContain("Adam · New session");
-    expect(result.stdout).toContain("fake.local · Certified");
-    expect(result.stdout).toContain("\u001b[?2004h");
-    expect(result.stdout).toContain("\u001b[?2004l");
-    expect(result.stdout).toContain("\u001b[?2026h");
-    expect(result.stdout).toContain("\u001b[?2026l");
-    expect(result.stdout).toContain("\u001b[?25h");
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("the production TUI entry exposes its usage contract", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-help-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(workspaceRoot);
-
-  try {
-    const fixture = startFixture({
-      program: { arguments: ["--help"], cwd: workspaceRoot, entrypoint: productionPath },
-      stateRoot,
-      workspaceRoot,
-    });
-    const result = await fixture.closed;
-    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
-    expect(result.stdout).toContain(
-      "Usage: adam-agent-tui [--target <exact-target-id> | --resume <session-id>]",
-    );
+    expect(result.stdout).toContain("Adam · Release triage");
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }
@@ -598,7 +783,12 @@ test("resume rebuilds prompt history from active authoritative chronology", asyn
   await mkdir(controlRoot);
 
   try {
-    const fixture = startFixture({ controlRoot, scenario: "history", stateRoot, workspaceRoot });
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "history",
+      stateRoot,
+      workspaceRoot,
+    });
     await fixture.waitFor("History prompt 3");
     fixture.write("\u001b[A");
     fixture.write("\u0011");
@@ -909,6 +1099,40 @@ test("Help remains locally available while a model run is active", async () => {
   }
 });
 
+test("editor submission renders Working then a streamed Markdown answer from real Presentation truth", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-streaming-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  const testEnvironment = process.env as NodeJS.ProcessEnv & { NO_COLOR?: string };
+  const inheritedNoColor = testEnvironment.NO_COLOR;
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+  Reflect.deleteProperty(testEnvironment, "NO_COLOR");
+
+  try {
+    const fixture = startFixture({ controlRoot, scenario: "streaming", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Explain streaming\r");
+    await waitForPath(join(controlRoot, "model-started"));
+    await fixture.waitFor("Working");
+    await writeFile(join(controlRoot, "release-model"), "release\n", "utf8");
+    await fixture.waitFor("Streaming answer");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain("\u001b[48;2;49;50;68m");
+    expect(result.stdout).toContain("\u001b[38;2;243;139;168m");
+  } finally {
+    if (inheritedNoColor === undefined) {
+      Reflect.deleteProperty(testEnvironment, "NO_COLOR");
+    } else {
+      testEnvironment.NO_COLOR = inheritedNoColor;
+    }
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("slash Session remains read-only and available while a model run is active", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-active-session-facts-"));
   const workspaceRoot = join(testRoot, "workspace");
@@ -1006,443 +1230,6 @@ test("permission preempts Help and restores its exact page after settlement", as
     const result = await fixture.closed;
     expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
     expect(result.stdout.slice(beforeParent)).toContain("Adam Help");
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("the production TUI entry rejects conflicting target and resume arguments", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-invalid-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(workspaceRoot);
-
-  try {
-    const fixture = startFixture({
-      program: {
-        arguments: [
-          "--resume",
-          "session-id",
-          "--target",
-          "deepseek-v4-flash.direct",
-          "--state-root",
-          stateRoot,
-        ],
-        cwd: workspaceRoot,
-        entrypoint: productionPath,
-      },
-      stateRoot,
-      workspaceRoot,
-    });
-    const result = await fixture.closed;
-    expect(result).toMatchObject({ code: 1, signal: null, stderr: "" });
-    expect(result.stdout).toContain("--resume and --target cannot be combined.");
-    expect(result.stdout).toContain("Usage: adam-agent-tui");
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("the production TUI entry reaches a credentialed exact-target session without a model call", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-startup-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(workspaceRoot);
-
-  try {
-    const fixture = startFixture({
-      program: {
-        arguments: ["--target", "deepseek-v4-flash.direct", "--state-root", stateRoot],
-        cwd: workspaceRoot,
-        entrypoint: productionPath,
-        environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
-      },
-      stateRoot,
-      workspaceRoot,
-    });
-    await fixture.waitFor("Adam · New session");
-    await fixture.waitFor("deepseek-v4-flash.direct · Certified");
-    fixture.write("\u0011");
-    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("the production TUI selects an exact available target before creating an empty-project session", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-target-picker-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(workspaceRoot);
-
-  try {
-    const fixture = startFixture({
-      program: {
-        arguments: ["--state-root", stateRoot],
-        cwd: workspaceRoot,
-        entrypoint: productionPath,
-        environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
-      },
-      stateRoot,
-      workspaceRoot,
-    });
-    await fixture.waitFor("Select an exact model target");
-    await fixture.waitFor("deepseek-v4-flash.direct");
-    await fixture.waitFor("deepseek-v4-pro.direct");
-    fixture.write("\r");
-    await fixture.waitFor("Adam · New session");
-    await fixture.waitFor("deepseek-v4-flash.direct · Certified");
-    fixture.write("\u0011");
-    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("Escape closes the target picker before idle Ctrl+C can arm exit", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-target-picker-escape-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(workspaceRoot);
-
-  try {
-    const fixture = startFixture({
-      program: {
-        arguments: ["--state-root", stateRoot],
-        cwd: workspaceRoot,
-        entrypoint: productionPath,
-        environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
-      },
-      stateRoot,
-      workspaceRoot,
-    });
-    await fixture.waitFor("Select an exact model target");
-    fixture.write("\u001b[27;1;27~");
-    fixture.write("\u0003");
-    await fixture.waitFor("Press Ctrl+C again within two seconds to exit");
-    fixture.write("\u0011");
-    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("the production TUI creates from one valid saved exact default without opening the target picker", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-default-target-"));
-  const configRoot = join(testRoot, "config");
-  const configDirectory = join(configRoot, "adam-agent");
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(configDirectory, { recursive: true, mode: 0o700 });
-  await mkdir(workspaceRoot);
-  await writeFile(
-    join(configDirectory, "config.json"),
-    JSON.stringify({ schemaVersion: 1, defaultTargetId: "deepseek-v4-flash.direct" }),
-    { encoding: "utf8", mode: 0o600 },
-  );
-
-  try {
-    const fixture = startFixture({
-      program: {
-        arguments: ["--state-root", stateRoot],
-        cwd: workspaceRoot,
-        entrypoint: productionPath,
-        environment: {
-          DEEPSEEK_API_KEY: "deterministic-non-network-fixture",
-          XDG_CONFIG_HOME: configRoot,
-        },
-      },
-      stateRoot,
-      workspaceRoot,
-    });
-    await fixture.waitFor("deepseek-v4-flash.direct · Certified");
-    fixture.write("\u0011");
-    const result = await fixture.closed;
-    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
-    expect(result.stdout).toContain("Adam · New session");
-    expect(result.stdout).not.toContain("Select an exact model target");
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("the production target picker saves its focused exact target separately from session creation", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-save-target-"));
-  const configRoot = join(testRoot, "config");
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(workspaceRoot);
-
-  try {
-    const fixture = startFixture({
-      program: {
-        arguments: ["--state-root", stateRoot],
-        cwd: workspaceRoot,
-        entrypoint: productionPath,
-        environment: {
-          DEEPSEEK_API_KEY: "deterministic-non-network-fixture",
-          XDG_CONFIG_HOME: configRoot,
-        },
-      },
-      stateRoot,
-      workspaceRoot,
-    });
-    await fixture.waitFor("Select an exact model target");
-    fixture.write("\u0013");
-    await fixture.waitFor("Saved deepseek-v4-flash.direct as the default");
-    const configurationPath = join(configRoot, "adam-agent", "config.json");
-    await waitForPath(configurationPath);
-    expect(await readFile(configurationPath, "utf8")).toBe(
-      `${JSON.stringify({
-        schemaVersion: 1,
-        defaultTargetId: "deepseek-v4-flash.direct",
-      })}\n`,
-    );
-    fixture.write("\u0011");
-    const result = await fixture.closed;
-    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
-    expect(result.stdout).not.toContain("Adam · New session");
-    expect(await readFilesRecursively(stateRoot)).not.toContain('"type":"session_genesis"');
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("the production target picker shows malformed configuration diagnostics without losing direct targets", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-invalid-target-config-"));
-  const configRoot = join(testRoot, "config");
-  const configDirectory = join(configRoot, "adam-agent");
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(configDirectory, { recursive: true, mode: 0o700 });
-  await mkdir(workspaceRoot);
-  await writeFile(join(configDirectory, "config.json"), "{not-json\n", {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-
-  try {
-    const fixture = startFixture({
-      program: {
-        arguments: ["--state-root", stateRoot],
-        cwd: workspaceRoot,
-        entrypoint: productionPath,
-        environment: {
-          DEEPSEEK_API_KEY: "deterministic-non-network-fixture",
-          XDG_CONFIG_HOME: configRoot,
-        },
-      },
-      stateRoot,
-      workspaceRoot,
-    });
-    await fixture.waitFor("deepseek-v4-flash.direct");
-    fixture.write("\u0011");
-    const result = await fixture.closed;
-    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
-    expect(result.stdout).toContain("The saved default target configuration is invalid.");
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("the production TUI shows the project session picker before any target resolution", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-session-picker-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(workspaceRoot);
-
-  try {
-    const seed = startFixture({
-      program: {
-        arguments: ["--target", "deepseek-v4-flash.direct", "--state-root", stateRoot],
-        cwd: workspaceRoot,
-        entrypoint: productionPath,
-        environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
-      },
-      stateRoot,
-      workspaceRoot,
-    });
-    await seed.waitFor("Adam · New session");
-    seed.write("\u0011");
-    await expect(seed.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-
-    const fixture = startFixture({
-      program: {
-        arguments: ["--state-root", stateRoot],
-        cwd: workspaceRoot,
-        entrypoint: productionPath,
-        environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
-      },
-      stateRoot,
-      workspaceRoot,
-    });
-    await fixture.waitFor("deepseek-v4-flash.direct");
-    await fixture.waitFor("Select a project session");
-    fixture.write("\u001b[27;1;27~");
-    fixture.write("\u0003");
-    await fixture.waitFor("Press Ctrl+C again within two seconds to exit");
-    fixture.write("\u0011");
-    const result = await fixture.closed;
-    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
-    expect(result.stdout).toContain("Select a project session");
-    expect(result.stdout).toContain("New Session");
-    expect(result.stdout).not.toContain("Select an exact model target");
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("an explicit target still waits for explicit New Session when project sessions exist", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-explicit-target-session-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(workspaceRoot);
-
-  try {
-    const seed = startFixture({
-      program: {
-        arguments: ["--target", "deepseek-v4-flash.direct", "--state-root", stateRoot],
-        cwd: workspaceRoot,
-        entrypoint: productionPath,
-        environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
-      },
-      stateRoot,
-      workspaceRoot,
-    });
-    await seed.waitFor("Adam · New session");
-    seed.write("\u0011");
-    await seed.closed;
-
-    const fixture = startFixture({
-      program: {
-        arguments: ["--target", "deepseek-v4-pro.direct", "--state-root", stateRoot],
-        cwd: workspaceRoot,
-        entrypoint: productionPath,
-        environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
-      },
-      stateRoot,
-      workspaceRoot,
-    });
-    await fixture.waitFor("deepseek-v4-");
-    fixture.write("\u0011");
-    const result = await fixture.closed;
-    expect(result.stdout).toContain("Select a project session");
-    expect(result.stdout).not.toContain("Adam · New session");
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("the production session picker opens the exact focused existing session", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-select-session-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(workspaceRoot);
-
-  try {
-    const seed = startFixture({
-      program: {
-        arguments: ["--target", "deepseek-v4-flash.direct", "--state-root", stateRoot],
-        cwd: workspaceRoot,
-        entrypoint: productionPath,
-        environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
-      },
-      stateRoot,
-      workspaceRoot,
-    });
-    await seed.waitFor("Adam · New session");
-    seed.write("\u0011");
-    await seed.closed;
-
-    const fixture = startFixture({
-      program: {
-        arguments: ["--state-root", stateRoot],
-        cwd: workspaceRoot,
-        entrypoint: productionPath,
-        environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
-      },
-      stateRoot,
-      workspaceRoot,
-    });
-    await fixture.waitFor("Select a project session");
-    const beforeSelection = fixture.output().length;
-    fixture.write("\r");
-    await fixture.waitForAfter("Adam · New session", beforeSelection);
-    await fixture.waitForAfter("deepseek-v4-flash.direct · Certified", beforeSelection);
-    fixture.write("\u0011");
-    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("the production session picker requires explicit New Session before target selection", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-new-session-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(workspaceRoot);
-
-  try {
-    const seed = startFixture({
-      program: {
-        arguments: ["--target", "deepseek-v4-flash.direct", "--state-root", stateRoot],
-        cwd: workspaceRoot,
-        entrypoint: productionPath,
-        environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
-      },
-      stateRoot,
-      workspaceRoot,
-    });
-    await seed.waitFor("Adam · New session");
-    seed.write("\u0011");
-    await seed.closed;
-
-    const fixture = startFixture({
-      program: {
-        arguments: ["--state-root", stateRoot],
-        cwd: workspaceRoot,
-        entrypoint: productionPath,
-        environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
-      },
-      stateRoot,
-      workspaceRoot,
-    });
-    await fixture.waitFor("Select a project session");
-    const beforeNewSession = fixture.output().length;
-    fixture.write("\u001b[B\r");
-    await fixture.waitForAfter("Select an exact model target", beforeNewSession);
-    fixture.write("\u0011");
-    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("the production editor renames the active session through canonical Presentation truth", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-name-session-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(workspaceRoot);
-
-  try {
-    const fixture = startFixture({
-      program: {
-        arguments: ["--target", "deepseek-v4-flash.direct", "--state-root", stateRoot],
-        cwd: workspaceRoot,
-        entrypoint: productionPath,
-        environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
-      },
-      stateRoot,
-      workspaceRoot,
-    });
-    await fixture.waitFor("Adam · New session");
-    const beforeRename = fixture.output().length;
-    fixture.write("/name Release triage\r");
-    await fixture.waitForAfter("Release triage", beforeRename);
-    fixture.write("\u0011");
-    const result = await fixture.closed;
-    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
-    expect(result.stdout).toContain("Adam · Release triage");
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }
@@ -1863,74 +1650,6 @@ test("the branch compatibility alias selects an authoritative complete boundary"
   }
 });
 
-test("slash Fork restores the selected boundary prompt in the child editor", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-fork-alias-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  const controlRoot = join(testRoot, "control");
-  await mkdir(workspaceRoot);
-  await mkdir(controlRoot);
-
-  try {
-    const fixture = startFixture({ controlRoot, scenario: "history", stateRoot, workspaceRoot });
-    await fixture.waitFor("History prompt 3");
-    const beforeFork = fixture.output().length;
-    fixture.write("/fork \r");
-    await fixture.waitForAfter("Fork from a boundary", beforeFork);
-    for (const [page, newlyLoadedPrompt] of ["History prompt 2", "History prompt 1"].entries()) {
-      for (let step = 0; step <= page; step += 1) {
-        const beforeMove = fixture.output().length;
-        fixture.write("\u001b[B");
-        await fixture.waitForAfter("Load Older", beforeMove);
-      }
-      const beforeLoad = fixture.output().length;
-      fixture.write("\r");
-      await fixture.waitForAfter(newlyLoadedPrompt, beforeLoad);
-    }
-    const beforeSearch = fixture.output().length;
-    fixture.write("prompt1");
-    await fixture.waitForAfter("Search: prompt1", beforeSearch);
-    await fixture.waitForAfter("History prompt 1", beforeSearch);
-    const beforeSelection = fixture.output().length;
-    fixture.write("\r");
-    const outcome = await Promise.race([
-      fixture.waitForAfter("Adam · Branch of ", beforeSelection).then(() => "fork" as const),
-      fixture.waitForAfter("History answer.", beforeSelection).then(() => "model" as const),
-    ]);
-    fixture.write("\u0011");
-    await fixture.closed;
-    expect(outcome).toBe("fork");
-    expect(await readFile(join(controlRoot, "clipboard.txt"), "utf8")).toBe("History prompt 1");
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("slash Clone branches at the latest complete boundary with an empty editor", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-clone-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  const controlRoot = join(testRoot, "control");
-  await mkdir(workspaceRoot);
-  await mkdir(controlRoot);
-
-  try {
-    const fixture = startFixture({ controlRoot, scenario: "history", stateRoot, workspaceRoot });
-    await fixture.waitFor("History prompt 3");
-    const beforeClone = fixture.output().length;
-    fixture.write("/clone \r");
-    await fixture.waitForAfter("Adam · Branch of ", beforeClone);
-    fixture.write("\u0011");
-    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-    await expect(access(join(controlRoot, "clipboard.txt"))).rejects.toMatchObject({
-      code: "ENOENT",
-    });
-    expect(await readFilesRecursively(stateRoot)).not.toContain('"text":"/clone"');
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
 test("slash Model and Target share an immutable-target transition page", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-target-navigation-"));
   const workspaceRoot = join(testRoot, "workspace");
@@ -1961,212 +1680,6 @@ test("slash Model and Target share an immutable-target transition page", async (
     expect(durableState).toContain('"targetId":"fake.other"');
     expect(durableState).not.toContain('"text":"/model"');
     expect(durableState).not.toContain('"text":"/target"');
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("the real TUI MCP wizard preserves every separate B8 authority step", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-mcp-wizard-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  const controlRoot = join(testRoot, "control");
-  const spawnMarker = join(testRoot, "mcp-spawned");
-  const closeMarker = join(testRoot, "mcp-closed");
-  await mkdir(workspaceRoot);
-  await mkdir(controlRoot);
-  await writeFile(
-    join(workspaceRoot, ".mcp.json"),
-    JSON.stringify({
-      mcpServers: {
-        fixture: {
-          command: process.execPath,
-          args: [mcpFixturePath, spawnMarker, closeMarker],
-        },
-      },
-    }),
-    "utf8",
-  );
-
-  try {
-    const fixture = startFixture({ controlRoot, scenario: "streaming", stateRoot, workspaceRoot });
-    await fixture.waitFor("Adam · New session");
-    fixture.write("/mc");
-    await fixture.waitFor("/mc");
-    fixture.write("\t");
-    await fixture.waitFor("/mcp");
-    const afterTyping = fixture.output().length;
-    fixture.write("\r");
-    const outcome = await Promise.race([
-      fixture
-        .waitForAfter("MCP authority · workspace confirmation required", afterTyping)
-        .then(() => "wizard" as const),
-      fixture.waitForAfter("Working", afterTyping).then(() => "prompt" as const),
-    ]);
-    expect(outcome).toBe("wizard");
-    fixture.write("\r");
-    await fixture.waitFor("MCP authority · server approval required");
-    fixture.write("\r");
-    await fixture.waitFor("MCP authority · activation required");
-    fixture.write("\r");
-    await fixture.waitFor("MCP authority · tool selection required");
-    await waitForPath(spawnMarker);
-    fixture.write("1");
-    fixture.write("\u001b[B");
-    fixture.write("c");
-    await fixture.waitFor("MCP authority · profile committed");
-    fixture.write("\u0011");
-    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-    await waitForPath(closeMarker);
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("the production TUI resumes and explicitly reactivates one committed MCP profile", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-mcp-reactivation-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  const spawnMarker = join(testRoot, "mcp-spawned");
-  const closeMarker = join(testRoot, "mcp-closed");
-  await mkdir(workspaceRoot);
-  await writeFile(
-    join(workspaceRoot, ".mcp.json"),
-    JSON.stringify({
-      mcpServers: {
-        fixture: {
-          command: process.execPath,
-          args: [mcpFixturePath, spawnMarker, closeMarker],
-        },
-      },
-    }),
-    "utf8",
-  );
-  const program = {
-    arguments: ["--state-root", stateRoot],
-    cwd: workspaceRoot,
-    entrypoint: productionPath,
-    environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
-  } as const;
-
-  try {
-    const seed = startFixture({ program, stateRoot, workspaceRoot });
-    await seed.waitFor("Select an exact model target");
-    seed.write("\r");
-    await seed.waitFor("Adam · New session");
-    seed.write("/mc");
-    await seed.waitFor("/mc");
-    seed.write("\t");
-    await seed.waitFor("/mcp");
-    seed.write("\r");
-    await seed.waitFor("MCP authority · workspace confirmation required");
-    seed.write("\r");
-    await seed.waitFor("MCP authority · server approval required");
-    seed.write("\r");
-    await seed.waitFor("MCP authority · activation required");
-    seed.write("\r");
-    await seed.waitFor("MCP authority · tool selection required");
-    seed.write("1");
-    seed.write("\u001b[B");
-    seed.write("c");
-    await seed.waitFor("MCP authority · profile committed");
-    seed.write("\u0011");
-    await expect(seed.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-
-    const resumed = startFixture({ program, stateRoot, workspaceRoot });
-    await resumed.waitFor("Select a project session");
-    resumed.write("\r");
-    await resumed.waitFor("Adam · New session");
-    resumed.write("/mc");
-    await resumed.waitFor("/mc");
-    resumed.write("\t");
-    await resumed.waitFor("/mcp");
-    resumed.write("\r");
-    await resumed.waitFor("MCP authority · profile reactivation required");
-    resumed.write("\r");
-    await resumed.waitFor("MCP authority · profile committed");
-    resumed.write("\u0011");
-    await expect(resumed.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("the TUI process fails visibly when MCP shutdown cannot be confirmed", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-mcp-close-unconfirmed-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  const spawnMarker = join(testRoot, "mcp-spawned");
-  const closeMarker = join(testRoot, "mcp-closed");
-  await mkdir(workspaceRoot);
-  await writeFile(
-    join(workspaceRoot, ".mcp.json"),
-    JSON.stringify({
-      mcpServers: {
-        fixture: {
-          command: process.execPath,
-          args: [mcpFixturePath, spawnMarker, closeMarker],
-        },
-      },
-    }),
-    "utf8",
-  );
-
-  try {
-    const fixture = startFixture({
-      scenario: "mcp-close-unconfirmed",
-      stateRoot,
-      workspaceRoot,
-    });
-    await fixture.waitFor("Adam · New session");
-    fixture.write("/mc");
-    await fixture.waitFor("/mc");
-    fixture.write("\t");
-    await fixture.waitFor("/mcp");
-    fixture.write("\r");
-    await fixture.waitFor("MCP authority · workspace confirmation required");
-    fixture.write("\r");
-    await fixture.waitFor("MCP authority · server approval required");
-    fixture.write("\r");
-    await fixture.waitFor("MCP authority · activation required");
-    fixture.write("\r");
-    await fixture.waitFor("MCP authority · tool selection required");
-    fixture.write("\u0011");
-    const result = await fixture.closed;
-    expect(result).toMatchObject({ code: 1, signal: null });
-    expect(`${result.stdout}${result.stderr}`).toContain("MCP shutdown could not be confirmed.");
-    await waitForPath(closeMarker);
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("editor submission renders Working then a streamed Markdown answer from real Presentation truth", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-streaming-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  const controlRoot = join(testRoot, "control");
-  await mkdir(workspaceRoot);
-  await mkdir(controlRoot);
-
-  try {
-    const fixture = startFixture({
-      controlRoot,
-      scenario: "streaming",
-      stateRoot,
-      workspaceRoot,
-    });
-    await fixture.waitFor("Adam · New session");
-    fixture.write("Explain streaming\r");
-    await fixture.waitFor("Explain streaming");
-    await fixture.waitFor("Working");
-    await writeFile(join(controlRoot, "release-model"), "release\n", "utf8");
-    await fixture.waitFor("Streaming answer");
-    fixture.write("\u0011");
-    const result = await fixture.closed;
-    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
-    expect(result.stdout).toContain("\u001b[48;2;49;50;68m");
-    expect(result.stdout).toContain("\u001b[38;2;243;139;168m");
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }
@@ -2290,69 +1803,6 @@ test("Ctrl+C cancels one active run and repeated input cannot arm exit while set
   }
 });
 
-test("idle Ctrl+C preserves a CJK draft and copies it only on the confirming press", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-retained-draft-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  const controlRoot = join(testRoot, "control");
-  await mkdir(workspaceRoot);
-  await mkdir(controlRoot);
-  const draft = "保留草稿 🚀";
-
-  try {
-    const fixture = startFixture({
-      controlRoot,
-      scenario: "clipboard-success",
-      stateRoot,
-      workspaceRoot,
-    });
-    await fixture.waitFor("Adam · New session");
-    fixture.write(draft);
-    await fixture.waitFor(draft);
-    fixture.write("\u001b[99;5:1u");
-    await fixture.waitFor("Press Ctrl+C again within two seconds to exit · draft will be copied");
-    expect(fixture.output()).not.toContain("clipboard copied");
-    fixture.write("\u0003");
-    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe(draft);
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("Kitty Ctrl+C repeat and release phases cannot confirm an armed exit", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-kitty-phases-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  const controlRoot = join(testRoot, "control");
-  await mkdir(workspaceRoot);
-  await mkdir(controlRoot);
-
-  try {
-    const fixture = startFixture({
-      controlRoot,
-      scenario: "clipboard-success",
-      stateRoot,
-      workspaceRoot,
-    });
-    await fixture.waitFor("Adam · New session");
-    fixture.write("草稿");
-    await fixture.waitFor("草稿");
-    fixture.write("\u001b[99;5:1u");
-    await fixture.waitFor("Press Ctrl+C again within two seconds to exit");
-    fixture.write("\u001b[99;5:2u\u001b[99;5:3ux");
-    await fixture.waitFor("草稿x");
-    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).rejects.toMatchObject({
-      code: "ENOENT",
-    });
-    fixture.write("\u0011");
-    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe("草稿x");
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
 test("the injected deadline causally expires an idle Ctrl+C exit arm", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-exit-expiry-"));
   const workspaceRoot = join(testRoot, "workspace");
@@ -2436,29 +1886,6 @@ test("a pending clipboard adapter fails closed from the injected deadline", asyn
   }
 });
 
-test("unsupported clipboard is reported after terminal restoration without blocking exit", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-clipboard-unsupported-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(workspaceRoot);
-
-  try {
-    const fixture = startFixture({ stateRoot, workspaceRoot });
-    await fixture.waitFor("Adam · New session");
-    fixture.write("draft without clipboard");
-    await fixture.waitFor("draft without clipboard");
-    fixture.write("\u0011");
-    const result = await fixture.closed;
-    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
-    expect(result.stdout).toContain("Clipboard unavailable; draft was not copied.");
-    expect(result.stdout.indexOf("\u001b[?2004l")).toBeLessThan(
-      result.stdout.indexOf("Clipboard unavailable; draft was not copied."),
-    );
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
 test("a restarted TUI resumes an existing authoritative transcript", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-resume-"));
   const workspaceRoot = join(testRoot, "workspace");
@@ -2505,269 +1932,66 @@ test("untrusted model terminal controls are rendered as inert text", async () =>
     await rm(testRoot, { recursive: true, force: true });
   }
 });
+test("slash Fork restores the selected boundary prompt in the child editor", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-fork-alias-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
 
-type FixtureResult = {
-  readonly code: number | null;
-  readonly signal: NodeJS.Signals | null;
-  readonly stderr: string;
-  readonly stdout: string;
-};
-
-type Fixture = {
-  readonly cleanup: () => Promise<void>;
-  readonly closed: Promise<FixtureResult>;
-  readonly output: () => string;
-  readonly waitFor: (text: string) => Promise<void>;
-  readonly waitForAfter: (text: string, offset: number) => Promise<void>;
-  readonly write: (text: string) => void;
-};
-
-function startFixture(input: {
-  readonly controlRoot?: string;
-  readonly noColor?: boolean;
-  readonly program?: {
-    readonly arguments: readonly string[];
-    readonly cwd: string;
-    readonly entrypoint: string;
-    readonly environment?: Readonly<Record<string, string>>;
-  };
-  readonly scenario?: FixtureScenario;
-  readonly stateRoot: string;
-  readonly workspaceRoot: string;
-}): Fixture {
-  const arguments_ =
-    input.program === undefined
-      ? [
-          process.execPath,
-          fixturePath,
-          "--state-root",
-          input.stateRoot,
-          "--workspace-root",
-          input.workspaceRoot,
-          ...(input.controlRoot === undefined ? [] : ["--control-root", input.controlRoot]),
-          ...(input.scenario === undefined ? [] : ["--scenario", input.scenario]),
-        ]
-      : [process.execPath, input.program.entrypoint, ...input.program.arguments];
-  const command = arguments_.map(shellQuote).join(" ");
-  const { NO_COLOR: _noColor, ...environment } = process.env;
-  const child = spawn("script", ["-qfec", command, "/dev/null"], {
-    ...(input.program === undefined ? {} : { cwd: input.program.cwd }),
-    detached: true,
-    env: {
-      ...environment,
-      ...input.program?.environment,
-      ...(input.noColor === true ? { NO_COLOR: "1" } : {}),
-      TERM: "xterm-256color",
-    },
-    stdio: ["pipe", "pipe", "pipe"],
-  });
-  child.stdout.setEncoding("utf8");
-  child.stderr.setEncoding("utf8");
-  let stdout = "";
-  let stderr = "";
-  let processClosed = false;
-  const outputWaiters = new Set<{
-    readonly offset: number;
-    readonly text: string;
-    readonly resolve: () => void;
-    readonly reject: (error: Error) => void;
-    readonly guard: ReturnType<typeof setTimeout>;
-  }>();
-  let failureGuard: ReturnType<typeof setTimeout> | undefined;
-  const processResult = Promise.withResolvers<{
-    readonly code: number | null;
-    readonly signal: NodeJS.Signals | null;
-  }>();
-  child.stdout.on("data", (chunk: string) => {
-    stdout += chunk;
-    for (const waiter of outputWaiters) {
-      if (stdout.indexOf(waiter.text, waiter.offset) >= 0) {
-        clearTimeout(waiter.guard);
-        outputWaiters.delete(waiter);
-        waiter.resolve();
-      }
-    }
-  });
-  child.stderr.on("data", (chunk: string) => {
-    stderr += chunk;
-  });
-  child.once("close", (code, signal) => {
-    processClosed = true;
-    processResult.resolve({ code, signal });
-  });
-  child.once("error", (error) => processResult.reject(error));
-
-  const signalProcessGroup = (signal: NodeJS.Signals): void => {
-    if (child.pid === undefined || processClosed) {
-      return;
-    }
-    try {
-      process.kill(-child.pid, signal);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
-        child.kill(signal);
-      }
-    }
-  };
-  const awaitCloseWithGuard = async (milliseconds: number): Promise<boolean> => {
-    if (processClosed) {
-      return true;
-    }
-    const guard = Promise.withResolvers<boolean>();
-    const timeout = setTimeout(() => guard.resolve(false), milliseconds);
-    timeout.unref();
-    try {
-      return await Promise.race([processResult.promise.then(() => true), guard.promise]);
-    } finally {
-      clearTimeout(timeout);
-    }
-  };
-  const cleanup = async (): Promise<void> => {
-    if (!processClosed) {
-      signalProcessGroup("SIGTERM");
-      if (!(await awaitCloseWithGuard(1_000))) {
-        signalProcessGroup("SIGKILL");
-      }
-    }
-    await processResult.promise.catch(() => undefined);
-  };
-  let timedOut = false;
-  const result = new Promise<FixtureResult>((resolve, reject) => {
-    processResult.promise.then(
-      (settled) => {
-        if (timedOut) {
-          reject(new Error("The real TUI process did not reach startup and causal close."));
-        } else {
-          resolve({ ...settled, stderr, stdout });
-        }
-      },
-      (error: unknown) => reject(error),
-    );
-    failureGuard = setTimeout(() => {
-      timedOut = true;
-      void cleanup();
-    }, fixtureFailureMilliseconds);
-    failureGuard.unref();
-  });
-  void result.then(
-    () => {
-      activeFixtures.delete(fixture);
-    },
-    () => {
-      activeFixtures.delete(fixture);
-    },
-  );
-  const settleOutputWaiters = () => {
-    if (failureGuard !== undefined) {
-      clearTimeout(failureGuard);
-    }
-    for (const waiter of outputWaiters) {
-      clearTimeout(waiter.guard);
-      waiter.reject(new Error(`The TUI process closed before rendering ${waiter.text}.`));
-    }
-    outputWaiters.clear();
-  };
-  void processResult.promise.then(settleOutputWaiters, settleOutputWaiters);
-  const fixture: Fixture = {
-    cleanup,
-    closed: result,
-    output: () => stdout,
-    waitFor(text) {
-      return waitForAfter(text, 0);
-    },
-    waitForAfter,
-    write(text) {
-      child.stdin.write(text);
-    },
-  };
-  function waitForAfter(text: string, offset: number): Promise<void> {
-    if (stdout.indexOf(text, offset) >= 0) {
-      return Promise.resolve();
-    }
-    return new Promise<void>((resolve, reject) => {
-      const waiter = {
-        offset,
-        text,
-        resolve,
-        reject,
-        guard: setTimeout(() => {
-          outputWaiters.delete(waiter);
-          void cleanup().then(
-            () => reject(new Error(`The real TUI process did not render ${text}.`)),
-            () => reject(new Error(`The real TUI process did not render ${text}.`)),
-          );
-        }, fixtureFailureMilliseconds),
-      };
-      outputWaiters.add(waiter);
-    });
-  }
-  activeFixtures.add(fixture);
-  return fixture;
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", `'"'"'`)}'`;
-}
-
-async function cleanupActiveFixtures(): Promise<void> {
-  await Promise.all([...activeFixtures].map((fixture) => fixture.cleanup()));
-  activeFixtures.clear();
-}
-
-async function rm(path: string, options: { readonly force: boolean; readonly recursive: boolean }) {
-  await cleanupActiveFixtures();
-  await remove(path, options);
-}
-
-async function waitForPath(path: string): Promise<void> {
-  const directory = join(path, "..");
-  const filename = path.slice(directory.length + 1);
-  const watcher = watch(directory);
-  const failure = Promise.withResolvers<never>();
-  const guard = setTimeout(
-    () => failure.reject(new Error(`The fixture did not create ${filename}.`)),
-    fixtureFailureMilliseconds,
-  );
   try {
-    if (
-      await access(path).then(
-        () => true,
-        () => false,
-      )
-    ) {
-      return;
-    }
-    await Promise.race([
-      (async () => {
-        for await (const event of watcher) {
-          if (
-            event.filename === filename &&
-            (await access(path).then(
-              () => true,
-              () => false,
-            ))
-          ) {
-            return;
-          }
-        }
-      })(),
-      failure.promise,
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "history",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("History prompt 3");
+    const beforeFork = fixture.output().length;
+    fixture.write("/fork \r");
+    await fixture.waitForAfter("Fork from a boundary", beforeFork);
+    const beforeSelection = fixture.output().length;
+    fixture.write("\r");
+    const outcome = await Promise.race([
+      fixture.waitForAfter("Adam · Branch of ", beforeSelection).then(() => "fork" as const),
+      fixture.waitForAfter("History answer.", beforeSelection).then(() => "model" as const),
     ]);
+    fixture.write("\u0011");
+    await fixture.closed;
+    expect(outcome).toBe("fork");
+    expect(await readFile(join(controlRoot, "clipboard.txt"), "utf8")).toBe("History prompt 3");
   } finally {
-    clearTimeout(guard);
-    await watcher.return?.();
+    await rm(testRoot, { recursive: true, force: true });
   }
-}
+});
 
-async function readFilesRecursively(root: string): Promise<string> {
-  const contents: string[] = [];
-  for (const entry of await readdir(root, { withFileTypes: true })) {
-    const path = join(root, entry.name);
-    if (entry.isDirectory()) {
-      contents.push(await readFilesRecursively(path));
-    } else if (entry.isFile()) {
-      contents.push(await readFile(path, "utf8"));
-    }
+test("slash Clone branches at the latest complete boundary with an empty editor", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-clone-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "history",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("History prompt 3");
+    const beforeClone = fixture.output().length;
+    fixture.write("/clone \r");
+    await fixture.waitForAfter("Adam · Branch of ", beforeClone);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    await expect(access(join(controlRoot, "clipboard.txt"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect(await readFilesRecursively(stateRoot)).not.toContain('"text":"/clone"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
   }
-  return contents.join("\n");
-}
+});

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -1,9 +1,11 @@
 import { access, watch, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   type ContextProfile,
   createPermissionPolicy,
+  createPresentationPreferences,
   createPresentationSession,
   createSessionLifecycle,
   type ModelDriver,
@@ -17,6 +19,7 @@ import {
   presentationHistoryPageSize,
 } from "@adam-agent/agent/internal-testing";
 import type { PresentationSession } from "@adam-agent/presentation";
+import type { Terminal } from "@earendil-works/pi-tui";
 import { type FixtureScenario, isFixtureScenario } from "./fixture-scenario.js";
 import { requireConfirmedLifecycleClose } from "./lifecycle-close.js";
 import { type ClipboardAdapter, type DeadlineScheduler, runTui } from "./tui-app.js";
@@ -37,6 +40,24 @@ const alternateTargetIdentity: ModelTargetIdentity = {
   profileVersion: 1,
   certification: "experimental",
 };
+const launchTargetIdentities: readonly ModelTargetIdentity[] = [
+  {
+    targetId: "deepseek-v4-flash.direct",
+    vendor: "deepseek",
+    modelId: "deepseek-v4-flash",
+    route: "direct",
+    profileVersion: 2,
+    certification: "certified",
+  },
+  {
+    targetId: "deepseek-v4-pro.direct",
+    vendor: "deepseek",
+    modelId: "deepseek-v4-pro",
+    route: "direct",
+    profileVersion: 2,
+    certification: "certified",
+  },
+];
 const contextProfile: ContextProfile = {
   version: 1,
   contextWindowTokens: 32_768,
@@ -47,111 +68,159 @@ const contextProfile: ContextProfile = {
   estimatorVersion: 1,
 };
 
-const options = parseArguments(process.argv.slice(2));
-const modelTargets = createFixtureModelTargets(options);
-const lifecycle = createSessionLifecycle({
-  ...(options.scenario === "mcp-close-unconfirmed"
-    ? {
-        [mcpCloseConfirmation]: {
-          async confirm() {
-            throw new Error("Fixture close confirmation failed.");
-          },
-        },
-      }
-    : {}),
-  ...(modelTargets === undefined ? {} : { modelTargets }),
-  permissions: createPermissionPolicy({ allowedEffects: ["read"], askedEffects: ["write"] }),
-  stateRoot: options.stateRoot,
-  workspaceRoot: options.workspaceRoot,
-});
+export type TuiFixtureOptions = {
+  readonly controlRoot?: string;
+  readonly launch?: {
+    readonly configRoot?: string;
+    readonly seedTargetIds?: readonly string[];
+    readonly startupTargetId?: string;
+  };
+  readonly scenario?: FixtureScenario;
+  readonly stateRoot: string;
+  readonly terminal?: Terminal;
+  readonly terminalProcessMarker?: string;
+  readonly workspaceRoot: string;
+};
 
-try {
-  const previewBarrier = previewReadBarrier(options);
-  if (options.scenario === "session-selection-history") {
-    const selectable = await lifecycle.create({ targetIdentity });
-    await lifecycle.continue({
-      sessionId: selectable.sessionId,
-      input: { text: "Selected session prompt" },
-    });
+export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
+  if (options.terminalProcessMarker !== undefined) {
+    await writeFile(options.terminalProcessMarker, `${process.pid}\n`, "utf8");
   }
-  const resumedSessionId =
-    options.scenario === "resume" ||
-    options.scenario === "history" ||
-    options.scenario === "target-navigation" ||
-    options.scenario === "unsafe-history"
-      ? await lifecycle.create({ targetIdentity }).then(async (created) => {
-          if (options.scenario === "history") {
-            for (let index = 1; index <= 3; index += 1) {
+  const modelTargets = createFixtureModelTargets(options);
+  const lifecycle = createSessionLifecycle({
+    ...(options.scenario === "mcp-close-unconfirmed"
+      ? {
+          [mcpCloseConfirmation]: {
+            async confirm() {
+              throw new Error("Fixture close confirmation failed.");
+            },
+          },
+        }
+      : {}),
+    ...(modelTargets === undefined ? {} : { modelTargets }),
+    permissions: createPermissionPolicy({ allowedEffects: ["read"], askedEffects: ["write"] }),
+    stateRoot: options.stateRoot,
+    workspaceRoot: options.workspaceRoot,
+  });
+
+  try {
+    const previewBarrier = previewReadBarrier(options);
+    for (const seedTargetId of options.launch?.seedTargetIds ?? []) {
+      await lifecycle.create({ targetIdentity: requireLaunchTargetIdentity(seedTargetId) });
+    }
+    if (options.scenario === "session-selection-history") {
+      const selectable = await lifecycle.create({ targetIdentity });
+      await lifecycle.continue({
+        sessionId: selectable.sessionId,
+        input: { text: "Selected session prompt" },
+      });
+    }
+    const resumedSessionId =
+      options.scenario === "resume" ||
+      options.scenario === "history" ||
+      options.scenario === "target-navigation" ||
+      options.scenario === "unsafe-history"
+        ? await lifecycle.create({ targetIdentity }).then(async (created) => {
+            if (options.scenario === "history") {
+              for (let index = 1; index <= 3; index += 1) {
+                await lifecycle.continue({
+                  sessionId: created.sessionId,
+                  input: { text: `History prompt ${index}` },
+                });
+              }
+            } else if (options.scenario === "resume") {
               await lifecycle.continue({
                 sessionId: created.sessionId,
-                input: { text: `History prompt ${index}` },
+                input: { text: "Resume transcript" },
+              });
+            } else if (options.scenario === "target-navigation") {
+              await lifecycle.continue({
+                sessionId: created.sessionId,
+                input: { text: "Keep historical target identity" },
+              });
+            } else {
+              await lifecycle.continue({
+                sessionId: created.sessionId,
+                input: { text: "\u001b]52;c;c2NvcGU=\u0007Visible history\u202E" },
               });
             }
-          } else if (options.scenario === "resume") {
-            await lifecycle.continue({
-              sessionId: created.sessionId,
-              input: { text: "Resume transcript" },
-            });
-          } else if (options.scenario === "target-navigation") {
-            await lifecycle.continue({
-              sessionId: created.sessionId,
-              input: { text: "Keep historical target identity" },
-            });
-          } else {
-            await lifecycle.continue({
-              sessionId: created.sessionId,
-              input: { text: "\u001b]52;c;c2NvcGU=\u0007Visible history\u202E" },
-            });
-          }
-          return created.sessionId;
-        })
-      : undefined;
-  const presentation = await createPresentationSession(
-    options.scenario === "session-selection-history"
-      ? {
-          lifecycle,
-          ...(modelTargets === undefined ? {} : { modelTargets }),
-          openProject: true,
-          projectLabel: "workspace",
-          stateRoot: options.stateRoot,
-          workspaceRoot: options.workspaceRoot,
-        }
-      : resumedSessionId === undefined
+            return created.sessionId;
+          })
+        : undefined;
+    const presentation = await createPresentationSession(
+      options.launch !== undefined
         ? {
             lifecycle,
             ...(modelTargets === undefined ? {} : { modelTargets }),
+            openProject: true,
+            preferences: createPresentationPreferences({
+              environment: {
+                ...process.env,
+                ...(options.launch.configRoot === undefined
+                  ? {}
+                  : { XDG_CONFIG_HOME: options.launch.configRoot }),
+              },
+            }),
             projectLabel: "workspace",
             stateRoot: options.stateRoot,
-            targetIdentity,
             workspaceRoot: options.workspaceRoot,
-            ...(previewBarrier === undefined
-              ? {}
-              : { [presentationArtifactReadBarrier]: previewBarrier }),
           }
-        : {
-            lifecycle,
-            ...(modelTargets === undefined ? {} : { modelTargets }),
-            projectLabel: "workspace",
-            sessionId: resumedSessionId,
-            stateRoot: options.stateRoot,
-            workspaceRoot: options.workspaceRoot,
-            ...(options.scenario === "history" ? { [presentationHistoryPageSize]: 2 } : {}),
-            ...(previewBarrier === undefined
-              ? {}
-              : { [presentationArtifactReadBarrier]: previewBarrier }),
-          },
-  );
-  const clipboard = clipboardAdapter(options);
-  const deadlineScheduler = controlledDeadlineScheduler(options);
-  const tuiPresentation = observePermissionDecision(presentation, options);
-  await runTui({
-    ...(clipboard === undefined ? {} : { clipboard }),
-    ...(deadlineScheduler === undefined ? {} : { deadlineScheduler }),
-    presentation: tuiPresentation,
-    targetStatus: { targetId: targetIdentity.targetId, certification: "Certified" },
-  });
-} finally {
-  requireConfirmedLifecycleClose(await lifecycle.close());
+        : options.scenario === "session-selection-history"
+          ? {
+              lifecycle,
+              ...(modelTargets === undefined ? {} : { modelTargets }),
+              openProject: true,
+              projectLabel: "workspace",
+              stateRoot: options.stateRoot,
+              workspaceRoot: options.workspaceRoot,
+            }
+          : resumedSessionId === undefined
+            ? {
+                lifecycle,
+                ...(modelTargets === undefined ? {} : { modelTargets }),
+                projectLabel: "workspace",
+                stateRoot: options.stateRoot,
+                targetIdentity,
+                workspaceRoot: options.workspaceRoot,
+                ...(previewBarrier === undefined
+                  ? {}
+                  : { [presentationArtifactReadBarrier]: previewBarrier }),
+              }
+            : {
+                lifecycle,
+                ...(modelTargets === undefined ? {} : { modelTargets }),
+                projectLabel: "workspace",
+                sessionId: resumedSessionId,
+                stateRoot: options.stateRoot,
+                workspaceRoot: options.workspaceRoot,
+                ...(options.scenario === "history" ? { [presentationHistoryPageSize]: 2 } : {}),
+                ...(previewBarrier === undefined
+                  ? {}
+                  : { [presentationArtifactReadBarrier]: previewBarrier }),
+              },
+    );
+    const clipboard = clipboardAdapter(options);
+    const deadlineScheduler = controlledDeadlineScheduler(options);
+    const tuiPresentation = observePermissionDecision(presentation, options);
+    await runTui({
+      ...(clipboard === undefined ? {} : { clipboard }),
+      ...(deadlineScheduler === undefined ? {} : { deadlineScheduler }),
+      presentation: tuiPresentation,
+      ...(options.launch === undefined
+        ? {
+            targetStatus: {
+              targetId: targetIdentity.targetId,
+              certification: "Certified" as const,
+            },
+          }
+        : options.launch.startupTargetId === undefined
+          ? {}
+          : { startupTargetId: options.launch.startupTargetId }),
+      ...(options.terminal === undefined ? {} : { terminal: options.terminal }),
+    });
+  } finally {
+    requireConfirmedLifecycleClose(await lifecycle.close());
+  }
 }
 
 function observePermissionDecision(
@@ -187,6 +256,7 @@ function parseArguments(arguments_: readonly string[]): {
   readonly controlRoot?: string;
   readonly scenario?: FixtureScenario;
   readonly stateRoot: string;
+  readonly terminalProcessMarker?: string;
   readonly workspaceRoot: string;
 } {
   const stateRoot = optionValue(arguments_, "--state-root");
@@ -199,12 +269,18 @@ function parseArguments(arguments_: readonly string[]): {
     throw new TypeError("The TUI fixture scenario is invalid.");
   }
   const controlRoot = optionValue(arguments_, "--control-root");
+  const terminalProcessMarker = optionValue(arguments_, "--terminal-process-marker");
   return {
     ...(controlRoot === undefined ? {} : { controlRoot }),
     ...(scenario === undefined ? {} : { scenario }),
     stateRoot,
+    ...(terminalProcessMarker === undefined ? {} : { terminalProcessMarker }),
     workspaceRoot,
   };
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  await runTuiFixture(parseArguments(process.argv.slice(2)));
 }
 
 function optionValue(arguments_: readonly string[], option: string): string | undefined {
@@ -214,13 +290,15 @@ function optionValue(arguments_: readonly string[], option: string): string | un
 
 function createFixtureModelTargets(options: {
   readonly controlRoot?: string;
+  readonly launch?: TuiFixtureOptions["launch"];
   readonly scenario?: FixtureScenario;
 }): ModelTargets | undefined {
   if (
-    options.scenario === undefined ||
-    options.scenario === "clipboard-success" ||
-    options.scenario === "clipboard-timeout" ||
-    options.scenario === "deadline"
+    options.launch === undefined &&
+    (options.scenario === undefined ||
+      options.scenario === "clipboard-success" ||
+      options.scenario === "clipboard-timeout" ||
+      options.scenario === "deadline")
   ) {
     return undefined;
   }
@@ -329,12 +407,25 @@ function createFixtureModelTargets(options: {
   return {
     async resolve(input) {
       const identity =
-        input.targetId === alternateTargetIdentity.targetId
+        launchTargetIdentities.find((candidate) => candidate.targetId === input.targetId) ??
+        (input.targetId === alternateTargetIdentity.targetId
           ? alternateTargetIdentity
-          : targetIdentity;
+          : targetIdentity);
       return { identity, driver: model, contextProfile };
     },
     async snapshot() {
+      if (options.launch !== undefined) {
+        return {
+          targets: launchTargetIdentities.map((identity) => ({
+            identity,
+            readiness: {
+              status: "available" as const,
+              credentialSource: "deterministic launch fixture",
+            },
+            contextProfile,
+          })),
+        };
+      }
       return {
         targets: [
           {
@@ -358,6 +449,14 @@ function createFixtureModelTargets(options: {
       };
     },
   };
+}
+
+function requireLaunchTargetIdentity(targetId: string): ModelTargetIdentity {
+  const identity = launchTargetIdentities.find((candidate) => candidate.targetId === targetId);
+  if (identity === undefined) {
+    throw new TypeError(`The launch fixture target ${targetId} is unavailable.`);
+  }
+  return identity;
 }
 
 function previewReadBarrier(options: {

--- a/apps/tui/src/test-topology.test.ts
+++ b/apps/tui/src/test-topology.test.ts
@@ -1,0 +1,66 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "vitest";
+
+const behaviorSuitePath = fileURLToPath(new URL("./main.test.ts", import.meta.url));
+const operatingSystemSuitePath = fileURLToPath(new URL("./main.os.test.ts", import.meta.url));
+const packagePath = fileURLToPath(new URL("../../../package.json", import.meta.url));
+const qualityWorkflowPath = fileURLToPath(
+  new URL("../../../.github/workflows/quality.yml", import.meta.url),
+);
+const vitestConfigurationPath = fileURLToPath(
+  new URL("../../../vitest.config.ts", import.meta.url),
+);
+
+test("TUI behavior and operating-system contracts keep separate harness ownership", async () => {
+  const [behaviorSource, operatingSystemSource] = await Promise.all([
+    readFile(behaviorSuitePath, "utf8"),
+    readFile(operatingSystemSuitePath, "utf8"),
+  ]);
+
+  expect(behaviorSource).not.toContain("node:child_process");
+  expect(behaviorSource).not.toContain("external: true");
+  expect(behaviorSource).not.toMatch(/\bprogram\s*:/u);
+  expect(behaviorSource).not.toContain("setTimeout(");
+  expect(operatingSystemSource).not.toContain("setTimeout(");
+  expect(`${behaviorSource}\n${operatingSystemSource}`).not.toContain("vi.mock(");
+
+  const operatingSystemCases = topLevelTestBlocks(operatingSystemSource);
+  expect(operatingSystemCases.length).toBeGreaterThan(0);
+  for (const testCase of operatingSystemCases) {
+    expect(testCase).toMatch(/external:\s*true|\bprogram\s*[:,]/u);
+  }
+
+  const names = [...topLevelTestBlocks(behaviorSource), ...operatingSystemCases].map(
+    (testCase) => testCase.match(/^test\("([^"]+)"/u)?.[1],
+  );
+  expect(names.every((name) => name !== undefined)).toBe(true);
+  expect(new Set(names).size).toBe(names.length);
+});
+
+test("Quality keeps every semantic and OS suite in one required Linux regression job", async () => {
+  const [packageSource, qualityWorkflow, vitestConfiguration] = await Promise.all([
+    readFile(packagePath, "utf8"),
+    readFile(qualityWorkflowPath, "utf8"),
+    readFile(vitestConfigurationPath, "utf8"),
+  ]);
+  const packageManifest = JSON.parse(packageSource) as {
+    readonly scripts?: { readonly test?: string };
+  };
+
+  expect(packageManifest.scripts?.test).toBe("tsc -b && vitest run");
+  expect(vitestConfiguration).toContain('"apps/**/src/**/*.test.ts"');
+  expect(qualityWorkflow).toContain("runs-on: ubuntu-24.04");
+  expect(qualityWorkflow).toContain("run: pnpm quality:check");
+  expect(qualityWorkflow).not.toMatch(/^\s+paths(?:-ignore)?:/gmu);
+  expect(qualityWorkflow).not.toContain("continue-on-error");
+  expect([...qualityWorkflow.matchAll(/^ {2}([a-z][a-z0-9_-]*):\n {4}runs-on:/gmu)]).toHaveLength(
+    1,
+  );
+});
+
+function topLevelTestBlocks(source: string): readonly string[] {
+  const starts = [...source.matchAll(/^test\(/gmu)].map((match) => match.index);
+  return starts.map((start, index) => source.slice(start, starts[index + 1] ?? source.length));
+}

--- a/apps/tui/src/tui-filesystem.test-support.ts
+++ b/apps/tui/src/tui-filesystem.test-support.ts
@@ -1,0 +1,67 @@
+import { access, readdir, readFile, rm, watch } from "node:fs/promises";
+import { join } from "node:path";
+
+import { cleanupActiveTuiFixtures } from "./tui-fixture.test-support.js";
+
+const missingFilesystemEffectFailureMilliseconds = 30_000;
+
+export async function removeTuiFixtureRoot(
+  path: string,
+  _options?: { readonly force: boolean; readonly recursive: boolean },
+): Promise<void> {
+  await cleanupActiveTuiFixtures();
+  await rm(path, { recursive: true, force: true });
+}
+
+export async function waitForPath(path: string): Promise<void> {
+  const directory = join(path, "..");
+  const filename = path.slice(directory.length + 1);
+  const watcher = watch(directory);
+  const failure = Promise.withResolvers<never>();
+  const guard = setTimeout(
+    () => failure.reject(new Error(`The fixture did not create ${filename}.`)),
+    missingFilesystemEffectFailureMilliseconds,
+  );
+  guard.unref();
+  try {
+    if (
+      await access(path).then(
+        () => true,
+        () => false,
+      )
+    ) {
+      return;
+    }
+    await Promise.race([
+      (async () => {
+        for await (const _event of watcher) {
+          if (
+            await access(path).then(
+              () => true,
+              () => false,
+            )
+          ) {
+            return;
+          }
+        }
+      })(),
+      failure.promise,
+    ]);
+  } finally {
+    clearTimeout(guard);
+    await watcher.return?.();
+  }
+}
+
+export async function readFilesRecursively(root: string): Promise<string> {
+  const contents: string[] = [];
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      contents.push(await readFilesRecursively(path));
+    } else if (entry.isFile()) {
+      contents.push(await readFile(path, "utf8"));
+    }
+  }
+  return contents.join("\n");
+}

--- a/apps/tui/src/tui-fixture.test-support.ts
+++ b/apps/tui/src/tui-fixture.test-support.ts
@@ -67,14 +67,16 @@ export async function cleanupActiveTuiFixtures(): Promise<void> {
 
 function startInProcessTuiFixture(input: StartTuiFixtureOptions): TuiFixture {
   const terminal = new VirtualTerminal();
-  const execution = runTuiFixture({
-    ...(input.controlRoot === undefined ? {} : { controlRoot: input.controlRoot }),
-    ...(input.launch === undefined ? {} : { launch: input.launch }),
-    ...(input.scenario === undefined ? {} : { scenario: input.scenario }),
-    stateRoot: input.stateRoot,
-    terminal,
-    workspaceRoot: input.workspaceRoot,
-  });
+  const execution = withTuiColorEnvironment(input.noColor === true, () =>
+    runTuiFixture({
+      ...(input.controlRoot === undefined ? {} : { controlRoot: input.controlRoot }),
+      ...(input.launch === undefined ? {} : { launch: input.launch }),
+      ...(input.scenario === undefined ? {} : { scenario: input.scenario }),
+      stateRoot: input.stateRoot,
+      terminal,
+      workspaceRoot: input.workspaceRoot,
+    }),
+  );
   const closed = execution.then(
     (): TuiFixtureResult => ({ code: 0, signal: null, stderr: "", stdout: terminal.output() }),
   );
@@ -105,6 +107,28 @@ function startInProcessTuiFixture(input: StartTuiFixtureOptions): TuiFixture {
   };
   trackFixture(fixture);
   return fixture;
+}
+
+async function withTuiColorEnvironment<T>(
+  noColor: boolean,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const environment = process.env as NodeJS.ProcessEnv & { NO_COLOR?: string };
+  const inheritedNoColor = environment.NO_COLOR;
+  if (noColor) {
+    environment.NO_COLOR = "1";
+  } else {
+    Reflect.deleteProperty(environment, "NO_COLOR");
+  }
+  try {
+    return await operation();
+  } finally {
+    if (inheritedNoColor === undefined) {
+      Reflect.deleteProperty(environment, "NO_COLOR");
+    } else {
+      environment.NO_COLOR = inheritedNoColor;
+    }
+  }
 }
 
 function startExternalTuiFixture(input: StartTuiFixtureOptions): TuiFixture {

--- a/apps/tui/src/tui-fixture.test-support.ts
+++ b/apps/tui/src/tui-fixture.test-support.ts
@@ -1,0 +1,342 @@
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import type { FixtureScenario } from "./fixture-scenario.js";
+import { runTuiFixture } from "./test-fixture.js";
+import { VirtualTerminal } from "./virtual-terminal.test-support.js";
+
+const fixturePath = fileURLToPath(new URL("../dist/test-fixture.js", import.meta.url));
+const fixtureFailureMilliseconds = 30_000;
+
+export type TuiFixtureResult = {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stderr: string;
+  readonly stdout: string;
+};
+
+export type TuiFixture = {
+  readonly cleanup: () => Promise<void>;
+  readonly closed: Promise<TuiFixtureResult>;
+  readonly output: () => string;
+  readonly resize: (columns: number, rows: number) => Promise<void>;
+  readonly waitFor: (text: string) => Promise<void>;
+  readonly waitForAfter: (text: string, offset: number) => Promise<void>;
+  readonly write: (text: string) => void;
+};
+
+export type StartTuiFixtureOptions = {
+  readonly controlRoot?: string;
+  readonly external?: boolean;
+  readonly launch?: {
+    readonly configRoot?: string;
+    readonly seedTargetIds?: readonly string[];
+    readonly startupTargetId?: string;
+  };
+  readonly noColor?: boolean;
+  readonly program?: {
+    readonly arguments: readonly string[];
+    readonly cwd: string;
+    readonly entrypoint: string;
+    readonly environment?: Readonly<Record<string, string>>;
+  };
+  readonly scenario?: FixtureScenario;
+  readonly stateRoot: string;
+  readonly terminalProcessMarker?: string;
+  readonly workspaceRoot: string;
+};
+
+const activeFixtures = new Set<TuiFixture>();
+
+export function startTuiFixture(input: StartTuiFixtureOptions): TuiFixture {
+  if (input.launch !== undefined && (input.external === true || input.program !== undefined)) {
+    throw new TypeError(
+      "Project-launch fixture state is available only through the in-process harness.",
+    );
+  }
+  return input.external === true || input.program !== undefined
+    ? startExternalTuiFixture(input)
+    : startInProcessTuiFixture(input);
+}
+
+export async function cleanupActiveTuiFixtures(): Promise<void> {
+  await Promise.all([...activeFixtures].map((fixture) => fixture.cleanup()));
+  activeFixtures.clear();
+}
+
+function startInProcessTuiFixture(input: StartTuiFixtureOptions): TuiFixture {
+  const terminal = new VirtualTerminal();
+  const execution = runTuiFixture({
+    ...(input.controlRoot === undefined ? {} : { controlRoot: input.controlRoot }),
+    ...(input.launch === undefined ? {} : { launch: input.launch }),
+    ...(input.scenario === undefined ? {} : { scenario: input.scenario }),
+    stateRoot: input.stateRoot,
+    terminal,
+    workspaceRoot: input.workspaceRoot,
+  });
+  const closed = execution.then(
+    (): TuiFixtureResult => ({ code: 0, signal: null, stderr: "", stdout: terminal.output() }),
+  );
+  const cleanup = async (): Promise<void> => {
+    await Promise.race([
+      terminal.whenStarted(),
+      closed.then(
+        () => undefined,
+        () => undefined,
+      ),
+    ]);
+    if (terminal.running()) {
+      terminal.input("\u0011");
+    }
+    await closed.catch(() => undefined);
+  };
+  const fixture: TuiFixture = {
+    cleanup,
+    closed,
+    output: () => terminal.output(),
+    resize(columns, rows) {
+      terminal.resize(columns, rows);
+      return Promise.resolve();
+    },
+    waitFor: (text) => terminal.nextOutputContaining(text),
+    waitForAfter: (text, offset) => terminal.nextOutputContaining(text, offset),
+    write: (text) => terminal.input(text),
+  };
+  trackFixture(fixture);
+  return fixture;
+}
+
+function startExternalTuiFixture(input: StartTuiFixtureOptions): TuiFixture {
+  const arguments_ =
+    input.program === undefined
+      ? [
+          process.execPath,
+          fixturePath,
+          "--state-root",
+          input.stateRoot,
+          "--workspace-root",
+          input.workspaceRoot,
+          ...(input.controlRoot === undefined ? [] : ["--control-root", input.controlRoot]),
+          ...(input.scenario === undefined ? [] : ["--scenario", input.scenario]),
+          ...(input.terminalProcessMarker === undefined
+            ? []
+            : ["--terminal-process-marker", input.terminalProcessMarker]),
+        ]
+      : [process.execPath, input.program.entrypoint, ...input.program.arguments];
+  const command = arguments_.map(shellQuote).join(" ");
+  const { NO_COLOR: _noColor, ...environment } = process.env;
+  const child = spawn("script", ["-qfec", command, "/dev/null"], {
+    ...(input.program === undefined ? {} : { cwd: input.program.cwd }),
+    detached: true,
+    env: {
+      ...environment,
+      ...input.program?.environment,
+      ...(input.noColor === true ? { NO_COLOR: "1" } : {}),
+      TERM: "xterm-256color",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  let stdout = "";
+  let stderr = "";
+  let processClosed = false;
+  const processClose = Promise.withResolvers<void>();
+  const outputWaiters = new Set<{
+    readonly offset: number;
+    readonly text: string;
+    readonly resolve: () => void;
+    readonly reject: (error: Error) => void;
+    readonly guard: ReturnType<typeof setTimeout>;
+  }>();
+  const processResult = Promise.withResolvers<{
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+  }>();
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+    for (const waiter of outputWaiters) {
+      if (stdout.indexOf(waiter.text, waiter.offset) >= 0) {
+        clearTimeout(waiter.guard);
+        outputWaiters.delete(waiter);
+        waiter.resolve();
+      }
+    }
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  child.once("close", (code, signal) => {
+    processClosed = true;
+    processClose.resolve();
+    processResult.resolve({ code, signal });
+  });
+  child.once("error", (error) => {
+    processResult.reject(error);
+  });
+
+  const signalProcessGroup = (signal: NodeJS.Signals): void => {
+    if (child.pid === undefined || processClosed) {
+      return;
+    }
+    try {
+      process.kill(-child.pid, signal);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+        child.kill(signal);
+      }
+    }
+  };
+  const awaitCloseWithGuard = async (milliseconds: number): Promise<boolean> => {
+    if (processClosed) {
+      return true;
+    }
+    const guard = Promise.withResolvers<boolean>();
+    const timeout = setTimeout(() => guard.resolve(false), milliseconds);
+    timeout.unref();
+    try {
+      return await Promise.race([processClose.promise.then(() => true), guard.promise]);
+    } finally {
+      clearTimeout(timeout);
+    }
+  };
+  const performCleanup = async (): Promise<void> => {
+    if (!processClosed) {
+      signalProcessGroup("SIGTERM");
+      if (!(await awaitCloseWithGuard(1_000))) {
+        signalProcessGroup("SIGKILL");
+        if (!(await awaitCloseWithGuard(1_000))) {
+          throw new Error("The real TUI process did not close after SIGKILL.");
+        }
+      }
+    }
+    await processResult.promise.catch(() => undefined);
+  };
+  let cleanupInFlight: Promise<void> | undefined;
+  const cleanup = (): Promise<void> => {
+    cleanupInFlight ??= performCleanup();
+    return cleanupInFlight;
+  };
+  const result = new Promise<TuiFixtureResult>((resolve, reject) => {
+    processResult.promise.then(
+      (settled) => resolve({ ...settled, stderr, stdout }),
+      (error: unknown) => reject(error),
+    );
+    const failureGuard = setTimeout(() => {
+      reject(
+        new Error(
+          `The real TUI process did not close after reaching its expected causal state. stdout tail: ${JSON.stringify(stdout.slice(-2_000))}; stderr: ${JSON.stringify(stderr)}`,
+        ),
+      );
+      void cleanup().catch(() => undefined);
+    }, fixtureFailureMilliseconds);
+    failureGuard.unref();
+    void processResult.promise.then(
+      () => clearTimeout(failureGuard),
+      () => clearTimeout(failureGuard),
+    );
+  });
+  const settleOutputWaiters = () => {
+    for (const waiter of outputWaiters) {
+      clearTimeout(waiter.guard);
+      waiter.reject(
+        new Error(
+          `The TUI process closed before rendering ${waiter.text}. stdout tail: ${JSON.stringify(stdout.slice(-2_000))}; stderr: ${JSON.stringify(stderr)}`,
+        ),
+      );
+    }
+    outputWaiters.clear();
+  };
+  void processResult.promise.then(settleOutputWaiters, settleOutputWaiters);
+  const waitForAfter = (text: string, offset: number): Promise<void> => {
+    if (stdout.indexOf(text, offset) >= 0) {
+      return Promise.resolve();
+    }
+    if (processClosed) {
+      return Promise.reject(
+        new Error(
+          `The TUI process already closed without rendering ${text}. stdout tail: ${JSON.stringify(stdout.slice(-2_000))}; stderr: ${JSON.stringify(stderr)}`,
+        ),
+      );
+    }
+    return new Promise<void>((resolve, reject) => {
+      const waiter = {
+        offset,
+        text,
+        resolve,
+        reject,
+        guard: setTimeout(() => {
+          outputWaiters.delete(waiter);
+          reject(
+            new Error(
+              `The real TUI process did not render ${text}. stdout tail: ${JSON.stringify(stdout.slice(-2_000))}; stderr: ${JSON.stringify(stderr)}`,
+            ),
+          );
+          void cleanup().catch(() => undefined);
+        }, fixtureFailureMilliseconds),
+      };
+      waiter.guard.unref();
+      outputWaiters.add(waiter);
+    });
+  };
+  const fixture: TuiFixture = {
+    cleanup,
+    closed: result,
+    output: () => stdout,
+    async resize(columns, rows) {
+      if (input.terminalProcessMarker === undefined) {
+        throw new Error("The external TUI fixture requires a terminal process marker to resize.");
+      }
+      const processId = Number.parseInt(await readFile(input.terminalProcessMarker, "utf8"), 10);
+      if (!Number.isSafeInteger(processId) || processId <= 0) {
+        throw new Error("The external TUI fixture recorded an invalid terminal process identity.");
+      }
+      await resizeTerminalProcess(processId, columns, rows);
+    },
+    waitFor: (text) => waitForAfter(text, 0),
+    waitForAfter,
+    write: (text) => child.stdin.write(text),
+  };
+  trackFixture(fixture, processClose.promise);
+  return fixture;
+}
+
+async function resizeTerminalProcess(
+  processId: number,
+  columns: number,
+  rows: number,
+): Promise<void> {
+  if (!Number.isSafeInteger(columns) || columns <= 0 || !Number.isSafeInteger(rows) || rows <= 0) {
+    throw new TypeError("Terminal dimensions must be positive safe integers.");
+  }
+  const resized = spawn(
+    "stty",
+    ["-F", `/proc/${processId}/fd/1`, "cols", String(columns), "rows", String(rows)],
+    { stdio: "ignore" },
+  );
+  const result = await new Promise<{
+    readonly code: number | null;
+    readonly signal: string | null;
+  }>((resolve, reject) => {
+    resized.once("error", reject);
+    resized.once("close", (code, signal) => resolve({ code, signal }));
+  });
+  if (result.code !== 0 || result.signal !== null) {
+    throw new Error("The external TUI fixture could not resize its pseudo-terminal.");
+  }
+  process.kill(processId, "SIGWINCH");
+}
+
+function trackFixture(fixture: TuiFixture, settlement: Promise<unknown> = fixture.closed): void {
+  activeFixtures.add(fixture);
+  void fixture.closed.catch(() => undefined);
+  void settlement.then(
+    () => activeFixtures.delete(fixture),
+    () => activeFixtures.delete(fixture),
+  );
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}

--- a/apps/tui/src/virtual-terminal.test-support.ts
+++ b/apps/tui/src/virtual-terminal.test-support.ts
@@ -1,0 +1,186 @@
+import { StdinBuffer, type Terminal } from "@earendil-works/pi-tui";
+
+const missingOutputFailureMilliseconds = 30_000;
+
+type OutputWaiter = {
+  readonly guard: ReturnType<typeof setTimeout>;
+  readonly offset: number;
+  readonly reject: (error: Error) => void;
+  readonly resolve: () => void;
+  readonly text: string;
+};
+
+export class VirtualTerminal implements Terminal {
+  readonly #events: Array<"started" | "stopped"> = [];
+  readonly #input = new StdinBuffer();
+  readonly #started = Promise.withResolvers<void>();
+  readonly #waiters = new Set<OutputWaiter>();
+  #columns: number;
+  #inputHandler: ((data: string) => void) | undefined;
+  #output = "";
+  #resizeHandler: (() => void) | undefined;
+  #rows: number;
+  #state: "new" | "started" | "stopped" = "new";
+
+  constructor(options: { readonly columns?: number; readonly rows?: number } = {}) {
+    this.#columns = options.columns ?? 80;
+    this.#rows = options.rows ?? 24;
+    this.#input.on("data", (sequence) => this.#inputHandler?.(sequence));
+    this.#input.on("paste", (content) => this.#inputHandler?.(`\u001b[200~${content}\u001b[201~`));
+  }
+
+  get columns(): number {
+    return this.#columns;
+  }
+
+  get kittyProtocolActive(): boolean {
+    return false;
+  }
+
+  get rows(): number {
+    return this.#rows;
+  }
+
+  start(onInput: (data: string) => void, onResize: () => void): void {
+    if (this.#state !== "new") {
+      throw new Error(`VirtualTerminal cannot start from ${this.#state} state.`);
+    }
+    this.#state = "started";
+    this.#events.push("started");
+    this.#inputHandler = onInput;
+    this.#resizeHandler = onResize;
+    this.#started.resolve();
+  }
+
+  stop(): void {
+    if (this.#state !== "started") {
+      throw new Error(`VirtualTerminal cannot stop from ${this.#state} state.`);
+    }
+    this.#state = "stopped";
+    this.#events.push("stopped");
+    this.#input.destroy();
+    this.#inputHandler = undefined;
+    this.#resizeHandler = undefined;
+    for (const waiter of this.#waiters) {
+      clearTimeout(waiter.guard);
+      waiter.reject(
+        new Error(
+          `VirtualTerminal stopped before rendering ${JSON.stringify(waiter.text)} after offset ${waiter.offset}. Output tail: ${JSON.stringify(this.#output.slice(Math.max(waiter.offset, this.#output.length - 2_000)))}`,
+        ),
+      );
+    }
+    this.#waiters.clear();
+  }
+
+  async drainInput(): Promise<void> {}
+
+  write(data: string): void {
+    this.#output += data;
+    for (const waiter of this.#waiters) {
+      if (this.#output.indexOf(waiter.text, waiter.offset) >= 0) {
+        clearTimeout(waiter.guard);
+        this.#waiters.delete(waiter);
+        waiter.resolve();
+      }
+    }
+  }
+
+  input(data: string): void {
+    if (this.#state !== "started" || this.#inputHandler === undefined) {
+      throw new Error("VirtualTerminal accepts input only while started.");
+    }
+    this.#input.process(data);
+  }
+
+  resize(columns: number, rows: number): void {
+    if (this.#state !== "started" || this.#resizeHandler === undefined) {
+      throw new Error("VirtualTerminal can resize only while started.");
+    }
+    this.#columns = columns;
+    this.#rows = rows;
+    this.#resizeHandler();
+  }
+
+  output(): string {
+    return this.#output;
+  }
+
+  lifecycle(): readonly ("started" | "stopped")[] {
+    return [...this.#events];
+  }
+
+  whenStarted(): Promise<void> {
+    return this.#started.promise;
+  }
+
+  running(): boolean {
+    return this.#state === "started";
+  }
+
+  nextOutputContaining(text: string, offset = 0): Promise<void> {
+    if (this.#output.indexOf(text, offset) >= 0) {
+      return Promise.resolve();
+    }
+    if (this.#state === "stopped") {
+      return Promise.reject(
+        new Error(
+          `VirtualTerminal already stopped without rendering ${JSON.stringify(text)} after offset ${offset}. Output tail: ${JSON.stringify(this.#output.slice(Math.max(offset, this.#output.length - 2_000)))}`,
+        ),
+      );
+    }
+    return new Promise<void>((resolve, reject) => {
+      const waiter: OutputWaiter = {
+        guard: setTimeout(() => {
+          this.#waiters.delete(waiter);
+          reject(
+            new Error(
+              `VirtualTerminal did not render ${JSON.stringify(text)} after offset ${offset}. Output tail: ${JSON.stringify(this.#output.slice(Math.max(offset, this.#output.length - 2_000)))}`,
+            ),
+          );
+        }, missingOutputFailureMilliseconds),
+        offset,
+        reject,
+        resolve,
+        text,
+      };
+      waiter.guard.unref();
+      this.#waiters.add(waiter);
+    });
+  }
+
+  moveBy(lines: number): void {
+    if (lines > 0) {
+      this.write(`\u001b[${lines}B`);
+    } else if (lines < 0) {
+      this.write(`\u001b[${-lines}A`);
+    }
+  }
+
+  hideCursor(): void {
+    this.write("\u001b[?25l");
+  }
+
+  showCursor(): void {
+    this.write("\u001b[?25h");
+  }
+
+  clearLine(): void {
+    this.write("\u001b[K");
+  }
+
+  clearFromCursor(): void {
+    this.write("\u001b[J");
+  }
+
+  clearScreen(): void {
+    this.write("\u001b[2J\u001b[H");
+  }
+
+  setTitle(title: string): void {
+    this.write(`\u001b]0;${title}\u0007`);
+  }
+
+  setProgress(active: boolean): void {
+    this.write(active ? "\u001b]9;4;3\u0007" : "\u001b]9;4;0\u0007");
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "quality:check": "pnpm code:check && pnpm markdown:check && pnpm typecheck && pnpm browser:check && pnpm test",
     "quality:fix": "pnpm code:fix && pnpm markdown:fix",
     "test": "tsc -b && vitest run",
+    "test:tui:behavior": "tsc -b --pretty false && vitest run apps/tui/src/main.test.ts apps/tui/src/test-topology.test.ts",
+    "test:tui:os": "tsc -b --pretty false && vitest run apps/tui/src/main.os.test.ts",
     "test:large-output": "ADAM_AGENT_LARGE_OUTPUT_TESTS=1 tsc -b --pretty false && ADAM_AGENT_LARGE_OUTPUT_TESTS=1 vitest run packages/testkit/src/context-compaction.test.ts -t '46.875 MiB'",
     "test:live:deepseek": "node --env-file-if-exists=.env ./node_modules/vitest/vitest.mjs run packages/testkit/src/openai-compatible-model-driver.live.test.ts",
     "test:live:skills": "node --env-file-if-exists=.env ./node_modules/vitest/vitest.mjs run packages/testkit/src/agent-skills.live.test.ts --reporter=verbose",


### PR DESCRIPTION
## Summary

- run TUI semantic behavior in-process through real Presentation, real runTui, and a harness-owned VirtualTerminal
- retain all 82 established TUI test names and add four real-terminal contracts while isolating 14 distinct process, MCP stdio, PTY, signal, paste, resize, and restoration cases in main.os.test.ts
- centralize causal output, filesystem, close, and cleanup ownership; reject implicit process routing and guard the single all-required Linux Quality topology
- document focused behavior and OS commands without adding changed-path skips, worker caps, duration gates, public API changes, or persistence changes

## Verification

- pnpm quality:check: 830 passed, 10 explicit opt-in skipped
- 86 TUI behavior and OS cases passed independently under exact-name selection; both structural guards also passed independently
- pnpm test:tui:behavior and pnpm test:tui:os passed, with the OS matrix run in a real Linux process and PTY environment
- final independent spec and standards reviews reported zero findings

Test duration is telemetry only; correctness remains synchronized on rendered output, lifecycle events, filesystem notification, and actual child close.