### PR TITLE
feat(tui): harden terminal interaction and cleanup

### DIFF
--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -42,6 +42,43 @@ test("real TUI starts on an authoritative empty session and restores the termina
   }
 });
 
+test.each([
+  { code: 143, signal: "SIGTERM" as const },
+  { code: 129, signal: "SIGHUP" as const },
+])(
+  "$signal closes authoritative state and restores the real terminal before exit",
+  async ({ code, signal }) => {
+    const testRoot = await mkdtemp(join(tmpdir(), `adam-agent-tui-${signal.toLowerCase()}-`));
+    const workspaceRoot = join(testRoot, "workspace");
+    const stateRoot = join(testRoot, "state");
+    const controlRoot = join(testRoot, "control");
+    const terminalProcessMarker = join(testRoot, "terminal-process");
+    await mkdir(workspaceRoot);
+    await mkdir(controlRoot);
+
+    try {
+      const fixture = startFixture({
+        controlRoot,
+        external: true,
+        stateRoot,
+        terminalProcessMarker,
+        workspaceRoot,
+      });
+      await fixture.waitFor("Adam · New session");
+      await fixture.terminate(signal);
+      const result = await fixture.closed;
+      expect(result).toMatchObject({ code, signal: null, stderr: "" });
+      await expect(readFile(join(controlRoot, "tui-fixture-closed"), "utf8")).resolves.toBe(
+        "closed\n",
+      );
+      expect(result.stdout).toContain("\u001b[?2004l");
+      expect(result.stdout).toContain("\u001b[?25h");
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
 test("a real tool output artifact opens through the active chronology picker", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-tool-artifact-page-"));
   const workspaceRoot = join(testRoot, "workspace");
@@ -501,13 +538,17 @@ test("the real terminal delivers Ctrl+C interruption without arming exit", async
     await rm(testRoot, { recursive: true, force: true });
   }
 });
-test("the real terminal preserves one bracketed multiline paste as editor input", async () => {
+test("the real terminal preserves one large bracketed multiline paste as editor input", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-bracketed-paste-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
   const controlRoot = join(testRoot, "control");
   await mkdir(workspaceRoot);
   await mkdir(controlRoot);
+  const pasted = Array.from(
+    { length: 24 },
+    (_, index) => `line ${index + 1} · 中文 · e\u0301 · 👩🏽‍💻`,
+  ).join("\n");
 
   try {
     const fixture = startFixture({
@@ -518,19 +559,40 @@ test("the real terminal preserves one bracketed multiline paste as editor input"
       workspaceRoot,
     });
     await fixture.waitFor("Adam · New session");
-    fixture.write("\u001b[200~first pasted line\n第二行\u001b[201~");
-    await fixture.waitFor("第二行");
+    fixture.write(`\u001b[200~${pasted}\u001b[201~`);
+    await fixture.waitFor("[paste #1 +24 lines]");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe(
-      "first pasted line\n第二行",
-    );
+    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe(pasted);
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }
 });
 
-test("the real terminal redraws after a pseudo-terminal resize", async () => {
+test("the real terminal positions the IME cursor on CJK and grapheme cell boundaries", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-ime-cursor-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ external: true, stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("A中e\u0301👩🏽‍💻Z");
+    await fixture.waitFor("A中e");
+    for (const expectedColumn of [8, 6, 5, 3]) {
+      const beforeMove = fixture.output().length;
+      fixture.write("\u001b[D");
+      await fixture.waitForAfter(`\u001b[${expectedColumn}G`, beforeMove);
+    }
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the real terminal redraws through 40, 80, 120, and minimum-size layouts", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-resize-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
@@ -545,9 +607,18 @@ test("the real terminal redraws after a pseudo-terminal resize", async () => {
       workspaceRoot,
     });
     await fixture.waitFor("Adam · New session");
-    const beforeResize = fixture.output().length;
-    await fixture.resize(52, 18);
-    await fixture.waitForAfter("Adam · New session", beforeResize);
+    let beforeResize = fixture.output().length;
+    await fixture.resize(120, 40);
+    await fixture.waitForAfter("context unavailable", beforeResize);
+    beforeResize = fixture.output().length;
+    await fixture.resize(40, 12);
+    await fixture.waitForAfter("/help · Tab complete", beforeResize);
+    beforeResize = fixture.output().length;
+    await fixture.resize(39, 11);
+    await fixture.waitForAfter("Terminal too small", beforeResize);
+    beforeResize = fixture.output().length;
+    await fixture.resize(80, 24);
+    await fixture.waitForAfter("workspace · idle", beforeResize);
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -609,16 +609,16 @@ test("the real terminal redraws through 40, 80, 120, and minimum-size layouts", 
     await fixture.waitFor("Adam · New session");
     let beforeResize = fixture.output().length;
     await fixture.resize(120, 40);
-    await fixture.waitForAfter("context unavailable", beforeResize);
+    await fixture.waitForCompleteFrameAfter("context unavailable", beforeResize);
     beforeResize = fixture.output().length;
     await fixture.resize(40, 12);
-    await fixture.waitForAfter("/help · Tab complete", beforeResize);
+    await fixture.waitForCompleteFrameAfter("/help · Tab complete", beforeResize);
     beforeResize = fixture.output().length;
     await fixture.resize(39, 11);
-    await fixture.waitForAfter("Terminal too small", beforeResize);
+    await fixture.waitForCompleteFrameAfter("Terminal too small", beforeResize);
     beforeResize = fixture.output().length;
     await fixture.resize(80, 24);
-    await fixture.waitForAfter("workspace · idle", beforeResize);
+    await fixture.waitForCompleteFrameAfter("workspace · idle", beforeResize);
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -1,8 +1,9 @@
 import { access, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { afterEach, expect, test } from "vitest";
+import { runTuiFixture } from "./test-fixture.js";
 import {
   readFilesRecursively,
   removeTuiFixtureRoot as rm,
@@ -12,10 +13,454 @@ import {
   cleanupActiveTuiFixtures,
   startTuiFixture as startFixture,
 } from "./tui-fixture.test-support.js";
+import { VirtualTerminal } from "./virtual-terminal.test-support.js";
 
 afterEach(async () => {
   await cleanupActiveTuiFixtures();
 });
+
+test("minimum-size rendering preserves the draft and returns to the supported layout", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-minimum-size-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("保留 draft 👩🏽‍💻");
+    await fixture.waitFor("保留 draft");
+    const beforeMinimum = fixture.output().length;
+    await fixture.resize(39, 11);
+    const minimumFrame = latestSynchronizedFrame(fixture.output().slice(beforeMinimum));
+    expect(minimumFrame.join("\n")).toContain("Terminal too small");
+    expect(minimumFrame.join("\n")).toContain("Ctrl+C abort/exit");
+    expect(minimumFrame.every((line) => visibleWidth(line) <= 39)).toBe(true);
+
+    const beforeRestore = fixture.output().length;
+    await fixture.resize(80, 24);
+    await fixture.waitForAfter("保留 draft", beforeRestore);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("minimum-size mode consumes ordinary editor input while preserving safe exit", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-minimum-input-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "clipboard-success",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("exact draft");
+    await fixture.waitFor("exact draft");
+    await fixture.resize(39, 11);
+    fixture.write(" must not enter the editor");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe("exact draft");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the 40, 80, and 120 column layouts expose progressively bounded footer facts", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-responsive-footer-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+
+    let beforeResize = fixture.output().length;
+    await fixture.resize(120, 40);
+    let frameLines = latestSynchronizedFrame(fixture.output().slice(beforeResize));
+    let frame = frameLines.join("\n");
+    expect(frame).toContain("workspace · context unavailable · idle");
+    expect(frame).toContain("/help [topic] · /hotkeys · Tab complete");
+    expect(frameLines.every((line) => visibleWidth(line) <= 120)).toBe(true);
+
+    beforeResize = fixture.output().length;
+    await fixture.resize(80, 24);
+    frameLines = latestSynchronizedFrame(fixture.output().slice(beforeResize));
+    frame = frameLines.join("\n");
+    expect(frame).toContain("workspace · idle");
+    expect(frame).not.toContain("context unavailable");
+    expect(frame).toContain("fake.local · Certified · /help · Tab complete");
+    expect(frameLines.every((line) => visibleWidth(line) <= 80)).toBe(true);
+
+    beforeResize = fixture.output().length;
+    await fixture.resize(40, 12);
+    frameLines = latestSynchronizedFrame(fixture.output().slice(beforeResize));
+    frame = frameLines.join("\n");
+    expect(frame).toContain("idle");
+    expect(frame).toContain("fake.local · Certified");
+    expect(frame).toContain("/help · Tab complete");
+    expect(frame).not.toContain("workspace");
+    expect(frame).not.toContain("context unavailable");
+    expect(frameLines.every((line) => visibleWidth(line) <= 40)).toBe(true);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("Help keeps its exact page and focus across minimum-size resize", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-help-resize-focus-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("/help\r\r");
+    await fixture.waitFor("Command Reference");
+
+    let beforeResize = fixture.output().length;
+    await fixture.resize(39, 11);
+    let frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    expect(frame).toContain("Terminal too small");
+    expect(frame).not.toContain("Command Reference");
+
+    beforeResize = fixture.output().length;
+    await fixture.resize(80, 24);
+    frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    expect(frame).toContain("Command Reference");
+    fixture.write("\u0003focus restored");
+    await fixture.waitFor("focus restored");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a permission remains authoritative across narrow and minimum-size focus repair", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-permission-resize-focus-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "edit.txt"), "before\n", "utf8");
+
+  try {
+    const fixture = startFixture({ scenario: "mutation", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Edit after resize\r");
+    await fixture.waitFor("+after");
+
+    let beforeResize = fixture.output().length;
+    await fixture.resize(40, 12);
+    let frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    expect(frame).toContain("Permission required");
+    expect(frame).toContain("Allow");
+    expect(frame).toContain("Deny");
+
+    beforeResize = fixture.output().length;
+    await fixture.resize(39, 11);
+    frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    expect(frame).toContain("Terminal too small");
+    expect(frame).not.toContain("Permission required");
+    fixture.write("\u001b[27;1;27~");
+    await fixture.resize(80, 24);
+    await fixture.waitFor("denied");
+    await expect(readFile(join(workspaceRoot, "edit.txt"), "utf8")).resolves.toBe("before\n");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("Shift+Enter and Ctrl+J preserve one exact multiline draft", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-multiline-draft-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "clipboard-success",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("first\u001b[13;2usecond\n第三行");
+    await fixture.waitFor("第三行");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe(
+      "first\nsecond\n第三行",
+    );
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a chunked large bracketed paste remains one exact expandable editor value", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-large-paste-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+  const pasted = Array.from(
+    { length: 24 },
+    (_, index) => `line ${index + 1} · 中文 · e\u0301 · 👩🏽‍💻`,
+  ).join("\n");
+  const split = Math.floor(pasted.length / 2);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "clipboard-success",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write(`\u001b[200~${pasted.slice(0, split)}`);
+    fixture.write(`${pasted.slice(split)}\u001b[201~`);
+    await fixture.waitFor("[paste #1 +24 lines]");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe(pasted);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the focused editor positions the IME hardware cursor on grapheme cell boundaries", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-ime-cursor-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("A中e\u0301👩🏽‍💻Z");
+    await fixture.waitFor("A中e");
+
+    for (const expectedColumn of [8, 6, 5, 3]) {
+      const beforeMove = fixture.output().length;
+      fixture.write("\u001b[D");
+      await fixture.resize(80, 24);
+      expect(lastAbsoluteCursorColumn(fixture.output().slice(beforeMove))).toBe(expectedColumn);
+    }
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("minimum-size Ctrl+C still aborts one active run without arming exit", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-minimum-abort-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ scenario: "cancellation", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Cancel from minimum mode\r");
+    await fixture.waitFor("Working");
+    await fixture.resize(39, 11);
+    fixture.write("\u0003");
+    const beforeRestore = fixture.output().length;
+    await fixture.resize(80, 24);
+    await fixture.waitForAfter("cancelled", beforeRestore);
+    expect(fixture.output().slice(beforeRestore)).not.toContain("Press Ctrl+C again");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a terminal start failure after acquisition still restores the terminal", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-start-failure-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const terminal = new VirtualTerminal({ throwAfterStart: true });
+  await mkdir(workspaceRoot);
+
+  try {
+    await expect(runTuiFixture({ stateRoot, terminal, workspaceRoot })).rejects.toThrow(
+      "Injected terminal start failure after acquisition.",
+    );
+    expect(terminal.lifecycle()).toEqual(["started", "stopped"]);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a terminal stop failure cannot skip Presentation close", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-stop-failure-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  const terminal = new VirtualTerminal({ throwAfterStop: true });
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const execution = runTuiFixture({
+      controlRoot,
+      presentationCloseMarker: join(controlRoot, "presentation-closed"),
+      stateRoot,
+      terminal,
+      workspaceRoot,
+    });
+    await terminal.whenStarted();
+    terminal.input("\u0011");
+    await expect(execution).rejects.toThrow("Injected terminal stop failure after restoration.");
+    await expect(readFile(join(controlRoot, "presentation-closed"), "utf8")).resolves.toBe(
+      "closed\n",
+    );
+    expect(terminal.lifecycle()).toEqual(["started", "stopped"]);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("terminal and clipboard failures remain independent and cannot skip Presentation close", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-multiple-close-failures-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  const terminal = new VirtualTerminal({ throwAfterStop: true });
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const execution = runTuiFixture({
+      clipboard: {
+        writeText() {
+          throw new Error("Injected clipboard failure.");
+        },
+      },
+      controlRoot,
+      presentationCloseMarker: join(controlRoot, "presentation-closed"),
+      stateRoot,
+      terminal,
+      workspaceRoot,
+    });
+    await terminal.whenStarted();
+    terminal.input("preserve this exact draft");
+    await terminal.nextOutputContaining("preserve this exact draft");
+    terminal.input("\u0011");
+    const failure = await execution.catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect((failure as AggregateError).errors).toEqual([
+      expect.objectContaining({
+        message: "Injected terminal stop failure after restoration.",
+      }),
+      expect.objectContaining({ message: "Injected clipboard failure." }),
+    ]);
+    await expect(readFile(join(controlRoot, "presentation-closed"), "utf8")).resolves.toBe(
+      "closed\n",
+    );
+    expect(terminal.lifecycle()).toEqual(["started", "stopped"]);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("an overlay cleanup failure cannot skip terminal restoration or Presentation close", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-overlay-close-failure-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  const terminal = new VirtualTerminal({ throwOnHideCursorAfterInput: "\u0011" });
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const execution = runTuiFixture({
+      controlRoot,
+      presentationCloseMarker: join(controlRoot, "presentation-closed"),
+      stateRoot,
+      terminal,
+      workspaceRoot,
+    });
+    await terminal.whenStarted();
+    terminal.input("/help\r");
+    await terminal.nextOutputContaining("Adam Help");
+    terminal.input("\u0011");
+    await expect(execution).rejects.toThrow(
+      "Injected overlay cleanup failure before terminal restoration.",
+    );
+    await expect(readFile(join(controlRoot, "presentation-closed"), "utf8")).resolves.toBe(
+      "closed\n",
+    );
+    expect(terminal.lifecycle()).toEqual(["started", "stopped"]);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("startup and cleanup failures preserve both causal errors", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-start-cleanup-failures-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const terminal = new VirtualTerminal({ throwAfterStart: true, throwAfterStop: true });
+  await mkdir(workspaceRoot);
+
+  try {
+    const failure = await runTuiFixture({ stateRoot, terminal, workspaceRoot }).catch(
+      (error: unknown) => error,
+    );
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect((failure as AggregateError).errors).toEqual([
+      expect.objectContaining({
+        message: "Injected terminal start failure after acquisition.",
+      }),
+      expect.objectContaining({
+        message: "Injected terminal stop failure after restoration.",
+      }),
+    ]);
+    expect(terminal.lifecycle()).toEqual(["started", "stopped"]);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+function latestSynchronizedFrame(output: string): readonly string[] {
+  const start = output.lastIndexOf("\u001b[?2026h");
+  const end = output.indexOf("\u001b[?2026l", start);
+  if (start < 0 || end < 0) {
+    throw new Error("The TUI did not emit one complete synchronized frame.");
+  }
+  return output
+    .slice(start + "\u001b[?2026h".length, end)
+    .replace("\u001b[2J\u001b[H\u001b[3J", "")
+    .split("\r\n");
+}
+
+function lastAbsoluteCursorColumn(output: string): number | undefined {
+  const absoluteColumn = new RegExp(`${String.fromCharCode(27)}\\[(\\d+)G`, "gu");
+  return [...output.matchAll(absoluteColumn)]
+    .map((match) => Number.parseInt(match[1] as string, 10))
+    .at(-1);
+}
 
 test("the production TUI selects an exact available target before creating an empty-project session", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-target-picker-"));
@@ -501,6 +946,7 @@ test("the idle footer exposes Registry-driven interaction hints", async () => {
   try {
     const fixture = startFixture({ stateRoot, workspaceRoot });
     await fixture.waitFor("Adam · New session");
+    await fixture.resize(120, 40);
     await fixture.waitFor("/help [topic] · /hotkeys · Tab complete");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
@@ -522,6 +968,7 @@ test("the footer exposes authoritative project context and run facts", async () 
       workspaceRoot,
     });
     await fixture.waitFor("Adam · New session");
+    await fixture.resize(120, 40);
     fixture.write("Produce an artifact-backed answer\r");
     await fixture.waitFor("Adam · Streaming session");
     const beforeCompaction = fixture.output().length;
@@ -1254,6 +1701,53 @@ test("permission preempts Help and restores its exact page after settlement", as
   }
 });
 
+test("permission settlement restores an existing ordinary overlay as the exact focus owner", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-session-permission-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+  await writeFile(join(workspaceRoot, "edit.txt"), "before", "utf8");
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "mutation-after-release",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Prepare an inspector-held edit\r");
+    await waitForPath(join(controlRoot, "model-started"));
+    fixture.write("/session\r");
+    await fixture.waitFor("Session facts");
+    expect(fixture.output()).toContain("Run     working");
+
+    const beforePermission = fixture.output().length;
+    await writeFile(join(controlRoot, "release-model"), "release\n", "utf8");
+    await fixture.waitForCompleteFrameAfter("Permission required", beforePermission);
+    const beforeRestore = fixture.output().length;
+    fixture.write("\u001b[27;1;27~");
+    await fixture.waitForCompleteFrameAfter("Session facts", beforeRestore);
+    const restoredOutput = fixture.output().slice(beforeRestore);
+    expect(restoredOutput.lastIndexOf("\u001b[?25l")).toBeGreaterThan(
+      restoredOutput.lastIndexOf("\u001b[?25h"),
+    );
+
+    fixture.write("\u001b[27;1;27~");
+    const beforeResize = fixture.output().length;
+    await fixture.resize(120, 40);
+    const frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    expect(frame).not.toContain("Session facts");
+    expect(frame).toContain("Adam · New session");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("the production editor clears a manual session name through canonical Presentation truth", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-clear-name-"));
   const workspaceRoot = join(testRoot, "workspace");
@@ -1743,6 +2237,10 @@ test("Ctrl+O toggles bounded authoritative tool details", async () => {
     await fixture.waitForAfter("read_file · read · completed · replay safe", beforeExpand);
     await fixture.waitForAfter("provider model response", beforeExpand);
     await fixture.waitForAfter("duration unavailable", beforeExpand);
+    await fixture.resize(39, 11);
+    const beforeRestore = fixture.output().length;
+    await fixture.resize(80, 24);
+    await fixture.waitForAfter("provider model response", beforeRestore);
     const beforeCollapse = fixture.output().length;
     fixture.write("\u000f");
     await fixture.waitForAfter("11 bytes", beforeCollapse);
@@ -1897,6 +2395,35 @@ test("a shell tool card uses the accepted dollar-command grammar", async () => {
     await fixture.waitFor("Adam · New session");
     fixture.write("Show shell card\r");
     await fixture.waitFor("$ printf shell-card-fixture");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("tool subjects keep their full bounded value only in the 120-column layout", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-responsive-tool-card-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ scenario: "shell", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Show responsive shell card\r");
+    await fixture.waitFor("Shell card complete.");
+
+    let beforeResize = fixture.output().length;
+    await fixture.resize(120, 40);
+    let frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    expect(frame).toContain("bounded-secondary-provenance-and-wide-tail");
+
+    beforeResize = fixture.output().length;
+    await fixture.resize(80, 24);
+    frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    expect(frame).toContain("$ printf shell-card-fixture");
+    expect(frame).not.toContain("bounded-secondary-provenance-and-wide-tail");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -1323,7 +1323,7 @@ test("session selection rebuilds prompt history from the selected authoritative 
     await fixture.waitFor("Search: Selected");
     const beforeSelection = fixture.output().length;
     fixture.write("\r");
-    await fixture.waitForAfter("Selected session prompt", beforeSelection);
+    await fixture.waitForCompleteFrameAfter("Selected session prompt", beforeSelection);
     fixture.write("\u001b[A");
     fixture.write("\u0011");
     const result = await fixture.closed;

--- a/apps/tui/src/permission-overlay.ts
+++ b/apps/tui/src/permission-overlay.ts
@@ -66,15 +66,26 @@ export class PermissionOverlay implements Component, Focusable {
           this.#selection === "deny" ? ">" : " "
         } Deny`
       : "  Allow unavailable    > Deny";
-    const content = [
-      this.#theme.toolTitle("Permission required"),
-      `${this.#interaction.effect} · ${subject}`,
-      "",
-      ...this.#preview.split("\n"),
-      "",
-      options,
-      "Enter confirm · ←/→ select · Esc deny · Ctrl+C abort",
-    ].map((line) => padLine(truncateToWidth(line, innerWidth), innerWidth));
+    const content = (
+      width < 60
+        ? [
+            this.#theme.toolTitle("Permission required"),
+            `${this.#interaction.effect} · ${subject}`,
+            options,
+            "Enter · Esc deny · Ctrl+C abort",
+            "",
+            ...this.#preview.split("\n"),
+          ]
+        : [
+            this.#theme.toolTitle("Permission required"),
+            `${this.#interaction.effect} · ${subject}`,
+            "",
+            ...this.#preview.split("\n"),
+            "",
+            options,
+            "Enter confirm · ←/→ select · Esc deny · Ctrl+C abort",
+          ]
+    ).map((line) => padLine(truncateToWidth(line, innerWidth), innerWidth));
     return [
       `┌${"─".repeat(Math.max(0, width - 2))}┐`,
       ...content.map((line) => `│ ${line} │`),

--- a/apps/tui/src/responsive-root.ts
+++ b/apps/tui/src/responsive-root.ts
@@ -1,0 +1,71 @@
+import { type Component, Container, Text, truncateToWidth } from "@earendil-works/pi-tui";
+
+export const minimumTerminalColumns = 40;
+export const minimumTerminalRows = 12;
+
+export function terminalSizeIsSupported(columns: number, rows: number): boolean {
+  return columns >= minimumTerminalColumns && rows >= minimumTerminalRows;
+}
+
+export class ResponsiveRoot extends Container {
+  readonly #rows: () => number;
+
+  constructor(rows: () => number) {
+    super();
+    this.#rows = rows;
+  }
+
+  override render(width: number): string[] {
+    const rows = this.#rows();
+    if (terminalSizeIsSupported(width, rows)) {
+      return super.render(width);
+    }
+    return [
+      "Terminal too small",
+      `${width}×${rows} · resize to ${minimumTerminalColumns}×${minimumTerminalRows} or larger`,
+      "Ctrl+C abort/exit · Esc deny/close · Ctrl+Q exit",
+    ].map((line) => truncateToWidth(line, Math.max(0, width)));
+  }
+}
+
+export type ResponsiveTextContent = {
+  readonly narrow: string;
+  readonly standard: string;
+  readonly wide: string;
+};
+
+export class ResponsiveText implements Component {
+  #content: ResponsiveTextContent = { narrow: "", standard: "", wide: "" };
+
+  invalidate(): void {}
+
+  setText(content: string | ResponsiveTextContent): void {
+    this.#content =
+      typeof content === "string" ? { narrow: content, standard: content, wide: content } : content;
+  }
+
+  render(width: number): string[] {
+    const content =
+      width >= 120
+        ? this.#content.wide
+        : width >= 80
+          ? this.#content.standard
+          : this.#content.narrow;
+    return new Text(content).render(width);
+  }
+}
+
+export class ResponsiveLine implements Component {
+  readonly #text: string;
+
+  constructor(text: string) {
+    this.#text = text;
+  }
+
+  invalidate(): void {}
+
+  render(width: number): string[] {
+    const maximumWidth = width >= 112 ? width : Math.min(width, 52);
+    return [truncateToWidth(this.#text, Math.max(0, maximumWidth))];
+  }
+}

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -69,12 +69,14 @@ const contextProfile: ContextProfile = {
 };
 
 export type TuiFixtureOptions = {
+  readonly clipboard?: ClipboardAdapter;
   readonly controlRoot?: string;
   readonly launch?: {
     readonly configRoot?: string;
     readonly seedTargetIds?: readonly string[];
     readonly startupTargetId?: string;
   };
+  readonly presentationCloseMarker?: string;
   readonly scenario?: FixtureScenario;
   readonly stateRoot: string;
   readonly terminal?: Terminal;
@@ -227,7 +229,7 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
                   : { [presentationArtifactReadBarrier]: previewBarrier }),
               },
     );
-    const clipboard = clipboardAdapter(options);
+    const clipboard = options.clipboard ?? clipboardAdapter(options);
     const deadlineScheduler = controlledDeadlineScheduler(options);
     const tuiPresentation = observeTuiDispatch(presentation, options);
     await runTui({
@@ -248,6 +250,9 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
     });
   } finally {
     requireConfirmedLifecycleClose(await lifecycle.close());
+    if (options.controlRoot !== undefined) {
+      await writeFile(join(options.controlRoot, "tui-fixture-closed"), "closed\n", "utf8");
+    }
   }
 }
 
@@ -255,27 +260,36 @@ function observeTuiDispatch(
   presentation: PresentationSession,
   options: {
     readonly controlRoot?: string;
+    readonly presentationCloseMarker?: string;
     readonly scenario?: FixtureScenario;
   },
 ): PresentationSession {
   const controlRoot = options.controlRoot;
-  if (
-    (options.scenario !== "mutation-delayed-preview" &&
-      options.scenario !== "tool-artifact" &&
-      options.scenario !== "artifact-backed-assistant" &&
-      options.scenario !== "artifact-page-race") ||
-    controlRoot === undefined
-  ) {
+  const observeDispatch =
+    controlRoot !== undefined &&
+    (options.scenario === "mutation-delayed-preview" ||
+      options.scenario === "tool-artifact" ||
+      options.scenario === "artifact-backed-assistant" ||
+      options.scenario === "artifact-page-race");
+  if (!observeDispatch && options.presentationCloseMarker === undefined) {
     return presentation;
   }
   let artifactReadCount = 0;
   return {
-    close: () => presentation.close(),
+    async close() {
+      await presentation.close();
+      if (options.presentationCloseMarker !== undefined) {
+        await writeFile(options.presentationCloseMarker, "closed\n", "utf8");
+      }
+    },
     dispatch: async (command) => {
       const receipt = presentation.dispatch(command);
+      if (!observeDispatch) {
+        return receipt;
+      }
       if (command.type === "decide_permission") {
         await writeFile(
-          join(controlRoot, "permission-decision-submitted"),
+          join(controlRoot as string, "permission-decision-submitted"),
           `${command.decision}\n`,
           "utf8",
         );
@@ -283,20 +297,24 @@ function observeTuiDispatch(
       if (command.type === "read_artifact") {
         artifactReadCount += 1;
         await writeFile(
-          join(controlRoot, `artifact-read-${artifactReadCount}`),
+          join(controlRoot as string, `artifact-read-${artifactReadCount}`),
           `${command.range?.offset ?? 0}\n`,
           "utf8",
         );
         const settled = await receipt;
         await writeFile(
-          join(controlRoot, `artifact-read-${artifactReadCount}-settled`),
+          join(controlRoot as string, `artifact-read-${artifactReadCount}-settled`),
           "settled\n",
           "utf8",
         );
         return settled;
       }
       if (command.type === "submit_prompt") {
-        await writeFile(join(controlRoot, "prompt-submitted"), `${command.text}\n`, "utf8");
+        await writeFile(
+          join(controlRoot as string, "prompt-submitted"),
+          `${command.text}\n`,
+          "utf8",
+        );
       }
       return receipt;
     },
@@ -461,7 +479,9 @@ function createFixtureModelTargets(options: {
           yield {
             type: "tool_call_delta",
             id: "shell-card",
-            json: JSON.stringify({ command: "printf shell-card-fixture" }),
+            json: JSON.stringify({
+              command: "printf shell-card-fixture-with-bounded-secondary-provenance-and-wide-tail",
+            }),
           };
           yield { type: "tool_call_end", id: "shell-card" };
           yield { type: "finish", reason: "tool_calls" };

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -7,12 +7,14 @@ import type {
 } from "@adam-agent/presentation";
 import {
   Box,
+  type Component,
   Container,
   Editor,
   isKeyRelease,
   isKeyRepeat,
   Loader,
   Markdown,
+  type OverlayOptions,
   ProcessTerminal,
   Spacer,
   type Terminal,
@@ -43,6 +45,12 @@ import { McpWizard } from "./mcp-wizard.js";
 import { PermissionOverlay } from "./permission-overlay.js";
 import { ProjectPathPicker } from "./project-path-picker.js";
 import { ResourceReloadPicker } from "./resource-reload-picker.js";
+import {
+  ResponsiveLine,
+  ResponsiveRoot,
+  ResponsiveText,
+  terminalSizeIsSupported,
+} from "./responsive-root.js";
 import { safeTerminalText } from "./safe-terminal-text.js";
 import { SessionInspector, type SessionRunStatus } from "./session-inspector.js";
 import { SessionPicker } from "./session-picker.js";
@@ -75,8 +83,13 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   let newSessionSelected =
     options.presentation.getState().authoritative.sessions.items.length === 0;
   const tui: TUI = new TuiMainScreen(terminal, true);
+  const showOverlay = (component: Component, overlayOptions: OverlayOptions) =>
+    tui.showOverlay(component, {
+      ...overlayOptions,
+      visible: (columns, rows) => terminalSizeIsSupported(columns, rows),
+    });
   const theme = createAdamTuiTheme();
-  const root = new Container();
+  const root = new ResponsiveRoot(() => terminal.rows);
   const header = new Text();
   const transcript = new Container();
   const editorSlot = new Container();
@@ -111,7 +124,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   );
   let projectedHistorySessionId = options.presentation.getState().authoritative.active?.session.id;
   const statusLine = new Text();
-  const footer = new Text();
+  const footer = new ResponsiveText();
   const working = new Loader(tui, theme.toolTitle, theme.muted, "Working", { intervalMs: 80 });
   let workingVisible = false;
   let cancelSettling = false;
@@ -401,7 +414,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
             });
         },
       });
-      handle = tui.showOverlay(picker, {
+      handle = showOverlay(picker, {
         width: "80%",
         minWidth: 36,
         maxHeight: "80%",
@@ -548,7 +561,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
             }
           });
       }
-      handle = tui.showOverlay(picker, {
+      handle = showOverlay(picker, {
         width: "80%",
         minWidth: 36,
         maxHeight: "80%",
@@ -598,10 +611,10 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
             : subject === undefined
               ? label
               : `${label} ${safeTerminalText(subject)}`;
-        tool.addChild(new Text(theme.toolTitle(title)));
+        tool.addChild(new ResponsiveLine(theme.toolTitle(title)));
         const detail = item.resultSummary ?? toolStatusText(item.status, item.outcome?.status);
         if (detail !== null) {
-          tool.addChild(new Text(theme.toolOutput(safeTerminalText(detail))));
+          tool.addChild(new ResponsiveLine(theme.toolOutput(safeTerminalText(detail))));
         }
         if (toolDetailsExpanded) {
           const replay = item.source?.replay ?? "unavailable";
@@ -694,7 +707,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       clearExitWindow();
       permission.hide();
       permission = undefined;
-      tui.setFocus(helpNavigator?.navigator ?? editor);
+      tui.requestRender(true);
     } else if (pending !== undefined && permission?.requestId !== pending.requestId) {
       clearExitWindow();
       permission?.hide();
@@ -709,7 +722,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           });
         },
       });
-      const handle = tui.showOverlay(overlay, {
+      const handle = showOverlay(overlay, {
         width: "80%",
         minWidth: 36,
         maxHeight: "80%",
@@ -739,29 +752,42 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     } else {
       editor.disableSubmit = false;
     }
-    footer.setText(
-      exitArm.armed
-        ? theme.muted(
-            `Press Ctrl+C again within two seconds to exit${
-              editor.getExpandedText().length === 0 ? "" : " · draft will be copied"
-            }`,
-          )
-        : active === null
-          ? theme.muted("Choose an exact model target to create a session")
-          : theme.muted(
-              `${safeTerminalText(state.authoritative.project.label)} · ${footerContextText(active)} · ${sessionRunStatus(state.transient?.activity ?? null, active, cancelSettling)}\n${safeTerminalText(active.session.targetId)} · ${
-                state.authoritative.targets.items.find(
-                  (target) => target.targetId === active.session.targetId,
-                )?.certification ??
-                options.targetStatus?.certification ??
-                "Experimental"
-              }${
-                selectedSkills.size === 0
-                  ? ""
-                  : ` · ${selectedSkills.size} Skill${selectedSkills.size === 1 ? "" : "s"} selected`
-              }${active.transcript.olderCursor === null ? "" : " · older history available"} · ${adamCommandRegistry.footerHint()}`,
-            ),
-    );
+    if (exitArm.armed) {
+      footer.setText(
+        theme.muted(
+          `Press Ctrl+C again within two seconds to exit${
+            editor.getExpandedText().length === 0 ? "" : " · draft will be copied"
+          }`,
+        ),
+      );
+    } else if (active === null) {
+      footer.setText(theme.muted("Choose an exact model target to create a session"));
+    } else {
+      const runStatus = sessionRunStatus(state.transient?.activity ?? null, active, cancelSettling);
+      const targetCertification =
+        state.authoritative.targets.items.find(
+          (target) => target.targetId === active.session.targetId,
+        )?.certification ??
+        options.targetStatus?.certification ??
+        "Experimental";
+      const selectedSkillSummary =
+        selectedSkills.size === 0
+          ? ""
+          : ` · ${selectedSkills.size} Skill${selectedSkills.size === 1 ? "" : "s"} selected`;
+      const olderHistorySummary =
+        active.transcript.olderCursor === null ? "" : " · older history available";
+      footer.setText({
+        wide: theme.muted(
+          `${safeTerminalText(state.authoritative.project.label)} · ${footerContextText(active)} · ${runStatus}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}${selectedSkillSummary}${olderHistorySummary} · ${adamCommandRegistry.footerHint()}`,
+        ),
+        standard: theme.muted(
+          `${safeTerminalText(state.authoritative.project.label)} · ${runStatus}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}${selectedSkillSummary}${olderHistorySummary} · /help · Tab complete`,
+        ),
+        narrow: theme.muted(
+          `${runStatus}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}\n/help · Tab complete`,
+        ),
+      });
+    }
     statusLine.setText(statusMessage === null ? "" : theme.muted(safeTerminalText(statusMessage)));
     tui.requestRender();
   };
@@ -799,7 +825,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         },
         theme,
       });
-      handle = tui.showOverlay(picker, {
+      handle = showOverlay(picker, {
         width: "90%",
         minWidth: 36,
         maxHeight: "80%",
@@ -899,7 +925,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       },
       theme,
     });
-    handle = tui.showOverlay(picker, {
+    handle = showOverlay(picker, {
       width: "90%",
       minWidth: 36,
       maxHeight: "80%",
@@ -982,7 +1008,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       },
       theme,
     });
-    handle = tui.showOverlay(navigator, {
+    handle = showOverlay(navigator, {
       width: "90%",
       minWidth: 36,
       maxHeight: "80%",
@@ -1138,7 +1164,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         theme,
         topics: adamCommandRegistry.helpTopics(),
       });
-      handle = tui.showOverlay(navigator, {
+      handle = showOverlay(navigator, {
         width: "80%",
         minWidth: 36,
         maxHeight: "80%",
@@ -1181,7 +1207,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         theme,
         throughSequence: continuity.status === "current" ? continuity.sessionThroughSequence : null,
       });
-      handle = tui.showOverlay(inspector, {
+      handle = showOverlay(inspector, {
         width: "90%",
         minWidth: 36,
         maxHeight: "80%",
@@ -1293,7 +1319,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         resources,
         theme,
       });
-      handle = tui.showOverlay(picker, {
+      handle = showOverlay(picker, {
         width: "90%",
         minWidth: 36,
         maxHeight: "80%",
@@ -1515,7 +1541,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           }
         },
       });
-      handle = tui.showOverlay(wizard, {
+      handle = showOverlay(wizard, {
         width: "95%",
         minWidth: 36,
         maxHeight: "90%",
@@ -1555,7 +1581,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
             return true;
           },
         });
-        handle = tui.showOverlay(palette, {
+        handle = showOverlay(palette, {
           width: "90%",
           minWidth: 36,
           maxHeight: "80%",
@@ -1700,26 +1726,39 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   const unsubscribe = options.presentation.subscribe(renderState);
   const exited = Promise.withResolvers<void>();
   let stopping = false;
+  const removeTerminationListeners = () => {
+    process.removeListener("SIGHUP", handleSighup);
+    process.removeListener("SIGTERM", handleSigterm);
+  };
   const stop = async (copyDraft: boolean) => {
     if (stopping) {
       return;
     }
     stopping = true;
-    clearExitWindow();
-    unsubscribe();
-    sessionPicker?.hide();
-    sessionInspector?.hide();
-    chronologyPicker?.hide();
-    resourceReloadPicker?.hide();
-    skillPalette?.hide();
-    pathPicker?.hide();
-    mcpWizard?.hide();
-    helpNavigator?.hide();
-    artifactNavigator?.hide();
-    targetPicker?.hide();
-    permission?.hide();
-    working.stop();
-    tui.stop();
+    const failures: unknown[] = [];
+    const attempt = (operation: () => void) => {
+      try {
+        operation();
+      } catch (error) {
+        failures.push(error);
+      }
+    };
+    attempt(removeTerminationListeners);
+    attempt(clearExitWindow);
+    attempt(unsubscribe);
+    attempt(() => sessionPicker?.hide());
+    attempt(() => sessionInspector?.hide());
+    attempt(() => chronologyPicker?.hide());
+    attempt(() => resourceReloadPicker?.hide());
+    attempt(() => skillPalette?.hide());
+    attempt(() => pathPicker?.hide());
+    attempt(() => mcpWizard?.hide());
+    attempt(() => helpNavigator?.hide());
+    attempt(() => artifactNavigator?.hide());
+    attempt(() => targetPicker?.hide());
+    attempt(() => permission?.hide());
+    attempt(() => working.stop());
+    attempt(() => tui.stop());
     try {
       if (copyDraft) {
         const clipboardResult = await copyDraftToClipboard(
@@ -1733,15 +1772,59 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           terminal.write("\r\nClipboard copy failed; draft was not copied.\r\n");
         }
       }
-      await options.presentation.close();
-      exited.resolve();
     } catch (error) {
-      exited.reject(error);
+      failures.push(error);
+    }
+    try {
+      await options.presentation.close();
+    } catch (error) {
+      failures.push(error);
+    }
+    if (failures.length === 0) {
+      exited.resolve();
+    } else if (failures.length === 1) {
+      exited.reject(failures[0]);
+    } else {
+      exited.reject(new AggregateError(failures, "The TUI could not close every owned resource."));
     }
   };
+  const handleTerminationSignal = (signal: "SIGHUP" | "SIGTERM") => {
+    process.exitCode = signal === "SIGHUP" ? 129 : 143;
+    void stop(false);
+  };
+  function handleSighup(): void {
+    handleTerminationSignal("SIGHUP");
+  }
+  function handleSigterm(): void {
+    handleTerminationSignal("SIGTERM");
+  }
   tui.addInputListener((data) => {
     if (adamCommandRegistry.matchesInput(data, "exit")) {
       void stop(true);
+      return { consume: true };
+    }
+    if (
+      !terminalSizeIsSupported(terminal.columns, terminal.rows) &&
+      !adamCommandRegistry.matchesInput(data, "interrupt")
+    ) {
+      if (adamCommandRegistry.matchesInput(data, "back")) {
+        if (permission !== undefined) {
+          permission.overlay.handleInput(data);
+        } else {
+          const closeOverlay =
+            helpNavigator?.close ??
+            artifactNavigator?.close ??
+            mcpWizard?.close ??
+            pathPicker?.close ??
+            skillPalette?.close ??
+            sessionInspector?.close ??
+            chronologyPicker?.close ??
+            resourceReloadPicker?.close ??
+            sessionPicker?.close ??
+            targetPicker?.close;
+          closeOverlay?.();
+        }
+      }
       return { consume: true };
     }
     if (adamCommandRegistry.matchesInput(data, "toggle_tool_details")) {
@@ -1812,8 +1895,29 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     }
     return undefined;
   });
-  tui.start();
-  await exited.promise;
+  process.once("SIGHUP", handleSighup);
+  process.once("SIGTERM", handleSigterm);
+  try {
+    tui.start();
+    await exited.promise;
+  } catch (error) {
+    if (!stopping) {
+      await stop(false);
+      const cleanupError = await exited.promise.then(
+        () => undefined,
+        (failure: unknown) => failure,
+      );
+      if (cleanupError !== undefined) {
+        throw new AggregateError(
+          [error, cleanupError],
+          "The TUI failed during startup and cleanup.",
+        );
+      }
+    }
+    throw error;
+  } finally {
+    removeTerminationListeners();
+  }
 }
 
 function clipboardAssistantStatus(result: "copied" | "failed" | "unsupported" | null): string {

--- a/apps/tui/src/tui-fixture.test-support.ts
+++ b/apps/tui/src/tui-fixture.test-support.ts
@@ -21,8 +21,10 @@ export type TuiFixture = {
   readonly closed: Promise<TuiFixtureResult>;
   readonly output: () => string;
   readonly resize: (columns: number, rows: number) => Promise<void>;
+  readonly terminate: (signal: "SIGHUP" | "SIGTERM") => Promise<void>;
   readonly waitFor: (text: string) => Promise<void>;
   readonly waitForAfter: (text: string, offset: number) => Promise<void>;
+  readonly waitForCompleteFrameAfter: (text: string, offset: number) => Promise<void>;
   readonly write: (text: string) => void;
 };
 
@@ -98,11 +100,17 @@ function startInProcessTuiFixture(input: StartTuiFixtureOptions): TuiFixture {
     closed,
     output: () => terminal.output(),
     resize(columns, rows) {
+      const offset = terminal.output().length;
       terminal.resize(columns, rows);
-      return Promise.resolve();
+      return terminal.nextOutputContaining("\u001b[?2026l", offset);
+    },
+    terminate() {
+      return Promise.reject(new Error("Only an external TUI fixture accepts process signals."));
     },
     waitFor: (text) => terminal.nextOutputContaining(text),
     waitForAfter: (text, offset) => terminal.nextOutputContaining(text, offset),
+    waitForCompleteFrameAfter: (text, offset) =>
+      terminal.nextSynchronizedFrameContaining(text, offset),
     write: (text) => terminal.input(text),
   };
   trackFixture(fixture);
@@ -318,8 +326,23 @@ function startExternalTuiFixture(input: StartTuiFixtureOptions): TuiFixture {
       }
       await resizeTerminalProcess(processId, columns, rows);
     },
+    async terminate(signal) {
+      if (input.terminalProcessMarker === undefined) {
+        throw new Error("The external TUI fixture requires a terminal process marker to signal.");
+      }
+      const processId = Number.parseInt(await readFile(input.terminalProcessMarker, "utf8"), 10);
+      if (!Number.isSafeInteger(processId) || processId <= 0) {
+        throw new Error("The external TUI fixture recorded an invalid terminal process identity.");
+      }
+      process.kill(processId, signal);
+    },
     waitFor: (text) => waitForAfter(text, 0),
     waitForAfter,
+    async waitForCompleteFrameAfter(text, offset) {
+      await waitForAfter(text, offset);
+      const occurrence = stdout.indexOf(text, offset);
+      await waitForAfter("\u001b[?2026l", occurrence + text.length);
+    },
     write: (text) => child.stdin.write(text),
   };
   trackFixture(fixture, processClose.promise);

--- a/apps/tui/src/virtual-terminal.test-support.ts
+++ b/apps/tui/src/virtual-terminal.test-support.ts
@@ -21,10 +21,25 @@ export class VirtualTerminal implements Terminal {
   #resizeHandler: (() => void) | undefined;
   #rows: number;
   #state: "new" | "started" | "stopped" = "new";
+  readonly #throwAfterStart: boolean;
+  readonly #throwAfterStop: boolean;
+  readonly #throwOnHideCursorAfterInput: string | undefined;
+  #throwOnNextHideCursor = false;
 
-  constructor(options: { readonly columns?: number; readonly rows?: number } = {}) {
+  constructor(
+    options: {
+      readonly columns?: number;
+      readonly rows?: number;
+      readonly throwAfterStart?: boolean;
+      readonly throwAfterStop?: boolean;
+      readonly throwOnHideCursorAfterInput?: string;
+    } = {},
+  ) {
     this.#columns = options.columns ?? 80;
     this.#rows = options.rows ?? 24;
+    this.#throwAfterStart = options.throwAfterStart ?? false;
+    this.#throwAfterStop = options.throwAfterStop ?? false;
+    this.#throwOnHideCursorAfterInput = options.throwOnHideCursorAfterInput;
     this.#input.on("data", (sequence) => this.#inputHandler?.(sequence));
     this.#input.on("paste", (content) => this.#inputHandler?.(`\u001b[200~${content}\u001b[201~`));
   }
@@ -50,6 +65,9 @@ export class VirtualTerminal implements Terminal {
     this.#inputHandler = onInput;
     this.#resizeHandler = onResize;
     this.#started.resolve();
+    if (this.#throwAfterStart) {
+      throw new Error("Injected terminal start failure after acquisition.");
+    }
   }
 
   stop(): void {
@@ -70,6 +88,9 @@ export class VirtualTerminal implements Terminal {
       );
     }
     this.#waiters.clear();
+    if (this.#throwAfterStop) {
+      throw new Error("Injected terminal stop failure after restoration.");
+    }
   }
 
   async drainInput(): Promise<void> {}
@@ -88,6 +109,9 @@ export class VirtualTerminal implements Terminal {
   input(data: string): void {
     if (this.#state !== "started" || this.#inputHandler === undefined) {
       throw new Error("VirtualTerminal accepts input only while started.");
+    }
+    if (data === this.#throwOnHideCursorAfterInput) {
+      this.#throwOnNextHideCursor = true;
     }
     this.#input.process(data);
   }
@@ -148,6 +172,12 @@ export class VirtualTerminal implements Terminal {
     });
   }
 
+  async nextSynchronizedFrameContaining(text: string, offset = 0): Promise<void> {
+    await this.nextOutputContaining(text, offset);
+    const occurrence = this.#output.indexOf(text, offset);
+    await this.nextOutputContaining("\u001b[?2026l", occurrence + text.length);
+  }
+
   moveBy(lines: number): void {
     if (lines > 0) {
       this.write(`\u001b[${lines}B`);
@@ -157,6 +187,10 @@ export class VirtualTerminal implements Terminal {
   }
 
   hideCursor(): void {
+    if (this.#throwOnNextHideCursor) {
+      this.#throwOnNextHideCursor = false;
+      throw new Error("Injected overlay cleanup failure before terminal restoration.");
+    }
     this.write("\u001b[?25l");
   }
 

--- a/packages/testkit/src/trusted-mcp-host.test.ts
+++ b/packages/testkit/src/trusted-mcp-host.test.ts
@@ -12,6 +12,7 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
+import { createServer, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -1493,43 +1494,63 @@ test("SessionLifecycle causally reaps a package-bootstrap process group after it
   const workspaceRoot = join(testRoot, "workspace");
   const packageManagerCliPath = join(testRoot, "package-manager.cjs");
   const descendantMarker = join(testRoot, "descendant.pid");
-  await mkdir(workspaceRoot);
-  await writeFile(
-    packageManagerCliPath,
-    [
-      'const { spawn } = require("node:child_process");',
-      `const descendant = spawn(process.execPath, ["-e", ${JSON.stringify(
-        `process.on("SIGTERM", () => {}); require("node:fs").writeFileSync(${JSON.stringify(
-          descendantMarker,
-        )}, String(process.pid)); setInterval(() => undefined, 60000);`,
-      )}], { stdio: "ignore" });`,
-      "if (descendant.pid === undefined) process.exit(2);",
-      'process.on("SIGTERM", () => process.exit(0));',
-      "setInterval(() => undefined, 60000);",
-    ].join("\n"),
-  );
-  await writeFile(
-    join(workspaceRoot, ".mcp.json"),
-    JSON.stringify({
-      mcpServers: {
-        fixture: {
-          command: "npx",
-          args: ["-y", "@adam-agent/mcp-fixture@1.2.3"],
-        },
-      },
-    }),
-  );
-
-  const manualBootstrapDeadline = createManualMcpIdleScheduler();
-  const lifecycle = createSessionLifecycle({
-    [mcpBootstrapScheduler]: manualBootstrapDeadline.scheduler,
-    [mcpPackageManagerCliPath]: packageManagerCliPath,
-    [mcpPackageRegistryUrl]: "http://127.0.0.1:1",
-    stateRoot,
-    workspaceRoot,
+  const descendantSocketPath = join(testRoot, "descendant.sock");
+  const descendantConnected = Promise.withResolvers<void>();
+  const descendantClosed = Promise.withResolvers<"closed">();
+  let descendantConnection: Socket | undefined;
+  const descendantServer = createServer((socket) => {
+    descendantConnection = socket;
+    descendantConnected.resolve();
+    socket.once("close", () => descendantClosed.resolve("closed"));
   });
+  let lifecycle: ReturnType<typeof createSessionLifecycle> | undefined;
   let descendantPid: number | undefined;
-  try {
+  const bodyOutcome = await (async () => {
+    await mkdir(workspaceRoot);
+    await new Promise<void>((resolve, reject) => {
+      const rejectListen = (error: Error) => reject(error);
+      descendantServer.once("error", rejectListen);
+      descendantServer.listen(descendantSocketPath, () => {
+        descendantServer.off("error", rejectListen);
+        resolve();
+      });
+    });
+    await writeFile(
+      packageManagerCliPath,
+      [
+        'const { spawn } = require("node:child_process");',
+        `const descendant = spawn(process.execPath, ["-e", ${JSON.stringify(
+          `const socket = require("node:net").createConnection(${JSON.stringify(
+            descendantSocketPath,
+          )}, () => require("node:fs").writeFileSync(${JSON.stringify(
+            descendantMarker,
+          )}, String(process.pid))); socket.on("error", () => {}); process.on("SIGTERM", () => {}); setInterval(() => undefined, 60000);`,
+        )}], { stdio: "ignore" });`,
+        "if (descendant.pid === undefined) process.exit(2);",
+        'process.on("SIGTERM", () => process.exit(0));',
+        "setInterval(() => undefined, 60000);",
+      ].join("\n"),
+    );
+    await writeFile(
+      join(workspaceRoot, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          fixture: {
+            command: "npx",
+            args: ["-y", "@adam-agent/mcp-fixture@1.2.3"],
+          },
+        },
+      }),
+    );
+
+    const manualBootstrapDeadline = createManualMcpIdleScheduler();
+    lifecycle = createSessionLifecycle({
+      [mcpBootstrapScheduler]: manualBootstrapDeadline.scheduler,
+      [mcpPackageManagerCliPath]: packageManagerCliPath,
+      [mcpPackageRegistryUrl]: "http://127.0.0.1:1",
+      stateRoot,
+      workspaceRoot,
+    });
     const created = await lifecycle.create({ targetIdentity });
     if (created.mcp === undefined) {
       throw new Error("The fixture requires an MCP configuration snapshot.");
@@ -1561,26 +1582,59 @@ test("SessionLifecycle causally reaps a package-bootstrap process group after it
       (error: unknown) => ({ status: "rejected" as const, error }),
     );
     await descendantSpawned;
+    await descendantConnected.promise;
     descendantPid = Number.parseInt(await readFile(descendantMarker, "utf8"), 10);
     await manualBootstrapDeadline.advanceBy(120_000);
     const outcome = await observedActivation;
-    let descendantAbsent = false;
-    try {
-      process.kill(descendantPid, 0);
-    } catch (error) {
-      descendantAbsent = error instanceof Error && "code" in error && error.code === "ESRCH";
-    }
+    const descendantState = await withFailureGuard(
+      descendantClosed.promise,
+      5_000,
+      "The package-bootstrap descendant did not close its causal connection.",
+    );
 
-    expect({ outcome, descendantAbsent }).toMatchObject({
+    expect({ outcome, descendantState }).toMatchObject({
       outcome: { status: "rejected", error: { code: "mcp_bootstrap_failed" } },
-      descendantAbsent: true,
+      descendantState: "closed",
     });
-  } finally {
+  })().then(
+    () => ({ status: "fulfilled" as const }),
+    (error: unknown) => ({ status: "rejected" as const, error }),
+  );
+
+  const failures: unknown[] = bodyOutcome.status === "rejected" ? [bodyOutcome.error] : [];
+  const attemptCleanup = async (operation: () => void | Promise<void>): Promise<void> => {
+    try {
+      await operation();
+    } catch (error) {
+      failures.push(error);
+    }
+  };
+  await attemptCleanup(async () => {
+    await lifecycle?.close();
+  });
+  await attemptCleanup(() => {
     if (descendantPid !== undefined) {
       bestEffortKillProcess(descendantPid);
     }
-    await lifecycle.close();
-    await rm(testRoot, { recursive: true, force: true });
+    descendantConnection?.destroy();
+  });
+  await attemptCleanup(async () => {
+    if (descendantServer.listening) {
+      await new Promise<void>((resolve, reject) => {
+        descendantServer.close((error) => (error === undefined ? resolve() : reject(error)));
+      });
+    }
+  });
+  await attemptCleanup(() => rm(testRoot, { recursive: true, force: true }));
+
+  if (failures.length === 1) {
+    throw failures[0];
+  }
+  if (failures.length > 1) {
+    throw new AggregateError(
+      failures,
+      "The package-bootstrap descendant fixture had multiple causal failures.",
+    );
   }
 });
 


### PR DESCRIPTION
## Summary

- add 40/80/120 responsive layouts, a 40x12 minimum supported terminal contract, bounded tool subjects, and safe minimum-mode abort, deny, and exit behavior
- preserve exact multiline and large bracketed-paste drafts plus grapheme-aware CJK, combining-mark, emoji, and IME hardware-cursor positioning
- preserve Help, permission, ordinary-overlay focus, draft, pending interaction, and tool expansion identity across resize and permission preemption
- handle SIGHUP and SIGTERM with exact exit codes, restore terminal state, and independently attempt every owned cleanup while preserving multiple causal failures
- harden resize, selection, focus, and package-bootstrap process cleanup tests around complete synchronized frames and child connection closure instead of elapsed time, polling, or wait-then PID absence

## Verification

- `pnpm quality:check`: 26 test files passed, 2 explicit opt-in files skipped; 863 tests passed, 10 explicit opt-in tests skipped
- semantic TUI suite: 103/103 passed
- real OS/PTY suite: 18/18 passed, including 40/80/120 resize, large bracketed paste, IME cursor columns, SIGHUP/SIGTERM, terminal restoration, and MCP stdio lifecycle
- concurrent full TUI behavior plus MCP Host files: 191/191 passed
- final independent Spec review after the hosted repair: PASS with no hard findings
- final independent Standards review after the hosted repair: PASS with no hard findings
- `git diff --check`

## Hosted failure repair

- initial PR Quality run `32562284847` exposed two causal synchronization defects: selection input could arrive before its synchronized terminal frame completed, and a package-bootstrap test confused delayed CI zombie reaping with a live descendant
- head `11f7e779fa550513ebf5b33855204009a593ca68` waits for the complete selection/resize frames, observes descendant termination through its exclusive socket close, and independently aggregates fixture body and resource-cleanup failures
- no timeout was expanded and no behavior assertion was weakened

## Boundaries

- B9-R1 PR4 only; no B9-E1/H1 or later-stage work
- no timeout expansion, assertion weakening, worker cap, changed-path skip, sleep, or polling
- responsive behavior remains renderer-local and does not change Agent or Presentation authority
