### PR TITLE
B9-R2a: correct TUI presentation surfaces

### DIFF
--- a/apps/tui/src/exit-policy.ts
+++ b/apps/tui/src/exit-policy.ts
@@ -5,6 +5,7 @@ export type DeadlineScheduler = {
 };
 
 export type ClipboardAdapter = {
+  close?(): Promise<void>;
   writeText(text: string): Promise<"copied" | "failed" | "unsupported">;
 };
 

--- a/apps/tui/src/fixture-scenario.ts
+++ b/apps/tui/src/fixture-scenario.ts
@@ -13,6 +13,8 @@ export const fixtureScenarios = [
   "mutation",
   "mutation-after-release",
   "mutation-delayed-preview",
+  "provider-no-usage",
+  "provider-usage",
   "read",
   "resume",
   "session-selection-history",

--- a/apps/tui/src/help-navigator.ts
+++ b/apps/tui/src/help-navigator.ts
@@ -4,7 +4,6 @@ import {
   Key,
   matchesKey,
   truncateToWidth,
-  visibleWidth,
 } from "@earendil-works/pi-tui";
 
 import {
@@ -81,26 +80,14 @@ export class HelpNavigator implements Component, Focusable {
   invalidate(): void {}
 
   render(width: number): string[] {
-    if (width < 4) {
-      return [truncateToWidth("Adam Help", Math.max(0, width))];
-    }
-    const innerWidth = width - 4;
-    const content = helpContent(
+    return helpContent(
       this.#page,
       this.#commands,
       this.#keybindings,
       this.#topics,
       this.#selectedTopicIndex,
       this.#theme,
-    ).map((line) => padLine(truncateToWidth(line, innerWidth), innerWidth));
-    return [
-      this.#theme.editor.borderColor(`┌${"─".repeat(Math.max(0, width - 2))}┐`),
-      ...content.map(
-        (line) =>
-          `${this.#theme.editor.borderColor("│")} ${line} ${this.#theme.editor.borderColor("│")}`,
-      ),
-      this.#theme.editor.borderColor(`└${"─".repeat(Math.max(0, width - 2))}┘`),
-    ];
+    ).map((line) => truncateToWidth(line, Math.max(0, width)));
   }
 }
 
@@ -130,7 +117,7 @@ function helpContent(
       "",
       ...commands.map(
         (command) =>
-          `${command.usage}${
+          `${theme.keyword(command.usage)}${
             command.aliases.length === 0
               ? ""
               : ` · alias ${command.aliases.map((alias) => `/${alias}`).join(", ")}`
@@ -162,8 +149,4 @@ function helpContent(
     "",
     theme.muted("Esc back"),
   ];
-}
-
-function padLine(line: string, width: number): string {
-  return `${line}${" ".repeat(Math.max(0, width - visibleWidth(line)))}`;
 }

--- a/apps/tui/src/linux-clipboard.os.test.ts
+++ b/apps/tui/src/linux-clipboard.os.test.ts
@@ -1,0 +1,125 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { expect, test } from "vitest";
+
+import type { DeadlineScheduler } from "./exit-policy.js";
+import { createLinuxClipboardAdapter } from "./linux-clipboard.js";
+import { removeTuiFixtureRoot as rm, waitForPath } from "./tui-filesystem.test-support.js";
+
+test("the Linux clipboard adapter copies exact UTF-8 text through wl-copy", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-linux-clipboard-"));
+  const helperPath = join(testRoot, "wl-copy");
+  const markerPath = join(testRoot, "clipboard.txt");
+  const text = "Adam clipboard · 中文\nsecond line";
+  await writeFile(helperPath, '#!/bin/sh\n/bin/cat > "$ADAM_TEST_CLIPBOARD_MARKER"\n', {
+    mode: 0o755,
+  });
+
+  try {
+    const adapter = createLinuxClipboardAdapter({
+      environment: {
+        ...process.env,
+        ADAM_TEST_CLIPBOARD_MARKER: markerPath,
+        PATH: testRoot,
+      },
+    });
+
+    await expect(adapter.writeText(text)).resolves.toBe("copied");
+    await expect(readFile(markerPath, "utf8")).resolves.toBe(text);
+  } finally {
+    await rm(testRoot, { force: true, recursive: true });
+  }
+});
+
+test("the Linux clipboard adapter falls back to xclip when wl-copy is unavailable", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-linux-clipboard-xclip-"));
+  const helperPath = join(testRoot, "xclip");
+  const markerPath = join(testRoot, "clipboard.txt");
+  const text = "fallback clipboard text";
+  await writeFile(
+    helperPath,
+    '#!/bin/sh\n[ "$1" = "-selection" ] && [ "$2" = "clipboard" ] && [ "$3" = "-in" ] || exit 64\n/bin/cat > "$ADAM_TEST_CLIPBOARD_MARKER"\n',
+    { mode: 0o755 },
+  );
+
+  try {
+    const adapter = createLinuxClipboardAdapter({
+      environment: {
+        ...process.env,
+        ADAM_TEST_CLIPBOARD_MARKER: markerPath,
+        PATH: testRoot,
+      },
+    });
+
+    await expect(adapter.writeText(text)).resolves.toBe("copied");
+    await expect(readFile(markerPath, "utf8")).resolves.toBe(text);
+  } finally {
+    await rm(testRoot, { force: true, recursive: true });
+  }
+});
+
+test("the Linux clipboard adapter falls back to xsel when Wayland and xclip helpers are unavailable", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-linux-clipboard-xsel-"));
+  const helperPath = join(testRoot, "xsel");
+  const markerPath = join(testRoot, "clipboard.txt");
+  const text = "last Linux clipboard fallback";
+  await writeFile(
+    helperPath,
+    '#!/bin/sh\n[ "$1" = "--clipboard" ] && [ "$2" = "--input" ] || exit 64\n/bin/cat > "$ADAM_TEST_CLIPBOARD_MARKER"\n',
+    { mode: 0o755 },
+  );
+
+  try {
+    const adapter = createLinuxClipboardAdapter({
+      environment: {
+        ...process.env,
+        ADAM_TEST_CLIPBOARD_MARKER: markerPath,
+        PATH: testRoot,
+      },
+    });
+
+    await expect(adapter.writeText(text)).resolves.toBe("copied");
+    await expect(readFile(markerPath, "utf8")).resolves.toBe(text);
+  } finally {
+    await rm(testRoot, { force: true, recursive: true });
+  }
+});
+
+test("the Linux clipboard adapter terminates a helper when its deadline expires", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-linux-clipboard-deadline-"));
+  const helperPath = join(testRoot, "wl-copy");
+  const readyPath = join(testRoot, "helper-ready");
+  await writeFile(
+    helperPath,
+    '#!/bin/sh\n: > "$ADAM_TEST_CLIPBOARD_READY"\nwhile :; do :; done\n',
+    { mode: 0o755 },
+  );
+  let expire: (() => void) | undefined;
+  const scheduler: DeadlineScheduler = {
+    schedule(_delayMilliseconds, onDeadline) {
+      expire = onDeadline;
+      return { cancel() {} };
+    },
+  };
+
+  try {
+    const adapter = createLinuxClipboardAdapter({
+      environment: {
+        ...process.env,
+        ADAM_TEST_CLIPBOARD_READY: readyPath,
+        PATH: testRoot,
+      },
+      scheduler,
+    });
+    const result = adapter.writeText("bounded clipboard text");
+    await waitForPath(readyPath);
+    expect(expire).toBeTypeOf("function");
+    expire?.();
+
+    await expect(result).resolves.toBe("failed");
+  } finally {
+    await rm(testRoot, { force: true, recursive: true });
+  }
+});

--- a/apps/tui/src/linux-clipboard.test.ts
+++ b/apps/tui/src/linux-clipboard.test.ts
@@ -1,0 +1,109 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+import { expect, test, vi } from "vitest";
+
+import type { DeadlineScheduler } from "./exit-policy.js";
+import {
+  createLinuxClipboardAdapter,
+  type LinuxClipboardChild,
+  linuxClipboardSpawn,
+} from "./linux-clipboard.js";
+
+class FakeClipboardChild extends EventEmitter {
+  readonly stdin = new PassThrough();
+  readonly kill = vi.fn((_signal: NodeJS.Signals) => false);
+}
+
+function controlledScheduler(): DeadlineScheduler & {
+  fire(delayMilliseconds: number): void;
+} {
+  const deadlines: Array<{
+    readonly delayMilliseconds: number;
+    readonly onDeadline: () => void;
+    cancelled: boolean;
+  }> = [];
+  return {
+    fire(delayMilliseconds) {
+      const deadline = deadlines.find(
+        (candidate) => candidate.delayMilliseconds === delayMilliseconds && !candidate.cancelled,
+      );
+      if (deadline === undefined) {
+        throw new Error(`No active ${delayMilliseconds}ms deadline exists.`);
+      }
+      deadline.cancelled = true;
+      deadline.onDeadline();
+    },
+    schedule(delayMilliseconds, onDeadline) {
+      const deadline = { delayMilliseconds, onDeadline, cancelled: false };
+      deadlines.push(deadline);
+      return { cancel: () => (deadline.cancelled = true) };
+    },
+  };
+}
+
+test("the Linux clipboard adapter waits for close before falling back after spawn error", async () => {
+  const scheduler = controlledScheduler();
+  const children: FakeClipboardChild[] = [];
+  const commands: string[] = [];
+  const secondSpawned = Promise.withResolvers<FakeClipboardChild>();
+  const adapter = createLinuxClipboardAdapter({
+    scheduler,
+    [linuxClipboardSpawn](command) {
+      commands.push(command);
+      const child = new FakeClipboardChild();
+      children.push(child);
+      if (children.length === 2) {
+        secondSpawned.resolve(child);
+      }
+      return child as LinuxClipboardChild;
+    },
+  });
+
+  const result = adapter.writeText("exact bytes");
+  const first = children[0] as FakeClipboardChild;
+  first.emit("error", Object.assign(new Error("missing"), { code: "ENOENT" }));
+  await Promise.resolve();
+  expect(commands).toEqual(["wl-copy"]);
+
+  first.emit("close", null);
+  const second = await secondSpawned.promise;
+  expect(commands).toEqual(["wl-copy", "xclip"]);
+  second.emit("close", 0);
+  await expect(result).resolves.toBe("copied");
+  await expect(adapter.close?.()).resolves.toBeUndefined();
+});
+
+test("the Linux clipboard adapter uses single-flight TERM then KILL and still waits for close", async () => {
+  const scheduler = controlledScheduler();
+  const child = new FakeClipboardChild();
+  const adapter = createLinuxClipboardAdapter({
+    deadlineMilliseconds: 100,
+    reclamationMilliseconds: 20,
+    scheduler,
+    terminationGraceMilliseconds: 10,
+    [linuxClipboardSpawn]() {
+      return child as LinuxClipboardChild;
+    },
+  });
+
+  let settled = false;
+  const result = adapter.writeText("bounded bytes").finally(() => {
+    settled = true;
+  });
+  scheduler.fire(100);
+  expect(child.kill).toHaveBeenCalledTimes(1);
+  expect(child.kill).toHaveBeenLastCalledWith("SIGTERM");
+  await Promise.resolve();
+  expect(settled).toBe(false);
+
+  scheduler.fire(10);
+  expect(child.kill).toHaveBeenCalledTimes(2);
+  expect(child.kill).toHaveBeenLastCalledWith("SIGKILL");
+  await Promise.resolve();
+  expect(settled).toBe(false);
+
+  child.emit("close", null);
+  await expect(result).resolves.toBe("failed");
+  await expect(adapter.close?.()).resolves.toBeUndefined();
+});

