### PR TITLE
feat(tui): recover bounded output inspection

### DIFF
--- a/apps/tui/src/artifact-navigator.ts
+++ b/apps/tui/src/artifact-navigator.ts
@@ -1,0 +1,254 @@
+import type {
+  ArtifactChunk,
+  ArtifactRange,
+  ArtifactReference,
+  TranscriptItem,
+} from "@adam-agent/presentation";
+import { presentationArtifactPageMaximumBytes } from "@adam-agent/presentation";
+import { type Component, getKeybindings } from "@earendil-works/pi-tui";
+
+import { safeTerminalText } from "./safe-terminal-text.js";
+import { type SearchableSelectItem, SearchableSelectList } from "./searchable-select-list.js";
+import type { AdamTuiTheme } from "./theme.js";
+
+const loadOlderEntryKey = "__load_older_chronology__";
+
+export type ArtifactEntry = {
+  readonly artifact: ArtifactReference;
+  readonly description: string;
+  readonly key: string;
+  readonly label: string;
+};
+
+export function activeChronologyArtifacts(
+  items: readonly TranscriptItem[],
+): readonly ArtifactEntry[] {
+  return items.flatMap((item) => {
+    if (item.type === "assistant_message" && item.artifact !== null) {
+      return [
+        {
+          artifact: item.artifact,
+          description: `${item.artifact.byteCount} bytes · ${item.artifact.mediaType}`,
+          key: `${item.id}:assistant`,
+          label: "assistant response",
+        },
+      ];
+    }
+    if (item.type !== "tool_call") {
+      return [];
+    }
+    return item.artifacts.map((artifact, index) => ({
+      artifact,
+      description: `${artifact.byteCount} bytes · ${artifact.mediaType}`,
+      key: `${item.id}:tool:${index}`,
+      label: `${item.label} output`,
+    }));
+  });
+}
+
+export function activeChronologyDiffs(items: readonly TranscriptItem[]): readonly ArtifactEntry[] {
+  return items.flatMap((item) =>
+    item.type === "tool_call" &&
+    item.changePreviewRef !== null &&
+    (item.status === "completed" || item.status === "failed" || item.status === "denied")
+      ? [
+          {
+            artifact: item.changePreviewRef,
+            description: `${item.changePreviewRef.byteCount} bytes · ${item.changePreviewRef.mediaType}`,
+            key: `${item.id}:change-preview`,
+            label: `${item.label} change preview`,
+          },
+        ]
+      : [],
+  );
+}
+
+export class ArtifactNavigator implements Component {
+  readonly #entries: ReadonlyMap<string, ArtifactEntry>;
+  readonly #list: SearchableSelectList;
+  readonly #onChange: () => void;
+  readonly #onRead: (artifact: ArtifactReference, range: ArtifactRange) => Promise<ArtifactChunk>;
+  readonly #paged: boolean;
+  readonly #theme: AdamTuiTheme;
+  readonly #title: string;
+  readonly #detailTitle: string;
+  #detail: {
+    readonly entry: ArtifactEntry;
+    readonly chunk: ArtifactChunk;
+    readonly previousRanges: readonly ArtifactRange[];
+    readonly range: ArtifactRange;
+  } | null = null;
+  #generation = 0;
+  #notice: string | null = null;
+
+  constructor(options: {
+    readonly entries: readonly ArtifactEntry[];
+    readonly onChange: () => void;
+    readonly onClose: () => void;
+    readonly onLoadOlder?: () => void;
+    readonly onRead: (artifact: ArtifactReference, range: ArtifactRange) => Promise<ArtifactChunk>;
+    readonly paged?: boolean;
+    readonly theme: AdamTuiTheme;
+    readonly title?: string;
+    readonly detailTitle?: string;
+  }) {
+    this.#entries = new Map(options.entries.map((entry) => [entry.key, entry]));
+    this.#onChange = options.onChange;
+    this.#onRead = options.onRead;
+    this.#paged = options.paged ?? true;
+    this.#theme = options.theme;
+    this.#title = options.title ?? "Session artifacts";
+    this.#detailTitle = options.detailTitle ?? "Artifact detail";
+    const items: SearchableSelectItem[] = [
+      ...options.entries.map((entry) => ({
+        item: {
+          value: entry.key,
+          label: safeTerminalText(entry.label),
+          description: safeTerminalText(entry.description),
+        },
+        searchText: `${entry.label} ${entry.description}`,
+      })),
+      ...(options.onLoadOlder === undefined
+        ? []
+        : [
+            {
+              alwaysVisible: true,
+              item: {
+                value: loadOlderEntryKey,
+                label: "Load older chronology",
+                description: "Read one older authoritative page",
+              },
+              searchText: "",
+            },
+          ]),
+    ];
+    this.#list = new SearchableSelectList({
+      items,
+      maxVisible: 8,
+      onCancel: () => {
+        this.cancelPendingRead();
+        options.onClose();
+      },
+      onSelect: (item) => {
+        if (item.value === loadOlderEntryKey) {
+          options.onLoadOlder?.();
+          return;
+        }
+        const entry = this.#entries.get(item.value);
+        if (entry !== undefined) {
+          this.#open(entry, artifactPageRange(0), []);
+        }
+      },
+      theme: options.theme.editor.selectList,
+    });
+  }
+
+  handleInput(data: string): void {
+    if (this.#detail !== null && getKeybindings().matches(data, "tui.select.cancel")) {
+      this.cancelPendingRead();
+      this.#detail = null;
+      this.#notice = null;
+      return;
+    }
+    if (
+      this.#detail !== null &&
+      this.#paged &&
+      this.#detail.chunk.nextRange !== null &&
+      getKeybindings().matches(data, "tui.select.pageDown")
+    ) {
+      this.#open(this.#detail.entry, this.#detail.chunk.nextRange, [
+        ...this.#detail.previousRanges,
+        this.#detail.range,
+      ]);
+      return;
+    }
+    if (
+      this.#detail !== null &&
+      this.#paged &&
+      this.#detail.previousRanges.length > 0 &&
+      getKeybindings().matches(data, "tui.select.pageUp")
+    ) {
+      const previousRange = this.#detail.previousRanges.at(-1);
+      if (previousRange !== undefined) {
+        this.#open(this.#detail.entry, previousRange, this.#detail.previousRanges.slice(0, -1));
+      }
+      return;
+    }
+    if (this.#detail === null) {
+      this.#list.handleInput(data);
+    }
+  }
+
+  invalidate(): void {
+    this.#list.invalidate();
+  }
+
+  cancelPendingRead(): void {
+    this.#generation += 1;
+  }
+
+  setNotice(notice: string | null): void {
+    this.#notice = notice;
+    this.#onChange();
+  }
+
+  render(width: number): string[] {
+    if (this.#detail === null) {
+      return [
+        this.#theme.toolTitle(this.#title),
+        "",
+        ...this.#list.render(width),
+        ...(this.#notice === null ? [] : ["", this.#theme.muted(this.#notice)]),
+        "",
+        this.#theme.muted("type search · Enter inspect · Esc close · Ctrl+Q exit"),
+      ];
+    }
+    const { chunk, entry } = this.#detail;
+    return [
+      this.#theme.toolTitle(this.#detailTitle),
+      safeTerminalText(entry.label),
+      `${chunk.offset + 1}-${chunk.offset + chunk.byteCount} of ${chunk.totalByteCount} bytes`,
+      "",
+      ...safeTerminalText(chunk.text).split("\n"),
+      "",
+      this.#theme.muted(
+        this.#paged
+          ? "PageUp previous · PageDown next · Esc back · Ctrl+Q exit"
+          : "Esc back · Ctrl+Q exit",
+      ),
+    ];
+  }
+
+  #open(
+    entry: ArtifactEntry,
+    range: ArtifactRange,
+    previousRanges: readonly ArtifactRange[],
+  ): void {
+    const generation = ++this.#generation;
+    this.#notice = "Reading bounded artifact page…";
+    void this.#onRead(entry.artifact, range).then(
+      (chunk) => {
+        if (generation !== this.#generation) {
+          return;
+        }
+        this.#detail = { entry, chunk, previousRanges, range };
+        this.#notice = null;
+        this.#onChange();
+      },
+      (error: unknown) => {
+        if (generation !== this.#generation) {
+          return;
+        }
+        this.#notice = error instanceof Error ? error.message : "The artifact page is unavailable.";
+        this.#onChange();
+      },
+    );
+  }
+}
+
+export function artifactPageRange(offset: number): {
+  readonly offset: number;
+  readonly maximumBytes: number;
+} {
+  return { offset, maximumBytes: presentationArtifactPageMaximumBytes };
+}