--- a/apps/tui/src/linux-clipboard.ts
+++ b/apps/tui/src/linux-clipboard.ts
@@ -1,0 +1,194 @@
+import { spawn } from "node:child_process";
+import type { Writable } from "node:stream";
+
+import {
+  type ClipboardAdapter,
+  type DeadlineHandle,
+  type DeadlineScheduler,
+  nodeDeadlineScheduler,
+} from "./exit-policy.js";
+
+export type LinuxClipboardChild = {
+  readonly stdin: Writable;
+  kill(signal: NodeJS.Signals): boolean;
+  once(event: "close", listener: (code: number | null) => void): LinuxClipboardChild;
+  once(event: "error", listener: (error: NodeJS.ErrnoException) => void): LinuxClipboardChild;
+};
+
+type LinuxClipboardSpawn = (
+  command: string,
+  arguments_: readonly string[],
+  options: { readonly env: NodeJS.ProcessEnv; readonly stdio: ["pipe", "ignore", "ignore"] },
+) => LinuxClipboardChild;
+
+/** Tests only. Production clipboard composition uses node:child_process spawn. */
+export const linuxClipboardSpawn = Symbol("adam-agent.linux-clipboard-spawn");
+
+type ActiveClipboardHelper = {
+  beginTermination(): void;
+  readonly settlement: Promise<"copied" | "failed" | "unsupported">;
+};
+
+export function createLinuxClipboardAdapter({
+  deadlineMilliseconds = 150,
+  environment = process.env,
+  reclamationMilliseconds = 50,
+  scheduler = nodeDeadlineScheduler,
+  terminationGraceMilliseconds = 25,
+  [linuxClipboardSpawn]: spawnProcess = nodeClipboardSpawn,
+}: {
+  readonly deadlineMilliseconds?: number;
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly reclamationMilliseconds?: number;
+  readonly scheduler?: DeadlineScheduler;
+  readonly terminationGraceMilliseconds?: number;
+  readonly [linuxClipboardSpawn]?: LinuxClipboardSpawn;
+} = {}): ClipboardAdapter {
+  const active = new Set<ActiveClipboardHelper>();
+  let closing = false;
+  return {
+    async close() {
+      closing = true;
+      const helpers = [...active];
+      for (const helper of helpers) {
+        helper.beginTermination();
+      }
+      const outcomes = await Promise.allSettled(helpers.map((helper) => helper.settlement));
+      const failures = outcomes.flatMap((outcome) =>
+        outcome.status === "rejected" ? [outcome.reason] : [],
+      );
+      if (failures.length === 1) {
+        throw failures[0];
+      }
+      if (failures.length > 1) {
+        throw new AggregateError(failures, "Clipboard helper reclamation was not confirmed.");
+      }
+    },
+    async writeText(text) {
+      if (closing) {
+        return "failed";
+      }
+      let deadlineExpired = false;
+      let current: ActiveClipboardHelper | undefined;
+      const deadline = scheduler.schedule(deadlineMilliseconds, () => {
+        deadlineExpired = true;
+        current?.beginTermination();
+      });
+      try {
+        let sawFailure = false;
+        for (const helper of [
+          { command: "wl-copy", arguments_: [] },
+          { command: "xclip", arguments_: ["-selection", "clipboard", "-in"] },
+          { command: "xsel", arguments_: ["--clipboard", "--input"] },
+        ]) {
+          if (closing || deadlineExpired) {
+            return "failed";
+          }
+          current = startClipboardHelper({
+            active,
+            environment,
+            helper,
+            reclamationMilliseconds,
+            scheduler,
+            spawnProcess,
+            terminationGraceMilliseconds,
+            text,
+          });
+          active.add(current);
+          const result = await current.settlement;
+          current = undefined;
+          if (result === "copied") {
+            return result;
+          }
+          sawFailure ||= result === "failed";
+        }
+        return sawFailure ? "failed" : "unsupported";
+      } finally {
+        deadline.cancel();
+      }
+    },
+  };
+}
+
+function startClipboardHelper(options: {
+  readonly active: Set<ActiveClipboardHelper>;
+  readonly environment: NodeJS.ProcessEnv;
+  readonly helper: { readonly arguments_: readonly string[]; readonly command: string };
+  readonly reclamationMilliseconds: number;
+  readonly scheduler: DeadlineScheduler;
+  readonly spawnProcess: LinuxClipboardSpawn;
+  readonly terminationGraceMilliseconds: number;
+  readonly text: string;
+}): ActiveClipboardHelper {
+  const child = options.spawnProcess(options.helper.command, options.helper.arguments_, {
+    env: options.environment,
+    stdio: ["pipe", "ignore", "ignore"],
+  });
+  let closeObserved = false;
+  let failure: "failed" | "unsupported" | undefined;
+  let guard: DeadlineHandle | undefined;
+  let kill: DeadlineHandle | undefined;
+  let settled = false;
+  let terminationStarted = false;
+  let rejectSettlement: ((error: Error) => void) | undefined;
+  let resolveSettlement: ((result: "copied" | "failed" | "unsupported") => void) | undefined;
+  const settlement = new Promise<"copied" | "failed" | "unsupported">((resolve, reject) => {
+    resolveSettlement = resolve;
+    rejectSettlement = reject;
+  });
+  let beginTermination = () => undefined;
+  const helper: ActiveClipboardHelper = {
+    beginTermination: () => beginTermination(),
+    settlement,
+  };
+  const armReclamationGuard = () => {
+    guard ??= options.scheduler.schedule(options.reclamationMilliseconds, () => {
+      guard = undefined;
+      if (!closeObserved && !settled) {
+        settled = true;
+        rejectSettlement?.(new Error("Clipboard helper reclamation was not confirmed."));
+      }
+    });
+  };
+  beginTermination = () => {
+    if (closeObserved || terminationStarted) {
+      return;
+    }
+    terminationStarted = true;
+    failure = "failed";
+    child.stdin.destroy();
+    child.kill("SIGTERM");
+    kill = options.scheduler.schedule(options.terminationGraceMilliseconds, () => {
+      kill = undefined;
+      if (!closeObserved) {
+        child.kill("SIGKILL");
+      }
+    });
+    armReclamationGuard();
+  };
+  child.once("error", (error) => {
+    failure = error.code === "ENOENT" ? "unsupported" : "failed";
+    child.stdin.destroy();
+    armReclamationGuard();
+  });
+  child.once("close", (code) => {
+    closeObserved = true;
+    guard?.cancel();
+    kill?.cancel();
+    options.active.delete(helper);
+    if (settled) {
+      return;
+    }
+    settled = true;
+    resolveSettlement?.(failure ?? (code === 0 ? "copied" : "failed"));
+  });
+  child.stdin.once("error", () => {
+    // The child close event remains authoritative for success and reclamation.
+  });
+  child.stdin.write(options.text, "utf8");
+  child.stdin.end();
+  return helper;
+}
+
+const nodeClipboardSpawn: LinuxClipboardSpawn = (command, arguments_, options) =>
+  spawn(command, [...arguments_], options) as LinuxClipboardChild;

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { createModelTargets, createSessionLifecycle } from "@adam-agent/agent";
 import { afterEach, expect, test } from "vitest";
 import { removeTuiFixtureRoot as rm, waitForPath } from "./tui-filesystem.test-support.js";
 import {
@@ -189,6 +190,77 @@ test("the production TUI entry rejects conflicting target and resume arguments",
   }
 });
 