--- a/apps/tui/src/command-registry.ts
+++ b/apps/tui/src/command-registry.ts
@@ -7,7 +7,10 @@ export type AdamCommandDefinition = {
   readonly aliases: readonly string[];
   readonly availability: "always" | "idle";
   readonly id:
+    | "artifacts"
     | "clone"
+    | "copy"
+    | "diffs"
     | "fork"
     | "help"
     | "history"
@@ -36,7 +39,8 @@ export type AdamKeybindingAction =
   | "new_session_from_target"
   | "rename_session"
   | "save_default_target"
-  | "submit";
+  | "submit"
+  | "toggle_tool_details";
 
 export type AdamKeybindingDefinition = {
   readonly action: AdamKeybindingAction | null;
@@ -142,6 +146,30 @@ class AdamCommandRegistry {
 }
 
 export const adamCommandRegistry = new AdamCommandRegistry([
+  {
+    aliases: [],
+    availability: "always",
+    id: "artifacts",
+    name: "artifacts",
+    summary: "Browse bounded artifacts from the active chronology.",
+    usage: "/artifacts",
+  },
+  {
+    aliases: [],
+    availability: "always",
+    id: "diffs",
+    name: "diffs",
+    summary: "Reopen settled change previews from the active chronology.",
+    usage: "/diffs",
+  },
+  {
+    aliases: [],
+    availability: "always",
+    id: "copy",
+    name: "copy",
+    summary: "Copy the last assistant response.",
+    usage: "/copy",
+  },
   {
     aliases: [],
     availability: "always",
@@ -313,6 +341,13 @@ const keybindingProjections: readonly KeybindingProjection[] = [
     adamInputs: ["ctrl+q"],
     keys: "Ctrl+Q",
     description: "Exit Adam",
+    section: "application",
+  },
+  {
+    action: "toggle_tool_details",
+    adamInputs: ["ctrl+o"],
+    keys: "Ctrl+O",
+    description: "Toggle bounded authoritative tool details in the transcript",
     section: "application",
   },
   {

--- a/apps/tui/src/exit-policy.ts
+++ b/apps/tui/src/exit-policy.ts
@@ -84,6 +84,14 @@ export async function copyDraftToClipboard(
   scheduler: DeadlineScheduler,
 ): Promise<"copied" | "failed" | "unsupported" | null> {
   const text = boundedUtf8(draft, 64 * 1024);
+  return copyTextToClipboard(text, adapter, scheduler);
+}
+
+export async function copyTextToClipboard(
+  text: string,
+  adapter: ClipboardAdapter | undefined,
+  scheduler: DeadlineScheduler,
+): Promise<"copied" | "failed" | "unsupported" | null> {
   if (text.length === 0) {
     return null;
   }

--- a/apps/tui/src/fixture-scenario.ts
+++ b/apps/tui/src/fixture-scenario.ts
@@ -1,7 +1,12 @@
 export const fixtureScenarios = [
+  "artifact-backed-assistant",
+  "artifact-page-race",
+  "artifact-history",
   "cancellation",
   "clipboard-timeout",
   "clipboard-success",
+  "copy-large-assistant",
+  "copy-older-assistant",
   "deadline",
   "history",
   "mcp-close-unconfirmed",
@@ -15,6 +20,7 @@ export const fixtureScenarios = [
   "skill-selection",
   "streaming",
   "target-navigation",
+  "tool-artifact",
   "unsafe-history",
   "unsafe-output",
 ] as const;

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -42,6 +42,62 @@ test("real TUI starts on an authoritative empty session and restores the termina
   }
 });
 
+test("a real tool output artifact opens through the active chronology picker", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-tool-artifact-page-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      external: true,
+      scenario: "tool-artifact",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Produce tool output\r");
+    await waitForPath(join(controlRoot, "prompt-submitted"));
+    const modelRequest = await Promise.race([
+      waitForPath(join(controlRoot, "tool-artifact-requested")).then(() => "requested" as const),
+      fixture.waitFor("The model run failed.").then(() => "failed" as const),
+    ]);
+    expect(modelRequest).toBe("requested");
+    const toolSettlement = await Promise.race([
+      waitForPath(join(controlRoot, "tool-artifact-result")).then(() => "completed" as const),
+      fixture.waitFor("artifact_store_failed").then(() => "artifact_failed" as const),
+    ]);
+    expect(toolSettlement).toBe("completed");
+    await fixture.waitFor("Tool artifact complete");
+    expect(fixture.output()).toContain("output truncated");
+    fixture.write("/artifacts \r");
+    const artifactList = await Promise.race([
+      fixture.waitFor("shell output").then(() => "listed" as const),
+      fixture
+        .waitFor("No artifacts are visible in the active chronology")
+        .then(() => "empty" as const),
+    ]);
+    expect(artifactList).toBe("listed");
+    fixture.write("\r");
+    await waitForPath(join(controlRoot, "artifact-read-1"));
+    const firstPage = await Promise.race([
+      fixture.waitFor("1-16384 of 70000 bytes").then(() => "opened" as const),
+      fixture.waitFor("The artifact could not be read safely").then(() => "unsafe" as const),
+      fixture
+        .waitFor("The artifact is not available through this Presentation session")
+        .then(() => "unavailable" as const),
+    ]);
+    expect(firstPage).toBe("opened");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("the production TUI entry exposes its usage contract", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-help-"));
   const workspaceRoot = join(testRoot, "workspace");

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -509,6 +509,33 @@ test("the idle footer exposes Registry-driven interaction hints", async () => {
   }
 });
 
+test("the footer exposes authoritative project context and run facts", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-footer-facts-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      scenario: "artifact-backed-assistant",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Produce an artifact-backed answer\r");
+    await fixture.waitFor("Adam · Streaming session");
+    const beforeCompaction = fixture.output().length;
+    fixture.write("Continue after the large answer\r");
+    await fixture.waitForAfter("Context compacted · window 1", beforeCompaction);
+    await fixture.waitForAfter("context · estimated · idle", beforeCompaction);
+    expect(fixture.output()).toMatch(/workspace · \d+\/32768 context · estimated · idle/u);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("Tab accepts a fuzzy slash-command suggestion from the Registry", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-fuzzy-slash-"));
   const workspaceRoot = join(testRoot, "workspace");
@@ -1698,6 +1725,167 @@ test("a real read tool is rendered as a bounded Pi-style tool card", async () =>
   }
 });
 
+test("Ctrl+O toggles bounded authoritative tool details", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-tool-details-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "README.md"), "alpha\nbeta\n", "utf8");
+
+  try {
+    const fixture = startFixture({ scenario: "read", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Read the README\r");
+    await fixture.waitFor("Read complete");
+    expect(fixture.output()).not.toContain("provider model response");
+    const beforeExpand = fixture.output().length;
+    fixture.write("\u000f");
+    await fixture.waitForAfter("read_file · read · completed · replay safe", beforeExpand);
+    await fixture.waitForAfter("provider model response", beforeExpand);
+    await fixture.waitForAfter("duration unavailable", beforeExpand);
+    const beforeCollapse = fixture.output().length;
+    fixture.write("\u000f");
+    await fixture.waitForAfter("11 bytes", beforeCollapse);
+    expect(fixture.output().slice(beforeCollapse)).not.toContain("provider model response");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("slash Copy copies the last inline assistant response without persisting a prompt", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-copy-assistant-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+  await writeFile(join(workspaceRoot, "README.md"), "copy fixture\n", "utf8");
+
+  try {
+    const fixture = startFixture({ controlRoot, scenario: "read", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Read the README\r");
+    await fixture.waitFor("Read complete");
+    const beforeCopy = fixture.output().length;
+    fixture.write("/copy \r");
+    const outcome = await Promise.race([
+      waitForPath(join(controlRoot, "clipboard.txt")).then(() => "copied" as const),
+      fixture.waitForAfter("Unknown command /copy", beforeCopy).then(() => "unknown" as const),
+    ]);
+    expect(outcome).toBe("copied");
+    expect(await readFile(join(controlRoot, "clipboard.txt"), "utf8")).toBe("Read complete.");
+    await fixture.waitForAfter("Copied last assistant response.", beforeCopy);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(await readFilesRecursively(stateRoot)).not.toContain('"text":"/copy"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("slash Copy never truncates a large inline assistant response", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-copy-large-assistant-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "copy-large-assistant",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Produce a large inline response\r");
+    await fixture.waitFor("Exact copy tail.");
+    fixture.write("/copy \r");
+    await waitForPath(join(controlRoot, "clipboard.txt"));
+    expect(await readFile(join(controlRoot, "clipboard.txt"), "utf8")).toBe(
+      `${"c".repeat(65 * 1024)}\nExact copy tail.`,
+    );
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("slash Copy reads and copies the complete last artifact-backed assistant response", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-copy-artifact-assistant-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "artifact-backed-assistant",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Produce an artifact-backed answer\r");
+    await fixture.waitFor("Assistant response stored as artifact");
+    fixture.write("/copy \r");
+    await waitForPath(join(controlRoot, "clipboard.txt"));
+    const copied = await readFile(join(controlRoot, "clipboard.txt"), "utf8");
+    expect(Buffer.byteLength(copied, "utf8")).toBe(270_057);
+    expect(copied).toMatch(/^Assistant artifact page one/u);
+    expect(copied).toContain("Assistant artifact page two");
+    expect(copied.endsWith("b")).toBe(true);
+    expect(await readFile(join(controlRoot, "artifact-read-1"), "utf8")).toBe("0\n");
+    await expect(access(join(controlRoot, "artifact-read-2"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("slash Copy loads older active chronology to find the last assistant response", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-copy-older-assistant-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "copy-older-assistant",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Later copy prompt two");
+    expect(fixture.output()).not.toContain("Older copy answer.");
+    const beforeCopy = fixture.output().length;
+    fixture.write("/copy \r");
+    const outcome = await Promise.race([
+      waitForPath(join(controlRoot, "clipboard.txt")).then(() => "copied" as const),
+      fixture
+        .waitForAfter("No assistant response is available to copy.", beforeCopy)
+        .then(() => "missing" as const),
+    ]);
+    expect(outcome).toBe("copied");
+    expect(await readFile(join(controlRoot, "clipboard.txt"), "utf8")).toBe("Older copy answer.");
+    await fixture.waitForAfter("Copied last assistant response.", beforeCopy);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("a shell tool card uses the accepted dollar-command grammar", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-shell-card-"));
   const workspaceRoot = join(testRoot, "workspace");
@@ -1709,6 +1897,196 @@ test("a shell tool card uses the accepted dollar-command grammar", async () => {
     await fixture.waitFor("Adam · New session");
     fixture.write("Show shell card\r");
     await fixture.waitFor("$ printf shell-card-fixture");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("an artifact-backed assistant response remains visible in the transcript", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-assistant-artifact-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      scenario: "artifact-backed-assistant",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Produce an artifact-backed answer\r");
+    await fixture.waitFor("Adam · Streaming session");
+    expect(fixture.output()).toContain("Assistant response stored as artifact");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("slash Artifacts opens one bounded assistant artifact page", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-assistant-artifact-page-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      scenario: "artifact-backed-assistant",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Produce an artifact-backed answer\r");
+    await fixture.waitFor("Adam · Streaming session");
+    const beforeArtifacts = fixture.output().length;
+    fixture.write("/artifacts \r");
+    const opened = await Promise.race([
+      fixture.waitForAfter("Session artifacts", beforeArtifacts).then(() => "opened" as const),
+      fixture
+        .waitForAfter("Unknown command /artifacts", beforeArtifacts)
+        .then(() => "unknown" as const),
+    ]);
+    expect(opened).toBe("opened");
+    await fixture.waitForAfter("assistant response", beforeArtifacts);
+    fixture.write("\r");
+    await fixture.waitForAfter("Artifact detail", beforeArtifacts);
+    const detailOutput = fixture.output().slice(beforeArtifacts);
+    expect(detailOutput).toContain("Assistant artifact page one");
+    expect(detailOutput).not.toContain("Assistant artifact page two");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("slash Artifacts loads artifact references from older active chronology", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-artifact-history-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ scenario: "artifact-history", stateRoot, workspaceRoot });
+    await fixture.waitFor("Later history answer.");
+    fixture.write("/artifacts \r");
+    await fixture.waitFor("Session artifacts");
+    await fixture.waitFor("Load older chronology");
+    const beforeFirstPage = fixture.output().length;
+    fixture.write("\r");
+    await fixture.waitForAfter("Load older chronology", beforeFirstPage);
+    fixture.write("\r");
+    await fixture.waitFor("assistant response");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PageDown reads the next bounded assistant artifact page", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-assistant-artifact-next-page-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "artifact-backed-assistant",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Produce an artifact-backed answer\r");
+    await fixture.waitFor("Assistant response stored as artifact");
+    fixture.write("/artifacts \r");
+    await fixture.waitFor("Session artifacts");
+    fixture.write("\r");
+    await waitForPath(join(controlRoot, "artifact-read-1"));
+    await fixture.waitFor("1-16384 of 270057 bytes");
+    const beforeNextPage = fixture.output().length;
+    fixture.write("\u001b[6~");
+    await waitForPath(join(controlRoot, "artifact-read-2"));
+    expect(await readFile(join(controlRoot, "artifact-read-2"), "utf8")).toBe("16384\n");
+    await fixture.waitForAfter("16385-32768 of 270057 bytes", beforeNextPage);
+    await fixture.waitForAfter("Assistant artifact page two", beforeNextPage);
+    const beforePreviousPage = fixture.output().length;
+    fixture.write("\u001b[5~");
+    await waitForPath(join(controlRoot, "artifact-read-3"));
+    expect(await readFile(join(controlRoot, "artifact-read-3"), "utf8")).toBe("0\n");
+    await fixture.waitForAfter("1-16384 of 270057 bytes", beforePreviousPage);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("Escape keeps a late artifact page response from restoring stale detail", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-artifact-page-race-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "artifact-page-race",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Produce an artifact-backed answer\r");
+    await fixture.waitFor("Assistant response stored as artifact");
+    fixture.write("/artifacts \r");
+    await fixture.waitFor("Session artifacts");
+    fixture.write("\r");
+    await fixture.waitFor("Artifact detail");
+    fixture.write("\u001b[6~");
+    await waitForPath(join(controlRoot, "page-read-pending"));
+    const beforeEscape = fixture.output().length;
+    fixture.write("\u001b");
+    await fixture.waitForAfter("type search · Enter inspect", beforeEscape);
+    await writeFile(join(controlRoot, "release-page-read"), "release\n", "utf8");
+    await waitForPath(join(controlRoot, "artifact-read-2-settled"));
+    fixture.write("no-such-artifact");
+    await fixture.waitFor("Search: no-such-artifact");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("completed durable-context compaction renders an explicit chronology marker", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-compaction-marker-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      scenario: "artifact-backed-assistant",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Produce an artifact-backed answer\r");
+    await fixture.waitFor("Assistant response stored as artifact");
+    await fixture.waitFor("Adam · Streaming session");
+    const beforeCompaction = fixture.output().length;
+    fixture.write("Continue after the large answer\r");
+    await fixture.waitForAfter("Context compacted · window 1", beforeCompaction);
+    await fixture.waitForAfter("Assistant response stored as artifact", beforeCompaction);
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
@@ -1733,6 +2111,39 @@ test("a mutation permission shows its canonical diff and Enter allows the exact 
     fixture.write("\r");
     await fixture.waitFor("Edit complete");
     await expect(readFile(join(workspaceRoot, "edit.txt"), "utf8")).resolves.toBe("after\n");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("slash Diffs reopens a settled mutation preview from authoritative chronology", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-settled-diff-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "edit.txt"), "before\n", "utf8");
+
+  try {
+    const fixture = startFixture({ scenario: "mutation", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Edit the file\r");
+    await fixture.waitFor("Permission required");
+    fixture.write("\r");
+    await fixture.waitFor("Edit complete");
+    const beforeDiffs = fixture.output().length;
+    fixture.write("/diffs \r");
+    const opened = await Promise.race([
+      fixture.waitForAfter("Settled diffs", beforeDiffs).then(() => "opened" as const),
+      fixture.waitForAfter("Unknown command /diffs", beforeDiffs).then(() => "unknown" as const),
+    ]);
+    expect(opened).toBe("opened");
+    await fixture.waitForAfter("edit change preview", beforeDiffs);
+    fixture.write("\r");
+    await fixture.waitForAfter("Diff detail", beforeDiffs);
+    await fixture.waitForAfter("-before", beforeDiffs);
+    await fixture.waitForAfter("+after", beforeDiffs);
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -98,7 +98,10 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
         }
       : {}),
     ...(modelTargets === undefined ? {} : { modelTargets }),
-    permissions: createPermissionPolicy({ allowedEffects: ["read"], askedEffects: ["write"] }),
+    permissions: createPermissionPolicy({
+      allowedEffects: options.scenario === "tool-artifact" ? ["read", "execute"] : ["read"],
+      askedEffects: ["write"],
+    }),
     stateRoot: options.stateRoot,
     workspaceRoot: options.workspaceRoot,
   });
@@ -118,6 +121,8 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
     const resumedSessionId =
       options.scenario === "resume" ||
       options.scenario === "history" ||
+      options.scenario === "artifact-history" ||
+      options.scenario === "copy-older-assistant" ||
       options.scenario === "target-navigation" ||
       options.scenario === "unsafe-history"
         ? await lifecycle.create({ targetIdentity }).then(async (created) => {
@@ -127,6 +132,25 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
                   sessionId: created.sessionId,
                   input: { text: `History prompt ${index}` },
                 });
+              }
+            } else if (options.scenario === "artifact-history") {
+              for (const text of [
+                "Artifact history prompt",
+                "Later history prompt one",
+                "Later history prompt two",
+              ]) {
+                await lifecycle.continue({
+                  sessionId: created.sessionId,
+                  input: { text },
+                });
+              }
+            } else if (options.scenario === "copy-older-assistant") {
+              for (const text of [
+                "Older copy prompt",
+                "Later copy prompt one",
+                "Later copy prompt two",
+              ]) {
+                await lifecycle.continue({ sessionId: created.sessionId, input: { text } });
               }
             } else if (options.scenario === "resume") {
               await lifecycle.continue({
@@ -193,7 +217,11 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
                 sessionId: resumedSessionId,
                 stateRoot: options.stateRoot,
                 workspaceRoot: options.workspaceRoot,
-                ...(options.scenario === "history" ? { [presentationHistoryPageSize]: 2 } : {}),
+                ...(options.scenario === "history" ||
+                options.scenario === "artifact-history" ||
+                options.scenario === "copy-older-assistant"
+                  ? { [presentationHistoryPageSize]: 2 }
+                  : {}),
                 ...(previewBarrier === undefined
                   ? {}
                   : { [presentationArtifactReadBarrier]: previewBarrier }),
@@ -201,7 +229,7 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
     );
     const clipboard = clipboardAdapter(options);
     const deadlineScheduler = controlledDeadlineScheduler(options);
-    const tuiPresentation = observePermissionDecision(presentation, options);
+    const tuiPresentation = observeTuiDispatch(presentation, options);
     await runTui({
       ...(clipboard === undefined ? {} : { clipboard }),
       ...(deadlineScheduler === undefined ? {} : { deadlineScheduler }),
@@ -223,7 +251,7 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
   }
 }
 
-function observePermissionDecision(
+function observeTuiDispatch(
   presentation: PresentationSession,
   options: {
     readonly controlRoot?: string;
@@ -231,9 +259,16 @@ function observePermissionDecision(
   },
 ): PresentationSession {
   const controlRoot = options.controlRoot;
-  if (options.scenario !== "mutation-delayed-preview" || controlRoot === undefined) {
+  if (
+    (options.scenario !== "mutation-delayed-preview" &&
+      options.scenario !== "tool-artifact" &&
+      options.scenario !== "artifact-backed-assistant" &&
+      options.scenario !== "artifact-page-race") ||
+    controlRoot === undefined
+  ) {
     return presentation;
   }
+  let artifactReadCount = 0;
   return {
     close: () => presentation.close(),
     dispatch: async (command) => {
@@ -244,6 +279,24 @@ function observePermissionDecision(
           `${command.decision}\n`,
           "utf8",
         );
+      }
+      if (command.type === "read_artifact") {
+        artifactReadCount += 1;
+        await writeFile(
+          join(controlRoot, `artifact-read-${artifactReadCount}`),
+          `${command.range?.offset ?? 0}\n`,
+          "utf8",
+        );
+        const settled = await receipt;
+        await writeFile(
+          join(controlRoot, `artifact-read-${artifactReadCount}-settled`),
+          "settled\n",
+          "utf8",
+        );
+        return settled;
+      }
+      if (command.type === "submit_prompt") {
+        await writeFile(join(controlRoot, "prompt-submitted"), `${command.text}\n`, "utf8");
       }
       return receipt;
     },
@@ -308,7 +361,22 @@ function createFixtureModelTargets(options: {
   const model: ModelDriver = {
     async *stream(request) {
       if (request.tools.length === 0) {
-        yield { type: "text_delta", text: "Streaming session" };
+        yield {
+          type: "text_delta",
+          text:
+            request.maximumOutputTokens === 64
+              ? "Streaming session"
+              : JSON.stringify({
+                  schemaVersion: 1,
+                  objective: "Preserve the active TUI fixture task.",
+                  constraints: [],
+                  progress: ["The shell tool completed and preserved its bounded output."],
+                  unresolvedQuestions: [],
+                  failures: [],
+                  remainingVerification: [],
+                  nextSafeAction: "Continue the active model turn.",
+                }),
+        };
         yield { type: "finish", reason: "stop" };
         return;
       }
@@ -371,6 +439,17 @@ function createFixtureModelTargets(options: {
         options.scenario === "unsafe-history"
       ) {
         yield { type: "text_delta", text: "History answer." };
+      } else if (options.scenario === "artifact-history") {
+        const latestUser = [...request.messages]
+          .reverse()
+          .find((message) => message.role === "user");
+        yield {
+          type: "text_delta",
+          text:
+            latestUser?.role === "user" && latestUser.content === "Artifact history prompt"
+              ? `Older artifact page\n${"h".repeat(270_000)}`
+              : "Later history answer.",
+        };
       } else if (options.scenario === "resume") {
         yield { type: "text_delta", text: "Previous answer." };
       } else if (options.scenario === "target-navigation") {
@@ -389,8 +468,53 @@ function createFixtureModelTargets(options: {
           return;
         }
         yield { type: "text_delta", text: "Shell card complete." };
+      } else if (options.scenario === "tool-artifact") {
+        const latest = request.messages.at(-1);
+        if (latest?.role === "user") {
+          await writeFile(
+            join(options.controlRoot as string, "tool-artifact-requested"),
+            "requested\n",
+            "utf8",
+          );
+          const command = "yes x | head -c 70000";
+          yield { type: "tool_call_start", id: "shell-artifact", name: "run_shell" };
+          yield {
+            type: "tool_call_delta",
+            id: "shell-artifact",
+            json: JSON.stringify({ command }),
+          };
+          yield { type: "tool_call_end", id: "shell-artifact" };
+          yield { type: "finish", reason: "tool_calls" };
+          return;
+        }
+        await writeFile(
+          join(options.controlRoot as string, "tool-artifact-result"),
+          JSON.stringify(latest),
+          "utf8",
+        );
+        yield { type: "text_delta", text: "Tool artifact complete." };
       } else if (options.scenario === "skill-selection") {
         yield { type: "text_delta", text: "Skill selection complete." };
+      } else if (
+        options.scenario === "artifact-backed-assistant" ||
+        options.scenario === "artifact-page-race"
+      ) {
+        yield {
+          type: "text_delta",
+          text: `Assistant artifact page one\n${"a".repeat(20_000)}\nAssistant artifact page two\n${"b".repeat(250_000)}`,
+        };
+      } else if (options.scenario === "copy-large-assistant") {
+        yield {
+          type: "text_delta",
+          text: `${"c".repeat(65 * 1024)}\nExact copy tail.`,
+        };
+      } else if (options.scenario === "copy-older-assistant") {
+        const latestUser = [...request.messages]
+          .reverse()
+          .find((message) => message.role === "user");
+        if (latestUser?.role === "user" && latestUser.content === "Older copy prompt") {
+          yield { type: "text_delta", text: "Older copy answer." };
+        }
       } else if (options.scenario === "unsafe-output") {
         yield {
           type: "text_delta",
@@ -463,15 +587,32 @@ function previewReadBarrier(options: {
   readonly controlRoot?: string;
   readonly scenario?: string;
 }): PresentationArtifactReadBarrier | undefined {
-  if (options.scenario !== "mutation-delayed-preview" || options.controlRoot === undefined) {
+  if (
+    (options.scenario !== "mutation-delayed-preview" &&
+      options.scenario !== "artifact-page-race") ||
+    options.controlRoot === undefined
+  ) {
     return undefined;
   }
+  let readCount = 0;
   return {
     async beforeRead() {
+      readCount += 1;
+      if (options.scenario === "artifact-page-race") {
+        if (readCount === 1) {
+          return;
+        }
+        await writeFile(join(options.controlRoot as string, "page-read-pending"), "pending\n");
+        await waitForFile(options.controlRoot as string, "release-page-read");
+        return;
+      }
       await writeFile(join(options.controlRoot as string, "preview-requested"), "requested\n");
       await waitForFile(options.controlRoot as string, "release-preview");
     },
     async afterRead() {
+      if (options.scenario === "artifact-page-race") {
+        return;
+      }
       await writeFile(join(options.controlRoot as string, "preview-read-complete"), "complete\n");
     },
   };
@@ -494,6 +635,10 @@ function clipboardAdapter(options: {
   }
   if (
     options.scenario !== "clipboard-success" &&
+    options.scenario !== "copy-large-assistant" &&
+    options.scenario !== "copy-older-assistant" &&
+    options.scenario !== "artifact-backed-assistant" &&
+    options.scenario !== "read" &&
     options.scenario !== "history" &&
     options.scenario !== "session-selection-history" &&
     options.scenario !== "unsafe-history"

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -1,5 +1,6 @@
 import type {
   ActiveSessionDisplay,
+  ArtifactReference,
   PresentationSession,
   RepositoryInstructionsDisplay,
   TargetDisplay,
@@ -19,12 +20,18 @@ import {
   type TUI,
   TuiMainScreen,
 } from "@earendil-works/pi-tui";
+import {
+  ArtifactNavigator,
+  activeChronologyArtifacts,
+  activeChronologyDiffs,
+} from "./artifact-navigator.js";
 import { ChronologyPicker, completeChronologyBoundaries } from "./chronology-picker.js";
 import { AdamAutocompleteProvider } from "./command-autocomplete.js";
 import { adamCommandRegistry } from "./command-registry.js";
 import {
   type ClipboardAdapter,
   copyDraftToClipboard,
+  copyTextToClipboard,
   type DeadlineScheduler,
   ExitArm,
   LegacyDuplicateGuard,
@@ -112,6 +119,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   const exitArm = new ExitArm(deadlineScheduler, () => requestPolicyRender());
   const legacyDuplicateGuard = new LegacyDuplicateGuard(deadlineScheduler);
   let previousRunActive: boolean | undefined;
+  let toolDetailsExpanded = false;
   let statusMessage: string | null = null;
   let permission:
     | {
@@ -179,6 +187,12 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         readonly close: () => void;
         readonly hide: () => void;
         readonly navigator: HelpNavigator;
+      }
+    | undefined;
+  let artifactNavigator:
+    | {
+        readonly close: () => void;
+        readonly hide: () => void;
       }
     | undefined;
   const selectedSkills = new Set<string>();
@@ -255,6 +269,8 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       chronologyPicker = undefined;
       resourceReloadPicker?.hide();
       resourceReloadPicker = undefined;
+      artifactNavigator?.hide();
+      artifactNavigator = undefined;
       if (active !== null) {
         sessionPickerDismissed = false;
         targetPickerDismissed = false;
@@ -556,9 +572,19 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         );
         transcript.addChild(user);
         previousWasAssistant = false;
-      } else if (item.type === "assistant_message" && item.text !== null) {
+      } else if (item.type === "assistant_message") {
         transcript.addChild(new Spacer(1));
-        transcript.addChild(new Markdown(safeTerminalText(item.text), 0, 0, theme.markdown));
+        if (item.text !== null) {
+          transcript.addChild(new Markdown(safeTerminalText(item.text), 0, 0, theme.markdown));
+        } else if (item.artifact !== null) {
+          transcript.addChild(
+            new Text(
+              theme.muted(
+                `Assistant response stored as artifact · ${item.artifact.byteCount} bytes · /artifacts to inspect`,
+              ),
+            ),
+          );
+        }
         previousWasAssistant = true;
       } else if (item.type === "tool_call") {
         const tool = new Box(1, 1, theme.toolBackground);
@@ -577,8 +603,51 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         if (detail !== null) {
           tool.addChild(new Text(theme.toolOutput(safeTerminalText(detail))));
         }
+        if (toolDetailsExpanded) {
+          const replay = item.source?.replay ?? "unavailable";
+          tool.addChild(
+            new Text(theme.muted(safeTerminalText(`safe summary · ${detail ?? "unavailable"}`))),
+          );
+          tool.addChild(
+            new Text(
+              theme.muted(
+                safeTerminalText(
+                  `${item.qualifiedName} · ${item.effect ?? "effect unknown"} · ${item.status} · replay ${replay} · duration ${item.durationMs === null ? "unavailable" : `${item.durationMs} ms`}`,
+                ),
+              ),
+            ),
+          );
+          if (item.source !== null) {
+            tool.addChild(
+              new Text(
+                theme.muted(
+                  safeTerminalText(
+                    `provider model response · response ${item.source.responseSequence} · arguments ${item.source.argumentsDigest} · definition ${item.source.definitionDigest ?? "unknown"}`,
+                  ),
+                ),
+              ),
+            );
+          }
+          tool.addChild(
+            new Text(
+              theme.muted(
+                `${item.artifacts.length} artifact${item.artifacts.length === 1 ? "" : "s"} · change preview ${item.changePreviewRef === null ? "none" : "available"}`,
+              ),
+            ),
+          );
+        }
         transcript.addChild(new Spacer(1));
         transcript.addChild(tool);
+        previousWasAssistant = false;
+      } else if (item.type === "compaction_marker") {
+        transcript.addChild(new Spacer(1));
+        transcript.addChild(
+          new Text(
+            theme.muted(
+              `Context compacted · window ${item.windowNumber} · through ${item.sourceThrough} · retained from ${item.retainedFrom}`,
+            ),
+          ),
+        );
         previousWasAssistant = false;
       } else if (item.type === "session_notice") {
         const message =
@@ -680,7 +749,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         : active === null
           ? theme.muted("Choose an exact model target to create a session")
           : theme.muted(
-              `${safeTerminalText(active.session.targetId)} · ${
+              `${safeTerminalText(state.authoritative.project.label)} · ${footerContextText(active)} · ${sessionRunStatus(state.transient?.activity ?? null, active, cancelSettling)}\n${safeTerminalText(active.session.targetId)} · ${
                 state.authoritative.targets.items.find(
                   (target) => target.targetId === active.session.targetId,
                 )?.certification ??
@@ -840,6 +909,96 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     tui.setFocus(picker);
     tui.requestRender();
   };
+  const showArtifactNavigator = (diffs: boolean, expectedSessionId: string): void => {
+    const current = options.presentation.getState().authoritative.active;
+    if (current?.session.id !== expectedSessionId) {
+      statusMessage = "The active session changed before its output picker opened.";
+      renderState();
+      return;
+    }
+    const entries = diffs
+      ? activeChronologyDiffs(current.transcript.items)
+      : activeChronologyArtifacts(current.transcript.items);
+    const olderCursor = current.transcript.olderCursor;
+    if (entries.length === 0 && olderCursor === null) {
+      statusMessage = diffs
+        ? "No settled diffs are visible in the active chronology."
+        : "No artifacts are visible in the active chronology.";
+      renderState();
+      return;
+    }
+    artifactNavigator?.hide();
+    let handle: { hide(): void } | undefined;
+    const close = () => {
+      navigator.cancelPendingRead();
+      handle?.hide();
+      artifactNavigator = undefined;
+      tui.setFocus(editor);
+      tui.requestRender();
+    };
+    const navigator = new ArtifactNavigator({
+      ...(diffs ? { detailTitle: "Diff detail", title: "Settled diffs" } : {}),
+      entries,
+      onChange: () => tui.requestRender(),
+      onClose: close,
+      ...(olderCursor === null
+        ? {}
+        : {
+            onLoadOlder() {
+              navigator.setNotice("Loading one older authoritative chronology page…");
+              void options.presentation
+                .dispatch({ type: "load_older_transcript", before: olderCursor })
+                .then((receipt) => {
+                  if (artifactNavigator?.close !== close) {
+                    return;
+                  }
+                  if (receipt.status === "rejected") {
+                    navigator.setNotice(receipt.message);
+                    return;
+                  }
+                  artifactNavigator.hide();
+                  artifactNavigator = undefined;
+                  showArtifactNavigator(diffs, expectedSessionId);
+                })
+                .catch(() => {
+                  if (artifactNavigator?.close === close) {
+                    navigator.setNotice("The older chronology page could not be loaded.");
+                  }
+                });
+            },
+          }),
+      async onRead(artifact, range) {
+        const receipt = await options.presentation.dispatch({
+          type: "read_artifact",
+          artifact,
+          range,
+        });
+        if (receipt.status === "rejected" || receipt.resource === null) {
+          throw new Error(
+            receipt.status === "rejected" ? receipt.message : "The artifact page is unavailable.",
+          );
+        }
+        return receipt.resource;
+      },
+      theme,
+    });
+    handle = tui.showOverlay(navigator, {
+      width: "90%",
+      minWidth: 36,
+      maxHeight: "80%",
+      margin: 1,
+    });
+    artifactNavigator = {
+      close,
+      hide: () => {
+        navigator.cancelPendingRead();
+        handle?.hide();
+      },
+    };
+    statusMessage = null;
+    tui.setFocus(navigator);
+    tui.requestRender();
+  };
   editor.onSubmit = (text) => {
     const state = options.presentation.getState();
     const active = state.authoritative.active;
@@ -900,6 +1059,43 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       editor.setText("");
       editor.disableSubmit = false;
       renderState();
+      return;
+    }
+    if (
+      parsedCommand.kind === "known" &&
+      parsedCommand.command.id === "copy" &&
+      parsedCommand.argumentsText.length === 0
+    ) {
+      editor.setText("");
+      editor.disableSubmit = false;
+      statusMessage = "Finding last assistant response for copy…";
+      renderState();
+      void copyLastAssistantResponse({
+        clipboard: options.clipboard,
+        deadlineScheduler,
+        presentation: options.presentation,
+        sessionId: active.session.id,
+      }).then(
+        (resultMessage) => {
+          statusMessage = resultMessage;
+          renderState();
+        },
+        () => {
+          statusMessage = "The last assistant response could not be read safely for copy.";
+          renderState();
+        },
+      );
+      return;
+    }
+    if (
+      parsedCommand.kind === "known" &&
+      (parsedCommand.command.id === "artifacts" || parsedCommand.command.id === "diffs") &&
+      parsedCommand.argumentsText.length === 0
+    ) {
+      editor.setText("");
+      editor.disableSubmit = false;
+      const diffs = parsedCommand.command.id === "diffs";
+      showArtifactNavigator(diffs, active.session.id);
       return;
     }
     if (
@@ -1519,6 +1715,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     pathPicker?.hide();
     mcpWizard?.hide();
     helpNavigator?.hide();
+    artifactNavigator?.hide();
     targetPicker?.hide();
     permission?.hide();
     working.stop();
@@ -1547,6 +1744,11 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       void stop(true);
       return { consume: true };
     }
+    if (adamCommandRegistry.matchesInput(data, "toggle_tool_details")) {
+      toolDetailsExpanded = !toolDetailsExpanded;
+      renderState();
+      return { consume: true };
+    }
     if (adamCommandRegistry.matchesInput(data, "interrupt")) {
       if (isKeyRepeat(data) || isKeyRelease(data)) {
         return { consume: true };
@@ -1557,6 +1759,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       const closeOverlay =
         permission === undefined
           ? (helpNavigator?.close ??
+            artifactNavigator?.close ??
             mcpWizard?.close ??
             pathPicker?.close ??
             skillPalette?.close ??
@@ -1611,6 +1814,102 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   });
   tui.start();
   await exited.promise;
+}
+
+function clipboardAssistantStatus(result: "copied" | "failed" | "unsupported" | null): string {
+  return result === "copied"
+    ? "Copied last assistant response."
+    : result === "unsupported"
+      ? "Clipboard unavailable; assistant response was not copied."
+      : "Clipboard copy failed; assistant response was not copied.";
+}
+
+async function copyLastAssistantResponse(options: {
+  readonly clipboard: ClipboardAdapter | undefined;
+  readonly deadlineScheduler: DeadlineScheduler;
+  readonly presentation: PresentationSession;
+  readonly sessionId: string;
+}): Promise<string> {
+  const assistant = await findLastAssistantResponse(options.presentation, options.sessionId);
+  if (assistant === undefined) {
+    return "No assistant response is available to copy.";
+  }
+  if (assistant.text !== null) {
+    return clipboardAssistantStatus(
+      await copyTextToClipboard(assistant.text, options.clipboard, options.deadlineScheduler),
+    );
+  }
+  if (assistant.artifact === null) {
+    return "The last assistant response is unavailable to copy.";
+  }
+  const text = await readCompleteArtifact(options.presentation, assistant.artifact);
+  return clipboardAssistantStatus(
+    await copyTextToClipboard(text, options.clipboard, options.deadlineScheduler),
+  );
+}
+
+async function findLastAssistantResponse(
+  presentation: PresentationSession,
+  sessionId: string,
+): Promise<
+  | Extract<
+      ActiveSessionDisplay["transcript"]["items"][number],
+      { readonly type: "assistant_message" }
+    >
+  | undefined
+> {
+  while (true) {
+    const active = presentation.getState().authoritative.active;
+    if (active?.session.id !== sessionId) {
+      throw new TypeError("The active session changed while locating its last assistant response.");
+    }
+    const assistant = active.transcript.items.findLast((item) => item.type === "assistant_message");
+    if (assistant !== undefined) {
+      return assistant;
+    }
+    const before = active.transcript.olderCursor;
+    if (before === null) {
+      return undefined;
+    }
+    const receipt = await presentation.dispatch({ type: "load_older_transcript", before });
+    if (receipt.status === "rejected") {
+      throw new TypeError("The older transcript page is unavailable.");
+    }
+    const refreshed = presentation.getState().authoritative.active;
+    if (refreshed?.session.id !== sessionId || refreshed.transcript.olderCursor === before) {
+      throw new TypeError("The older transcript page did not advance.");
+    }
+  }
+}
+
+async function readCompleteArtifact(
+  presentation: PresentationSession,
+  artifact: ArtifactReference,
+): Promise<string> {
+  const receipt = await presentation.dispatch({ type: "read_artifact", artifact, range: null });
+  if (
+    receipt.status === "rejected" ||
+    receipt.resource === null ||
+    receipt.resource.offset !== 0 ||
+    receipt.resource.byteCount !== artifact.byteCount ||
+    receipt.resource.totalByteCount !== artifact.byteCount ||
+    !receipt.resource.eof ||
+    receipt.resource.nextRange !== null
+  ) {
+    throw new TypeError("The complete artifact is unavailable for copy.");
+  }
+  return receipt.resource.text;
+}
+
+function footerContextText(active: ActiveSessionDisplay): string {
+  const context = active.context;
+  if (context === null) {
+    return "context unavailable";
+  }
+  if (context.active.source === "unknown") {
+    return `?/${context.profile.contextWindowTokens} context · unknown`;
+  }
+  return `${context.active.tokens}/${context.profile.contextWindowTokens} context · ${context.active.source}`;
 }
 
 function toolStatusText(

--- a/packages/agent/src/artifact-store.ts
+++ b/packages/agent/src/artifact-store.ts
@@ -184,6 +184,91 @@ export async function readFileArtifact(options: {
   }
 }
 
+export async function readFileArtifactRange(options: {
+  readonly root: string;
+  readonly id: string;
+  readonly expectedByteCount: number;
+  readonly offset: number;
+  readonly maximumBytes: number;
+}): Promise<
+  | {
+      readonly bytes: Uint8Array;
+      readonly totalByteCount: number;
+      readonly eof: boolean;
+    }
+  | undefined
+> {
+  const root = resolve(options.root);
+  if (!root.startsWith("/")) {
+    throw new TypeError("The artifact root must resolve to an absolute path.");
+  }
+  if (
+    !Number.isSafeInteger(options.expectedByteCount) ||
+    options.expectedByteCount < 0 ||
+    !Number.isSafeInteger(options.offset) ||
+    options.offset < 0 ||
+    !Number.isSafeInteger(options.maximumBytes) ||
+    options.maximumBytes <= 0
+  ) {
+    throw new RangeError("The artifact range must use bounded nonnegative safe integers.");
+  }
+  const digest = parseArtifactId(options.id);
+  let file: Awaited<ReturnType<typeof open>>;
+  try {
+    file = await open(join(root, digest), "r");
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+  try {
+    const { size } = await file.stat();
+    if (
+      !Number.isSafeInteger(size) ||
+      size !== options.expectedByteCount ||
+      options.offset > size
+    ) {
+      throw new Error("The artifact size does not match its reference.");
+    }
+    const hash = createHash("sha256");
+    const retained: Buffer[] = [];
+    const retainedEnd = Math.min(size, options.offset + options.maximumBytes);
+    const readBuffer = Buffer.allocUnsafe(64 * 1024);
+    let position = 0;
+    while (position < size) {
+      const { bytesRead } = await file.read(
+        readBuffer,
+        0,
+        Math.min(readBuffer.length, size - position),
+        position,
+      );
+      if (bytesRead === 0) {
+        throw new Error("The artifact ended before its recorded byte count.");
+      }
+      const bytes = readBuffer.subarray(0, bytesRead);
+      hash.update(bytes);
+      const overlapStart = Math.max(position, options.offset);
+      const overlapEnd = Math.min(position + bytesRead, retainedEnd);
+      if (overlapStart < overlapEnd) {
+        retained.push(Buffer.from(bytes.subarray(overlapStart - position, overlapEnd - position)));
+      }
+      position += bytesRead;
+    }
+    if (hash.digest("hex") !== digest) {
+      throw new Error("The content-addressed artifact does not match its ID.");
+    }
+    const bytes = Buffer.concat(retained);
+    return {
+      bytes,
+      totalByteCount: size,
+      eof: options.offset + bytes.byteLength >= size,
+    };
+  } finally {
+    await file.close();
+  }
+}
+
 async function readFileWithinLimit(path: string, maximumBytes: number): Promise<Buffer> {
   if (!Number.isSafeInteger(maximumBytes) || maximumBytes < 0) {
     throw new RangeError("The artifact read limit must be a nonnegative safe integer.");

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -14,8 +14,12 @@ import type {
   ToolCallDisplay,
   TranscriptItem,
 } from "@adam-agent/presentation";
-import { reconcilePresentationUpdate } from "@adam-agent/presentation";
-import { readFileArtifact } from "./artifact-store.js";
+import {
+  presentationArtifactPageMaximumBytes,
+  reconcilePresentationUpdate,
+} from "@adam-agent/presentation";
+import { readFileArtifact, readFileArtifactRange } from "./artifact-store.js";
+import { maximumModelResponseContentBytes } from "./durable-model-response-policy.js";
 import type { ModelTargetIdentity, ModelTargets } from "./model-targets.js";
 import type { PresentationPreferences } from "./presentation-preferences.js";
 import { listProjectPaths } from "./project-path-catalog.js";
@@ -1005,18 +1009,29 @@ export async function createPresentationSession(
       }
       if (command.type === "read_artifact") {
         const active = state.authoritative.active;
-        if (
-          active === null ||
-          command.artifact.source !== "change_preview" ||
-          !isKnownArtifact(active, command.artifact)
-        ) {
+        if (active === null || !isKnownArtifact(active, command.artifact)) {
           return {
             status: "rejected",
             code: "stale_interaction",
             message: "The requested artifact is no longer part of the active presentation.",
           };
         }
-        if (options.stateRoot === undefined || command.artifact.byteCount > 64 * 1024) {
+        const range = command.range;
+        const completeReadAvailable =
+          (command.artifact.source === "change_preview" &&
+            command.artifact.byteCount <= 64 * 1024) ||
+          (command.artifact.source === "model_response" &&
+            command.artifact.byteCount <= maximumModelResponseContentBytes);
+        if (
+          options.stateRoot === undefined ||
+          (range === null && !completeReadAvailable) ||
+          (range !== null &&
+            (!Number.isSafeInteger(range.offset) ||
+              range.offset < 0 ||
+              !Number.isSafeInteger(range.maximumBytes) ||
+              range.maximumBytes <= 0 ||
+              range.maximumBytes > presentationArtifactPageMaximumBytes))
+        ) {
           return {
             status: "rejected",
             code: "not_available",
@@ -1025,26 +1040,54 @@ export async function createPresentationSession(
         }
         try {
           await options[presentationArtifactReadBarrier]?.beforeRead();
-          const bytes = await readFileArtifact({
-            root: join(options.stateRoot, "artifacts"),
-            id: command.artifact.id,
-            maximumBytes: command.artifact.byteCount,
-          });
-          if (bytes === undefined || bytes.byteLength !== command.artifact.byteCount) {
+          const page =
+            range === null
+              ? await readFileArtifact({
+                  root: join(options.stateRoot, "artifacts"),
+                  id: command.artifact.id,
+                  maximumBytes: command.artifact.byteCount,
+                }).then((bytes) =>
+                  bytes === undefined
+                    ? undefined
+                    : {
+                        bytes,
+                        totalByteCount: bytes.byteLength,
+                        eof: true,
+                      },
+                )
+              : await readFileArtifactRange({
+                  root: join(options.stateRoot, "artifacts"),
+                  id: command.artifact.id,
+                  expectedByteCount: command.artifact.byteCount,
+                  offset: range.offset,
+                  maximumBytes: range.maximumBytes,
+                });
+          if (page === undefined || page.totalByteCount !== command.artifact.byteCount) {
             throw new TypeError("The artifact bytes are unavailable.");
           }
-          const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+          const decoded = decodeArtifactPage(page.bytes, page.eof);
+          const eof = page.eof && decoded.byteCount === page.bytes.byteLength;
+          if (!eof && decoded.byteCount === 0) {
+            throw new TypeError("The artifact page did not make UTF-8 progress.");
+          }
           await options[presentationArtifactReadBarrier]?.afterRead?.();
           return {
             status: "admitted",
             commandId: randomUUID(),
             resource: {
               mediaType: command.artifact.mediaType,
-              offset: 0,
-              byteCount: bytes.byteLength,
-              totalByteCount: bytes.byteLength,
-              eof: true,
-              text,
+              offset: range?.offset ?? 0,
+              byteCount: decoded.byteCount,
+              totalByteCount: page.totalByteCount,
+              eof,
+              nextRange:
+                range === null || eof
+                  ? null
+                  : {
+                      offset: range.offset + decoded.byteCount,
+                      maximumBytes: presentationArtifactPageMaximumBytes,
+                    },
+              text: decoded.text,
             },
           };
         } catch {
@@ -1436,6 +1479,25 @@ export async function createPresentationSession(
     unsubscribeMetadata();
     throw error;
   }
+}
+
+function decodeArtifactPage(
+  bytes: Uint8Array,
+  eof: boolean,
+): { readonly byteCount: number; readonly text: string } {
+  const maximumTrim = eof ? 0 : Math.min(3, bytes.byteLength);
+  for (let trim = 0; trim <= maximumTrim; trim += 1) {
+    const candidate = bytes.subarray(0, bytes.byteLength - trim);
+    try {
+      return {
+        byteCount: candidate.byteLength,
+        text: new TextDecoder("utf-8", { fatal: true }).decode(candidate),
+      };
+    } catch {
+      // A bounded non-final page may end inside one UTF-8 scalar; retry without its partial bytes.
+    }
+  }
+  throw new TypeError("The artifact page is not valid UTF-8.");
 }
 
 function isKnownArtifact(
@@ -2190,18 +2252,41 @@ function safeToolSubject(
 function toolResultSummary(name: string, output: JsonValue | undefined): string | null {
   const outputRecord = jsonRecord(output);
   if (name === "read_file" && typeof outputRecord?.content === "string") {
-    return `${Buffer.byteLength(outputRecord.content, "utf8")} bytes`;
+    return `${Buffer.byteLength(outputRecord.content, "utf8")} bytes${
+      outputRecord.truncated === true ? " · output truncated" : ""
+    }`;
   }
   if (name === "run_shell") {
     const termination = jsonRecord(outputRecord?.termination);
     const stdout = jsonRecord(outputRecord?.stdout);
+    const stderr = jsonRecord(outputRecord?.stderr);
     if (
       termination?.type === "exited" &&
       typeof termination.exitCode === "number" &&
-      typeof stdout?.totalBytes === "number"
+      typeof stdout?.totalBytes === "number" &&
+      typeof stderr?.totalBytes === "number"
     ) {
-      return `exit ${termination.exitCode} · ${stdout.totalBytes} stdout bytes`;
+      const streamSummaries = [
+        ...(stdout.totalBytes > 0 || stderr.totalBytes === 0
+          ? [`${stdout.totalBytes} stdout bytes`]
+          : []),
+        ...(stderr.totalBytes > 0 ? [`${stderr.totalBytes} stderr bytes`] : []),
+      ];
+      const outputTruncated =
+        (typeof stdout.omittedBytes === "number" && stdout.omittedBytes > 0) ||
+        (typeof stderr.omittedBytes === "number" && stderr.omittedBytes > 0);
+      return `exit ${termination.exitCode} · ${streamSummaries.join(" · ")}${
+        outputTruncated ? " · output truncated" : ""
+      }`;
     }
+  }
+  if (name.startsWith("mcp__")) {
+    const content = outputRecord?.content;
+    const outputTruncated =
+      (Array.isArray(content) && content.some((block) => jsonRecord(block)?.truncated === true)) ||
+      (typeof outputRecord?.omittedContentBlocks === "number" &&
+        outputRecord.omittedContentBlocks > 0);
+    return output === undefined ? null : `Completed${outputTruncated ? " · output truncated" : ""}`;
   }
   return output === undefined ? null : "Completed";
 }
@@ -2231,6 +2316,7 @@ function toolArtifacts(
 ): readonly ToolCallDisplay["artifacts"][number][] {
   const outputRecord = jsonRecord(output);
   const candidates = [
+    jsonRecord(outputRecord?.artifact),
     jsonRecord(jsonRecord(outputRecord?.stdout)?.artifact),
     jsonRecord(jsonRecord(outputRecord?.stderr)?.artifact),
   ];
@@ -2254,6 +2340,9 @@ type KnownJsonRecord = Readonly<Record<string, JsonValue>> & {
   readonly type?: JsonValue;
   readonly exitCode?: JsonValue;
   readonly totalBytes?: JsonValue;
+  readonly omittedBytes?: JsonValue;
+  readonly omittedContentBlocks?: JsonValue;
+  readonly truncated?: JsonValue;
   readonly id?: JsonValue;
   readonly mediaType?: JsonValue;
   readonly byteCount?: JsonValue;

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -606,6 +606,9 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     tools:
       providedOptions.tools ??
       createCodingToolRegistry({
+        artifactStore: createLazyArtifactStore(
+          join(effectiveSessionStateRoot(providedOptions.stateRoot), "artifacts"),
+        ),
         workspaceRoot: providedOptions.workspaceRoot,
         ...(providedOptions.stateRoot === undefined
           ? {}

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -85,8 +85,16 @@ export type ArtifactChunk = {
   readonly byteCount: number;
   readonly totalByteCount: number;
   readonly eof: boolean;
+  readonly nextRange: ArtifactRange | null;
   readonly text: string;
 };
+
+export type ArtifactRange = {
+  readonly offset: number;
+  readonly maximumBytes: number;
+};
+
+export const presentationArtifactPageMaximumBytes = 16 * 1024;
 
 export type UserMessageDisplay = {
   readonly type: "user_message";
@@ -446,7 +454,7 @@ export type PresentationCommand =
   | {
       readonly type: "read_artifact";
       readonly artifact: ArtifactReference;
-      readonly range: null;
+      readonly range: ArtifactRange | null;
     }
   | {
       readonly type: "set_session_manual_name";

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -1694,7 +1694,8 @@ test("PresentationSession links an artifact-backed assistant response without em
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
-  const answer = "a".repeat(256 * 1024 + 1);
+  const answer = `${"a".repeat(16_383)}😀${"b".repeat(256 * 1024)}`;
+  const answerByteCount = Buffer.byteLength(answer, "utf8");
   const driver = new FakeModelDriver([
     { type: "text_delta", text: answer },
     { type: "finish", reason: "stop" },
@@ -1731,7 +1732,12 @@ test("PresentationSession links an artifact-backed assistant response without em
       workspaceRoot,
     });
 
-    expect(presentation.getState().authoritative.active?.transcript.items).toContainEqual({
+    const assistant = presentation
+      .getState()
+      .authoritative.active?.transcript.items.find(
+        (item) => item.type === "assistant_message" && item.artifact !== null,
+      );
+    expect(assistant).toMatchObject({
       type: "assistant_message",
       id: expect.stringMatching(new RegExp(`^${created.sessionId}:[0-9]+$`, "u")),
       sequence: expect.any(Number),
@@ -1741,13 +1747,116 @@ test("PresentationSession links an artifact-backed assistant response without em
       artifact: {
         id: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
         mediaType: "text/plain; charset=utf-8",
-        byteCount: 256 * 1024 + 1,
+        byteCount: answerByteCount,
         source: "model_response",
       },
     });
     expect(JSON.stringify(presentation.getState())).not.toContain(answer.slice(0, 4_096));
-
+    if (assistant?.type !== "assistant_message" || assistant.artifact === null) {
+      throw new Error("Expected an artifact-backed assistant response.");
+    }
+    const firstPage = await presentation.dispatch({
+      type: "read_artifact",
+      artifact: assistant.artifact,
+      range: { offset: 0, maximumBytes: 16 * 1024 },
+    });
+    expect(firstPage).toMatchObject({
+      status: "admitted",
+      resource: {
+        offset: 0,
+        totalByteCount: answerByteCount,
+      },
+    });
+    if (firstPage.status !== "admitted" || firstPage.resource === null) {
+      throw new Error("Expected the first bounded assistant artifact page.");
+    }
+    expect(firstPage.resource.text).not.toContain("�");
+    const secondPage = await presentation.dispatch({
+      type: "read_artifact",
+      artifact: assistant.artifact,
+      range: {
+        offset: firstPage.resource.byteCount,
+        maximumBytes: 16 * 1024,
+      },
+    });
+    expect(secondPage).toMatchObject({ status: "admitted" });
+    if (secondPage.status !== "admitted" || secondPage.resource === null) {
+      throw new Error("Expected the second bounded assistant artifact page.");
+    }
+    expect(`${firstPage.resource.text}${secondPage.resource.text}`).toBe(
+      answer.slice(0, firstPage.resource.text.length + secondPage.resource.text.length),
+    );
+    await expect(
+      presentation.dispatch({
+        type: "read_artifact",
+        artifact: assistant.artifact,
+        range: { offset: 0, maximumBytes: 16 * 1024 + 1 },
+      }),
+    ).resolves.toMatchObject({ status: "rejected", code: "not_available" });
+    await expect(
+      presentation.dispatch({
+        type: "read_artifact",
+        artifact: { ...assistant.artifact, source: "tool_output" },
+        range: { offset: 0, maximumBytes: 16 * 1024 },
+      }),
+    ).resolves.toMatchObject({ status: "rejected", code: "stale_interaction" });
+    const artifactPath = join(
+      stateRoot,
+      "artifacts",
+      assistant.artifact.id.replace(/^sha256:/u, ""),
+    );
+    await chmod(artifactPath, 0o600);
+    await writeFile(artifactPath, Buffer.alloc(answerByteCount, 0x78));
+    await expect(
+      presentation.dispatch({
+        type: "read_artifact",
+        artifact: assistant.artifact,
+        range: { offset: 0, maximumBytes: 16 * 1024 },
+      }),
+    ).resolves.toMatchObject({ status: "rejected", code: "not_available" });
+    await writeFile(artifactPath, answer, "utf8");
     await presentation.close();
+
+    const projectId = createHash("sha256").update(workspaceRoot).digest("hex");
+    const sessionPath = join(
+      stateRoot,
+      "projects",
+      projectId,
+      "sessions",
+      `${created.sessionId}.jsonl`,
+    );
+    const durableLog = await readFile(sessionPath, "utf8");
+    const forgedLog = durableLog.replaceAll(
+      `"byteCount":${answerByteCount}`,
+      `"byteCount":${answerByteCount + 1}`,
+    );
+    expect(forgedLog).not.toBe(durableLog);
+    await writeFile(sessionPath, forgedLog, "utf8");
+    const forgedPresentation = await createPresentationSession({
+      lifecycle,
+      projectLabel: "workspace",
+      sessionId: created.sessionId,
+      stateRoot,
+      workspaceRoot,
+    });
+    const forgedAssistant = forgedPresentation
+      .getState()
+      .authoritative.active?.transcript.items.find(
+        (item) => item.type === "assistant_message" && item.artifact !== null,
+      );
+    if (forgedAssistant?.type !== "assistant_message" || forgedAssistant.artifact === null) {
+      throw new Error("Expected a forged artifact-backed assistant response.");
+    }
+    expect(forgedAssistant.artifact.byteCount).toBe(answerByteCount + 1);
+    await expect(
+      forgedPresentation.dispatch({
+        type: "read_artifact",
+        artifact: forgedAssistant.artifact,
+        range: null,
+      }),
+    ).resolves.toMatchObject({ status: "rejected", code: "not_available" });
+
+    await forgedPresentation.close();
   } finally {
     await lifecycle.close();
     await rm(testRoot, { recursive: true, force: true });
@@ -3250,7 +3359,7 @@ test("PresentationSession normalizes a real read call without exposing raw argum
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
-  await writeFile(join(workspaceRoot, "notes.txt"), "hello read\n");
+  await writeFile(join(workspaceRoot, "notes.txt"), "r".repeat(70_000));
   let call = 0;
   const model: ModelDriver = {
     async *stream(request) {
@@ -3323,12 +3432,12 @@ test("PresentationSession normalizes a real read call without exposing raw argum
       label: "read",
       subject: { type: "path", value: "notes.txt" },
       status: "completed",
-      resultSummary: "11 bytes",
+      resultSummary: "65536 bytes · output truncated",
       artifacts: [],
       changePreviewRef: null,
     });
     expect(JSON.stringify(tool)).not.toContain('{"path":"notes.txt"}');
-    expect(JSON.stringify(tool)).not.toContain("hello read");
+    expect(JSON.stringify(tool)).not.toContain("r".repeat(1_024));
 
     await presentation.close();
   } finally {
@@ -3342,7 +3451,8 @@ test("PresentationSession exposes a bounded shell summary and durable overflow a
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
-  const command = "yes x | head -c 70000";
+  const command =
+    "{ printf '%*s' 16382 '' | tr ' ' x; printf '😀'; printf '%*s' 53614 '' | tr ' ' x; } >&2";
   let call = 0;
   const model: ModelDriver = {
     async *stream(request) {
@@ -3421,7 +3531,7 @@ test("PresentationSession exposes a bounded shell summary and durable overflow a
       label: "shell",
       subject: { type: "command", value: command },
       status: "completed",
-      resultSummary: "exit 0 · 70000 stdout bytes",
+      resultSummary: "exit 0 · 70000 stderr bytes · output truncated",
       artifacts: [
         {
           id: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
@@ -3431,6 +3541,37 @@ test("PresentationSession exposes a bounded shell summary and durable overflow a
         },
       ],
     });
+    if (tool?.type !== "tool_call" || tool.artifacts[0] === undefined) {
+      throw new Error("Expected one shell output artifact.");
+    }
+    const firstPage = await presentation.dispatch({
+      type: "read_artifact",
+      artifact: tool.artifacts[0],
+      range: { offset: 0, maximumBytes: 16 * 1024 },
+    });
+    expect(firstPage).toMatchObject({
+      status: "admitted",
+      resource: { byteCount: 16 * 1024 - 2, offset: 0, totalByteCount: 70_000 },
+    });
+    if (
+      firstPage.status !== "admitted" ||
+      firstPage.resource === null ||
+      firstPage.resource.nextRange === null
+    ) {
+      throw new Error("Expected a second shell output artifact page.");
+    }
+    expect(firstPage.resource.text).not.toContain("�");
+    const secondPage = await presentation.dispatch({
+      type: "read_artifact",
+      artifact: tool.artifacts[0],
+      range: firstPage.resource.nextRange,
+    });
+    expect(secondPage).toMatchObject({ status: "admitted" });
+    if (secondPage.status !== "admitted" || secondPage.resource === null) {
+      throw new Error("Expected the second shell output artifact page.");
+    }
+    expect(secondPage.resource.text.startsWith("😀")).toBe(true);
+    expect(secondPage.resource.text).not.toContain("�");
 
     await presentation.close();
   } finally {

--- a/packages/testkit/src/trusted-mcp-host.test.ts
+++ b/packages/testkit/src/trusted-mcp-host.test.ts
@@ -20,6 +20,7 @@ import {
   type ContextProfile,
   createCodingToolRegistry,
   createPermissionPolicy,
+  createPresentationSession,
   type ModelRequest,
   type ModelTargetIdentity,
   type ModelTargets,
@@ -6037,9 +6038,13 @@ test("SessionLifecycle spills a complete MCP result above 64 KiB before publishi
   await mkdir(workspaceRoot);
   await writeScriptedMcpConfiguration(testRoot, workspaceRoot);
 
-  const fullText = "x".repeat(70_000);
+  const envelopePrefix = '{"content":[{"text":"';
+  const unicodePrefixBytes = 16 * 1024 - Buffer.byteLength(envelopePrefix, "utf8") - 2;
+  const fullText = `${"x".repeat(unicodePrefixBytes)}😀${"x".repeat(
+    70_000 - unicodePrefixBytes - Buffer.byteLength("😀", "utf8"),
+  )}`;
   const fullEnvelopeBytes = Buffer.from(
-    `{"content":[{"text":"${fullText}","type":"text"}],"isError":false,"version":1}`,
+    `${envelopePrefix}${fullText}","type":"text"}],"isError":false,"version":1}`,
     "utf8",
   );
   const expectedArtifactId = `sha256:${createHash("sha256")
@@ -6108,24 +6113,23 @@ test("SessionLifecycle spills a complete MCP result above 64 KiB before publishi
       };
     },
   };
-  const { lifecycle } = createScriptedMcpLifecycle(
-    {
-      modelTargets,
-      permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
-      stateRoot,
-      workspaceRoot,
-    },
-    {
-      fixture: {
-        ...ordinaryScriptedMcpServer(),
-        respond(request, defaultReply) {
-          return request.method === "tools/call"
-            ? { kind: "result", result: { content: [{ type: "text", text: fullText }] } }
-            : defaultReply;
-        },
+  const peer = createScriptedMcpTransportFactory({
+    fixture: {
+      ...ordinaryScriptedMcpServer(),
+      respond(request, defaultReply) {
+        return request.method === "tools/call"
+          ? { kind: "result", result: { content: [{ type: "text", text: fullText }] } }
+          : defaultReply;
       },
     },
-  );
+  });
+  const lifecycle = createSessionLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    stateRoot,
+    workspaceRoot,
+    [mcpTransportFactory]: peer,
+  });
   const events: RuntimeEvent[] = [];
   lifecycle.subscribe((event) => events.push(event));
 
@@ -6206,6 +6210,75 @@ test("SessionLifecycle spills a complete MCP result above 64 KiB before publishi
     await expect(
       readFile(join(stateRoot, "artifacts", expectedArtifactId.slice("sha256:".length))),
     ).resolves.toEqual(fullEnvelopeBytes);
+    const presentation = await createPresentationSession({
+      lifecycle,
+      projectLabel: "workspace",
+      sessionId: created.sessionId,
+      stateRoot,
+      workspaceRoot,
+    });
+    while (presentation.getState().authoritative.active?.transcript.olderCursor !== null) {
+      const before = presentation.getState().authoritative.active?.transcript.olderCursor;
+      if (typeof before !== "string") {
+        break;
+      }
+      await presentation.dispatch({ type: "load_older_transcript", before });
+    }
+    const transcriptItems = presentation.getState().authoritative.active?.transcript.items;
+    const tool = transcriptItems?.find(
+      (item) => item.type === "tool_call" && item.callId === "mcp-large",
+    );
+    if (tool === undefined) {
+      throw new Error(`Projected transcript: ${JSON.stringify(transcriptItems)}`);
+    }
+    expect(tool).toMatchObject({
+      type: "tool_call",
+      resultSummary: "Completed · output truncated",
+      artifacts: [
+        {
+          id: expectedArtifactId,
+          mediaType: "application/json",
+          byteCount: fullEnvelopeBytes.byteLength,
+          source: "tool_output",
+        },
+      ],
+    });
+    if (tool?.type !== "tool_call" || tool.artifacts[0] === undefined) {
+      throw new Error("The Presentation fixture requires one MCP tool artifact.");
+    }
+    const firstPage = await presentation.dispatch({
+      type: "read_artifact",
+      artifact: tool.artifacts[0],
+      range: { offset: 0, maximumBytes: 16 * 1024 },
+    });
+    expect(firstPage).toMatchObject({
+      status: "admitted",
+      resource: {
+        offset: 0,
+        byteCount: 16 * 1024 - 2,
+        totalByteCount: fullEnvelopeBytes.byteLength,
+      },
+    });
+    if (
+      firstPage.status !== "admitted" ||
+      firstPage.resource === null ||
+      firstPage.resource.nextRange === null
+    ) {
+      throw new Error("The Presentation fixture requires a second MCP artifact page.");
+    }
+    expect(firstPage.resource.text).not.toContain("�");
+    const secondPage = await presentation.dispatch({
+      type: "read_artifact",
+      artifact: tool.artifacts[0],
+      range: firstPage.resource.nextRange,
+    });
+    expect(secondPage).toMatchObject({ status: "admitted" });
+    if (secondPage.status !== "admitted" || secondPage.resource === null) {
+      throw new Error("The Presentation fixture requires the second MCP artifact page.");
+    }
+    expect(secondPage.resource.text.startsWith("😀")).toBe(true);
+    expect(secondPage.resource.text).not.toContain("�");
+    await presentation.close();
   } finally {
     await lifecycle.close();
     await rm(testRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- render artifact-backed assistant placeholders, bounded assistant/tool artifact pages, settled change previews, expanded tool facts, compaction markers, and authoritative context/footer state
- make `/copy` recover the exact last assistant response across opaque active-chronology cursors and use one integrity-checked bounded full read for artifact-backed responses
- preserve explicit read, shell, and MCP truncation truth while validating byte count, SHA-256 identity, and UTF-8 page boundaries for every text-only artifact resource
- keep artifact navigation renderer-local with generation guards, session-stale cleanup, and one-page-at-a-time chronology hydration

## Verification

- `pnpm quality:check`: 26 test files passed, 2 explicit opt-in files skipped; 844 tests passed, 10 explicit opt-in tests skipped
- focused final regression set: 6/6 passed across real TUI, Presentation, shell artifact, and MCP artifact seams
- named OS artifact picker and topology guards passed independently
- final independent Spec review: PASS with no blocking findings
- final independent Standards review: PASS with no blocking findings
- `git diff --check`

## Boundaries

- B9-R1 PR3 only; no responsive/input/signal PR4 work and no B9-E1/H1 or later-stage work
- no timeout expansion, assertion weakening, worker cap, changed-path skip, sleep, or polling
- artifact detail remains capped at 16 KiB per page; exact artifact copy remains an explicit action bounded by the existing 64 MiB model-response authority