+test("the production TUI composes the Linux clipboard adapter for copy commands", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-clipboard-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const helperPath = join(testRoot, "wl-copy");
+  const clipboardMarker = join(testRoot, "clipboard.txt");
+  const assistantText = "Production clipboard response.";
+  await mkdir(workspaceRoot);
+  await writeFile(helperPath, '#!/bin/sh\n/bin/cat > "$ADAM_TEST_CLIPBOARD_MARKER"\n', {
+    mode: 0o755,
+  });
+
+  try {
+    const modelTargets = createModelTargets({
+      environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
+      fetch: async () =>
+        new Response(
+          `data: {"id":"clipboard-answer","object":"chat.completion.chunk","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":${JSON.stringify(assistantText)}},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n`,
+          { headers: { "content-type": "text/event-stream" }, status: 200 },
+        ),
+    });
+    const targets = await modelTargets.snapshot({
+      signal: AbortSignal.timeout(5_000),
+    });
+    const targetIdentity = targets.targets.find(
+      ({ identity }) => identity.targetId === "deepseek-v4-flash.direct",
+    )?.identity;
+    if (targetIdentity === undefined) {
+      throw new Error("The production clipboard fixture requires the DeepSeek Flash target.");
+    }
+    const seedLifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const created = await seedLifecycle.create({ targetIdentity });
+    await seedLifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Create a response for the production clipboard tracer." },
+    });
+    await seedLifecycle.close();
+    const { PATH: inheritedPath = "" } = process.env;
+
+    const fixture = startFixture({
+      program: {
+        arguments: ["--resume", created.sessionId, "--state-root", stateRoot],
+        cwd: workspaceRoot,
+        entrypoint: productionPath,
+        environment: {
+          ADAM_TEST_CLIPBOARD_MARKER: clipboardMarker,
+          DEEPSEEK_API_KEY: "test-deepseek-key",
+          PATH: `${testRoot}:${inheritedPath}`,
+        },
+      },
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor(assistantText);
+    fixture.write("/copy\r");
+    const copyStatus = await Promise.race([
+      fixture.waitFor("Copied last assistant response.").then(() => "copied" as const),
+      fixture
+        .waitFor("Clipboard unavailable; assistant response was not copied.")
+        .then(() => "unavailable" as const),
+    ]);
+    expect(copyStatus).toBe("copied");
+    await waitForPath(clipboardMarker);
+    await expect(readFile(clipboardMarker, "utf8")).resolves.toBe(assistantText);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("the production TUI entry reaches a credentialed exact-target session without a model call", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-startup-"));
   const workspaceRoot = join(testRoot, "workspace");
@@ -254,24 +326,31 @@ test("the real TUI MCP wizard preserves every separate B8 authority step", async
     fixture.write("\r");
     const outcome = await Promise.race([
       fixture
-        .waitForAfter("MCP authority · workspace confirmation required", afterTyping)
+        .waitForCompleteFrameAfter("MCP authority · workspace confirmation required", afterTyping)
         .then(() => "wizard" as const),
       fixture.waitForAfter("Working", afterTyping).then(() => "prompt" as const),
     ]);
     expect(outcome).toBe("wizard");
+    let beforeStep = fixture.output().length;
     fixture.write("\r");
-    await fixture.waitFor("MCP authority · server approval required");
+    await fixture.waitForCompleteFrameAfter("MCP authority · server approval required", beforeStep);
+    beforeStep = fixture.output().length;
     fixture.write("\r");
-    await fixture.waitFor("MCP authority · activation required");
+    await fixture.waitForCompleteFrameAfter("MCP authority · activation required", beforeStep);
+    beforeStep = fixture.output().length;
     fixture.write("\r");
-    await fixture.waitFor("MCP authority · tool selection required");
     await waitForPath(spawnMarker);
+    await fixture.waitForCompleteFrameAfter("MCP authority · tool selection required", beforeStep);
     fixture.write("1");
     fixture.write("\u001b[B");
+    beforeStep = fixture.output().length;
     fixture.write("c");
-    await fixture.waitFor("MCP authority · profile committed");
+    await fixture.waitForCompleteFrameAfter("MCP authority · profile committed", beforeStep);
     fixture.write("\u0011");
-    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout.slice(afterTyping)).toContain("┌");
+    expect(result.stdout.slice(afterTyping)).toContain("└");
     await waitForPath(closeMarker);
   } finally {
     await rm(testRoot, { recursive: true, force: true });
@@ -313,18 +392,26 @@ test("the production TUI resumes and explicitly reactivates one committed MCP pr
     await seed.waitFor("/mc");
     seed.write("\t");
     await seed.waitFor("/mcp");
+    let beforeStep = seed.output().length;
     seed.write("\r");
-    await seed.waitFor("MCP authority · workspace confirmation required");
+    await seed.waitForCompleteFrameAfter(
+      "MCP authority · workspace confirmation required",
+      beforeStep,
+    );
+    beforeStep = seed.output().length;
     seed.write("\r");
-    await seed.waitFor("MCP authority · server approval required");
+    await seed.waitForCompleteFrameAfter("MCP authority · server approval required", beforeStep);
+    beforeStep = seed.output().length;
     seed.write("\r");
-    await seed.waitFor("MCP authority · activation required");
+    await seed.waitForCompleteFrameAfter("MCP authority · activation required", beforeStep);
+    beforeStep = seed.output().length;
     seed.write("\r");
-    await seed.waitFor("MCP authority · tool selection required");
+    await seed.waitForCompleteFrameAfter("MCP authority · tool selection required", beforeStep);
     seed.write("1");
     seed.write("\u001b[B");
+    beforeStep = seed.output().length;
     seed.write("c");
-    await seed.waitFor("MCP authority · profile committed");
+    await seed.waitForCompleteFrameAfter("MCP authority · profile committed", beforeStep);
     seed.write("\u0011");
     await expect(seed.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
 
@@ -336,10 +423,15 @@ test("the production TUI resumes and explicitly reactivates one committed MCP pr
     await resumed.waitFor("/mc");
     resumed.write("\t");
     await resumed.waitFor("/mcp");
+    beforeStep = resumed.output().length;
     resumed.write("\r");
-    await resumed.waitFor("MCP authority · profile reactivation required");
+    await resumed.waitForCompleteFrameAfter(
+      "MCP authority · profile reactivation required",
+      beforeStep,
+    );
+    beforeStep = resumed.output().length;
     resumed.write("\r");
-    await resumed.waitFor("MCP authority · profile committed");
+    await resumed.waitForCompleteFrameAfter("MCP authority · profile committed", beforeStep);
     resumed.write("\u0011");
     await expect(resumed.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
@@ -379,14 +471,21 @@ test("the TUI process fails visibly when MCP shutdown cannot be confirmed", asyn
     await fixture.waitFor("/mc");
     fixture.write("\t");
     await fixture.waitFor("/mcp");
+    let beforeStep = fixture.output().length;
     fixture.write("\r");
-    await fixture.waitFor("MCP authority · workspace confirmation required");
+    await fixture.waitForCompleteFrameAfter(
+      "MCP authority · workspace confirmation required",
+      beforeStep,
+    );
+    beforeStep = fixture.output().length;
     fixture.write("\r");
-    await fixture.waitFor("MCP authority · server approval required");
+    await fixture.waitForCompleteFrameAfter("MCP authority · server approval required", beforeStep);
+    beforeStep = fixture.output().length;
     fixture.write("\r");
-    await fixture.waitFor("MCP authority · activation required");
+    await fixture.waitForCompleteFrameAfter("MCP authority · activation required", beforeStep);
+    beforeStep = fixture.output().length;
     fixture.write("\r");
-    await fixture.waitFor("MCP authority · tool selection required");
+    await fixture.waitForCompleteFrameAfter("MCP authority · tool selection required", beforeStep);
     fixture.write("\u0011");
     const result = await fixture.closed;
     expect(result).toMatchObject({ code: 1, signal: null });
@@ -618,7 +717,7 @@ test("the real terminal redraws through 40, 80, 120, and minimum-size layouts", 
     await fixture.waitForCompleteFrameAfter("Terminal too small", beforeResize);
     beforeResize = fixture.output().length;
     await fixture.resize(80, 24);
-    await fixture.waitForCompleteFrameAfter("workspace · idle", beforeResize);
+    await fixture.waitForCompleteFrameAfter("workspace · context unavailable · idle", beforeResize);
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -417,6 +417,9 @@ test("the production TUI resumes and explicitly reactivates one committed MCP pr
 
     const resumed = startFixture({ program, stateRoot, workspaceRoot });
     await resumed.waitFor("Select a project session");
+    const beforeSessionSelection = resumed.output().length;
+    resumed.write("\u001b[B");
+    await resumed.waitForCompleteFrameAfter("New session", beforeSessionSelection);
     resumed.write("\r");
     await resumed.waitFor("Adam · New session");
     resumed.write("/mc");

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -97,8 +97,7 @@ test("the 40, 80, and 120 column layouts expose progressively bounded footer fac
     await fixture.resize(80, 24);
     frameLines = latestSynchronizedFrame(fixture.output().slice(beforeResize));
     frame = frameLines.join("\n");
-    expect(frame).toContain("workspace · idle");
-    expect(frame).not.toContain("context unavailable");
+    expect(frame).toContain("workspace · context unavailable · idle");
     expect(frame).toContain("fake.local · Certified · /help · Tab complete");
     expect(frameLines.every((line) => visibleWidth(line) <= 80)).toBe(true);
 
@@ -106,11 +105,10 @@ test("the 40, 80, and 120 column layouts expose progressively bounded footer fac
     await fixture.resize(40, 12);
     frameLines = latestSynchronizedFrame(fixture.output().slice(beforeResize));
     frame = frameLines.join("\n");
-    expect(frame).toContain("idle");
+    expect(frame).toContain("idle · ctx unavailable");
     expect(frame).toContain("fake.local · Certified");
     expect(frame).toContain("/help · Tab complete");
     expect(frame).not.toContain("workspace");
-    expect(frame).not.toContain("context unavailable");
     expect(frameLines.every((line) => visibleWidth(line) <= 40)).toBe(true);
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
@@ -455,6 +453,20 @@ function latestSynchronizedFrame(output: string): readonly string[] {
     .split("\r\n");
 }
 
+function expectFramedOverlay(output: string, title: string): void {
+  const lines = latestSynchronizedFrame(output);
+  const titleIndex = lines.findIndex((line) => line.includes(title));
+  const topIndex = lines.findLastIndex(
+    (line, index) => index < titleIndex && line.includes("┌") && line.includes("┐"),
+  );
+  const bottomIndex = lines.findIndex(
+    (line, index) => index > titleIndex && line.includes("└") && line.includes("┘"),
+  );
+  expect(titleIndex).toBeGreaterThan(topIndex);
+  expect(bottomIndex).toBeGreaterThan(titleIndex);
+  expect([...(lines[titleIndex] ?? "").matchAll(/│/gu)]).toHaveLength(2);
+}
+
 function lastAbsoluteCursorColumn(output: string): number | undefined {
   const absoluteColumn = new RegExp(`${String.fromCharCode(27)}\\[(\\d+)G`, "gu");
   return [...output.matchAll(absoluteColumn)]
@@ -470,7 +482,8 @@ test("the production TUI selects an exact available target before creating an em
 
   try {
     const fixture = startFixture({ launch: {}, stateRoot, workspaceRoot });
-    await fixture.waitFor("Select an exact model target");
+    await fixture.waitForCompleteFrameAfter("Select an exact model target", 0);
+    expectFramedOverlay(fixture.output(), "Select an exact model target");
     await fixture.waitFor("deepseek-v4-flash.direct");
     await fixture.waitFor("deepseek-v4-pro.direct");
     fixture.write("\r");
@@ -597,12 +610,60 @@ test("the production TUI shows the project session picker before any target reso
       workspaceRoot,
     });
     await fixture.waitFor("deepseek-v4-flash.direct");
-    await fixture.waitFor("Select a project session");
-    fixture.write("\u001b[27;1;27~");
-    fixture.write("\u0003");
-    await fixture.waitFor("Press Ctrl+C again within two seconds to exit");
+    await fixture.waitForCompleteFrameAfter("Select a project session", 0);
+    expectFramedOverlay(fixture.output(), "Select a project session");
+    const frame = latestSynchronizedFrame(fixture.output()).join("\n");
+    const titleIndex = frame.indexOf("Select a project session");
+    const newSessionIndex = frame.indexOf("New Session");
+    const searchIndex = frame.indexOf("Search:");
+    const existingSessionIndex = frame.indexOf("deepseek-v4-flash.direct");
+    expect(titleIndex).toBeGreaterThanOrEqual(0);
+    expect(newSessionIndex).toBeGreaterThan(titleIndex);
+    expect(searchIndex).toBeGreaterThan(newSessionIndex);
+    expect(existingSessionIndex).toBeGreaterThan(searchIndex);
+    expect(frame).toContain("┌");
+    expect(frame).toContain("└");
+    const inverseStart = "\u001b[48;2;205;214;244m\u001b[38;2;17;17;27m";
+    const inverseEnd = "\u001b[39m\u001b[49m";
+    const pinnedLine = frame.split("\n").find((line) => line.includes("→ New Session"));
+    expect(pinnedLine).toBeDefined();
+    const pinnedStart = pinnedLine?.indexOf(inverseStart) ?? -1;
+    const pinnedEnd = pinnedLine?.indexOf(inverseEnd, pinnedStart + inverseStart.length) ?? -1;
+    expect(pinnedStart).toBeGreaterThanOrEqual(0);
+    expect(pinnedEnd).toBeGreaterThan(pinnedStart);
+    const pinnedContent = pinnedLine?.slice(pinnedStart + inverseStart.length, pinnedEnd) ?? "";
+    expect(pinnedContent).toContain("→ New Session");
+    expect(pinnedContent).toContain("Choose an exact target");
+    expect(pinnedContent.endsWith("  ")).toBe(true);
+    expect(visibleWidth(pinnedContent)).toBe(60);
+    const resizedFrames: Array<{ readonly columns: number; readonly lines: readonly string[] }> =
+      [];
+    for (const [columns, rows] of [
+      [120, 40],
+      [40, 12],
+    ] as const) {
+      const beforeResize = fixture.output().length;
+      await Promise.race([
+        fixture.resize(columns, rows),
+        fixture.closed.then(() => {
+          throw new Error("The session picker closed while resizing.");
+        }),
+      ]);
+      resizedFrames.push({
+        columns,
+        lines: latestSynchronizedFrame(fixture.output().slice(beforeResize)),
+      });
+    }
     fixture.write("\u0011");
     const result = await fixture.closed;
+    for (const { columns, lines } of resizedFrames) {
+      const resizedFrame = lines.join("\n");
+      expect(resizedFrame).toContain("New Session");
+      expect(resizedFrame).toContain("Search:");
+      expect(resizedFrame).toContain("┌");
+      expect(resizedFrame).toContain("└");
+      expect(lines.every((line) => visibleWidth(line) <= columns)).toBe(true);
+    }
     expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
     expect(result.stdout).toContain("Select a project session");
     expect(result.stdout).toContain("New Session");
@@ -651,7 +712,7 @@ test("the production session picker opens the exact focused existing session", a
     });
     await fixture.waitFor("Select a project session");
     const beforeSelection = fixture.output().length;
-    fixture.write("\r");
+    fixture.write("\u001b[B\r");
     await fixture.waitForAfter("Adam · New session", beforeSelection);
     await fixture.waitForAfter("deepseek-v4-flash.direct · Certified", beforeSelection);
     fixture.write("\u0011");
@@ -675,7 +736,7 @@ test("the production session picker requires explicit New Session before target 
     });
     await fixture.waitFor("Select a project session");
     const beforeNewSession = fixture.output().length;
-    fixture.write("\u001b[B\r");
+    fixture.write("\u001b[B\u001b[A\r");
     await fixture.waitForAfter("Select an exact model target", beforeNewSession);
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
@@ -717,9 +778,10 @@ test("the real TUI opens slash Help locally without submitting it to the model",
     const beforeHelp = fixture.output().length;
     fixture.write("/help\r");
     const outcome = await Promise.race([
-      fixture.waitForAfter("Adam Help", beforeHelp).then(() => "help" as const),
+      fixture.waitForCompleteFrameAfter("Adam Help", beforeHelp).then(() => "help" as const),
       fixture.waitForAfter("Skill selection complete.", beforeHelp).then(() => "model" as const),
     ]);
+    expectFramedOverlay(fixture.output().slice(beforeHelp), "Adam Help");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
     expect(outcome).toBe("help");
@@ -799,7 +861,11 @@ test("Enter opens the focused topic in the Help navigator", async () => {
     await fixture.waitFor("Adam Help");
     const beforeTopic = fixture.output().length;
     fixture.write("\r");
-    await fixture.waitForAfter("Command Reference", beforeTopic);
+    await fixture.waitForCompleteFrameAfter("Command Reference", beforeTopic);
+    expectFramedOverlay(fixture.output().slice(beforeTopic), "Command Reference");
+    expect(fixture.output().slice(beforeTopic)).toContain(
+      "\u001b[1m\u001b[38;2;203;166;247m/help [topic]\u001b[39m\u001b[22m",
+    );
     fixture.write("\u0011");
     const result = await fixture.closed;
     expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
@@ -821,9 +887,12 @@ test("slash Hotkeys opens the shared local Help navigator", async () => {
     const beforeHotkeys = fixture.output().length;
     fixture.write("/hotkeys\r");
     const outcome = await Promise.race([
-      fixture.waitForAfter("Effective Hotkeys", beforeHotkeys).then(() => "hotkeys" as const),
+      fixture
+        .waitForCompleteFrameAfter("Effective Hotkeys", beforeHotkeys)
+        .then(() => "hotkeys" as const),
       fixture.waitForAfter("Skill selection complete.", beforeHotkeys).then(() => "model" as const),
     ]);
+    expectFramedOverlay(fixture.output().slice(beforeHotkeys), "Effective Hotkeys");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
     expect(outcome).toBe("hotkeys");
@@ -976,6 +1045,92 @@ test("the footer exposes authoritative project context and run facts", async () 
     await fixture.waitForAfter("Context compacted · window 1", beforeCompaction);
     await fixture.waitForAfter("context · estimated · idle", beforeCompaction);
     expect(fixture.output()).toMatch(/workspace · \d+\/32768 context · estimated · idle/u);
+
+    let beforeResize = fixture.output().length;
+    await fixture.resize(80, 24);
+    await fixture.waitForAfter("context · estimated · idle", beforeResize);
+    let frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    expect(frame).toMatch(/workspace · \d+\/32768 context · estimated · idle/u);
+
+    beforeResize = fixture.output().length;
+    await fixture.resize(40, 12);
+    await fixture.waitForAfter(" est", beforeResize);
+    frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    expect(frame).toMatch(/idle · ctx [\d.]+(?:k|m)?\/32\.8k est/u);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the footer distinguishes provider-reported context occupancy at every width", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-footer-provider-context-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ scenario: "provider-usage", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    const beforePrompt = fixture.output().length;
+    fixture.write("Report exact usage\r");
+    await fixture.waitFor("Provider usage answer.");
+    await fixture.waitForAfter(" · idle", beforePrompt);
+    expect(await readFilesRecursively(stateRoot)).toContain('"inputTokens":12345');
+
+    let beforeResize = fixture.output().length;
+    await fixture.resize(120, 40);
+    let frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    expect(frame).toContain("workspace · 12345/32768 context · provider reported · idle");
+
+    beforeResize = fixture.output().length;
+    await fixture.resize(80, 24);
+    frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    expect(frame).toContain("workspace · 12345/32768 context · provider reported · idle");
+
+    beforeResize = fixture.output().length;
+    await fixture.resize(40, 12);
+    frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    expect(frame).toContain("idle · ctx 12.3k/32.8k reported");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the footer distinguishes unknown context occupancy at every width", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-footer-unknown-context-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ scenario: "provider-no-usage", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    const beforePrompt = fixture.output().length;
+    fixture.write("Report usage availability\r");
+    await fixture.waitForAfter("Provider usage unavailable.", beforePrompt);
+    await fixture.waitForAfter("context · unknown · idle", beforePrompt);
+
+    let beforeResize = fixture.output().length;
+    await fixture.resize(120, 40);
+    await fixture.waitForCompleteFrameAfter("context · unknown · idle", beforeResize);
+    let frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    expect(frame).toContain("workspace · ?/32768 context · unknown · idle");
+
+    beforeResize = fixture.output().length;
+    await fixture.resize(80, 24);
+    await fixture.waitForCompleteFrameAfter("context · unknown · idle", beforeResize);
+    frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    expect(frame).toContain("workspace · ?/32768 context · unknown · idle");
+
+    beforeResize = fixture.output().length;
+    await fixture.resize(40, 12);
+    await fixture.waitForCompleteFrameAfter("ctx ?/32.8k unknown", beforeResize);
+    frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    expect(frame).toContain("idle · ctx ?/32.8k unknown");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
@@ -1396,9 +1551,12 @@ test("slash Session opens bounded authoritative session and context facts", asyn
     const beforeSession = fixture.output().length;
     fixture.write("/session \r");
     const outcome = await Promise.race([
-      fixture.waitForAfter("Session facts", beforeSession).then(() => "facts" as const),
+      fixture
+        .waitForCompleteFrameAfter("Session facts", beforeSession)
+        .then(() => "facts" as const),
       fixture.waitForAfter("History answer.", beforeSession).then(() => "model" as const),
     ]);
+    expectFramedOverlay(fixture.output().slice(beforeSession), "Session facts");
     fixture.write("\u0011");
     const result = await fixture.closed;
     expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
@@ -1426,7 +1584,8 @@ test("slash Tree opens a read-only browser over visible complete chronology boun
     await fixture.waitFor("History prompt 3");
     const beforeTree = fixture.output().length;
     fixture.write("/tree \r");
-    await fixture.waitForAfter("Active chronology · read only", beforeTree);
+    await fixture.waitForCompleteFrameAfter("Active chronology · read only", beforeTree);
+    expectFramedOverlay(fixture.output().slice(beforeTree), "Active chronology · read only");
     fixture.write("prompt3");
     await fixture.waitForAfter("Search: prompt3", beforeTree);
     fixture.write("\u0011");
@@ -1822,7 +1981,8 @@ test("slash Reload selects one existing resource authority explicitly", async ()
     await writeFile(instructionsPath, "# Rules\n\nSecond revision.\n", "utf8");
     const beforeReload = fixture.output().length;
     fixture.write("/reload \r");
-    await fixture.waitForAfter("Reload project resources", beforeReload);
+    await fixture.waitForCompleteFrameAfter("Reload project resources", beforeReload);
+    expectFramedOverlay(fixture.output().slice(beforeReload), "Reload project resources");
     fixture.write("\r");
     await fixture.waitForAfter("Reloaded repository instructions.", beforeReload);
     fixture.write("\u0011");
@@ -1877,9 +2037,12 @@ test("the real TUI opens exact next-turn Skill metadata instead of submitting a 
     const afterTyping = fixture.output().length;
     fixture.write("\r");
     const outcome = await Promise.race([
-      fixture.waitForAfter("Select next-turn Skills", afterTyping).then(() => "palette" as const),
+      fixture
+        .waitForCompleteFrameAfter("Select next-turn Skills", afterTyping)
+        .then(() => "palette" as const),
       fixture.waitForAfter("Working", afterTyping).then(() => "prompt" as const),
     ]);
+    expectFramedOverlay(fixture.output().slice(afterTyping), "Select next-turn Skills");
     fixture.write("\u0011");
     await fixture.closed;
     expect(outcome).toBe("palette");
@@ -2047,7 +2210,8 @@ test("the real TUI opens the bounded project path selector from the at trigger",
     const fixture = startFixture({ stateRoot, workspaceRoot });
     await fixture.waitFor("Adam · New session");
     fixture.write("Open @");
-    await fixture.waitFor("Open @");
+    await fixture.waitForCompleteFrameAfter("Select a project path", 0);
+    expectFramedOverlay(fixture.output(), "Select a project path");
     fixture.write("\u0011");
     await fixture.closed;
     expect(fixture.output()).toContain("Select a project path");
@@ -2171,12 +2335,13 @@ test("slash Model and Target share an immutable-target transition page", async (
 
   try {
     const fixture = startFixture({ scenario: "target-navigation", stateRoot, workspaceRoot });
-    await fixture.waitFor("Target navigation answer.");
+    await fixture.waitForCompleteFrameAfter("Target navigation answer.", 0);
+    await fixture.waitForCompleteFrameAfter(" · idle", 0);
     const beforeModel = fixture.output().length;
     fixture.write("/model \r");
     await fixture.waitForAfter("Select an exact model target", beforeModel);
     await fixture.waitForAfter(
-      "Current target fake.local · existing session target is immutable",
+      "Current fake.local · existing session target immutable",
       beforeModel,
     );
     fixture.write("other");
@@ -2207,7 +2372,8 @@ test("a real read tool is rendered as a bounded Pi-style tool card", async () =>
 
   try {
     const fixture = startFixture({ scenario: "read", stateRoot, workspaceRoot });
-    await fixture.waitFor("Adam · New session");
+    await fixture.waitForCompleteFrameAfter("Adam · New session", 0);
+    await fixture.waitForCompleteFrameAfter(" · idle", 0);
     fixture.write("Read README\r");
     await fixture.waitFor("read README.md");
     await fixture.waitFor("29 bytes");
@@ -2472,11 +2638,14 @@ test("slash Artifacts opens one bounded assistant artifact page", async () => {
     const beforeArtifacts = fixture.output().length;
     fixture.write("/artifacts \r");
     const opened = await Promise.race([
-      fixture.waitForAfter("Session artifacts", beforeArtifacts).then(() => "opened" as const),
+      fixture
+        .waitForCompleteFrameAfter("Session artifacts", beforeArtifacts)
+        .then(() => "opened" as const),
       fixture
         .waitForAfter("Unknown command /artifacts", beforeArtifacts)
         .then(() => "unknown" as const),
     ]);
+    expectFramedOverlay(fixture.output().slice(beforeArtifacts), "Session artifacts");
     expect(opened).toBe("opened");
     await fixture.waitForAfter("assistant response", beforeArtifacts);
     fixture.write("\r");
@@ -2631,13 +2800,57 @@ test("a mutation permission shows its canonical diff and Enter allows the exact 
   try {
     const fixture = startFixture({ scenario: "mutation", stateRoot, workspaceRoot });
     await fixture.waitFor("Adam · New session");
+    const beforePermission = fixture.output().length;
     fixture.write("Edit the file\r");
     await fixture.waitFor("Permission required");
     await fixture.waitFor("-before");
-    await fixture.waitFor("+after");
+    await fixture.waitForCompleteFrameAfter("+after", beforePermission);
+    expectFramedOverlay(fixture.output().slice(beforePermission), "Permission required");
+    const permissionOutput = fixture.output().slice(beforePermission);
+    expect(permissionOutput).toContain(
+      "\u001b[1m\u001b[38;2;203;166;247mAction\u001b[39m\u001b[22m",
+    );
+    expect(permissionOutput).toContain("\u001b[38;2;243;139;168mwrite\u001b[39m");
+    expect(permissionOutput).toContain("\u001b[38;2;137;180;250mpatch\u001b[39m");
+    expect(permissionOutput).toContain("\u001b[38;2;166;227;161mAllow\u001b[39m");
+    expect(permissionOutput).toContain("\u001b[38;2;243;139;168mDeny\u001b[39m");
     fixture.write("\r");
     await fixture.waitFor("Edit complete");
     await expect(readFile(join(workspaceRoot, "edit.txt"), "utf8")).resolves.toBe("after\n");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("permission semantics remain explicit without color", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-permission-no-color-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "edit.txt"), "before\n", "utf8");
+
+  try {
+    const fixture = startFixture({
+      noColor: true,
+      scenario: "mutation",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    const beforePermission = fixture.output().length;
+    fixture.write("Edit without color\r");
+    await fixture.waitForCompleteFrameAfter("+after", beforePermission);
+    const frame = latestSynchronizedFrame(fixture.output().slice(beforePermission)).join("\n");
+    expect(frame).toContain("Action write · Subject patch");
+    expect(frame).toContain("> Allow");
+    expect(frame).toContain("Deny");
+    expect(frame).not.toContain("\u001b[38;2;");
+    expect(frame).not.toContain("\u001b[48;2;");
+    fixture.write("\u001b[27;1;27~");
+    await fixture.waitFor("denied");
+    await expect(readFile(join(workspaceRoot, "edit.txt"), "utf8")).resolves.toBe("before\n");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
@@ -2662,9 +2875,10 @@ test("slash Diffs reopens a settled mutation preview from authoritative chronolo
     const beforeDiffs = fixture.output().length;
     fixture.write("/diffs \r");
     const opened = await Promise.race([
-      fixture.waitForAfter("Settled diffs", beforeDiffs).then(() => "opened" as const),
+      fixture.waitForCompleteFrameAfter("Settled diffs", beforeDiffs).then(() => "opened" as const),
       fixture.waitForAfter("Unknown command /diffs", beforeDiffs).then(() => "unknown" as const),
     ]);
+    expectFramedOverlay(fixture.output().slice(beforeDiffs), "Settled diffs");
     expect(opened).toBe("opened");
     await fixture.waitForAfter("edit change preview", beforeDiffs);
     fixture.write("\r");
@@ -2695,9 +2909,10 @@ test("Enter cannot allow a mutation while its canonical preview is still loading
       workspaceRoot,
     });
     await fixture.waitFor("Adam · New session");
+    const beforePrompt = fixture.output().length;
     fixture.write("Edit before preview\r");
-    await fixture.waitFor("Loading canonical preview");
-    await fixture.waitFor("Allow unavailable");
+    await fixture.waitForCompleteFrameAfter("Loading canonical preview", beforePrompt);
+    expect(fixture.output().slice(beforePrompt)).toContain("unavailable");
     await waitForPath(join(controlRoot, "preview-requested"));
     fixture.write("\r");
     await waitForPath(join(controlRoot, "permission-decision-submitted"));
@@ -2811,6 +3026,7 @@ test("a pending clipboard adapter fails closed from the injected deadline", asyn
     const result = await fixture.closed;
     expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
     expect(result.stdout).toContain("Clipboard copy failed; draft was not copied.");
+    await waitForPath(join(controlRoot, "clipboard-closed"));
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }

--- a/apps/tui/src/main.ts
+++ b/apps/tui/src/main.ts
@@ -15,6 +15,7 @@ import {
 } from "@adam-agent/agent";
 
 import { McpShutdownUnconfirmedError, requireConfirmedLifecycleClose } from "./lifecycle-close.js";
+import { createLinuxClipboardAdapter } from "./linux-clipboard.js";
 import { runTui } from "./tui-app.js";
 
 class TuiConfigurationError extends Error {}
@@ -30,6 +31,7 @@ try {
       command.stateRoot ?? configuredStateRoot ?? join(homedir(), ".local", "state", "adam-agent");
     const modelTargets = createModelTargets({ environment: process.env });
     const preferences = createPresentationPreferences({ environment: process.env });
+    const clipboard = createLinuxClipboardAdapter();
     const lifecycle = createSessionLifecycle({
       modelTargets,
       permissions: createPermissionPolicy({
@@ -58,6 +60,7 @@ try {
           workspaceRoot,
         });
         await runTui({
+          clipboard,
           presentation,
           targetStatus: {
             targetId: snapshot.targetIdentity.targetId,
@@ -89,6 +92,7 @@ try {
           workspaceRoot,
         });
         await runTui({
+          clipboard,
           presentation,
           ...(startupTargetId === undefined ? {} : { startupTargetId }),
         });

--- a/apps/tui/src/overlay-frame.ts
+++ b/apps/tui/src/overlay-frame.ts
@@ -1,0 +1,70 @@
+import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+
+import type { AdamTuiTheme } from "./theme.js";
+
+export class OverlayFrame implements Component {
+  readonly #content: Component;
+  readonly #maximumHeight: (() => number | undefined) | undefined;
+  readonly #theme: AdamTuiTheme;
+  #focused = false;
+
+  constructor(content: Component, theme: AdamTuiTheme, maximumHeight?: () => number | undefined) {
+    this.#content = content;
+    this.#theme = theme;
+    this.#maximumHeight = maximumHeight;
+  }
+
+  get focused(): boolean {
+    return this.#focused;
+  }
+
+  set focused(value: boolean) {
+    this.#focused = value;
+    if ("focused" in this.#content) {
+      (this.#content as Component & { focused: boolean }).focused = value;
+    }
+  }
+
+  get wantsKeyRelease(): boolean {
+    return this.#content.wantsKeyRelease === true;
+  }
+
+  handleInput(data: string): void {
+    this.#content.handleInput?.(data);
+  }
+
+  invalidate(): void {
+    this.#content.invalidate();
+  }
+
+  render(width: number): string[] {
+    if (width < 4) {
+      return this.#content.render(width).map((line) => truncateToWidth(line, Math.max(0, width)));
+    }
+    const innerWidth = width - 4;
+    const maximumHeight = this.#maximumHeight?.();
+    const maximumContentHeight =
+      maximumHeight === undefined ? undefined : Math.max(0, Math.floor(maximumHeight) - 2);
+    const rendered = this.#content
+      .render(innerWidth)
+      .slice(0, maximumContentHeight ?? Number.POSITIVE_INFINITY);
+    const content = rendered.map((line) =>
+      padLine(
+        visibleWidth(line) > innerWidth ? truncateToWidth(line, innerWidth) : line,
+        innerWidth,
+      ),
+    );
+    return [
+      this.#theme.editor.borderColor(`┌${"─".repeat(Math.max(0, width - 2))}┐`),
+      ...content.map(
+        (line) =>
+          `${this.#theme.editor.borderColor("│")} ${line} ${this.#theme.editor.borderColor("│")}`,
+      ),
+      this.#theme.editor.borderColor(`└${"─".repeat(Math.max(0, width - 2))}┘`),
+    ];
+  }
+}
+
+function padLine(line: string, width: number): string {
+  return `${line}${" ".repeat(Math.max(0, width - visibleWidth(line)))}`;
+}

--- a/apps/tui/src/permission-overlay.ts
+++ b/apps/tui/src/permission-overlay.ts
@@ -5,7 +5,6 @@ import {
   Key,
   matchesKey,
   truncateToWidth,
-  visibleWidth,
 } from "@earendil-works/pi-tui";
 import { safeTerminalText } from "./safe-terminal-text.js";
 import type { AdamTuiTheme } from "./theme.js";
@@ -56,21 +55,24 @@ export class PermissionOverlay implements Component, Focusable {
   invalidate(): void {}
 
   render(width: number): string[] {
-    if (width < 4) {
-      return [truncateToWidth("Permission required", Math.max(0, width))];
-    }
-    const innerWidth = width - 4;
-    const subject = truncateToWidth(safeTerminalText(this.#interaction.subject.value), innerWidth);
+    const subject = truncateToWidth(safeTerminalText(this.#interaction.subject.value), width);
+    const effect =
+      this.#interaction.effect === "read"
+        ? this.#theme.keyword(this.#interaction.effect)
+        : this.#theme.danger(this.#interaction.effect);
+    const actionLine = `${this.#theme.keyword("Action")} ${effect} · ${this.#theme.keyword(
+      "Subject",
+    )} ${this.#theme.subject(subject)}`;
     const options = this.#allowEnabled
-      ? `${this.#selection === "allow" ? ">" : " "} Allow    ${
+      ? `${this.#selection === "allow" ? ">" : " "} ${this.#theme.allow("Allow")}    ${
           this.#selection === "deny" ? ">" : " "
-        } Deny`
-      : "  Allow unavailable    > Deny";
-    const content = (
+        } ${this.#theme.deny("Deny")}`
+      : `  ${this.#theme.allow("Allow")} unavailable    > ${this.#theme.deny("Deny")}`;
+    return (
       width < 60
         ? [
             this.#theme.toolTitle("Permission required"),
-            `${this.#interaction.effect} · ${subject}`,
+            actionLine,
             options,
             "Enter · Esc deny · Ctrl+C abort",
             "",
@@ -78,22 +80,13 @@ export class PermissionOverlay implements Component, Focusable {
           ]
         : [
             this.#theme.toolTitle("Permission required"),
-            `${this.#interaction.effect} · ${subject}`,
+            actionLine,
             "",
             ...this.#preview.split("\n"),
             "",
             options,
             "Enter confirm · ←/→ select · Esc deny · Ctrl+C abort",
           ]
-    ).map((line) => padLine(truncateToWidth(line, innerWidth), innerWidth));
-    return [
-      `┌${"─".repeat(Math.max(0, width - 2))}┐`,
-      ...content.map((line) => `│ ${line} │`),
-      `└${"─".repeat(Math.max(0, width - 2))}┘`,
-    ];
+    ).map((line) => truncateToWidth(line, Math.max(0, width)));
   }
-}
-
-function padLine(line: string, width: number): string {
-  return `${line}${" ".repeat(Math.max(0, width - visibleWidth(line)))}`;
 }

--- a/apps/tui/src/session-picker.test.ts
+++ b/apps/tui/src/session-picker.test.ts
@@ -1,0 +1,181 @@
+import { Text, TuiMainScreen, visibleWidth } from "@earendil-works/pi-tui";
+import { expect, test, vi } from "vitest";
+import { McpWizard } from "./mcp-wizard.js";
+import { OverlayFrame } from "./overlay-frame.js";
+import { SessionPicker } from "./session-picker.js";
+import { createAdamTuiTheme } from "./theme.js";
+import { VirtualTerminal } from "./virtual-terminal.test-support.js";
+
+test("the pinned New Session row remains a complete narrow-width selection", () => {
+  const picker = new SessionPicker({
+    sessions: [
+      {
+        id: "session-1",
+        label: "New session",
+        targetId: "deepseek-v4-flash.direct",
+        status: "idle",
+        naming: {
+          manualName: null,
+          generatedTitle: null,
+          fallbackTitle: "New session",
+          displayLabel: "New session",
+          generation: { status: "not_started" },
+        },
+      },
+    ],
+    theme: createAdamTuiTheme(false),
+    onNewSession: vi.fn(),
+    onLoadMore: vi.fn(),
+    onRename: vi.fn(),
+    onSelect: vi.fn(),
+    onClose: vi.fn(),
+    hasMore: false,
+  });
+
+  const lines = new OverlayFrame(picker, createAdamTuiTheme(false)).render(36);
+  const rendered = lines.join("\n");
+  expect(rendered.indexOf("New Session")).toBeLessThan(rendered.indexOf("Search:"));
+  const inverseStart = "\u001b[48;2;205;214;244m\u001b[38;2;17;17;27m";
+  const inverseEnd = "\u001b[39m\u001b[49m";
+  const pinnedLine = lines.find((line) => line.includes("→ New Session"));
+  expect(pinnedLine).toBeDefined();
+  const pinnedStart = pinnedLine?.indexOf(inverseStart) ?? -1;
+  const pinnedEnd = pinnedLine?.indexOf(inverseEnd, pinnedStart + inverseStart.length) ?? -1;
+  expect(pinnedStart).toBeGreaterThanOrEqual(0);
+  expect(pinnedEnd).toBeGreaterThan(pinnedStart);
+  const pinnedContent = pinnedLine?.slice(pinnedStart + inverseStart.length, pinnedEnd) ?? "";
+  expect(pinnedContent).toBe(`→ New Session${" ".repeat(19)}`);
+  expect(visibleWidth(pinnedContent)).toBe(32);
+  expect(rendered).toContain("┌");
+  expect(rendered).toContain("└");
+  expect(lines.every((line) => visibleWidth(line) <= 36)).toBe(true);
+});
+
+test("the pinned row keeps explicit selection semantics without color", () => {
+  const theme = createAdamTuiTheme(true);
+  const picker = new SessionPicker({
+    sessions: [],
+    theme,
+    onNewSession: vi.fn(),
+    onLoadMore: vi.fn(),
+    onRename: vi.fn(),
+    onSelect: vi.fn(),
+    onClose: vi.fn(),
+    hasMore: false,
+  });
+
+  const lines = new OverlayFrame(picker, theme).render(40);
+  const rendered = lines.join("\n");
+  expect(rendered).toContain("→ New Session");
+  expect(rendered).toContain("Search:");
+  expect(rendered).not.toContain("\u001b[38;");
+  expect(rendered).not.toContain("\u001b[48;");
+  expect(lines.every((line) => visibleWidth(line) <= 40)).toBe(true);
+});
+
+test("the framed picker composites into a synchronized 40-column terminal frame", async () => {
+  const terminal = new VirtualTerminal();
+  const theme = createAdamTuiTheme(false);
+  const picker = new SessionPicker({
+    sessions: [
+      {
+        id: "session-1",
+        label: "New session",
+        targetId: "deepseek-v4-flash.direct",
+        status: "idle",
+        naming: {
+          manualName: null,
+          generatedTitle: null,
+          fallbackTitle: "New session",
+          displayLabel: "New session",
+          generation: { status: "not_started" },
+        },
+      },
+    ],
+    theme,
+    onNewSession: vi.fn(),
+    onLoadMore: vi.fn(),
+    onRename: vi.fn(),
+    onSelect: vi.fn(),
+    onClose: vi.fn(),
+    hasMore: false,
+  });
+  const tui = new TuiMainScreen(terminal, true);
+  tui.addChild(new Text("base"));
+  tui.showOverlay(new OverlayFrame(picker, theme), {
+    width: "80%",
+    minWidth: 36,
+    maxHeight: "80%",
+    margin: 1,
+  });
+
+  try {
+    tui.start();
+    await terminal.nextOutputContaining("\u001b[?2026l");
+    let offset = terminal.output().length;
+    terminal.resize(120, 40);
+    await terminal.nextSynchronizedFrameContaining("New Session", offset);
+    offset = terminal.output().length;
+    terminal.resize(40, 12);
+    await terminal.nextSynchronizedFrameContaining("New Session", offset);
+  } finally {
+    tui.stop();
+  }
+});
+
+test("the shared frame preserves both borders when overlay height is bounded", () => {
+  const content = {
+    invalidate() {},
+    render: () => ["one", "two", "three", "four", "five", "six"],
+  };
+  const frame = new OverlayFrame(content, createAdamTuiTheme(true), () => 5);
+
+  expect(frame.render(20)).toEqual([
+    "┌──────────────────┐",
+    "│ one              │",
+    "│ two              │",
+    "│ three            │",
+    "└──────────────────┘",
+  ]);
+});
+
+test("the MCP overlay family renders its authority title inside the shared frame", () => {
+  const digest = `sha256:${"0".repeat(64)}` as const;
+  const theme = createAdamTuiTheme(true);
+  const wizard = new McpWizard({
+    state: {
+      schemaVersion: 1,
+      status: "workspace_confirmation_required",
+      workspaceConfirmed: false,
+      source: { path: ".mcp.json", digest },
+      servers: [
+        {
+          serverId: "fixture",
+          status: "approval_required",
+          transport: "stdio",
+          command: { kind: "executable", path: "/usr/bin/fixture" },
+          arguments: [],
+          cwd: ".",
+          requestedEnvironmentNames: [],
+          startupEffects: ["execute"],
+          definitionDigest: digest,
+        },
+      ],
+      activation: null,
+      catalog: null,
+      profile: null,
+      diagnostics: [],
+    },
+    theme,
+    onAdvance: vi.fn(),
+    onClose: vi.fn(),
+    onCommit: vi.fn(),
+  });
+
+  const lines = new OverlayFrame(wizard, theme).render(80);
+  const titleIndex = lines.findIndex((line) => line.includes("MCP authority"));
+  expect(titleIndex).toBeGreaterThan(0);
+  expect(lines[titleIndex]).toMatch(/│ .*MCP authority.* │/u);
+  expect(lines.at(0)).toContain("┌");
+  expect(lines.at(-1)).toContain("└");
+});

--- a/apps/tui/src/session-picker.ts
+++ b/apps/tui/src/session-picker.ts
@@ -1,22 +1,33 @@
 import type { SessionSummary } from "@adam-agent/presentation";
-import type { Component, SelectItem } from "@earendil-works/pi-tui";
+import {
+  type Component,
+  fuzzyFilter,
+  getKeybindings,
+  truncateToWidth,
+  visibleWidth,
+} from "@earendil-works/pi-tui";
 
 import { adamCommandRegistry } from "./command-registry.js";
 import { safeTerminalText } from "./safe-terminal-text.js";
-import { SearchableSelectList } from "./searchable-select-list.js";
 import type { AdamTuiTheme } from "./theme.js";
 
-const newSessionValue = "new-session";
-const loadMoreValue = "load-more";
+type SessionPickerItem =
+  | { readonly kind: "new_session" }
+  | { readonly kind: "session"; readonly session: SessionSummary }
+  | { readonly kind: "load_more" };
 
 export class SessionPicker implements Component {
-  readonly #list: SearchableSelectList;
+  readonly #hasMore: boolean;
+  readonly #onClose: () => void;
+  readonly #onLoadMore: () => void;
   readonly #onNewSession: () => void;
   readonly #onRename: (session: SessionSummary) => void;
   readonly #onSelect: (session: SessionSummary) => void;
-  readonly #sessions: ReadonlyMap<string, SessionSummary>;
+  readonly #sessions: readonly SessionSummary[];
   readonly #theme: AdamTuiTheme;
   #notice: string | null = null;
+  #query = "";
+  #selectedIndex = 0;
 
   constructor(options: {
     readonly sessions: readonly SessionSummary[];
@@ -29,55 +40,13 @@ export class SessionPicker implements Component {
     readonly hasMore: boolean;
   }) {
     this.#onNewSession = options.onNewSession;
+    this.#onClose = options.onClose;
+    this.#onLoadMore = options.onLoadMore;
     this.#onRename = options.onRename;
     this.#onSelect = options.onSelect;
-    this.#sessions = new Map(options.sessions.map((session) => [session.id, session]));
+    this.#sessions = options.sessions;
+    this.#hasMore = options.hasMore;
     this.#theme = options.theme;
-    const sessionItems: SelectItem[] = options.sessions.map((session) => ({
-      value: session.id,
-      label: safeTerminalText(session.naming.displayLabel),
-      description: safeTerminalText(`${session.targetId} · ${session.status}`),
-    }));
-    const items: SelectItem[] = [
-      ...sessionItems,
-      ...(options.hasMore
-        ? [
-            {
-              value: loadMoreValue,
-              label: "Load More",
-              description: "Use the opaque catalog cursor",
-            },
-          ]
-        : []),
-      { value: newSessionValue, label: "New Session", description: "Choose an exact target" },
-    ];
-    this.#list = new SearchableSelectList({
-      items: items.map((item) => ({
-        item,
-        searchText:
-          item.value === newSessionValue || item.value === loadMoreValue
-            ? ""
-            : `${item.label ?? ""} ${item.description ?? ""} ${item.value}`,
-        alwaysVisible: item.value === newSessionValue || item.value === loadMoreValue,
-      })),
-      maxVisible: 8,
-      onCancel: options.onClose,
-      onSelect: (item) => {
-        if (item.value === newSessionValue) {
-          this.#onNewSession();
-          return;
-        }
-        if (item.value === loadMoreValue) {
-          options.onLoadMore();
-          return;
-        }
-        const session = this.#sessions.get(item.value);
-        if (session !== undefined) {
-          this.#onSelect(session);
-        }
-      },
-      theme: options.theme.editor.selectList,
-    });
   }
 
   setNotice(notice: string): void {
@@ -86,25 +55,76 @@ export class SessionPicker implements Component {
 
   handleInput(data: string): void {
     if (adamCommandRegistry.matchesInput(data, "rename_session")) {
-      const selected = this.#list.getSelectedItem();
-      const session = selected === null ? undefined : this.#sessions.get(selected.value);
-      if (session !== undefined) {
-        this.#onRename(session);
+      const selected = this.#items()[this.#selectedIndex];
+      if (selected?.kind === "session") {
+        this.#onRename(selected.session);
       }
       return;
     }
-    this.#list.handleInput(data);
+    const keybindings = getKeybindings();
+    if (keybindings.matches(data, "tui.editor.deleteCharBackward") && this.#query.length > 0) {
+      this.#query = Array.from(this.#query).slice(0, -1).join("");
+      this.#selectFirstSearchResult();
+      return;
+    }
+    if (isSearchText(data)) {
+      this.#query += safeTerminalText(data);
+      this.#selectFirstSearchResult();
+      return;
+    }
+    const items = this.#items();
+    if (keybindings.matches(data, "tui.select.up")) {
+      this.#selectedIndex = this.#selectedIndex === 0 ? items.length - 1 : this.#selectedIndex - 1;
+      return;
+    }
+    if (keybindings.matches(data, "tui.select.down")) {
+      this.#selectedIndex = this.#selectedIndex === items.length - 1 ? 0 : this.#selectedIndex + 1;
+      return;
+    }
+    if (keybindings.matches(data, "tui.select.confirm")) {
+      const selected = items[this.#selectedIndex];
+      if (selected?.kind === "new_session") {
+        this.#onNewSession();
+      } else if (selected?.kind === "load_more") {
+        this.#onLoadMore();
+      } else if (selected?.kind === "session") {
+        this.#onSelect(selected.session);
+      }
+      return;
+    }
+    if (keybindings.matches(data, "tui.select.cancel")) {
+      this.#onClose();
+    }
   }
 
-  invalidate(): void {
-    this.#list.invalidate();
-  }
+  invalidate(): void {}
 
   render(width: number): string[] {
+    const items = this.#items();
+    const resultItems = items.slice(1);
+    const selectedResultIndex = this.#selectedIndex - 1;
+    const startIndex = Math.max(
+      0,
+      Math.min(selectedResultIndex - 3, Math.max(0, resultItems.length - 8)),
+    );
+    const visibleItems = resultItems.slice(startIndex, startIndex + 8);
     return [
       this.#theme.toolTitle("Select a project session"),
+      this.#renderNewSession(width),
+      `Search: ${safeTerminalText(this.#query)}`,
       "",
-      ...this.#list.render(width),
+      ...(visibleItems.length === 0
+        ? [this.#theme.editor.selectList.noMatch("  No matching sessions")]
+        : visibleItems.map((item, index) =>
+            this.#renderResultItem(item, startIndex + index === selectedResultIndex, width),
+          )),
+      ...(startIndex > 0 || startIndex + visibleItems.length < resultItems.length
+        ? [
+            this.#theme.editor.selectList.scrollInfo(
+              `  (${Math.max(1, selectedResultIndex + 1)}/${resultItems.length})`,
+            ),
+          ]
+        : []),
       ...(this.#notice === null ? [] : ["", this.#theme.muted(this.#notice)]),
       "",
       this.#theme.muted(
@@ -112,4 +132,69 @@ export class SessionPicker implements Component {
       ),
     ];
   }
+
+  #items(): readonly SessionPickerItem[] {
+    const sessions = fuzzyFilter(
+      [...this.#sessions],
+      this.#query,
+      (session) =>
+        `${session.naming.displayLabel} ${session.targetId} ${session.status} ${session.id}`,
+    );
+    return [
+      { kind: "new_session" },
+      ...sessions.map((session) => ({ kind: "session" as const, session })),
+      ...(this.#hasMore ? [{ kind: "load_more" as const }] : []),
+    ];
+  }
+
+  #selectFirstSearchResult(): void {
+    const items = this.#items();
+    this.#selectedIndex = items[1]?.kind === "session" ? 1 : 0;
+  }
+
+  #renderNewSession(width: number): string {
+    const selected = this.#selectedIndex === 0;
+    const content = renderColumns("New Session", "Choose an exact target", selected, width);
+    const padded = content + " ".repeat(Math.max(0, width - visibleWidth(content)));
+    return selected ? this.#theme.inverseSelection(padded) : padded;
+  }
+
+  #renderResultItem(item: SessionPickerItem, selected: boolean, width: number): string {
+    const content =
+      item.kind === "session"
+        ? renderColumns(
+            safeTerminalText(item.session.naming.displayLabel),
+            safeTerminalText(`${item.session.targetId} · ${item.session.status}`),
+            selected,
+            width,
+          )
+        : renderColumns("Load More", "Use the opaque catalog cursor", selected, width);
+    return selected ? this.#theme.editor.selectList.selectedText(content) : content;
+  }
+}
+
+function renderColumns(
+  label: string,
+  description: string,
+  selected: boolean,
+  width: number,
+): string {
+  const prefix = selected ? "→ " : "  ";
+  const available = Math.max(0, width - visibleWidth(prefix));
+  if (width <= 40) {
+    return prefix + truncateToWidth(label, available, "");
+  }
+  const primaryWidth = Math.max(1, Math.min(32, available - 1));
+  const labelText = truncateToWidth(label, Math.max(1, primaryWidth - 2), "");
+  const spacing = " ".repeat(Math.max(1, primaryWidth - visibleWidth(labelText)));
+  const descriptionText = truncateToWidth(
+    description,
+    Math.max(0, width - visibleWidth(prefix) - visibleWidth(labelText) - spacing.length),
+    "",
+  );
+  return prefix + labelText + spacing + descriptionText;
+}
+
+function isSearchText(data: string): boolean {
+  return data.length > 0 && !/[\p{Cc}\p{Cf}]/u.test(data);
 }

--- a/apps/tui/src/target-picker.ts
+++ b/apps/tui/src/target-picker.ts
@@ -37,7 +37,7 @@ export class TargetPicker implements Component {
         ? options.currentTargetId === undefined
           ? null
           : safeTerminalText(
-              `Current target ${options.currentTargetId} · existing session target is immutable`,
+              `Current ${options.currentTargetId} · existing session target immutable`,
             )
         : safeTerminalText(options.initialNotice);
     this.#onSaveDefault = options.onSaveDefault;

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -513,6 +513,11 @@ function createFixtureModelTargets(options: {
           "utf8",
         );
         yield { type: "text_delta", text: "Tool artifact complete." };
+      } else if (options.scenario === "provider-usage") {
+        yield { type: "text_delta", text: "Provider usage answer." };
+        yield { type: "usage", inputTokens: 12_345, outputTokens: 99 };
+      } else if (options.scenario === "provider-no-usage") {
+        yield { type: "text_delta", text: "Provider usage unavailable." };
       } else if (options.scenario === "skill-selection") {
         yield { type: "text_delta", text: "Skill selection complete." };
       } else if (
@@ -647,6 +652,9 @@ function clipboardAdapter(options: {
   }
   if (options.scenario === "clipboard-timeout") {
     return {
+      async close() {
+        await writeFile(join(options.controlRoot as string, "clipboard-closed"), "closed\n");
+      },
       async writeText() {
         await writeFile(join(options.controlRoot as string, "clipboard-started"), "started\n");
         return new Promise(() => undefined);

--- a/apps/tui/src/test-topology.test.ts
+++ b/apps/tui/src/test-topology.test.ts
@@ -5,6 +5,7 @@ import { expect, test } from "vitest";
 
 const behaviorSuitePath = fileURLToPath(new URL("./main.test.ts", import.meta.url));
 const operatingSystemSuitePath = fileURLToPath(new URL("./main.os.test.ts", import.meta.url));
+const productionTuiPath = fileURLToPath(new URL("./tui-app.ts", import.meta.url));
 const packagePath = fileURLToPath(new URL("../../../package.json", import.meta.url));
 const qualityWorkflowPath = fileURLToPath(
   new URL("../../../.github/workflows/quality.yml", import.meta.url),
@@ -58,6 +59,29 @@ test("Quality keeps every semantic and OS suite in one required Linux regression
   expect([...qualityWorkflow.matchAll(/^ {2}([a-z][a-z0-9_-]*):\n {4}runs-on:/gmu)]).toHaveLength(
     1,
   );
+});
+
+test("every production overlay family enters Pi through the shared Adam frame", async () => {
+  const source = await readFile(productionTuiPath, "utf8");
+
+  expect([...source.matchAll(/\btui\.showOverlay\(/gu)]).toHaveLength(1);
+  expect(source).toContain("new OverlayFrame(component, theme");
+  expect([...source.matchAll(/\bshowOverlay\(/gu)].length).toBeGreaterThanOrEqual(12);
+  for (const family of [
+    "SessionPicker",
+    "TargetPicker",
+    "PermissionOverlay",
+    "SkillPalette",
+    "ProjectPathPicker",
+    "ArtifactNavigator",
+    "ChronologyPicker",
+    "SessionInspector",
+    "ResourceReloadPicker",
+    "McpWizard",
+    "HelpNavigator",
+  ]) {
+    expect(source).toContain(`new ${family}`);
+  }
 });
 
 function topLevelTestBlocks(source: string): readonly string[] {

--- a/apps/tui/src/theme.ts
+++ b/apps/tui/src/theme.ts
@@ -6,10 +6,16 @@ import type { EditorTheme, MarkdownTheme } from "@earendil-works/pi-tui";
  */
 
 export type AdamTuiTheme = {
+  readonly allow: (text: string) => string;
+  readonly danger: (text: string) => string;
+  readonly deny: (text: string) => string;
   readonly editor: EditorTheme;
+  readonly inverseSelection: (text: string) => string;
+  readonly keyword: (text: string) => string;
   readonly markdown: MarkdownTheme;
   readonly muted: (text: string) => string;
   readonly primary: (text: string) => string;
+  readonly subject: (text: string) => string;
   readonly toolBackground: (text: string) => string;
   readonly toolOutput: (text: string) => string;
   readonly toolTitle: (text: string) => string;
@@ -39,10 +45,17 @@ export function createAdamTuiTheme(noColor = noColorRequested()): AdamTuiTheme {
   const teal = color(148, 226, 213);
   const overlay = color(108, 112, 134);
   const subtext = color(186, 194, 222);
+  const crust = color(17, 17, 27);
 
   return {
     primary: text,
     muted,
+    keyword: bold(mauve),
+    subject: blue,
+    danger: red,
+    allow: green,
+    deny: red,
+    inverseSelection: (value) => background(205, 214, 244)(crust(value)),
     userText: text,
     userBackground: background(49, 50, 68),
     userMarker: noColor ? "› " : "",

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -42,6 +42,7 @@ import {
 import { HelpNavigator, type HelpPage } from "./help-navigator.js";
 import { mcpAdvanceCommand } from "./mcp-advance.js";
 import { McpWizard } from "./mcp-wizard.js";
+import { OverlayFrame } from "./overlay-frame.js";
 import { PermissionOverlay } from "./permission-overlay.js";
 import { ProjectPathPicker } from "./project-path-picker.js";
 import { ResourceReloadPicker } from "./resource-reload-picker.js";
@@ -83,12 +84,17 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   let newSessionSelected =
     options.presentation.getState().authoritative.sessions.items.length === 0;
   const tui: TUI = new TuiMainScreen(terminal, true);
-  const showOverlay = (component: Component, overlayOptions: OverlayOptions) =>
-    tui.showOverlay(component, {
-      ...overlayOptions,
-      visible: (columns, rows) => terminalSizeIsSupported(columns, rows),
-    });
   const theme = createAdamTuiTheme();
+  const showOverlay = (component: Component, overlayOptions: OverlayOptions) =>
+    tui.showOverlay(
+      new OverlayFrame(component, theme, () =>
+        resolveOverlayMaximumHeight(overlayOptions, terminal.rows),
+      ),
+      {
+        ...overlayOptions,
+        visible: (columns, rows) => terminalSizeIsSupported(columns, rows),
+      },
+    );
   const root = new ResponsiveRoot(() => terminal.rows);
   const header = new Text();
   const transcript = new Container();
@@ -781,10 +787,10 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           `${safeTerminalText(state.authoritative.project.label)} · ${footerContextText(active)} · ${runStatus}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}${selectedSkillSummary}${olderHistorySummary} · ${adamCommandRegistry.footerHint()}`,
         ),
         standard: theme.muted(
-          `${safeTerminalText(state.authoritative.project.label)} · ${runStatus}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}${selectedSkillSummary}${olderHistorySummary} · /help · Tab complete`,
+          `${safeTerminalText(state.authoritative.project.label)} · ${footerContextText(active)} · ${runStatus}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}${selectedSkillSummary}${olderHistorySummary} · /help · Tab complete`,
         ),
         narrow: theme.muted(
-          `${runStatus}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}\n/help · Tab complete`,
+          `${runStatus} · ${footerContextCompactText(active)}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}\n/help · Tab complete`,
         ),
       });
     }
@@ -932,7 +938,6 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       margin: 1,
     });
     chronologyPicker = { close, hide: () => handle?.hide(), picker };
-    tui.setFocus(picker);
     tui.requestRender();
   };
   const showArtifactNavigator = (diffs: boolean, expectedSessionId: string): void => {
@@ -1022,7 +1027,6 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       },
     };
     statusMessage = null;
-    tui.setFocus(navigator);
     tui.requestRender();
   };
   editor.onSubmit = (text) => {
@@ -1776,6 +1780,11 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       failures.push(error);
     }
     try {
+      await options.clipboard?.close?.();
+    } catch (error) {
+      failures.push(error);
+    }
+    try {
       await options.presentation.close();
     } catch (error) {
       failures.push(error);
@@ -1920,6 +1929,30 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   }
 }
 
+function resolveOverlayMaximumHeight(
+  options: OverlayOptions,
+  terminalRows: number,
+): number | undefined {
+  let requested: number | undefined;
+  if (typeof options.maxHeight === "number") {
+    requested = options.maxHeight;
+  } else if (options.maxHeight !== undefined) {
+    const match = options.maxHeight.match(/^(\d+(?:\.\d+)?)%$/u);
+    requested =
+      match === null
+        ? undefined
+        : Math.floor((terminalRows * Number.parseFloat(match[1] as string)) / 100);
+  }
+  if (requested === undefined) {
+    return undefined;
+  }
+  const margin = options.margin;
+  const top = typeof margin === "number" ? margin : (margin?.top ?? 0);
+  const bottom = typeof margin === "number" ? margin : (margin?.bottom ?? 0);
+  const available = Math.max(1, terminalRows - Math.max(0, top) - Math.max(0, bottom));
+  return Math.max(1, Math.min(requested, available));
+}
+
 function clipboardAssistantStatus(result: "copied" | "failed" | "unsupported" | null): string {
   return result === "copied"
     ? "Copied last assistant response."
@@ -2013,7 +2046,31 @@ function footerContextText(active: ActiveSessionDisplay): string {
   if (context.active.source === "unknown") {
     return `?/${context.profile.contextWindowTokens} context · unknown`;
   }
-  return `${context.active.tokens}/${context.profile.contextWindowTokens} context · ${context.active.source}`;
+  const source = context.active.source === "provider_reported" ? "provider reported" : "estimated";
+  return `${context.active.tokens}/${context.profile.contextWindowTokens} context · ${source}`;
+}
+
+function footerContextCompactText(active: ActiveSessionDisplay): string {
+  const context = active.context;
+  if (context === null) {
+    return "ctx unavailable";
+  }
+  const maximum = compactTokenCount(context.profile.contextWindowTokens);
+  if (context.active.source === "unknown") {
+    return `ctx ?/${maximum} unknown`;
+  }
+  const source = context.active.source === "provider_reported" ? "reported" : "est";
+  return `ctx ${compactTokenCount(context.active.tokens)}/${maximum} ${source}`;
+}
+
+function compactTokenCount(tokens: number): string {
+  if (tokens >= 999_950) {
+    return `${Number((tokens / 1_000_000).toFixed(1))}m`;
+  }
+  if (tokens >= 1_000) {
+    return `${Number((tokens / 1_000).toFixed(1))}k`;
+  }
+  return String(tokens);
 }
 
 function toolStatusText(

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -40,6 +40,7 @@ export {
   presentationHistoryPageSize,
   presentationHydrationBarrier,
   presentationRuntimeRefreshBarrier,
+  resolvePresentationTerminalContext,
 } from "./presentation-session.js";
 export type {
   ProjectLifecycleOwner,

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -20,11 +20,17 @@ import {
 } from "@adam-agent/presentation";
 import { readFileArtifact, readFileArtifactRange } from "./artifact-store.js";
 import { maximumModelResponseContentBytes } from "./durable-model-response-policy.js";
-import type { ModelTargetIdentity, ModelTargets } from "./model-targets.js";
+import {
+  type ModelTargetIdentity,
+  type ModelTargetSnapshot,
+  type ModelTargets,
+  sameModelTargetIdentity,
+} from "./model-targets.js";
 import type { PresentationPreferences } from "./presentation-preferences.js";
 import { listProjectPaths } from "./project-path-catalog.js";
 import type {
   CurrentSessionSnapshot,
+  SessionContextUsageSnapshot,
   SessionLifecycle,
   SessionMetadataEvent,
   SessionRuntimeNotification,
@@ -183,6 +189,10 @@ export async function createPresentationSession(
       discoverGateway: false,
       signal: new AbortController().signal,
     });
+    const initialContextUsage =
+      created === undefined
+        ? null
+        : await options.lifecycle.inspectContextUsage({ sessionId: created.sessionId });
     const configuredPreferences = await options.preferences?.load();
     const configuredTarget = modelTargetSnapshot?.targets.find(
       (target) => target.identity.targetId === configuredPreferences?.defaultTargetId,
@@ -267,7 +277,7 @@ export async function createPresentationSession(
           : {
               session: summary,
               transcript: transcriptPage(transcript, loadedTranscriptStart, created.sessionId),
-              context: projectSessionContext(created),
+              context: projectSessionContext(created, initialContextUsage, modelTargetSnapshot),
               pendingInteractions: await projectPendingInteractions(records, options),
               repositoryInstructions: projectRepositoryInstructions(created),
               skills: projectSkills(created),
@@ -305,6 +315,9 @@ export async function createPresentationSession(
       | undefined;
     const activateSnapshot = async (snapshot: CurrentSessionSnapshot): Promise<void> => {
       const activatedRecords = await readActiveBranchRecords(options, snapshot.sessionId);
+      const activatedContextUsage = await options.lifecycle.inspectContextUsage({
+        sessionId: snapshot.sessionId,
+      });
       transcript = projectTranscript(activatedRecords);
       loadedTranscriptStart = Math.max(0, transcript.length - historyPageSize);
       const activatedNaming = sessionNamingFromRecords(activatedRecords, snapshot.sessionId);
@@ -346,7 +359,7 @@ export async function createPresentationSession(
           active: {
             session: activatedSummary,
             transcript: transcriptPage(transcript, loadedTranscriptStart, snapshot.sessionId),
-            context: projectSessionContext(snapshot),
+            context: projectSessionContext(snapshot, activatedContextUsage, modelTargetSnapshot),
             pendingInteractions: await projectPendingInteractions(activatedRecords, options),
             repositoryInstructions: projectRepositoryInstructions(snapshot),
             skills: projectSkills(snapshot),
@@ -486,6 +499,37 @@ export async function createPresentationSession(
               publishStateChange();
               return;
             }
+            if (event.type === "context_usage") {
+              const activeIdentity = knownTargets.get(active.session.targetId);
+              const profile = modelTargetSnapshot?.targets.find(
+                (target) =>
+                  activeIdentity !== undefined &&
+                  sameModelTargetIdentity(target.identity, activeIdentity),
+              )?.contextProfile;
+              const current = state.authoritative.active;
+              if (profile !== undefined && current?.session.id === active.session.id) {
+                state = {
+                  revision: state.revision + 1,
+                  authoritative: {
+                    ...state.authoritative,
+                    active: {
+                      ...current,
+                      context: {
+                        profile,
+                        ordinaryUsage: event.ordinary,
+                        compactionUsage: event.compaction,
+                        active:
+                          event.active.source === "unknown"
+                            ? { source: "unknown" }
+                            : { source: event.active.source, tokens: event.active.tokens },
+                      },
+                    },
+                  },
+                  transient: state.transient,
+                };
+                publishStateChange();
+              }
+            }
             const previousSequence =
               state.authoritative.continuity.status === "current"
                 ? state.authoritative.continuity.sessionThroughSequence
@@ -534,6 +578,9 @@ export async function createPresentationSession(
               publishStateChange();
             }
             const pendingInteractions = await projectPendingInteractions(refreshedRecords, options);
+            const terminalContextUsage = isAssistantTerminalEvent(event)
+              ? await options.lifecycle.inspectContextUsage({ sessionId: active.session.id })
+              : null;
             const latest = state.authoritative.active;
             if (closed || latest === null || latest.session.id !== active.session.id) {
               return;
@@ -554,6 +601,14 @@ export async function createPresentationSession(
                 active: {
                   ...latest,
                   transcript: transcriptPage(transcript, loadedTranscriptStart, current.session.id),
+                  context: resolvePresentationTerminalContext(
+                    latest.context,
+                    projectSessionContextUsage(
+                      knownTargets.get(latest.session.targetId),
+                      terminalContextUsage,
+                      modelTargetSnapshot,
+                    ),
+                  ),
                   pendingInteractions,
                 },
               },
@@ -1532,17 +1587,46 @@ function isKnownArtifact(
 
 function projectSessionContext(
   snapshot: CurrentSessionSnapshot,
+  usage: SessionContextUsageSnapshot | null,
+  targets: ModelTargetSnapshot | undefined,
 ): import("@adam-agent/presentation").SessionContextDisplay | null {
   const context = snapshot.context;
-  if (context === undefined) {
+  if (context !== undefined) {
+    return {
+      profile: context.profile,
+      ordinaryUsage: context.ordinaryUsage,
+      compactionUsage: context.compactionUsage,
+      active: context.active,
+    };
+  }
+  return projectSessionContextUsage(snapshot.targetIdentity, usage, targets);
+}
+
+function projectSessionContextUsage(
+  identity: ModelTargetIdentity | undefined,
+  usage: SessionContextUsageSnapshot | null,
+  targets: ModelTargetSnapshot | undefined,
+): import("@adam-agent/presentation").SessionContextDisplay | null {
+  const profile = targets?.targets.find(
+    (target) => identity !== undefined && sameModelTargetIdentity(target.identity, identity),
+  )?.contextProfile;
+  if (profile === undefined || usage === null) {
     return null;
   }
   return {
-    profile: context.profile,
-    ordinaryUsage: context.ordinaryUsage,
-    compactionUsage: context.compactionUsage,
-    active: context.active,
+    profile,
+    ordinaryUsage: usage.ordinaryUsage,
+    compactionUsage: usage.compactionUsage,
+    active: usage.active,
   };
+}
+
+/** Tests only through the internal-testing entry; production uses this for terminal refreshes. */
+export function resolvePresentationTerminalContext(
+  latest: import("@adam-agent/presentation").SessionContextDisplay | null,
+  terminal: import("@adam-agent/presentation").SessionContextDisplay | null,
+): import("@adam-agent/presentation").SessionContextDisplay | null {
+  return terminal ?? latest;
 }
 
 function boundedHistoryPageSize(value: number | undefined): number {

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -218,6 +218,11 @@ export type SessionContextSnapshot = {
     | { readonly source: "unknown" };
 };
 
+export type SessionContextUsageSnapshot = Pick<
+  SessionContextSnapshot,
+  "active" | "compactionUsage" | "ordinaryUsage"
+>;
+
 export type LegacySessionSnapshot = {
   readonly schemaVersion: 1 | 2;
   readonly sessionId: string;
@@ -507,6 +512,9 @@ export interface SessionLifecycle {
   enableAutomaticTitles(): void;
   ensureAutomaticTitle(input: { readonly sessionId: string }): Promise<SessionNamingResult>;
   inspect(input: { readonly sessionId: string }): Promise<SessionSnapshot>;
+  inspectContextUsage(input: {
+    readonly sessionId: string;
+  }): Promise<SessionContextUsageSnapshot | null>;
   listProjectSessions(input?: {
     readonly cursor?: string;
     readonly limit?: number;
@@ -1279,6 +1287,47 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     };
   };
 
+  const inspectSessionContextUsage = async (
+    input: { readonly sessionId: string },
+    artifactCache = createArtifactMaterializationCache(),
+  ): Promise<SessionContextUsageSnapshot | null> => {
+    const records = await storeDirectory.open(input.sessionId).then((store) => store?.read() ?? []);
+    const first = records[0];
+    if (first === undefined) {
+      throw new SessionLifecycleError("session_not_found");
+    }
+    if (first.schemaVersion === 1 || first.schemaVersion === 2) {
+      return null;
+    }
+    const projectId = await canonicalProjectId(options.workspaceRoot);
+    if (!isGenesisRecord(first) || first.record.sessionId !== input.sessionId) {
+      throw new SessionLifecycleError("session_invalid");
+    }
+    if (first.record.projectId !== projectId) {
+      throw new SessionLifecycleError("session_project_mismatch");
+    }
+    validateCurrentSessionHistory(first, records, options.workspaceRoot);
+    await validateSessionLineage(options, first, new Set([input.sessionId]));
+    await validateInheritedContextEvidence(options, first, records);
+    const artifactInspection = await inspectModelResponseArtifactLineage(
+      options,
+      first,
+      records,
+      artifactCache,
+    );
+    if (artifactInspection.degradation !== undefined) {
+      return null;
+    }
+    return (
+      (await contextUsageSnapshotFromLineage(
+        options,
+        first,
+        artifactInspection.records,
+        artifactCache,
+      )) ?? null
+    );
+  };
+
   const resumeSession = async (
     input: { readonly sessionId: string },
     artifactCache = createArtifactMaterializationCache(),
@@ -1447,6 +1496,17 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         message: "Legacy session history can be inspected but cannot be resumed safely.",
       },
     };
+  };
+
+  const prepareSessionInspection = async (sessionId: string): Promise<void> => {
+    await waitForMcpIdleOperation(sessionId);
+    if (activeSession !== undefined) {
+      return;
+    }
+    await pendingMcpCatalogDurability.get(sessionId);
+    if ([...pendingMcpCatalogChanges.values()].some((change) => change.sessionId === sessionId)) {
+      await runWithOwner(() => flushPendingMcpCatalogChanges(sessionId));
+    }
   };
 
   return {
@@ -2970,18 +3030,12 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       return { status: "updated", snapshot: titleSnapshot ?? snapshot };
     },
     async inspect(input) {
-      await waitForMcpIdleOperation(input.sessionId);
-      if (activeSession === undefined) {
-        await pendingMcpCatalogDurability.get(input.sessionId);
-        if (
-          [...pendingMcpCatalogChanges.values()].some(
-            (change) => change.sessionId === input.sessionId,
-          )
-        ) {
-          await runWithOwner(() => flushPendingMcpCatalogChanges(input.sessionId));
-        }
-      }
+      await prepareSessionInspection(input.sessionId);
       return inspectSession(input);
+    },
+    async inspectContextUsage(input) {
+      await prepareSessionInspection(input.sessionId);
+      return inspectSessionContextUsage(input);
     },
     async listProjectSessions(input = {}) {
       const limit = input.limit ?? 100;
@@ -5526,6 +5580,46 @@ async function contextSnapshotFromLineage(
   );
 }
 
+async function contextUsageSnapshotFromLineage(
+  options: SessionLifecycleOptions,
+  genesis: SessionGenesisRecord,
+  records: readonly SessionRecord[],
+  artifactCache: ModelResponseArtifactCache,
+): Promise<SessionContextUsageSnapshot | undefined> {
+  const ownUsage = contextUsageSnapshotFromRecords(records);
+  if (genesis.record.lineage === undefined) {
+    return ownUsage;
+  }
+  const { parentGenesis, prefixRecords } = await readValidatedLineagePrefix(options, genesis);
+  const artifactInspection = await materializeModelResponseArtifacts(
+    options,
+    parentGenesis,
+    prefixRecords,
+    { allowDegraded: false },
+    artifactCache,
+  );
+  const inheritedUsage = await contextUsageSnapshotFromLineage(
+    options,
+    parentGenesis,
+    artifactInspection.records,
+    artifactCache,
+  );
+  if (ownUsage === undefined) {
+    return inheritedUsage;
+  }
+  if (inheritedUsage === undefined) {
+    return ownUsage;
+  }
+  return {
+    ordinaryUsage: addContextUsageTotals(inheritedUsage.ordinaryUsage, ownUsage.ordinaryUsage),
+    compactionUsage: addContextUsageTotals(
+      inheritedUsage.compactionUsage,
+      ownUsage.compactionUsage,
+    ),
+    active: ownUsage.active,
+  };
+}
+
 async function createBranchMessages(
   options: SessionLifecycleOptions,
   records: readonly SessionRecord[],
@@ -6330,40 +6424,7 @@ function contextSnapshotFromRecords(
   if (checkpointRecord === undefined && startedRecord === undefined) {
     return undefined;
   }
-  const compactionUsage: ContextUsageTotals = currentRecords.reduce<ContextUsageTotals>(
-    (totals, entry) => {
-      if (
-        entry.record.type !== "context_compaction_committed" &&
-        entry.record.type !== "context_compaction_failed" &&
-        entry.record.type !== "context_compaction_interrupted"
-      ) {
-        return totals;
-      }
-      const usage = entry.record.usage;
-      if (usage === undefined) {
-        return incrementUnknownContextUsage(totals);
-      }
-      if ("status" in usage) {
-        return incrementUnknownContextUsage(totals);
-      }
-      return {
-        inputTokens: totals.inputTokens + usage.inputTokens,
-        outputTokens: totals.outputTokens + usage.outputTokens,
-        reasoningTokens: totals.reasoningTokens + (usage.reasoningTokens ?? 0),
-        cachedInputTokens: totals.cachedInputTokens + (usage.cachedInputTokens ?? 0),
-        cacheMissInputTokens: totals.cacheMissInputTokens + (usage.cacheMissInputTokens ?? 0),
-        unknownCalls: totals.unknownCalls,
-      };
-    },
-    {
-      inputTokens: 0,
-      outputTokens: 0,
-      reasoningTokens: 0,
-      cachedInputTokens: 0,
-      cacheMissInputTokens: 0,
-      unknownCalls: 0,
-    },
-  );
+  const compactionUsage = compactionContextUsageFromRecords(currentRecords);
   const ordinaryUsage = ordinaryContextUsageFromRecords(currentRecords);
   const lastTerminal =
     startedRecord === undefined
@@ -6458,6 +6519,93 @@ function contextSnapshotFromRecords(
     ordinaryUsage,
     compactionUsage,
     active,
+  };
+}
+
+function contextUsageSnapshotFromRecords(
+  records: readonly SessionRecord[],
+): SessionContextUsageSnapshot | undefined {
+  const currentRecords = records.filter((record) => record.schemaVersion === 3);
+  if (
+    !currentRecords.some(
+      ({ record }) =>
+        record.type === "provider_attempt_started" ||
+        record.type === "context_compaction_started" ||
+        record.type === "context_compaction_committed" ||
+        record.type === "context_compaction_failed" ||
+        record.type === "context_compaction_interrupted",
+    )
+  ) {
+    return undefined;
+  }
+  const latestAttemptBoundary = currentRecords.findLast(
+    ({ record }) =>
+      record.type === "provider_attempt_started" ||
+      record.type === "model_response_completed" ||
+      record.type === "provider_attempt_interrupted",
+  );
+  return {
+    ordinaryUsage: ordinaryContextUsageFromRecords(currentRecords),
+    compactionUsage: compactionContextUsageFromRecords(currentRecords),
+    active:
+      latestAttemptBoundary?.record.type === "model_response_completed" &&
+      latestAttemptBoundary.record.response.usage !== undefined
+        ? {
+            source: "provider_reported",
+            tokens: latestAttemptBoundary.record.response.usage.inputTokens,
+          }
+        : { source: "unknown" },
+  };
+}
+
+function compactionContextUsageFromRecords(
+  records: readonly Extract<SessionRecord, { readonly schemaVersion: 3 }>[],
+): ContextUsageTotals {
+  return records.reduce<ContextUsageTotals>((totals, entry) => {
+    if (
+      entry.record.type !== "context_compaction_committed" &&
+      entry.record.type !== "context_compaction_failed" &&
+      entry.record.type !== "context_compaction_interrupted"
+    ) {
+      return totals;
+    }
+    const usage = entry.record.usage;
+    if (usage === undefined || "status" in usage) {
+      return incrementUnknownContextUsage(totals);
+    }
+    return {
+      inputTokens: totals.inputTokens + usage.inputTokens,
+      outputTokens: totals.outputTokens + usage.outputTokens,
+      reasoningTokens: totals.reasoningTokens + (usage.reasoningTokens ?? 0),
+      cachedInputTokens: totals.cachedInputTokens + (usage.cachedInputTokens ?? 0),
+      cacheMissInputTokens: totals.cacheMissInputTokens + (usage.cacheMissInputTokens ?? 0),
+      unknownCalls: totals.unknownCalls,
+    };
+  }, emptyContextUsageTotals());
+}
+
+function addContextUsageTotals(
+  left: ContextUsageTotals,
+  right: ContextUsageTotals,
+): ContextUsageTotals {
+  return {
+    inputTokens: left.inputTokens + right.inputTokens,
+    outputTokens: left.outputTokens + right.outputTokens,
+    reasoningTokens: left.reasoningTokens + right.reasoningTokens,
+    cachedInputTokens: left.cachedInputTokens + right.cachedInputTokens,
+    cacheMissInputTokens: left.cacheMissInputTokens + right.cacheMissInputTokens,
+    unknownCalls: left.unknownCalls + right.unknownCalls,
+  };
+}
+
+function emptyContextUsageTotals(): ContextUsageTotals {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    cachedInputTokens: 0,
+    cacheMissInputTokens: 0,
+    unknownCalls: 0,
   };
 }
 

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -29,6 +29,7 @@ import {
   presentationHistoryPageSize,
   presentationHydrationBarrier,
   presentationRuntimeRefreshBarrier,
+  resolvePresentationTerminalContext,
   type SessionRecord,
   sessionAutomaticTitlesEnabled,
   sessionLogicalRunStartedBarrier,
@@ -37,6 +38,7 @@ import {
 } from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
 import {
+  createInMemorySessionLifecycleHarness,
   createScriptedMcpTransportFactory,
   FakeModelDriver,
   type ScriptedMcpServer,
@@ -1604,6 +1606,195 @@ test("PresentationSession projects one settled run as stable user and assistant 
     await lifecycle.close();
     await rm(testRoot, { recursive: true, force: true });
   }
+});
+
+test("PresentationSession restores provider-reported context occupancy after restart", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-provider-context-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const driver = new FakeModelDriver([
+    { type: "text_delta", text: "Provider usage answer." },
+    { type: "usage", inputTokens: 12_345, outputTokens: 99 },
+    { type: "finish", reason: "stop" },
+  ]);
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Persist exact provider usage" },
+    });
+    await lifecycle.close();
+
+    const restarted = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const presentation = await createPresentationSession({
+      lifecycle: restarted,
+      modelTargets,
+      projectLabel: "workspace",
+      sessionId: created.sessionId,
+      stateRoot,
+      workspaceRoot,
+    });
+
+    expect(presentation.getState().authoritative.active?.context).toEqual({
+      profile: contextProfile,
+      ordinaryUsage: {
+        inputTokens: 12_345,
+        outputTokens: 99,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        cacheMissInputTokens: 0,
+        unknownCalls: 0,
+      },
+      compactionUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        cacheMissInputTokens: 0,
+        unknownCalls: 0,
+      },
+      active: { source: "provider_reported", tokens: 12_345 },
+    });
+
+    await presentation.close();
+    await restarted.close();
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession restores inherited provider context for a fresh child", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-branch-context-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const driver = new FakeModelDriver([
+    { type: "text_delta", text: "Inherited provider usage answer." },
+    { type: "usage", inputTokens: 23_456, outputTokens: 101 },
+    { type: "finish", reason: "stop" },
+  ]);
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const parent = await lifecycle.create({ targetIdentity });
+    const completed = await lifecycle.continue({
+      sessionId: parent.sessionId,
+      input: { text: "Persist usage before branching" },
+    });
+    const child = await lifecycle.branch({
+      parentSessionId: parent.sessionId,
+      atSequence: completed.snapshot.lastSequence,
+    });
+    await lifecycle.close();
+
+    const restarted = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const presentation = await createPresentationSession({
+      lifecycle: restarted,
+      modelTargets,
+      projectLabel: "workspace",
+      sessionId: child.sessionId,
+      stateRoot,
+      workspaceRoot,
+    });
+
+    expect(presentation.getState().authoritative.active?.context).toEqual({
+      profile: contextProfile,
+      ordinaryUsage: {
+        inputTokens: 23_456,
+        outputTokens: 101,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        cacheMissInputTokens: 0,
+        unknownCalls: 0,
+      },
+      compactionUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        cacheMissInputTokens: 0,
+        unknownCalls: 0,
+      },
+      active: { source: "provider_reported", tokens: 23_456 },
+    });
+
+    await presentation.close();
+    await restarted.close();
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession prefers terminal lifecycle context over stale Presentation context", () => {
+  const latest = {
+    profile: contextProfile,
+    ordinaryUsage: {
+      inputTokens: 12_345,
+      outputTokens: 99,
+      reasoningTokens: 0,
+      cachedInputTokens: 0,
+      cacheMissInputTokens: 0,
+      unknownCalls: 0,
+    },
+    compactionUsage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      cachedInputTokens: 0,
+      cacheMissInputTokens: 0,
+      unknownCalls: 0,
+    },
+    active: { source: "provider_reported" as const, tokens: 12_345 },
+  };
+  const terminal = {
+    ...latest,
+    ordinaryUsage: { ...latest.ordinaryUsage, unknownCalls: 1 },
+    active: { source: "unknown" as const },
+  };
+
+  expect({
+    terminal: resolvePresentationTerminalContext(latest, terminal),
+    fallback: resolvePresentationTerminalContext(latest, null),
+  }).toEqual({ terminal, fallback: latest });
 });
 
 test("PresentationSession loads older chronology through an opaque tail cursor", async () => {

--- a/packages/testkit/src/session-lifecycle.test.ts
+++ b/packages/testkit/src/session-lifecycle.test.ts
@@ -1378,6 +1378,251 @@ test("SessionLifecycle durably completes a canonical provider response while kee
   }
 });
 
+test("SessionLifecycle projects provider context usage through a cold child lineage", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-context-lineage-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const driver = new FakeModelDriver([
+    { type: "text_delta", text: "Lineage answer." },
+    { type: "usage", inputTokens: 23_456, outputTokens: 101 },
+    { type: "finish", reason: "stop" },
+  ]);
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+
+  try {
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const parent = await lifecycle.create({ targetIdentity });
+    const completed = await lifecycle.continue({
+      sessionId: parent.sessionId,
+      input: { text: "Record context before branching" },
+    });
+    const child = await lifecycle.branch({
+      parentSessionId: parent.sessionId,
+      atSequence: completed.snapshot.lastSequence,
+    });
+    await lifecycle.close();
+
+    const cold = harness.createLifecycle({ stateRoot, workspaceRoot });
+    await expect(cold.inspectContextUsage({ sessionId: child.sessionId })).resolves.toEqual({
+      ordinaryUsage: {
+        inputTokens: 23_456,
+        outputTokens: 101,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        cacheMissInputTokens: 0,
+        unknownCalls: 0,
+      },
+      compactionUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        cacheMissInputTokens: 0,
+        unknownCalls: 0,
+      },
+      active: { source: "provider_reported", tokens: 23_456 },
+    });
+    await cold.close();
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle counts an ordinary provider attempt without usage as unknown", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-context-unknown-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const driver = new FakeModelDriver([
+    { type: "text_delta", text: "Usage unavailable." },
+    { type: "finish", reason: "stop" },
+  ]);
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+
+  try {
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Return no usage event" },
+    });
+
+    await expect(lifecycle.inspectContextUsage({ sessionId: created.sessionId })).resolves.toEqual({
+      ordinaryUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        cacheMissInputTokens: 0,
+        unknownCalls: 1,
+      },
+      compactionUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        cacheMissInputTokens: 0,
+        unknownCalls: 0,
+      },
+      active: { source: "unknown" },
+    });
+    await lifecycle.close();
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle does not retain provider usage after a later interrupted attempt", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-context-stale-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const driver = new FakeModelDriver([
+    { type: "text_delta", text: "First answer." },
+    { type: "usage", inputTokens: 12_345, outputTokens: 99 },
+    { type: "finish", reason: "stop" },
+  ]);
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+
+  try {
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const created = await lifecycle.create({ targetIdentity });
+    const completed = await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Return provider usage" },
+    });
+    const runId = "123e4567-e89b-42d3-a456-426614174098";
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
+    const records: readonly Omit<
+      Extract<SessionRecord, { readonly schemaVersion: 3 }>,
+      "sequence"
+    >[] = [
+      {
+        schemaVersion: 3,
+        record: { type: "logical_run_started", runId, userMessage: "Interrupt later" },
+      },
+      {
+        schemaVersion: 3,
+        record: {
+          type: "runtime_event",
+          runId,
+          event: { type: "user_message", text: "Interrupt later" },
+        },
+      },
+      {
+        schemaVersion: 3,
+        record: {
+          type: "provider_attempt_started",
+          runId,
+          turn: 1,
+          attempt: 1,
+          targetIdentity,
+          promptProjection: promptProjectionFor(created, [
+            { role: "user", content: "Return provider usage" },
+            { role: "assistant", content: "First answer.", toolCalls: [] },
+            { role: "user", content: "Interrupt later" },
+          ]),
+        },
+      },
+      {
+        schemaVersion: 3,
+        record: { type: "runtime_event", runId, event: { type: "model_message_started" } },
+      },
+      {
+        schemaVersion: 3,
+        record: {
+          type: "runtime_event",
+          runId,
+          event: { type: "session_interrupted", reason: "cancelled" },
+        },
+      },
+    ];
+    for (const [index, record] of records.entries()) {
+      await store.append({
+        ...record,
+        sequence: completed.snapshot.lastSequence + index + 1,
+      } as SessionRecord);
+    }
+
+    await lifecycle.resume({ sessionId: created.sessionId });
+
+    await expect(lifecycle.inspectContextUsage({ sessionId: created.sessionId })).resolves.toEqual({
+      ordinaryUsage: {
+        inputTokens: 12_345,
+        outputTokens: 99,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        cacheMissInputTokens: 0,
+        unknownCalls: 1,
+      },
+      compactionUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        cacheMissInputTokens: 0,
+        unknownCalls: 0,
+      },
+      active: { source: "unknown" },
+    });
+    await lifecycle.close();
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("SessionLifecycle continues a run that crashed before its first provider attempt", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-pre-attempt-recovery-"));
   const stateRoot = join(testRoot, "state");
@@ -1604,8 +1849,33 @@ test("SessionLifecycle terminalizes a durable cancellation instead of reopening 
       code: "session_invalid",
     });
     const durableRecords = await store.read();
+    const contextUsage = await lifecycle.inspectContextUsage({ sessionId: created.sessionId });
 
-    expect({ resumed, modelRequests, terminalRecords: durableRecords.slice(-2) }).toEqual({
+    expect({
+      contextUsage,
+      resumed,
+      modelRequests,
+      terminalRecords: durableRecords.slice(-2),
+    }).toEqual({
+      contextUsage: {
+        ordinaryUsage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          reasoningTokens: 0,
+          cachedInputTokens: 0,
+          cacheMissInputTokens: 0,
+          unknownCalls: 1,
+        },
+        compactionUsage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          reasoningTokens: 0,
+          cachedInputTokens: 0,
+          cacheMissInputTokens: 0,
+          unknownCalls: 0,
+        },
+        active: { source: "unknown" },
+      },
       resumed: {
         status: "ready",
         snapshot: {


### PR DESCRIPTION
## Summary

- add a bounded Linux clipboard adapter with `wl-copy`, `xclip`, and `xsel` fallback plus causal helper cleanup
- unify command, picker, artifact, diff, MCP, and permission overlays behind one ANSI-aware frame and semantic color grammar
- render provider-reported, estimated, and unknown context occupancy at 120/80/40 columns from authoritative lifecycle projection
- keep a full-row inverse New Session choice pinned in the searchable project-session picker

## Verification

- `pnpm code:check`
- `pnpm markdown:check`
- `pnpm typecheck`
- `pnpm browser:check`
- changed semantic set: 233/233 passed
- selected clipboard/copy/resize OS and PTY set: 6/6 passed
- independent Standards and Spec review: zero remaining findings

The managed sandbox full run reached 861 passed and 10 skipped out of 895 tests. Its 24 failures are limited to prohibited FIFO, Unix/TCP socket, MCP stdio/process fixtures, and the three dependent TUI MCP timeouts; no timeout or assertion was weakened.

## Scope

This PR contains B9-R2a only. It does not implement draft-session persistence, Skill mentions, thinking-effort policy, or streaming reasoning presentation.
