### PR TITLE
Admit sessions on the first prompt

### DIFF
--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -230,6 +230,27 @@ describe("one-shot CLI", () => {
     }
   });
 
+  test("rejects an unavailable first-prompt Skill before creating a session log", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-skill-unavailable-"));
+    const workspaceRoot = join(testRoot, "workspace");
+    const stateRoot = join(testRoot, "state");
+    await mkdir(workspaceRoot);
+
+    try {
+      const result = await runCliArguments({
+        args: ["--skill", "skill:v1:user:missing", "Do not create a partial session"],
+        cwd: workspaceRoot,
+        stateRoot,
+      });
+      const stateEntries = await readdir(stateRoot, { recursive: true }).catch(() => []);
+
+      expect(result).toMatchObject({ exitCode: 1, signal: null });
+      expect(stateEntries.filter((entry) => entry.endsWith(".jsonl"))).toEqual([]);
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+
   test("rejects a non-ASCII Agent Skill selection before creating session state", async () => {
     const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-skill-ascii-"));
     const workspaceRoot = join(testRoot, "workspace");

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -444,9 +444,8 @@ async function runCliCommand(activeCommand: CliCommand): Promise<void> {
         allowExperimental: false,
         signal: new AbortController().signal,
       });
-      const created = await lifecycle.create({ targetIdentity: resolved.identity });
-      await continueAndPresent(lifecycle, {
-        sessionId: created.sessionId,
+      await admitAndPresent(lifecycle, {
+        targetIdentity: resolved.identity,
         input: {
           text: activeCommand.prompt,
           ...(activeCommand.skills === undefined ? {} : { skills: activeCommand.skills }),
@@ -506,6 +505,20 @@ async function continueAndPresent(
   lifecycle: SessionLifecycle,
   input: Parameters<SessionLifecycle["continue"]>[0],
 ): Promise<void> {
+  return runAndPresent(lifecycle, (signal) => lifecycle.continue({ ...input, signal }));
+}
+
+async function admitAndPresent(
+  lifecycle: SessionLifecycle,
+  input: Parameters<SessionLifecycle["admit"]>[0],
+): Promise<void> {
+  return runAndPresent(lifecycle, (signal) => lifecycle.admit({ ...input, signal }));
+}
+
+async function runAndPresent(
+  lifecycle: SessionLifecycle,
+  run: (signal: AbortSignal) => ReturnType<SessionLifecycle["continue"]>,
+): Promise<void> {
   const permissionInput = new PermissionLineReader(process.stdin);
   const pendingPermissionHandlers = new Set<Promise<void>>();
   const unsubscribe = lifecycle.subscribe((event) => {
@@ -527,7 +540,7 @@ async function continueAndPresent(
   };
   process.once("SIGINT", handleInterrupt);
   try {
-    const continued = await lifecycle.continue({ ...input, signal: abortController.signal });
+    const continued = await run(abortController.signal);
     if (continued.result.status === "completed" || continued.result.status === "incomplete") {
       writeText(1, `${continued.result.answer}\n`);
       if (continued.result.status === "incomplete") {

--- a/apps/tui/src/fixture-scenario.ts
+++ b/apps/tui/src/fixture-scenario.ts
@@ -8,6 +8,7 @@ export const fixtureScenarios = [
   "copy-large-assistant",
   "copy-older-assistant",
   "deadline",
+  "draft-admission-cancellation",
   "history",
   "mcp-close-unconfirmed",
   "mutation",

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -384,10 +384,42 @@ test("the production TUI resumes and explicitly reactivates one committed MCP pr
   } as const;
 
   try {
-    const seed = startFixture({ program, stateRoot, workspaceRoot });
-    await seed.waitFor("Select an exact model target");
-    seed.write("\r");
-    await seed.waitFor("Adam · New session");
+    const modelTargets = createModelTargets({
+      environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
+      fetch: async () =>
+        new Response(
+          'data: {"id":"mcp-seed","object":"chat.completion.chunk","created":1,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"MCP seed ready."},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n',
+          { headers: { "content-type": "text/event-stream" }, status: 200 },
+        ),
+    });
+    const targets = await modelTargets.snapshot({ signal: new AbortController().signal });
+    const targetIdentity = targets.targets.find(
+      ({ identity }) => identity.targetId === "deepseek-v4-flash.direct",
+    )?.identity;
+    if (targetIdentity === undefined) {
+      throw new Error("The MCP reactivation fixture requires the DeepSeek Flash target.");
+    }
+    const seedLifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const created = await seedLifecycle.create({ targetIdentity });
+    await seedLifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Create the durable MCP reactivation session." },
+    });
+    await seedLifecycle.setSessionManualName({
+      sessionId: created.sessionId,
+      name: "MCP reactivation session",
+    });
+    await seedLifecycle.close();
+
+    const seed = startFixture({
+      program: {
+        ...program,
+        arguments: ["--resume", created.sessionId, "--state-root", stateRoot],
+      },
+      stateRoot,
+      workspaceRoot,
+    });
+    await seed.waitForCompleteFrameAfter("Adam · MCP reactivation session", 0);
     seed.write("/mc");
     await seed.waitFor("/mc");
     seed.write("\t");
@@ -419,9 +451,10 @@ test("the production TUI resumes and explicitly reactivates one committed MCP pr
     await resumed.waitFor("Select a project session");
     const beforeSessionSelection = resumed.output().length;
     resumed.write("\u001b[B");
-    await resumed.waitForCompleteFrameAfter("New session", beforeSessionSelection);
+    await resumed.waitForCompleteFrameAfter("MCP reactivation session", beforeSessionSelection);
+    const beforeOpen = resumed.output().length;
     resumed.write("\r");
-    await resumed.waitFor("Adam · New session");
+    await resumed.waitForCompleteFrameAfter("Adam · MCP reactivation session", beforeOpen);
     resumed.write("/mc");
     await resumed.waitFor("/mc");
     resumed.write("\t");

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -572,6 +572,334 @@ test("the production target picker saves its focused exact target separately fro
   }
 });
 
+test("the production TUI keeps an edited new-session draft out of persistence until submit", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-session-draft-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ launch: {}, stateRoot, workspaceRoot });
+    await fixture.waitFor("Select an exact model target");
+    const beforeTarget = fixture.output().length;
+    fixture.write("\r");
+    await fixture.waitForAfter("Adam · New session", beforeTarget);
+    fixture.write("temporary unsent draft");
+    await fixture.waitForAfter("temporary unsent draft", beforeTarget);
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain("deepseek-v4-flash.direct · Certified");
+    expect(await readFilesRecursively(stateRoot)).not.toContain('"type":"session_genesis"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI selects a draft Skill without creating durable session identity", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-draft-skill-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "draft-review");
+  await mkdir(skillDirectory, { recursive: true });
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: draft-review\ndescription: Reviews a draft before admission.\n---\nDraft Skill body.\n",
+    "utf8",
+  );
+
+  try {
+    const fixture = startFixture({
+      launch: {},
+      scenario: "skill-selection",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    fixture.write("/skills\r");
+    await fixture.waitFor("Select next-turn Skills");
+    fixture.write("\r");
+    await fixture.waitFor("1 Skill selected");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain("skill:v1:project:.:draft-review");
+    expect(await readFilesRecursively(stateRoot)).not.toContain('"type":"session_genesis"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI admits one selected draft Skill with the first prompt", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-draft-skill-admission-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "draft-review");
+  const qualifiedId = "skill:v1:project:.:draft-review";
+  await mkdir(skillDirectory, { recursive: true });
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: draft-review\ndescription: Reviews a draft before admission.\n---\nDraft Skill body.\n",
+    "utf8",
+  );
+
+  try {
+    const fixture = startFixture({
+      launch: {},
+      scenario: "skill-selection",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    fixture.write("/skills\r");
+    await fixture.waitFor("Select next-turn Skills");
+    fixture.write("\r");
+    await fixture.waitFor("1 Skill selected");
+    fixture.write("Apply the draft procedure\r");
+    await fixture.waitFor("Skill selection complete.");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    const durable = await readFilesRecursively(stateRoot);
+
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(durable).toContain(`"qualifiedId":"${qualifiedId}"`);
+    expect(durable).toContain('"reason":"user_explicit"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI opens command Help from a draft without creating durable session identity", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-draft-help-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ launch: {}, stateRoot, workspaceRoot });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    fixture.write("/help commands\r");
+    await fixture.waitFor("Command Reference");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(await readFilesRecursively(stateRoot)).not.toContain('"type":"session_genesis"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI reopens the project session picker from a draft without admitting it", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-draft-resume-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      launch: { seedTargetIds: ["deepseek-v4-flash.direct"] },
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Select a project session");
+    fixture.write("\r");
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    const beforeResume = fixture.output().length;
+    fixture.write("/resume\r");
+    await fixture.waitForAfter("Select a project session", beforeResume);
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    const durable = await readFilesRecursively(stateRoot);
+
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(durable.match(/"type":"session_genesis"/gu)).toHaveLength(1);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI switches an exact draft target without creating durable session identity", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-draft-target-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ launch: {}, stateRoot, workspaceRoot });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("deepseek-v4-flash.direct · Certified");
+    const beforeTarget = fixture.output().length;
+    fixture.write("/target\r");
+    await fixture.waitForAfter("Select an exact model target", beforeTarget);
+    fixture.write("\u001b[B");
+    fixture.write("\r");
+    await fixture.waitForAfter("deepseek-v4-pro.direct · Certified", beforeTarget);
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(await readFilesRecursively(stateRoot)).not.toContain('"type":"session_genesis"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI clears draft Skill selections when the exact target changes", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-draft-target-skills-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "draft-review");
+  await mkdir(skillDirectory, { recursive: true });
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: draft-review\ndescription: Must not remain selected across exact targets.\n---\nDraft Skill body.\n",
+    "utf8",
+  );
+
+  try {
+    const fixture = startFixture({ launch: {}, stateRoot, workspaceRoot });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    fixture.write("/skills\r");
+    await fixture.waitFor("Select next-turn Skills");
+    fixture.write("\r");
+    await fixture.waitFor("1 Skill selected");
+    const beforeTarget = fixture.output().length;
+    fixture.write("/target\r");
+    await fixture.waitForAfter("Select an exact model target", beforeTarget);
+    fixture.write("\u001b[B\r");
+    await fixture.waitForCompleteFrameAfter("deepseek-v4-pro.direct · Certified", beforeTarget);
+    const frame = latestSynchronizedFrame(fixture.output().slice(beforeTarget)).join("\n");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(frame).not.toContain("1 Skill selected");
+    expect(await readFilesRecursively(stateRoot)).not.toContain('"type":"session_genesis"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI explains durable-identity commands without admitting a draft", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-draft-identity-command-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ launch: {}, stateRoot, workspaceRoot });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    const beforeName = fixture.output().length;
+    fixture.write("/name Draft name\r");
+    const outcome = await Promise.race([
+      fixture
+        .waitForAfter("/name needs a session. Submit the first prompt or use /resume.", beforeName)
+        .then(() => "actionable" as const),
+      fixture
+        .waitForAfter(
+          "This command is not available before the first prompt is admitted.",
+          beforeName,
+        )
+        .then(() => "generic" as const),
+    ]);
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(outcome).toBe("actionable");
+    expect(await readFilesRecursively(stateRoot)).not.toContain('"type":"session_genesis"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI admits the first draft prompt before showing its durable answer", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-draft-admission-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      launch: {},
+      scenario: "skill-selection",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    const beforePrompt = fixture.output().length;
+    fixture.write("Admit this first draft prompt\r");
+    await fixture.waitForAfter("Skill selection complete.", beforePrompt);
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    const durable = await readFilesRecursively(stateRoot);
+
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(durable).toContain('"type":"session_genesis"');
+    expect(durable).toContain('"type":"logical_run_started"');
+    expect(durable).toContain('"userMessage":"Admit this first draft prompt"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("Ctrl+C cancels draft admission preflight without persisting or arming exit", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-draft-admission-cancel-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      launch: {},
+      scenario: "draft-admission-cancellation",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Cancel this draft admission\r");
+    await waitForPath(join(controlRoot, "model-resolve-pending"));
+    const beforeCancel = fixture.output().length;
+    fixture.write("\u0003");
+    await fixture.waitForCompleteFrameAfter(
+      "The exact target or draft resources are no longer available.",
+      beforeCancel,
+    );
+    const frame = latestSynchronizedFrame(fixture.output().slice(beforeCancel)).join("\n");
+
+    expect(frame).toContain("Cancel this draft admission");
+    expect(frame).not.toContain("Press Ctrl+C again");
+    expect(await readFilesRecursively(stateRoot)).not.toContain('"type":"session_genesis"');
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("the production target picker shows malformed configuration diagnostics without losing direct targets", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-invalid-target-config-"));
   const configRoot = join(testRoot, "config");
@@ -713,7 +1041,7 @@ test("the production session picker opens the exact focused existing session", a
     await fixture.waitFor("Select a project session");
     const beforeSelection = fixture.output().length;
     fixture.write("\u001b[B\r");
-    await fixture.waitForAfter("Adam · New session", beforeSelection);
+    await fixture.waitForAfter("Adam · Streaming session", beforeSelection);
     await fixture.waitForAfter("deepseek-v4-flash.direct · Certified", beforeSelection);
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
@@ -1042,8 +1370,13 @@ test("the footer exposes authoritative project context and run facts", async () 
     await fixture.waitFor("Adam · Streaming session");
     const beforeCompaction = fixture.output().length;
     fixture.write("Continue after the large answer\r");
+    await fixture.waitForCompleteFrameAfter("Working", beforeCompaction);
+    const afterWorking = fixture.output().length;
     await fixture.waitForAfter("Context compacted · window 1", beforeCompaction);
-    await fixture.waitForAfter("context · estimated · idle", beforeCompaction);
+    const secondAssistantSummary = "· 270058 bytes · /artifacts to inspect";
+    await fixture.waitForAfter(secondAssistantSummary, afterWorking);
+    const afterAssistant = fixture.output().lastIndexOf(secondAssistantSummary);
+    await fixture.waitForCompleteFrameAfter("context · estimated · idle", afterAssistant);
     expect(fixture.output()).toMatch(/workspace · \d+\/32768 context · estimated · idle/u);
 
     let beforeResize = fixture.output().length;
@@ -1054,7 +1387,7 @@ test("the footer exposes authoritative project context and run facts", async () 
 
     beforeResize = fixture.output().length;
     await fixture.resize(40, 12);
-    await fixture.waitForAfter(" est", beforeResize);
+    await fixture.waitForCompleteFrameAfter("32.8k est", beforeResize);
     frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
     expect(frame).toMatch(/idle · ctx [\d.]+(?:k|m)?\/32\.8k est/u);
     fixture.write("\u0011");

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -15,6 +15,7 @@ import {
 import {
   mcpCloseConfirmation,
   type PresentationArtifactReadBarrier,
+  preparedDirectDeepSeekV2ContextProfile,
   presentationArtifactReadBarrier,
   presentationHistoryPageSize,
 } from "@adam-agent/agent/internal-testing";
@@ -111,13 +112,23 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
   try {
     const previewBarrier = previewReadBarrier(options);
     for (const seedTargetId of options.launch?.seedTargetIds ?? []) {
-      await lifecycle.create({ targetIdentity: requireLaunchTargetIdentity(seedTargetId) });
+      const seeded = await lifecycle.create({
+        targetIdentity: requireLaunchTargetIdentity(seedTargetId),
+      });
+      await lifecycle.continue({
+        sessionId: seeded.sessionId,
+        input: { text: `Seeded project session for ${seedTargetId}` },
+      });
     }
     if (options.scenario === "session-selection-history") {
       const selectable = await lifecycle.create({ targetIdentity });
       await lifecycle.continue({
         sessionId: selectable.sessionId,
         input: { text: "Selected session prompt" },
+      });
+      await lifecycle.setSessionManualName({
+        sessionId: selectable.sessionId,
+        name: "Selected project session",
       });
     }
     const resumedSessionId =
@@ -172,7 +183,9 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
             }
             return created.sessionId;
           })
-        : undefined;
+        : options.launch === undefined && options.scenario !== "session-selection-history"
+          ? await lifecycle.create({ targetIdentity }).then((created) => created.sessionId)
+          : undefined;
     const presentation = await createPresentationSession(
       options.launch !== undefined
         ? {
@@ -376,6 +389,7 @@ function createFixtureModelTargets(options: {
   if (options.scenario === "streaming" && options.controlRoot === undefined) {
     throw new TypeError("The streaming fixture requires --control-root.");
   }
+  let artifactResponseOrdinal = 0;
   const model: ModelDriver = {
     async *stream(request) {
       if (request.tools.length === 0) {
@@ -395,6 +409,15 @@ function createFixtureModelTargets(options: {
                   nextSafeAction: "Continue the active model turn.",
                 }),
         };
+        yield { type: "finish", reason: "stop" };
+        return;
+      }
+      const latestUser = [...request.messages].reverse().find((message) => message.role === "user");
+      if (
+        latestUser?.role === "user" &&
+        latestUser.content.startsWith("Seeded project session for ")
+      ) {
+        yield { type: "text_delta", text: "Seeded project session ready." };
         yield { type: "finish", reason: "stop" };
         return;
       }
@@ -524,9 +547,14 @@ function createFixtureModelTargets(options: {
         options.scenario === "artifact-backed-assistant" ||
         options.scenario === "artifact-page-race"
       ) {
+        artifactResponseOrdinal += 1;
+        const responseIdentity =
+          options.scenario === "artifact-backed-assistant" && artifactResponseOrdinal === 2
+            ? "c"
+            : "";
         yield {
           type: "text_delta",
-          text: `Assistant artifact page one\n${"a".repeat(20_000)}\nAssistant artifact page two\n${"b".repeat(250_000)}`,
+          text: `Assistant artifact page one\n${"a".repeat(20_000)}\nAssistant artifact page two\n${"b".repeat(250_000)}${responseIdentity}`,
         };
       } else if (options.scenario === "copy-large-assistant") {
         yield {
@@ -555,12 +583,26 @@ function createFixtureModelTargets(options: {
   };
   return {
     async resolve(input) {
+      if (
+        options.scenario === "draft-admission-cancellation" &&
+        options.controlRoot !== undefined
+      ) {
+        await writeFile(join(options.controlRoot, "model-resolve-pending"), "pending\n", "utf8");
+        if (!(await waitForFile(options.controlRoot, "release-model-resolve", input.signal))) {
+          throw new Error("The draft admission target resolution was cancelled.");
+        }
+      }
       const identity =
         launchTargetIdentities.find((candidate) => candidate.targetId === input.targetId) ??
         (input.targetId === alternateTargetIdentity.targetId
           ? alternateTargetIdentity
           : targetIdentity);
-      return { identity, driver: model, contextProfile };
+      return {
+        identity,
+        driver: model,
+        contextProfile:
+          identity.profileVersion === 2 ? preparedDirectDeepSeekV2ContextProfile : contextProfile,
+      };
     },
     async snapshot() {
       if (options.launch !== undefined) {
@@ -571,7 +613,7 @@ function createFixtureModelTargets(options: {
               status: "available" as const,
               credentialSource: "deterministic launch fixture",
             },
-            contextProfile,
+            contextProfile: preparedDirectDeepSeekV2ContextProfile,
           })),
         };
       }

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -104,7 +104,9 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     created.setAutocompleteProvider(
       new AdamAutocompleteProvider({
         getProjectPaths: () =>
-          options.presentation.getState().authoritative.active?.projectPaths.items ?? [],
+          options.presentation.getState().authoritative.active?.projectPaths.items ??
+          options.presentation.getState().draft?.projectPaths.items ??
+          [],
         getRunActive: () => {
           const state = options.presentation.getState();
           return (
@@ -432,6 +434,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       !targetPickerDismissed &&
       (targetPickerRequested ||
         (active === null &&
+          state.draft === null &&
           !needsSessionChoice &&
           (startupTargetId === null || startupTargetId === undefined || defaultTargetRejected))) &&
       state.authoritative.targets.items.length > 0
@@ -549,11 +552,20 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           tui.requestRender();
           return;
         }
+        const previousDraftTargetId = options.presentation.getState().draft?.targetId;
         void options.presentation
           .dispatch({ type: "create_session", targetId: target.targetId })
           .then((receipt) => {
             if (receipt.status === "admitted") {
+              const targetChanged =
+                previousDraftTargetId !== undefined && previousDraftTargetId !== target.targetId;
+              if (targetChanged) {
+                selectedSkills.clear();
+              }
               close();
+              if (targetChanged) {
+                renderState();
+              }
               afterAdmission?.();
             } else if (targetPicker?.picker === picker) {
               picker.setNotice(receipt.message);
@@ -576,7 +588,11 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       targetPicker = { close, picker, hide: () => handle?.hide() };
     }
     header.setText(
-      theme.primary(`Adam · ${safeTerminalText(active?.session.label ?? "No session")}`),
+      theme.primary(
+        `Adam · ${safeTerminalText(
+          active?.session.label ?? (state.draft === null ? "No session" : "New session"),
+        )}`,
+      ),
     );
     transcript.clear();
     let previousWasAssistant = false;
@@ -699,8 +715,8 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     if (
       cancelSettling &&
       state.transient === null &&
-      active?.pendingInteractions.length === 0 &&
-      active.session.status !== "idle"
+      (active === null ||
+        (active.pendingInteractions.length === 0 && active.session.status !== "idle"))
     ) {
       cancelSettling = false;
     }
@@ -753,7 +769,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           });
       }
     }
-    if (active === null) {
+    if (active === null && state.draft === null) {
       editor.disableSubmit = true;
     } else {
       editor.disableSubmit = false;
@@ -766,9 +782,29 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           }`,
         ),
       );
-    } else if (active === null) {
+    } else if (active === null && state.draft === null) {
       footer.setText(theme.muted("Choose an exact model target to create a session"));
-    } else {
+    } else if (active === null && state.draft !== null) {
+      const draft = state.draft;
+      const target = state.authoritative.targets.items.find(
+        (candidate) => candidate.targetId === draft.targetId,
+      );
+      const selectedSkillSummary =
+        selectedSkills.size === 0
+          ? ""
+          : ` · ${selectedSkills.size} Skill${selectedSkills.size === 1 ? "" : "s"} selected`;
+      footer.setText({
+        wide: theme.muted(
+          `${safeTerminalText(state.authoritative.project.label)} · New session draft · idle\n${safeTerminalText(draft.targetId)} · ${target?.certification ?? "Experimental"}${selectedSkillSummary} · /help · Tab complete`,
+        ),
+        standard: theme.muted(
+          `New session draft · idle\n${safeTerminalText(draft.targetId)} · ${target?.certification ?? "Experimental"}${selectedSkillSummary} · /help · Tab complete`,
+        ),
+        narrow: theme.muted(
+          `draft · idle\n${safeTerminalText(draft.targetId)}\n/help · Tab complete`,
+        ),
+      });
+    } else if (active !== null) {
       const runStatus = sessionRunStatus(state.transient?.activity ?? null, active, cancelSettling);
       const targetCertification =
         state.authoritative.targets.items.find(
@@ -802,11 +838,13 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       clearExitWindow();
       renderState();
     }
-    const active = options.presentation.getState().authoritative.active;
+    const state = options.presentation.getState();
+    const active = state.authoritative.active;
+    const projectPaths = active?.projectPaths ?? state.draft?.projectPaths;
     if (
       pathPicker === undefined &&
-      active !== null &&
-      active.projectPaths.items.length > 0 &&
+      projectPaths !== undefined &&
+      projectPaths.items.length > 0 &&
       isProjectPathTrigger(editor.getExpandedText())
     ) {
       let handle: { hide(): void } | undefined;
@@ -817,7 +855,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         tui.requestRender();
       };
       const picker = new ProjectPathPicker({
-        catalog: active.projectPaths,
+        catalog: projectPaths,
         onClose: close,
         onSelect(path) {
           const draft = editor.getExpandedText();
@@ -1029,10 +1067,177 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     statusMessage = null;
     tui.requestRender();
   };
+  const showHelpNavigator = (commandId: "help" | "hotkeys", argumentsText: string): void => {
+    const requestedTopic = commandId === "hotkeys" ? "hotkeys" : argumentsText.trim();
+    const initialPage: HelpPage =
+      requestedTopic.length === 0
+        ? "root"
+        : (adamCommandRegistry.helpTopics().find((topic) => topic.id === requestedTopic)?.id ??
+          "root");
+    if (requestedTopic.length > 0 && initialPage === "root") {
+      const suggestions = adamCommandRegistry.suggestHelpTopics(requestedTopic);
+      statusMessage = `Unknown Help topic ${safeTerminalText(requestedTopic)}${
+        suggestions.length === 0
+          ? ""
+          : ` · Did you mean ${suggestions.map((topic) => topic.id).join(", ")}?`
+      }`;
+      editor.disableSubmit = false;
+      renderState();
+      return;
+    }
+    editor.setText("");
+    editor.disableSubmit = false;
+    helpNavigator?.hide();
+    let handle: { hide(): void } | undefined;
+    const close = () => {
+      handle?.hide();
+      helpNavigator = undefined;
+      tui.setFocus(editor);
+      tui.requestRender();
+    };
+    const navigator = new HelpNavigator({
+      commands: adamCommandRegistry.entries(),
+      initialPage,
+      keybindings: adamCommandRegistry.keybindings(),
+      onClose: close,
+      theme,
+      topics: adamCommandRegistry.helpTopics(),
+    });
+    handle = showOverlay(navigator, {
+      width: "80%",
+      minWidth: 36,
+      maxHeight: "80%",
+      margin: 1,
+    });
+    helpNavigator = { close, hide: () => handle?.hide(), navigator };
+    tui.requestRender();
+  };
   editor.onSubmit = (text) => {
     const state = options.presentation.getState();
     const active = state.authoritative.active;
-    if (active === null || text.trim().length === 0) {
+    if (text.trim().length === 0) {
+      return;
+    }
+    if (active === null) {
+      if (state.draft === null) {
+        return;
+      }
+      const parsedDraft = adamCommandRegistry.parse(text);
+      if (
+        parsedDraft.kind === "known" &&
+        (parsedDraft.command.id === "help" || parsedDraft.command.id === "hotkeys")
+      ) {
+        showHelpNavigator(parsedDraft.command.id, parsedDraft.argumentsText);
+        return;
+      }
+      if (
+        parsedDraft.kind === "known" &&
+        parsedDraft.command.id === "resume" &&
+        parsedDraft.argumentsText.length === 0
+      ) {
+        editor.setText("");
+        editor.disableSubmit = false;
+        sessionPickerDismissed = false;
+        sessionPickerRequested = true;
+        renderState();
+        return;
+      }
+      if (
+        parsedDraft.kind === "known" &&
+        (parsedDraft.command.id === "model" ||
+          parsedDraft.command.id === "target" ||
+          parsedDraft.command.id === "new") &&
+        parsedDraft.argumentsText.length === 0
+      ) {
+        editor.setText("");
+        editor.disableSubmit = false;
+        targetPickerDismissed = false;
+        targetPickerIntent = "create";
+        targetPickerRequested = true;
+        renderState();
+        return;
+      }
+      if (
+        parsedDraft.kind === "known" &&
+        parsedDraft.command.id === "skills" &&
+        parsedDraft.argumentsText.length === 0
+      ) {
+        editor.setText("");
+        editor.disableSubmit = false;
+        let handle: { hide(): void } | undefined;
+        const close = () => {
+          handle?.hide();
+          skillPalette = undefined;
+          tui.setFocus(editor);
+          tui.requestRender();
+        };
+        const palette = new SkillPalette({
+          catalog: state.draft.skills,
+          theme,
+          onClose: close,
+          onToggle(skill) {
+            if (selectedSkills.delete(skill.qualifiedId)) {
+              renderState();
+              return false;
+            }
+            selectedSkills.add(skill.qualifiedId);
+            renderState();
+            return true;
+          },
+        });
+        handle = showOverlay(palette, {
+          width: "90%",
+          minWidth: 36,
+          maxHeight: "80%",
+          margin: 1,
+        });
+        skillPalette = { close, hide: () => handle?.hide() };
+        tui.requestRender();
+        return;
+      }
+      if (parsedDraft.kind === "unknown") {
+        const suggestions = adamCommandRegistry.suggest(parsedDraft.name);
+        statusMessage = `Unknown command /${parsedDraft.name}${
+          suggestions.length === 0
+            ? ""
+            : ` · Did you mean ${suggestions.map((command) => `/${command.name}`).join(", ")}?`
+        }`;
+        editor.disableSubmit = false;
+        renderState();
+        return;
+      }
+      if (parsedDraft.kind === "known") {
+        statusMessage = `/${parsedDraft.command.name} needs a session. Submit the first prompt or use /resume.`;
+        editor.disableSubmit = false;
+        renderState();
+        return;
+      }
+      clearExitWindow();
+      editor.disableSubmit = true;
+      void options.presentation
+        .dispatch({
+          type: "submit_draft_prompt",
+          text,
+          skills: [...selectedSkills],
+        })
+        .then((receipt) => {
+          if (receipt.status === "admitted") {
+            editor.setText("");
+            selectedSkills.clear();
+          } else {
+            editor.setText(text);
+            statusMessage = receipt.message;
+            editor.disableSubmit = false;
+          }
+        })
+        .catch(() => {
+          editor.setText(text);
+          statusMessage = "The first prompt could not be admitted to a durable session.";
+          editor.disableSubmit = false;
+        })
+        .finally(() => {
+          renderState();
+        });
       return;
     }
     const runActive =
@@ -1132,50 +1337,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       parsedCommand.kind === "known" &&
       (parsedCommand.command.id === "help" || parsedCommand.command.id === "hotkeys")
     ) {
-      const requestedTopic =
-        parsedCommand.command.id === "hotkeys" ? "hotkeys" : parsedCommand.argumentsText.trim();
-      const initialPage: HelpPage =
-        requestedTopic.length === 0
-          ? "root"
-          : (adamCommandRegistry.helpTopics().find((topic) => topic.id === requestedTopic)?.id ??
-            "root");
-      if (requestedTopic.length > 0 && initialPage === "root") {
-        const suggestions = adamCommandRegistry.suggestHelpTopics(requestedTopic);
-        statusMessage = `Unknown Help topic ${safeTerminalText(requestedTopic)}${
-          suggestions.length === 0
-            ? ""
-            : ` · Did you mean ${suggestions.map((topic) => topic.id).join(", ")}?`
-        }`;
-        editor.disableSubmit = false;
-        renderState();
-        return;
-      }
-      editor.setText("");
-      editor.disableSubmit = false;
-      helpNavigator?.hide();
-      let handle: { hide(): void } | undefined;
-      const close = () => {
-        handle?.hide();
-        helpNavigator = undefined;
-        tui.setFocus(editor);
-        tui.requestRender();
-      };
-      const navigator = new HelpNavigator({
-        commands: adamCommandRegistry.entries(),
-        initialPage,
-        keybindings: adamCommandRegistry.keybindings(),
-        onClose: close,
-        theme,
-        topics: adamCommandRegistry.helpTopics(),
-      });
-      handle = showOverlay(navigator, {
-        width: "80%",
-        minWidth: 36,
-        maxHeight: "80%",
-        margin: 1,
-      });
-      helpNavigator = { close, hide: () => handle?.hide(), navigator };
-      tui.requestRender();
+      showHelpNavigator(parsedCommand.command.id, parsedCommand.argumentsText);
       return;
     }
     if (
@@ -1871,18 +2033,19 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         options.presentation.getState().transient !== null ||
         (active?.pendingInteractions.length ?? 0) > 0;
       if (runActive || cancelSettling) {
-        if (!cancelSettling && active !== null) {
+        if (!cancelSettling) {
           cancelSettling = true;
           void options.presentation
-            .dispatch({ type: "cancel_run", sessionId: active.session.id })
+            .dispatch({ type: "cancel_run", sessionId: active?.session.id ?? null })
             .then((receipt) => {
               const state = options.presentation.getState();
               const current = state.authoritative.active;
               if (
                 receipt.status === "rejected" ||
                 (state.transient === null &&
-                  current?.pendingInteractions.length === 0 &&
-                  current.session.status !== "idle")
+                  (current === null ||
+                    (current.pendingInteractions.length === 0 &&
+                      current.session.status !== "idle")))
               ) {
                 cancelSettling = false;
                 renderState();

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1951,15 +1951,17 @@ export class AgentSession {
         if (candidate === undefined || this.#repositoryWorkspaceRoot === undefined) {
           return skillActivationFailure("Explicit Agent Skill content is unavailable.");
         }
-        const manifest = await buildSkillResourceManifestV1({
-          candidate,
-          workspaceRoot: this.#repositoryWorkspaceRoot,
-          userHome: homedir(),
-          userHomeDigest: stagedContext.userHomeDigest,
-          ...(this.#durableContext?.extensionSkillSources === undefined
-            ? {}
-            : { extensionSources: this.#durableContext.extensionSkillSources }),
-        });
+        const manifest =
+          this.#durableContext?.preparedExplicitSkillManifests?.get(selection.requestId) ??
+          (await buildSkillResourceManifestV1({
+            candidate,
+            workspaceRoot: this.#repositoryWorkspaceRoot,
+            userHome: homedir(),
+            userHomeDigest: stagedContext.userHomeDigest,
+            ...(this.#durableContext?.extensionSkillSources === undefined
+              ? {}
+              : { extensionSources: this.#durableContext.extensionSkillSources }),
+          }));
         activation = activateSkillContextV1({
           context: stagedContext,
           qualifiedId: selection.qualifiedId,
@@ -2014,7 +2016,10 @@ export class AgentSession {
           qualifiedId: selection.qualifiedId,
         },
       };
-      const policyDecision = this.#permissions?.decide(permissionInput) ?? "deny";
+      const policyDecision =
+        this.#durableContext?.preparedExplicitSkillPolicies?.get(selection.requestId) ??
+        this.#permissions?.decide(permissionInput) ??
+        "deny";
       let decision: "allow" | "deny";
       const reusableDecision = reusablePermissions.get(selection.requestId);
       if (reusableDecision !== undefined && policyDecision !== "deny") {

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -35,11 +35,13 @@ export {
   type PresentationArtifactReadBarrier,
   type PresentationHydrationBarrier,
   type PresentationRuntimeRefreshBarrier,
+  type PresentationSessionRecordReader,
   presentationArtifactReadBarrier,
   presentationCatalogPageSize,
   presentationHistoryPageSize,
   presentationHydrationBarrier,
   presentationRuntimeRefreshBarrier,
+  presentationSessionRecordReader,
   resolvePresentationTerminalContext,
 } from "./presentation-session.js";
 export type {
@@ -83,6 +85,7 @@ export {
   type SessionProviderAttemptStartedRecord,
   type SessionRecord,
   type SessionRuntimeEventRecord,
+  type SessionStore,
   type SessionStoreDirectory,
   type SessionToolIntent,
   type SessionV3Record,

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -28,12 +28,13 @@ import {
 } from "./model-targets.js";
 import type { PresentationPreferences } from "./presentation-preferences.js";
 import { listProjectPaths } from "./project-path-catalog.js";
-import type {
-  CurrentSessionSnapshot,
-  SessionContextUsageSnapshot,
-  SessionLifecycle,
-  SessionMetadataEvent,
-  SessionRuntimeNotification,
+import {
+  type CurrentSessionSnapshot,
+  type SessionContextUsageSnapshot,
+  type SessionLifecycle,
+  SessionLifecycleError,
+  type SessionMetadataEvent,
+  type SessionRuntimeNotification,
 } from "./session-lifecycle.js";
 import { sessionTitleFallback } from "./session-naming.js";
 import { readJsonlSessionRecords, type SessionRecord } from "./session-store.js";
@@ -48,6 +49,9 @@ export const presentationRuntimeRefreshBarrier = Symbol(
 );
 export const presentationArtifactReadBarrier = Symbol(
   "adam-agent.presentation-artifact-read-barrier",
+);
+export const presentationSessionRecordReader = Symbol(
+  "adam-agent.presentation-session-record-reader",
 );
 
 export type PresentationHydrationBarrier = {
@@ -66,6 +70,10 @@ export type PresentationArtifactReadBarrier = {
   afterRead?(): Promise<void>;
 };
 
+export type PresentationSessionRecordReader = (
+  sessionId: string,
+) => Promise<readonly SessionRecord[]>;
+
 type PresentationSessionBaseOptions = {
   readonly lifecycle: SessionLifecycle;
   readonly modelTargets?: ModelTargets;
@@ -76,9 +84,15 @@ type PresentationSessionBaseOptions = {
   readonly [presentationHydrationBarrier]?: PresentationHydrationBarrier;
   readonly [presentationRuntimeRefreshBarrier]?: PresentationRuntimeRefreshBarrier;
   readonly [presentationArtifactReadBarrier]?: PresentationArtifactReadBarrier;
+  readonly [presentationSessionRecordReader]?: PresentationSessionRecordReader;
   readonly [presentationHistoryPageSize]?: number;
   readonly [presentationCatalogPageSize]?: number;
 };
+
+type PresentationSessionRecordOptions = Pick<
+  PresentationSessionBaseOptions,
+  "stateRoot" | "workspaceRoot" | typeof presentationSessionRecordReader
+>;
 
 export type CreatePresentationSessionOptions = PresentationSessionBaseOptions &
   (
@@ -124,17 +138,11 @@ export async function createPresentationSession(
 
   try {
     let created: CurrentSessionSnapshot | undefined;
-    if (options.openProject === true) {
+    if (options.sessionId === undefined) {
       created = undefined;
-    } else if (options.sessionId === undefined) {
-      created = await options.lifecycle.create({ targetIdentity: options.targetIdentity });
     } else {
       const inspected = await options.lifecycle.inspect({ sessionId: options.sessionId });
-      const existingRecords = await readJsonlSessionRecords({
-        sessionId: options.sessionId,
-        workspaceRoot: options.workspaceRoot,
-        ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-      });
+      const existingRecords = await readPresentationSessionRecords(options, options.sessionId);
       if (
         inspected.schemaVersion === 3 &&
         inspected.status !== "interrupted" &&
@@ -218,8 +226,15 @@ export async function createPresentationSession(
         knownTargets.set(target.identity.targetId, target.identity);
       }
     }
-    if (created !== undefined) {
+    if (created !== undefined && !knownTargets.has(created.targetIdentity.targetId)) {
       knownTargets.set(created.targetIdentity.targetId, created.targetIdentity);
+    }
+    if (
+      "targetIdentity" in options &&
+      options.targetIdentity !== undefined &&
+      !knownTargets.has(options.targetIdentity.targetId)
+    ) {
+      knownTargets.set(options.targetIdentity.targetId, options.targetIdentity);
     }
     const catalogPage = await options.lifecycle.listProjectSessions({ limit: catalogPageSize });
     const projectPaths = await listProjectPaths(options.workspaceRoot);
@@ -229,7 +244,9 @@ export async function createPresentationSession(
           if (snapshot.schemaVersion !== 3) {
             return null;
           }
-          knownTargets.set(snapshot.targetIdentity.targetId, snapshot.targetIdentity);
+          if (!knownTargets.has(snapshot.targetIdentity.targetId)) {
+            knownTargets.set(snapshot.targetIdentity.targetId, snapshot.targetIdentity);
+          }
           return sessionSummaryFromSnapshot(
             snapshot,
             snapshot.sessionId === created?.sessionId
@@ -249,6 +266,10 @@ export async function createPresentationSession(
         : catalogItems.some((candidate) => candidate.id === created.sessionId)
           ? catalogItems
           : [...catalogItems, activeSummary];
+    const initialDraft =
+      "targetIdentity" in options && options.targetIdentity !== undefined
+        ? await options.lifecycle.previewNewSession({ targetIdentity: options.targetIdentity })
+        : null;
     const authoritative: AuthoritativePresentationSnapshot = {
       schemaVersion: 1,
       continuity: {
@@ -288,8 +309,17 @@ export async function createPresentationSession(
     let state: PresentationDisplayState = {
       revision: 1,
       authoritative,
+      draft:
+        initialDraft === null
+          ? null
+          : {
+              targetId: initialDraft.targetIdentity.targetId,
+              skills: projectSkillContext(initialDraft.skillContext, false),
+              projectPaths,
+            },
       transient: null,
     };
+    let draftTargetIdentity: ModelTargetIdentity | null = initialDraft?.targetIdentity ?? null;
     const metadataThrough = new Map<string, number>();
     if (created !== undefined) {
       metadataThrough.set(`session_naming_changed:${created.sessionId}`, created.lastSequence);
@@ -308,12 +338,13 @@ export async function createPresentationSession(
     let closed = false;
     let activeRun:
       | {
-          readonly sessionId: string;
+          sessionId: string | null;
           readonly controller: AbortController;
           readonly settlement: Promise<void>;
         }
       | undefined;
-    const activateSnapshot = async (snapshot: CurrentSessionSnapshot): Promise<void> => {
+    let snapshotActivationQueue = Promise.resolve();
+    const activateSnapshotNow = async (snapshot: CurrentSessionSnapshot): Promise<void> => {
       const activatedRecords = await readActiveBranchRecords(options, snapshot.sessionId);
       const activatedContextUsage = await options.lifecycle.inspectContextUsage({
         sessionId: snapshot.sessionId,
@@ -328,7 +359,9 @@ export async function createPresentationSession(
         targetId: snapshot.targetIdentity.targetId,
         status: snapshot.status,
       };
-      knownTargets.set(snapshot.targetIdentity.targetId, snapshot.targetIdentity);
+      if (!knownTargets.has(snapshot.targetIdentity.targetId)) {
+        knownTargets.set(snapshot.targetIdentity.targetId, snapshot.targetIdentity);
+      }
       const catalogItems = state.authoritative.sessions.items.some(
         (session) => session.id === snapshot.sessionId,
       )
@@ -367,9 +400,19 @@ export async function createPresentationSession(
             mcp: projectMcp(snapshot),
           },
         },
+        draft: null,
         transient: null,
       };
+      draftTargetIdentity = null;
       publishStateChange();
+    };
+    const activateSnapshot = (snapshot: CurrentSessionSnapshot): Promise<void> => {
+      const activation = snapshotActivationQueue.then(() => activateSnapshotNow(snapshot));
+      snapshotActivationQueue = activation.then(
+        () => undefined,
+        () => undefined,
+      );
+      return activation;
     };
     const refreshActiveNaming = async (
       sessionId: string,
@@ -412,6 +455,7 @@ export async function createPresentationSession(
           },
           active: { ...current, session: refreshedSummary },
         },
+        draft: state.draft,
         transient: state.transient,
       };
       publishStateChange();
@@ -440,6 +484,7 @@ export async function createPresentationSession(
           },
           active: { ...current, mcp: projectMcp(inspected) },
         },
+        draft: state.draft,
         transient: state.transient,
       };
       publishStateChange();
@@ -473,6 +518,7 @@ export async function createPresentationSession(
               state = {
                 revision: state.revision + 1,
                 authoritative: state.authoritative,
+                draft: state.draft,
                 transient: { activity: "working", assistant: null },
               };
               publishStateChange();
@@ -480,6 +526,7 @@ export async function createPresentationSession(
               state = {
                 revision: state.revision + 1,
                 authoritative: state.authoritative,
+                draft: state.draft,
                 transient: { activity: "using_tool", assistant: null },
               };
               publishStateChange();
@@ -525,6 +572,7 @@ export async function createPresentationSession(
                       },
                     },
                   },
+                  draft: state.draft,
                   transient: state.transient,
                 };
                 publishStateChange();
@@ -544,6 +592,7 @@ export async function createPresentationSession(
                   ...state.authoritative,
                   continuity: { status: "repairing", reason: "gap" },
                 },
+                draft: state.draft,
                 transient: null,
               };
               publishStateChange();
@@ -573,6 +622,7 @@ export async function createPresentationSession(
                   ...state.authoritative,
                   continuity: { status: "repairing", reason: "gap" },
                 },
+                draft: state.draft,
                 transient: null,
               };
               publishStateChange();
@@ -612,6 +662,7 @@ export async function createPresentationSession(
                   pendingInteractions,
                 },
               },
+              draft: state.draft,
               transient: isAssistantTerminalEvent(event) ? null : state.transient,
             };
             publishStateChange();
@@ -631,6 +682,7 @@ export async function createPresentationSession(
                   },
                 },
               },
+              draft: state.draft,
               transient: null,
             };
             publishStateChange();
@@ -689,6 +741,7 @@ export async function createPresentationSession(
                 },
               },
             },
+            draft: state.draft,
             transient: null,
           };
           publishStateChange();
@@ -732,6 +785,7 @@ export async function createPresentationSession(
                 diagnostic: null,
               },
             },
+            draft: state.draft,
             transient: state.transient,
           };
           publishStateChange();
@@ -745,6 +799,13 @@ export async function createPresentationSession(
         }
       }
       if (command.type === "create_session") {
+        if (activeRun !== undefined) {
+          return {
+            status: "rejected",
+            code: "conflict",
+            message: "A new session cannot be drafted while a run is active.",
+          };
+        }
         const targetIdentity = knownTargets.get(command.targetId);
         if (targetIdentity === undefined) {
           return {
@@ -753,17 +814,37 @@ export async function createPresentationSession(
             message: "The exact target is not available in this Presentation session.",
           };
         }
+        let preview: Awaited<ReturnType<SessionLifecycle["previewNewSession"]>>;
         try {
-          const snapshot = await options.lifecycle.create({ targetIdentity });
-          await activateSnapshot(snapshot);
-          return { status: "admitted", commandId: randomUUID(), resource: null };
+          preview = await options.lifecycle.previewNewSession({ targetIdentity });
         } catch {
           return {
             status: "rejected",
-            code: "authority_rejected",
-            message: "The session could not be created.",
+            code: "not_available",
+            message: "The exact target and draft Skill catalog could not be prepared.",
           };
         }
+        state = {
+          revision: state.revision + 1,
+          authoritative: {
+            ...state.authoritative,
+            continuity: {
+              status: "current",
+              sessionThroughSequence: 0,
+              operationThrough: [],
+            },
+            active: null,
+          },
+          draft: {
+            targetId: targetIdentity.targetId,
+            skills: projectSkillContext(preview.skillContext, false),
+            projectPaths,
+          },
+          transient: null,
+        };
+        draftTargetIdentity = targetIdentity;
+        publishStateChange();
+        return { status: "admitted", commandId: randomUUID(), resource: null };
       }
       if (command.type === "select_session") {
         if (activeRun !== undefined) {
@@ -892,6 +973,125 @@ export async function createPresentationSession(
         }
         return { status: "admitted", commandId, resource: null };
       }
+      if (command.type === "submit_draft_prompt") {
+        const draft = state.draft;
+        if (draft === null || command.text.trim().length === 0) {
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message: "A non-empty prompt and exact draft target are required.",
+          };
+        }
+        if (activeRun !== undefined) {
+          return {
+            status: "rejected",
+            code: "conflict",
+            message: "The active session already has a running command.",
+          };
+        }
+        const targetIdentity = draftTargetIdentity;
+        if (targetIdentity === null || targetIdentity.targetId !== draft.targetId) {
+          return {
+            status: "rejected",
+            code: "not_available",
+            message: "The exact draft target is no longer available.",
+          };
+        }
+        const controller = new AbortController();
+        const commandId = randomUUID();
+        const admission = Promise.withResolvers<string>();
+        let admittedSessionId: string | null = null;
+        state = {
+          ...state,
+          revision: state.revision + 1,
+          transient: { activity: "working", assistant: null },
+        };
+        publishStateChange();
+        const continuation = options.lifecycle.admit({
+          targetIdentity,
+          input: {
+            text: command.text,
+            ...(command.skills.length === 0 ? {} : { skills: command.skills }),
+          },
+          runId: commandId,
+          signal: controller.signal,
+          onAdmitted(receipt) {
+            if (receipt.runId !== commandId) {
+              return;
+            }
+            admittedSessionId = receipt.sessionId;
+            admission.resolve(receipt.sessionId);
+          },
+        });
+        const settlement = continuation
+          .then(async (continued) => {
+            if (!closed && admittedSessionId !== null) {
+              await activateSnapshot(continued.snapshot);
+            }
+          })
+          .catch(async () => {
+            const sessionId = admittedSessionId;
+            if (closed || sessionId === null) {
+              return;
+            }
+            const inspected = await options.lifecycle.inspect({ sessionId });
+            if (inspected.schemaVersion === 3) {
+              await activateSnapshot(inspected);
+            }
+          })
+          .finally(() => {
+            if (activeRun?.settlement === settlement) {
+              activeRun = undefined;
+            }
+            if (
+              !closed &&
+              admittedSessionId === null &&
+              state.authoritative.active === null &&
+              state.transient !== null
+            ) {
+              state = { ...state, revision: state.revision + 1, transient: null };
+              publishStateChange();
+            }
+          });
+        activeRun = {
+          sessionId: null,
+          controller,
+          settlement,
+        };
+        let admissionFailure: unknown;
+        const admitted = await Promise.race([
+          admission.promise.then((sessionId) => ({ status: "admitted" as const, sessionId })),
+          continuation.then(
+            (continued) => {
+              admissionFailure =
+                continued.result.status === "failed" ? continued.result.error.code : null;
+              return { status: "rejected" as const };
+            },
+            (error) => {
+              admissionFailure = error;
+              return { status: "rejected" as const };
+            },
+          ),
+        ]);
+        if (admitted.status === "rejected") {
+          await settlement;
+          return draftAdmissionRejection(admissionFailure);
+        }
+        if (activeRun?.settlement === settlement) {
+          activeRun.sessionId = admitted.sessionId;
+        }
+        const admittedSnapshot = await options.lifecycle.inspect({ sessionId: admitted.sessionId });
+        if (admittedSnapshot.schemaVersion !== 3) {
+          await settlement;
+          return {
+            status: "rejected",
+            code: "persistence_failed",
+            message: "The admitted draft session could not be read from durable history.",
+          };
+        }
+        await activateSnapshot(admittedSnapshot);
+        return { status: "admitted", commandId, resource: null };
+      }
       if (command.type === "branch_session") {
         if (command.parentSessionId !== state.authoritative.active?.session.id) {
           return {
@@ -1005,6 +1205,7 @@ export async function createPresentationSession(
               transcript: transcriptPage(transcript, loadedTranscriptStart, active.session.id),
             },
           },
+          draft: state.draft,
           transient: state.transient,
         };
         publishStateChange();
@@ -1050,6 +1251,7 @@ export async function createPresentationSession(
                 nextCursor: page.nextCursor,
               },
             },
+            draft: state.draft,
             transient: state.transient,
           };
           publishStateChange();
@@ -1711,18 +1913,14 @@ function sessionSummaryFromSnapshot(
 }
 
 async function readActiveBranchRecords(
-  options: Pick<CreatePresentationSessionOptions, "stateRoot" | "workspaceRoot">,
+  options: PresentationSessionRecordOptions,
   sessionId: string,
   visited: ReadonlySet<string> = new Set(),
 ): Promise<readonly SourcedSessionRecord[]> {
   if (visited.has(sessionId) || visited.size >= 64) {
     throw new TypeError("The presentation lineage is recursive or too deep.");
   }
-  const records = await readJsonlSessionRecords({
-    sessionId,
-    workspaceRoot: options.workspaceRoot,
-    ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
-  });
+  const records = await readPresentationSessionRecords(options, sessionId);
   const own = records.map((entry) => ({ sessionId, entry }));
   const genesis = records[0];
   if (
@@ -1747,6 +1945,20 @@ async function readActiveBranchRecords(
     ),
     ...own,
   ];
+}
+
+async function readPresentationSessionRecords(
+  options: PresentationSessionRecordOptions,
+  sessionId: string,
+): Promise<readonly SessionRecord[]> {
+  return (
+    options[presentationSessionRecordReader]?.(sessionId) ??
+    readJsonlSessionRecords({
+      sessionId,
+      workspaceRoot: options.workspaceRoot,
+      ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
+    })
+  );
 }
 
 function projectTranscript(records: readonly SourcedSessionRecord[]): readonly TranscriptItem[] {
@@ -2257,7 +2469,10 @@ async function isActionableChangePreview(
 }
 
 async function isCurrentActionableChangePreview(
-  options: Pick<CreatePresentationSessionOptions, "lifecycle" | "stateRoot" | "workspaceRoot">,
+  options: Pick<
+    PresentationSessionBaseOptions,
+    "lifecycle" | "stateRoot" | "workspaceRoot" | typeof presentationSessionRecordReader
+  >,
   sessionId: string,
   requestId: string,
 ): Promise<boolean> {
@@ -2470,6 +2685,13 @@ function projectSkills(snapshot: CurrentSessionSnapshot): SkillCatalogDisplay | 
   if (skills === undefined) {
     return null;
   }
+  return projectSkillContext(skills, snapshot.status === "idle");
+}
+
+function projectSkillContext(
+  skills: NonNullable<CurrentSessionSnapshot["skillContext"]>,
+  reloadAvailable: boolean,
+): SkillCatalogDisplay {
   const activeQualifiedIds = new Set(
     skills.active
       .filter(
@@ -2509,7 +2731,65 @@ function projectSkills(snapshot: CurrentSessionSnapshot): SkillCatalogDisplay | 
       omittedCount: skills.catalog.omittedCount,
       shortenedCount: skills.catalog.shortenedCount,
     },
-    reloadAvailable: snapshot.status === "idle",
+    reloadAvailable,
+  };
+}
+
+function draftAdmissionRejection(
+  failure: unknown,
+): Extract<CommandReceipt, { readonly status: "rejected" }> {
+  const code =
+    failure instanceof SessionLifecycleError
+      ? failure.code
+      : typeof failure === "string"
+        ? failure
+        : null;
+  if (code === "session_skill_policy_rejected") {
+    return {
+      status: "rejected",
+      code: "authority_rejected",
+      message: "One selected Agent Skill is denied by the draft admission policy.",
+    };
+  }
+  if (code === "session_skill_confirmation_required") {
+    return {
+      status: "rejected",
+      code: "authority_rejected",
+      message: "One selected Agent Skill requires confirmation before draft admission.",
+    };
+  }
+  if (code === "session_persistence_failed") {
+    return {
+      status: "rejected",
+      code: "persistence_failed",
+      message: "The first prompt could not be persisted as a durable session.",
+    };
+  }
+  if (code === "project_in_use") {
+    return {
+      status: "rejected",
+      code: "conflict",
+      message: "Another process is changing this project session state.",
+    };
+  }
+  if (code === "session_invalid" || code === "invalid_run_limits") {
+    return {
+      status: "rejected",
+      code: "invalid_command",
+      message: "The first prompt contains invalid draft admission input.",
+    };
+  }
+  if (code === "session_skill_unavailable") {
+    return {
+      status: "rejected",
+      code: "not_available",
+      message: "One selected Agent Skill is no longer available for the first prompt.",
+    };
+  }
+  return {
+    status: "rejected",
+    code: "not_available",
+    message: "The exact target or draft resources are no longer available.",
   };
 }
 

--- a/packages/agent/src/session-durable-context.ts
+++ b/packages/agent/src/session-durable-context.ts
@@ -2,7 +2,11 @@ import type { ContextEvidenceV1 } from "./durable-context.js";
 import type { ModelMessage } from "./index.js";
 import type { ModelTargetIdentity } from "./model-targets.js";
 import type { PromptContextRecord } from "./prompt-assembly.js";
-import type { ExtensionSkillSourceV1, SkillContextRecordV1 } from "./skills.js";
+import type {
+  ExtensionSkillSourceV1,
+  SkillContextRecordV1,
+  SkillResourceManifestV1,
+} from "./skills.js";
 import type { PermissionPolicyInput, ToolCall, ToolResult } from "./tool-runtime.js";
 
 export const sessionDurableContext = Symbol("adam-agent.session-durable-context");
@@ -25,6 +29,8 @@ export type AgentSessionDurableContext = {
   readonly skillContext?: SkillContextRecordV1 | undefined;
   readonly activeSkillContents?: ReadonlyMap<string, string> | undefined;
   readonly extensionSkillSources?: readonly ExtensionSkillSourceV1[] | undefined;
+  readonly preparedExplicitSkillManifests?: ReadonlyMap<string, SkillResourceManifestV1>;
+  readonly preparedExplicitSkillPolicies?: ReadonlyMap<string, "allow">;
   readonly withCurrentExtensionSkillSources?:
     | (<T>(
         sources: readonly ExtensionSkillSourceV1[],

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -6,6 +6,7 @@ import { isDeepStrictEqual } from "node:util";
 import { z } from "zod";
 import {
   type ArtifactReference,
+  type ArtifactSource,
   type ArtifactStore,
   type ChangePreviewArtifactSource,
   createFileArtifactStore,
@@ -130,6 +131,7 @@ import {
   type SessionStoreDirectory,
 } from "./session-store.js";
 import {
+  buildSkillResourceManifestV1,
   createInitialSkillContextV1,
   type ExtensionSkillSourceV1,
   isSkillContextRecordV1Valid,
@@ -137,6 +139,7 @@ import {
   reloadSkillContextV1,
   type SkillContextRecordV1,
   type SkillContextSnapshot,
+  type SkillResourceManifestV1,
   skillContextSnapshot,
 } from "./skills.js";
 import {
@@ -352,6 +355,17 @@ export type SessionContinueResult = {
   readonly snapshot: CurrentSessionSnapshot;
 };
 
+export type NewSessionDraftSnapshot = {
+  readonly targetIdentity: ModelTargetIdentity;
+  readonly skillContext: SkillContextSnapshot;
+};
+
+export type SessionAdmissionReceipt = {
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly sequence: number;
+};
+
 export type SessionNamingResult = {
   readonly status: "updated";
   readonly snapshot: CurrentSessionSnapshot;
@@ -497,6 +511,14 @@ export type SessionCommand =
   | McpConfigurationCommand;
 
 export interface SessionLifecycle {
+  admit(input: {
+    readonly targetIdentity: ModelTargetIdentity;
+    readonly input: UserInput;
+    readonly limits?: RunOptions["limits"];
+    readonly runId?: string;
+    readonly signal?: AbortSignal;
+    readonly onAdmitted?: (receipt: SessionAdmissionReceipt) => void;
+  }): Promise<SessionContinueResult>;
   branch(input: SessionBranchInput): Promise<CurrentSessionSnapshot>;
   close(): Promise<McpCloseResult>;
   continue(input: {
@@ -519,6 +541,10 @@ export interface SessionLifecycle {
     readonly cursor?: string;
     readonly limit?: number;
   }): Promise<ProjectSessionCatalogPage>;
+  previewNewSession(input: {
+    readonly targetIdentity: ModelTargetIdentity;
+    readonly signal?: AbortSignal;
+  }): Promise<NewSessionDraftSnapshot>;
   reloadRepositoryInstructions(input: {
     readonly sessionId: string;
   }): Promise<RepositoryInstructionsReloadResult>;
@@ -541,6 +567,10 @@ export class SessionLifecycleError extends Error {
     | "session_invalid"
     | "session_model_target_incompatible"
     | "session_model_target_unavailable"
+    | "session_persistence_failed"
+    | "session_skill_confirmation_required"
+    | "session_skill_policy_rejected"
+    | "session_skill_unavailable"
     | "session_not_found"
     | "session_project_mismatch"
     | "mcp_config_invalid"
@@ -632,6 +662,16 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
   let automaticTitlesEnabled = options[sessionAutomaticTitlesEnabled] ?? true;
   let lifecycleClosePromise: Promise<McpCloseResult> | undefined;
   const pendingMcpCatalogDurability = new Map<string, Promise<void>>();
+  const preparedAdmissionTargets = new Map<
+    string,
+    {
+      readonly runId: string;
+      readonly resolved: Awaited<ReturnType<ModelTargets["resolve"]>>;
+      readonly skillManifests: ReadonlyMap<string, SkillResourceManifestV1>;
+      readonly skillPolicies: ReadonlyMap<string, "allow">;
+      readonly onAdmitted?: (receipt: SessionAdmissionReceipt) => void;
+    }
+  >();
   const pendingMcpMetadataThrough = new Map<string, number>();
   let scheduleMcpCatalogFlush = (_sessionId: string) => {};
   const publishMetadata = async (event: SessionMetadataEvent): Promise<void> => {
@@ -1509,7 +1549,204 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     }
   };
 
+  const prepareSessionCreation = async (input: {
+    readonly targetIdentity: ModelTargetIdentity;
+    readonly runId?: string;
+    readonly signal?: AbortSignal;
+    readonly skills?: readonly string[];
+    readonly resolved?: Awaited<ReturnType<ModelTargets["resolve"]>>;
+  }): Promise<{
+    readonly genesis: SessionGenesisRecord;
+    readonly mcp: McpSessionSnapshot | undefined;
+    readonly skillManifests: ReadonlyMap<string, SkillResourceManifestV1>;
+    readonly skillPolicies: ReadonlyMap<string, "allow">;
+    readonly selectedSkills?: readonly string[];
+  }> => {
+    input.signal?.throwIfAborted();
+    let mcp: McpSessionSnapshot | undefined;
+    try {
+      mcp = await inspectMcpConfiguration(options.workspaceRoot);
+    } catch (error) {
+      if (error instanceof McpConfigurationError) {
+        throw new SessionLifecycleError("mcp_config_invalid");
+      }
+      throw error;
+    }
+    const sessionId = randomUUID();
+    const projectId = await canonicalProjectId(options.workspaceRoot);
+    const repository = await loadInitialRepositoryInstructions({
+      workspaceRoot: options.workspaceRoot,
+    });
+    const skillBudgetContext =
+      input.resolved === undefined
+        ? await resolveSkillBudgetContext(options, input.targetIdentity)
+        : {
+            effectiveContextTokens: input.resolved.contextProfile.contextWindowTokens,
+            estimatorVersion: input.resolved.contextProfile.estimatorVersion,
+          };
+    const extensionSources = await resolveExtensionSkillSources(options);
+    const stagedArtifactStore = createStagedArtifactStore();
+    const skillContext = await createInitialSkillContextV1({
+      artifactStore: stagedArtifactStore,
+      ...skillBudgetContext,
+      projectId,
+      sessionId,
+      userHome: homedir(),
+      workspaceRoot: options.workspaceRoot,
+      extensionSources,
+    });
+    const selectedSkills: string[] = [];
+    const skillManifests = new Map<string, SkillResourceManifestV1>();
+    const skillPolicies = new Map<string, "allow">();
+    if (input.skills !== undefined) {
+      if (input.runId === undefined || !draftSkillSelectionsAreValid(input.skills)) {
+        throw new SessionLifecycleError("session_skill_unavailable");
+      }
+      for (const [index, selection] of input.skills.entries()) {
+        const exactCandidate = skillContext.registry.candidates.find(
+          (entry) => entry.qualifiedId === selection,
+        );
+        const shortCandidates = skillContext.registry.candidates.filter(
+          (entry) => entry.name === selection,
+        );
+        const candidate =
+          exactCandidate ?? (shortCandidates.length === 1 ? shortCandidates[0] : undefined);
+        if (candidate === undefined) {
+          throw new SessionLifecycleError("session_skill_unavailable");
+        }
+        const requestId = `${input.runId}:skill:${index + 1}`;
+        selectedSkills.push(candidate.qualifiedId);
+        const manifest = await buildSkillResourceManifestV1({
+          candidate,
+          workspaceRoot: options.workspaceRoot,
+          userHome: homedir(),
+          userHomeDigest: skillContext.userHomeDigest,
+          ...(extensionSources.length === 0 ? {} : { extensionSources }),
+        });
+        const policy =
+          options.permissions?.decide({
+            callId: requestId,
+            name: "activate_skill",
+            effect: "read",
+            scope: "call",
+            subject: {
+              type: "skill",
+              operation: "activate",
+              qualifiedId: candidate.qualifiedId,
+            },
+          }) ?? "deny";
+        if (policy === "deny") {
+          throw new SessionLifecycleError("session_skill_policy_rejected");
+        }
+        if (policy === "ask") {
+          throw new SessionLifecycleError("session_skill_confirmation_required");
+        }
+        skillManifests.set(requestId, manifest);
+        skillPolicies.set(requestId, policy);
+      }
+    }
+    if (options.tools === undefined) {
+      throw new SessionLifecycleError("session_invalid");
+    }
+    input.signal?.throwIfAborted();
+    await stagedArtifactStore.flushTo(
+      createLazyArtifactStore(join(effectiveSessionStateRoot(options.stateRoot), "artifacts")),
+    );
+    input.signal?.throwIfAborted();
+    return {
+      genesis: {
+        schemaVersion: 3,
+        sequence: 1,
+        record: {
+          type: "session_genesis",
+          sessionId,
+          projectId,
+          targetIdentity: input.targetIdentity,
+          promptContext: createPromptContextV3(options.tools, repository, skillContext),
+          skillContext,
+        },
+      },
+      mcp,
+      skillManifests,
+      skillPolicies,
+      ...(input.skills === undefined ? {} : { selectedSkills }),
+    };
+  };
+
+  const persistPreparedSession = async (prepared: {
+    readonly genesis: SessionGenesisRecord;
+    readonly mcp: McpSessionSnapshot | undefined;
+  }): Promise<CurrentSessionSnapshot> => {
+    const store = await storeDirectory.create(prepared.genesis.record.sessionId);
+    await store.append(prepared.genesis);
+    const snapshot = snapshotFromGenesis(prepared.genesis, 1);
+    return prepared.mcp === undefined ? snapshot : { ...snapshot, mcp: prepared.mcp };
+  };
+
   return {
+    async admit(input) {
+      const runId = input.runId ?? randomUUID();
+      if (
+        !z.uuid().safeParse(runId).success ||
+        input.input.text.trim().length === 0 ||
+        !draftRunLimitsAreValid(input.limits) ||
+        options.modelTargets === undefined
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      const created = await withOwner(async () => {
+        const resolved = await options.modelTargets?.resolve({
+          targetId: input.targetIdentity.targetId,
+          targetIdentity: input.targetIdentity,
+          allowExperimental: input.targetIdentity.certification === "experimental",
+          signal: input.signal ?? new AbortController().signal,
+        });
+        if (
+          resolved === undefined ||
+          !sameModelTargetIdentity(resolved.identity, input.targetIdentity) ||
+          resolved.contextProfile.version !== input.targetIdentity.profileVersion ||
+          !isContextProfileSupported(resolved.contextProfile)
+        ) {
+          throw new SessionLifecycleError("session_model_target_incompatible");
+        }
+        const prepared = await prepareSessionCreation({
+          targetIdentity: input.targetIdentity,
+          runId,
+          ...(input.signal === undefined ? {} : { signal: input.signal }),
+          ...(input.input.skills === undefined ? {} : { skills: input.input.skills }),
+          resolved,
+        });
+        input.signal?.throwIfAborted();
+        let snapshot: CurrentSessionSnapshot;
+        try {
+          snapshot = await persistPreparedSession(prepared);
+        } catch {
+          throw new SessionLifecycleError("session_persistence_failed");
+        }
+        preparedAdmissionTargets.set(snapshot.sessionId, {
+          runId,
+          resolved,
+          skillManifests: prepared.skillManifests,
+          skillPolicies: prepared.skillPolicies,
+          ...(input.onAdmitted === undefined ? {} : { onAdmitted: input.onAdmitted }),
+        });
+        return { snapshot, selectedSkills: prepared.selectedSkills };
+      });
+      try {
+        return await this.continue({
+          sessionId: created.snapshot.sessionId,
+          input:
+            created.selectedSkills === undefined
+              ? input.input
+              : { ...input.input, skills: created.selectedSkills },
+          runId,
+          ...(input.limits === undefined ? {} : { limits: input.limits }),
+          ...(input.signal === undefined ? {} : { signal: input.signal }),
+        });
+      } finally {
+        preparedAdmissionTargets.delete(created.snapshot.sessionId);
+      }
+    },
     async branch(input) {
       return withOwner(async () => {
         const artifactCache = createArtifactMaterializationCache();
@@ -1846,54 +2083,11 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       return lifecycleClosePromise;
     },
     async create(input) {
-      return withOwner(async () => {
-        let mcp: McpSessionSnapshot | undefined;
-        try {
-          mcp = await inspectMcpConfiguration(options.workspaceRoot);
-        } catch (error) {
-          if (error instanceof McpConfigurationError) {
-            throw new SessionLifecycleError("mcp_config_invalid");
-          }
-          throw error;
-        }
-        const sessionId = randomUUID();
-        const projectId = await canonicalProjectId(options.workspaceRoot);
-        const repository = await loadInitialRepositoryInstructions({
-          workspaceRoot: options.workspaceRoot,
-        });
-        const store = await storeDirectory.create(sessionId);
-        const skillBudgetContext = await resolveSkillBudgetContext(options, input.targetIdentity);
-        const extensionSources = await resolveExtensionSkillSources(options);
-        const skillContext = await createInitialSkillContextV1({
-          artifactStore: createLazyArtifactStore(
-            join(effectiveSessionStateRoot(options.stateRoot), "artifacts"),
-          ),
-          ...skillBudgetContext,
-          projectId,
-          sessionId,
-          userHome: homedir(),
-          workspaceRoot: options.workspaceRoot,
-          extensionSources,
-        });
-        if (options.tools === undefined) {
-          throw new SessionLifecycleError("session_invalid");
-        }
-        const genesis: SessionGenesisRecord = {
-          schemaVersion: 3,
-          sequence: 1,
-          record: {
-            type: "session_genesis",
-            sessionId,
-            projectId,
-            targetIdentity: input.targetIdentity,
-            promptContext: createPromptContextV3(options.tools, repository, skillContext),
-            skillContext,
-          },
-        };
-        await store.append(genesis);
-        const snapshot = snapshotFromGenesis(genesis, 1);
-        return mcp === undefined ? snapshot : { ...snapshot, mcp };
-      });
+      return withOwner(async () =>
+        persistPreparedSession(
+          await prepareSessionCreation({ targetIdentity: input.targetIdentity }),
+        ),
+      );
     },
     async continue(input) {
       if (input.runId !== undefined && !z.uuid().safeParse(input.runId).success) {
@@ -1938,12 +2132,16 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         if (options.modelTargets === undefined) {
           throw new SessionLifecycleError("session_model_target_unavailable");
         }
-        const resolved = await options.modelTargets.resolve({
-          targetId: resumed.snapshot.targetIdentity.targetId,
-          targetIdentity: resumed.snapshot.targetIdentity,
-          allowExperimental: resumed.snapshot.targetIdentity.certification === "experimental",
-          signal: input.signal ?? new AbortController().signal,
-        });
+        const preparedAdmission = preparedAdmissionTargets.get(input.sessionId);
+        const resolved =
+          preparedAdmission !== undefined && preparedAdmission.runId === input.runId
+            ? preparedAdmission.resolved
+            : await options.modelTargets.resolve({
+                targetId: resumed.snapshot.targetIdentity.targetId,
+                targetIdentity: resumed.snapshot.targetIdentity,
+                allowExperimental: resumed.snapshot.targetIdentity.certification === "experimental",
+                signal: input.signal ?? new AbortController().signal,
+              });
         if (
           !sameModelTargetIdentity(resolved.identity, resumed.snapshot.targetIdentity) ||
           resolved.contextProfile.version !== resumed.snapshot.targetIdentity.profileVersion ||
@@ -2250,21 +2448,33 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
               ? {}
               : { repositoryWorkspaceRoot: options.workspaceRoot }),
             sessionId: resumed.snapshot.sessionId,
-            ...(options[sessionLogicalRunStartedBarrier] === undefined
+            ...(options[sessionLogicalRunStartedBarrier] === undefined &&
+            preparedAdmission?.onAdmitted === undefined
               ? {}
               : {
-                  afterLogicalRunStarted: (started: {
+                  afterLogicalRunStarted: async (started: {
                     readonly sessionId: string;
                     readonly runId: string;
                     readonly sequence: number;
-                  }) =>
-                    options[sessionLogicalRunStartedBarrier]?.afterDurableRecord(started) ??
-                    Promise.resolve(),
+                  }) => {
+                    try {
+                      preparedAdmission?.onAdmitted?.(started);
+                    } catch {
+                      // Admission observers cannot change an already durable logical input.
+                    }
+                    await options[sessionLogicalRunStartedBarrier]?.afterDurableRecord(started);
+                  },
                 }),
             targetIdentity: resumed.snapshot.targetIdentity,
             ...(activePromptContext === undefined ? {} : { promptContext: activePromptContext }),
             ...(activeSkillContext === undefined ? {} : { skillContext: activeSkillContext }),
             ...(extensionSources.length === 0 ? {} : { extensionSkillSources: extensionSources }),
+            ...(preparedAdmission === undefined
+              ? {}
+              : {
+                  preparedExplicitSkillManifests: preparedAdmission.skillManifests,
+                  preparedExplicitSkillPolicies: preparedAdmission.skillPolicies,
+                }),
             ...(options.extensionHost === undefined
               ? {}
               : {
@@ -3044,7 +3254,19 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       }
       const afterSessionId = decodeProjectSessionCatalogCursor(input.cursor);
       const projectId = await canonicalProjectId(options.workspaceRoot);
-      const sessionIds = [...(await storeDirectory.listSessionIds())].sort();
+      const sessionIds: string[] = [];
+      for (const sessionId of [...(await storeDirectory.listSessionIds())].sort()) {
+        const records = await readSessionRecords(options, sessionId);
+        if (
+          records.some((entry) =>
+            entry.schemaVersion === 3
+              ? entry.record.type === "logical_run_started"
+              : entry.event.type === "user_message",
+          )
+        ) {
+          sessionIds.push(sessionId);
+        }
+      }
       const afterIndex =
         afterSessionId === undefined
           ? 0
@@ -3063,6 +3285,45 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             ? encodeProjectSessionCatalogCursor(lastSessionId)
             : null,
       };
+    },
+    async previewNewSession(input) {
+      return withOwner(async () => {
+        if (options.modelTargets === undefined) {
+          throw new SessionLifecycleError("session_model_target_unavailable");
+        }
+        const targets = await options.modelTargets.snapshot({
+          includeHistoricalProfiles: true,
+          signal: input.signal ?? new AbortController().signal,
+        });
+        const target = targets.targets.find((candidate) =>
+          sameModelTargetIdentity(candidate.identity, input.targetIdentity),
+        );
+        if (target === undefined || target.readiness.status !== "available") {
+          throw new SessionLifecycleError("session_model_target_unavailable");
+        }
+        if (
+          target.contextProfile.version !== input.targetIdentity.profileVersion ||
+          !isContextProfileSupported(target.contextProfile)
+        ) {
+          throw new SessionLifecycleError("session_model_target_incompatible");
+        }
+        const projectId = await canonicalProjectId(options.workspaceRoot);
+        const extensionSources = await resolveExtensionSkillSources(options);
+        const skillContext = await createInitialSkillContextV1({
+          artifactStore: createStagedArtifactStore(),
+          effectiveContextTokens: target.contextProfile.contextWindowTokens,
+          estimatorVersion: target.contextProfile.estimatorVersion,
+          projectId,
+          sessionId: randomUUID(),
+          userHome: homedir(),
+          workspaceRoot: options.workspaceRoot,
+          extensionSources,
+        });
+        return {
+          targetIdentity: input.targetIdentity,
+          skillContext: skillContextSnapshot(skillContext),
+        };
+      });
     },
     async reloadRepositoryInstructions(input) {
       if (activeSession !== undefined) {
@@ -7860,6 +8121,50 @@ function createLazyArtifactStore(root: string): ArtifactStore {
   };
 }
 
+function createStagedArtifactStore(): ArtifactStore & {
+  readonly flushTo: (store: ArtifactStore) => Promise<void>;
+} {
+  const artifacts = new Map<
+    string,
+    {
+      readonly bytes: Uint8Array;
+      readonly mediaType: string;
+      readonly source: ArtifactSource;
+    }
+  >();
+  return {
+    async write(input) {
+      const bytes = Uint8Array.from(input.bytes);
+      const id = `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+      artifacts.set(id, { bytes, mediaType: input.mediaType, source: input.source });
+      return {
+        id,
+        mediaType: input.mediaType,
+        byteCount: bytes.byteLength,
+        source: input.source,
+      };
+    },
+    async read(id, options) {
+      const bytes = artifacts.get(id)?.bytes;
+      if (
+        bytes === undefined ||
+        (options?.maximumBytes !== undefined && bytes.byteLength > options.maximumBytes)
+      ) {
+        return undefined;
+      }
+      return Uint8Array.from(bytes);
+    },
+    async flushTo(store) {
+      for (const [id, artifact] of artifacts) {
+        const persisted = await store.write(artifact);
+        if (persisted.id !== id) {
+          throw new SessionLifecycleError("session_invalid");
+        }
+      }
+    },
+  };
+}
+
 async function materializeActiveSkillContents(
   options: SessionLifecycleOptions,
   context: SkillContextRecordV1 | undefined,
@@ -8188,6 +8493,27 @@ function inlineModelResponseField(field: string | SessionModelResponseField): st
   throw new SessionLifecycleError("session_invalid");
 }
 
+function draftSkillSelectionsAreValid(selections: readonly string[]): boolean {
+  return (
+    selections.length <= 8 &&
+    selections.every(
+      (selection) =>
+        selection.length > 0 &&
+        Buffer.byteLength(selection, "utf8") <= 16_384 &&
+        /^[\x20-\x7e]+$/u.test(selection),
+    )
+  );
+}
+
+function draftRunLimitsAreValid(limits: RunOptions["limits"]): boolean {
+  return (
+    (limits?.maxTurns === undefined ||
+      (Number.isSafeInteger(limits.maxTurns) && limits.maxTurns > 0)) &&
+    (limits?.maxTokens === undefined ||
+      (Number.isSafeInteger(limits.maxTokens) && limits.maxTokens > 0))
+  );
+}
+
 function sessionLifecycleErrorMessage(code: SessionLifecycleError["code"]): string {
   switch (code) {
     case "mcp_bootstrap_failed":
@@ -8220,6 +8546,14 @@ function sessionLifecycleErrorMessage(code: SessionLifecycleError["code"]): stri
       return "The requested exact model target is not compatible with this session boundary.";
     case "session_model_target_unavailable":
       return "The requested exact model target is not ready in this runtime.";
+    case "session_persistence_failed":
+      return "The new session could not be persisted.";
+    case "session_skill_unavailable":
+      return "One selected Agent Skill is unavailable for draft admission.";
+    case "session_skill_confirmation_required":
+      return "One selected Agent Skill requires confirmation before draft admission.";
+    case "session_skill_policy_rejected":
+      return "One selected Agent Skill is denied by the draft admission policy.";
     case "session_not_found":
       return "The session does not exist in this project.";
     case "session_project_mismatch":

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -368,6 +368,12 @@ export type PresentationFault = {
   readonly message: string;
 };
 
+export type NewSessionDraftDisplay = {
+  readonly targetId: string;
+  readonly skills: SkillCatalogDisplay;
+  readonly projectPaths: ProjectPathCatalogDisplay;
+};
+
 export type AuthoritativePresentationSnapshot = {
   readonly schemaVersion: 1;
   readonly continuity:
@@ -396,6 +402,7 @@ export type PresentationTransientState = {
 export type PresentationDisplayState = {
   readonly revision: number;
   readonly authoritative: AuthoritativePresentationSnapshot;
+  readonly draft: NewSessionDraftDisplay | null;
   readonly transient: PresentationTransientState | null;
 };
 
@@ -523,8 +530,13 @@ export type PresentationCommand =
       readonly skills: readonly string[];
     }
   | {
+      readonly type: "submit_draft_prompt";
+      readonly text: string;
+      readonly skills: readonly string[];
+    }
+  | {
       readonly type: "cancel_run";
-      readonly sessionId: string;
+      readonly sessionId: string | null;
     }
   | {
       readonly type: "decide_permission";
@@ -555,6 +567,7 @@ export function reconcilePresentationUpdate(
     return {
       revision: state.revision + 1,
       authoritative: update.snapshot,
+      draft: update.snapshot.active === null ? state.draft : null,
       transient: null,
     };
   }
@@ -569,6 +582,7 @@ export function reconcilePresentationUpdate(
         ...state.authoritative,
         continuity: { status: "repairing", reason: "gap" },
       },
+      draft: state.draft,
       transient: null,
     };
   }
@@ -576,6 +590,7 @@ export function reconcilePresentationUpdate(
   return {
     revision: state.revision + 1,
     authoritative: state.authoritative,
+    draft: state.draft,
     transient: {
       activity: "replying",
       assistant: {

--- a/packages/presentation/src/presentation.test.ts
+++ b/packages/presentation/src/presentation.test.ts
@@ -61,6 +61,7 @@ describe("presentation reconciliation", () => {
     const initial: PresentationDisplayState = {
       revision: 1,
       authoritative: emptySnapshot,
+      draft: null,
       transient: null,
     };
 
@@ -74,6 +75,7 @@ describe("presentation reconciliation", () => {
     expect(streaming).toEqual({
       revision: 2,
       authoritative: emptySnapshot,
+      draft: null,
       transient: {
         activity: "replying",
         assistant: {
@@ -136,6 +138,7 @@ describe("presentation reconciliation", () => {
     ).toEqual({
       revision: 3,
       authoritative: completedSnapshot,
+      draft: null,
       transient: null,
     });
   });
@@ -144,6 +147,7 @@ describe("presentation reconciliation", () => {
     const initial: PresentationDisplayState = {
       revision: 7,
       authoritative: emptySnapshot,
+      draft: null,
       transient: null,
     };
 
@@ -160,6 +164,7 @@ describe("presentation reconciliation", () => {
         ...emptySnapshot,
         continuity: { status: "repairing", reason: "gap" },
       },
+      draft: null,
       transient: null,
     });
   });

--- a/packages/testkit/src/presentation-session.os.test.ts
+++ b/packages/testkit/src/presentation-session.os.test.ts
@@ -1,0 +1,120 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  type ContextProfile,
+  createPresentationSession,
+  createSessionLifecycle,
+  type ModelTargetIdentity,
+  type ModelTargets,
+} from "@adam-agent/agent";
+import {
+  openJsonlSessionStore,
+  type SessionRecord,
+  sessionLogicalRunStartedBarrier,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+import { FakeModelDriver } from "./index.js";
+
+const targetIdentity: ModelTargetIdentity = {
+  targetId: "deepseek-v4-flash.direct",
+  vendor: "deepseek",
+  modelId: "deepseek-v4-flash",
+  route: "direct",
+  profileVersion: 1,
+  certification: "certified",
+};
+
+const contextProfile: ContextProfile = {
+  version: 1,
+  contextWindowTokens: 1_000_000,
+  maximumOutputTokens: 32_768,
+  compactAtTokens: 800_000,
+  postCompactTargetTokens: 200_000,
+  retainedTargetTokens: 20_000,
+  estimatorVersion: 1,
+};
+
+test("PresentationSession publishes admission only after the durable logical-input record", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-draft-durable-input-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const driver = new FakeModelDriver(() => {
+    throw new Error("The model must not start past the injected durability boundary.");
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createSessionLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+    [sessionLogicalRunStartedBarrier]: {
+      async afterDurableRecord() {
+        throw new Error("Injected interruption after durable logical input.");
+      },
+    },
+  });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      openProject: true,
+      projectLabel: "workspace",
+      stateRoot,
+      workspaceRoot,
+    });
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+
+    await expect(
+      presentation.dispatch({
+        type: "submit_draft_prompt",
+        text: "Keep the durable logical input",
+        skills: [],
+      }),
+    ).resolves.toMatchObject({ status: "admitted", resource: null });
+
+    const sessionId = presentation.getState().authoritative.active?.session.id;
+    if (sessionId === undefined) {
+      throw new Error("The durable admission boundary must publish its resumable session.");
+    }
+    const store = await openJsonlSessionStore<SessionRecord>({
+      sessionId,
+      stateRoot,
+      workspaceRoot,
+    });
+    expect(await store.read()).toEqual([
+      expect.objectContaining({ record: expect.objectContaining({ type: "session_genesis" }) }),
+      expect.objectContaining({
+        record: expect.objectContaining({
+          type: "logical_run_started",
+          userMessage: "Keep the durable logical input",
+        }),
+      }),
+    ]);
+    await expect(lifecycle.listProjectSessions()).resolves.toMatchObject({
+      items: [{ sessionId }],
+    });
+
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -10,7 +10,7 @@ import {
   createFileArtifactStore,
   createPermissionPolicy,
   createPresentationPreferences,
-  createPresentationSession,
+  createPresentationSession as createProductPresentationSession,
   createReadToolRegistry,
   createSessionLifecycle,
   type ModelDriver,
@@ -21,19 +21,25 @@ import {
 } from "@adam-agent/agent";
 import {
   assemblePromptMessagesV1,
+  createInMemorySessionStoreDirectory,
   digestPromptRequestV1,
   mcpCatalogStaleDurableBarrier,
   mcpTransportFactory,
   openJsonlSessionStore,
+  preparedDirectDeepSeekV2ContextProfile,
   presentationCatalogPageSize,
   presentationHistoryPageSize,
   presentationHydrationBarrier,
   presentationRuntimeRefreshBarrier,
+  presentationSessionRecordReader,
   resolvePresentationTerminalContext,
   type SessionRecord,
+  type SessionStore,
+  type SessionStoreDirectory,
   sessionAutomaticTitlesEnabled,
   sessionLogicalRunStartedBarrier,
   sessionRuntimeNotificationTransform,
+  sessionStoreDirectory,
   sessionTitleDeadlineScheduler,
 } from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
@@ -62,6 +68,48 @@ const contextProfile: ContextProfile = {
   retainedTargetTokens: 20_000,
   estimatorVersion: 1,
 };
+
+async function createPresentationSession(
+  options: Parameters<typeof createProductPresentationSession>[0],
+) {
+  if ("targetIdentity" in options && options.targetIdentity !== undefined) {
+    const { lifecycle, targetIdentity: fixtureTargetIdentity, ...base } = options;
+    const created = await lifecycle.create({ targetIdentity: fixtureTargetIdentity });
+    return createProductPresentationSession({
+      ...base,
+      lifecycle,
+      sessionId: created.sessionId,
+    });
+  }
+  return createProductPresentationSession(options);
+}
+function settledModelTargets(answer = "Presentation fixture answer."): ModelTargets {
+  const driver = new FakeModelDriver([
+    { type: "text_delta", text: answer },
+    { type: "finish", reason: "stop" },
+  ]);
+  return {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+}
+
+function readInMemoryPresentationRecords(directory: SessionStoreDirectory<SessionRecord>) {
+  return async (sessionId: string): Promise<readonly SessionRecord[]> =>
+    (await directory.open(sessionId))?.read() ?? [];
+}
 const testEnvironment = process.env as NodeJS.ProcessEnv & { HOME?: string };
 async function writeScriptedMcpConfiguration(
   testRoot: string,
@@ -193,6 +241,7 @@ test("PresentationSession opens an empty project catalog without creating a sess
         sessions: { items: [], nextCursor: null },
         active: null,
       },
+      draft: null,
       transient: null,
     });
     expect(state.authoritative.project.id).toMatch(/^sha256:[0-9a-f]{64}$/u);
@@ -240,7 +289,8 @@ test("PresentationSession projects exact target identity and readiness for proje
     },
   };
 
-  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
   try {
     const presentation = await createPresentationSession({
       lifecycle,
@@ -249,6 +299,7 @@ test("PresentationSession projects exact target identity and readiness for proje
       projectLabel: "workspace",
       stateRoot,
       workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
     });
 
     expect(presentation.getState().authoritative.targets).toEqual({
@@ -272,6 +323,509 @@ test("PresentationSession projects exact target identity and readiness for proje
       diagnostic: null,
     });
     expect(presentation.getState().authoritative.active).toBeNull();
+
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession begins a new-session draft without creating durable session identity", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-session-draft-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      throw new Error("Draft target selection does not resolve a model driver.");
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "DEEPSEEK_API_KEY" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      openProject: true,
+      projectLabel: "workspace",
+      stateRoot,
+      workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    });
+
+    await expect(
+      presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId }),
+    ).resolves.toMatchObject({ status: "admitted", resource: null });
+
+    expect(presentation.getState()).toMatchObject({
+      draft: { targetId: targetIdentity.targetId },
+      authoritative: {
+        active: null,
+        sessions: { items: [] },
+      },
+    });
+    await expect(lifecycle.listProjectSessions()).resolves.toMatchObject({ items: [] });
+
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession previews the draft Skill catalog without creating durable session identity", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-draft-skills-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "draft-review");
+  await mkdir(skillDirectory, { recursive: true });
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: draft-review\ndescription: Reviews the first draft prompt.\n---\nDraft-only preview body.\n",
+    "utf8",
+  );
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      throw new Error("Draft catalog preview does not resolve a model driver.");
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "DEEPSEEK_API_KEY" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      openProject: true,
+      projectLabel: "workspace",
+      stateRoot,
+      workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    });
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+
+    expect(presentation.getState().draft).toMatchObject({
+      targetId: targetIdentity.targetId,
+      skills: {
+        items: [
+          {
+            qualifiedId: "skill:v1:project:.:draft-review",
+            name: "draft-review",
+            active: false,
+          },
+        ],
+        reloadAvailable: false,
+      },
+    });
+    await expect(lifecycle.listProjectSessions()).resolves.toMatchObject({ items: [] });
+
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession freezes the current exact target identity against historical catalog entries", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-draft-exact-target-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const currentIdentity: ModelTargetIdentity = { ...targetIdentity, profileVersion: 2 };
+  const observedAdmissionProfiles: number[] = [];
+  const modelTargets: ModelTargets = {
+    async resolve(input) {
+      const exact = (input as typeof input & { readonly targetIdentity?: ModelTargetIdentity })
+        .targetIdentity;
+      const identity = exact?.profileVersion === 1 ? targetIdentity : currentIdentity;
+      observedAdmissionProfiles.push(identity.profileVersion);
+      return {
+        identity,
+        driver: new FakeModelDriver([
+          { type: "text_delta", text: `Profile ${identity.profileVersion} admitted.` },
+          { type: "finish", reason: "stop" },
+        ]),
+        contextProfile:
+          identity.profileVersion === 1 ? contextProfile : preparedDirectDeepSeekV2ContextProfile,
+      };
+    },
+    async snapshot(input) {
+      const current = {
+        identity: currentIdentity,
+        readiness: { status: "available" as const, credentialSource: "current profile" },
+        contextProfile: preparedDirectDeepSeekV2ContextProfile,
+      };
+      const historical = {
+        identity: targetIdentity,
+        readiness: { status: "available" as const, credentialSource: "historical profile" },
+        contextProfile,
+      };
+      return {
+        targets: input.includeHistoricalProfiles ? [current, historical] : [current],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const historical = await lifecycle.create({ targetIdentity });
+    await lifecycle.continue({
+      sessionId: historical.sessionId,
+      input: { text: "Persist the historical exact profile" },
+    });
+    observedAdmissionProfiles.length = 0;
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      openProject: true,
+      projectLabel: "workspace",
+      stateRoot,
+      workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    });
+    await presentation.dispatch({ type: "create_session", targetId: currentIdentity.targetId });
+
+    await expect(
+      presentation.dispatch({
+        type: "submit_draft_prompt",
+        text: "Use the current exact profile",
+        skills: [],
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    const admittedSessionId = presentation.getState().authoritative.active?.session.id;
+    if (admittedSessionId === undefined) {
+      throw new Error("Expected the current exact target draft to be admitted.");
+    }
+    await expect(lifecycle.inspect({ sessionId: admittedSessionId })).resolves.toMatchObject({
+      targetIdentity: currentIdentity,
+    });
+    expect(observedAdmissionProfiles[0]).toBe(2);
+
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession admits the first non-empty draft prompt as one durable session", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-draft-admission-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const driver = new FakeModelDriver([
+    { type: "text_delta", text: "Draft admitted." },
+    { type: "finish", reason: "stop" },
+  ]);
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "DEEPSEEK_API_KEY" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      openProject: true,
+      projectLabel: "workspace",
+      stateRoot,
+      workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    });
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+    const completed = Promise.withResolvers<void>();
+    const unsubscribe = presentation.subscribe(() => {
+      const items = presentation.getState().authoritative.active?.transcript.items ?? [];
+      if (
+        items.some((item) => item.type === "assistant_message" && item.text === "Draft admitted.")
+      ) {
+        completed.resolve();
+      }
+    });
+
+    await expect(
+      presentation.dispatch({
+        type: "submit_draft_prompt",
+        text: "Persist this first prompt",
+        skills: [],
+      }),
+    ).resolves.toMatchObject({ status: "admitted", resource: null });
+    await completed.promise;
+    unsubscribe();
+
+    const state = presentation.getState();
+    expect(state).toMatchObject({
+      draft: null,
+      authoritative: {
+        active: {
+          session: { targetId: targetIdentity.targetId },
+          transcript: {
+            items: [
+              { type: "user_message", text: "Persist this first prompt" },
+              { type: "assistant_message", text: "Draft admitted." },
+            ],
+          },
+        },
+        sessions: { items: [{ targetId: targetIdentity.targetId }] },
+      },
+    });
+    await expect(lifecycle.listProjectSessions()).resolves.toMatchObject({
+      items: [{ sessionId: state.authoritative.active?.session.id }],
+    });
+
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession keeps the draft unpersisted when target resolution rejects admission", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-draft-target-reject-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      throw new Error("The exact target became unavailable.");
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "DEEPSEEK_API_KEY" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      openProject: true,
+      projectLabel: "workspace",
+      stateRoot,
+      workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    });
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+
+    await expect(
+      presentation.dispatch({
+        type: "submit_draft_prompt",
+        text: "Do not partially persist this prompt",
+        skills: [],
+      }),
+    ).resolves.toMatchObject({ status: "rejected" });
+
+    expect(presentation.getState()).toMatchObject({
+      draft: { targetId: targetIdentity.targetId },
+      authoritative: { active: null, sessions: { items: [] } },
+    });
+    await expect(lifecycle.listProjectSessions()).resolves.toMatchObject({ items: [] });
+
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession keeps an admitted draft durable when the provider fails", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-draft-provider-failure-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const driver: ModelDriver = {
+    async *stream() {
+      yield await Promise.reject(
+        new ModelDriverError("transport", "private provider failure", {
+          cause: new Error("fixture transport failure"),
+        }),
+      );
+    },
+  };
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "DEEPSEEK_API_KEY" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      openProject: true,
+      projectLabel: "workspace",
+      stateRoot,
+      workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    });
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+    const failed = Promise.withResolvers<void>();
+    const unsubscribe = presentation.subscribe(() => {
+      if (
+        presentation
+          .getState()
+          .authoritative.active?.transcript.items.some(
+            (item) => item.type === "session_notice" && item.status === "failed",
+          ) === true
+      ) {
+        failed.resolve();
+      }
+    });
+
+    await expect(
+      presentation.dispatch({
+        type: "submit_draft_prompt",
+        text: "Persist before provider failure",
+        skills: [],
+      }),
+    ).resolves.toMatchObject({ status: "admitted", resource: null });
+    await failed.promise;
+    unsubscribe();
+
+    const state = presentation.getState();
+    expect(state).toMatchObject({
+      draft: null,
+      authoritative: {
+        active: {
+          transcript: {
+            items: [
+              { type: "user_message", text: "Persist before provider failure" },
+              { type: "session_notice", status: "failed", code: "model_request_failed" },
+            ],
+          },
+        },
+        sessions: { items: [{ id: state.authoritative.active?.session.id }] },
+      },
+    });
+    await expect(lifecycle.listProjectSessions()).resolves.toMatchObject({
+      items: [{ sessionId: state.authoritative.active?.session.id }],
+    });
+
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession keeps its draft when logical input persistence fails", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-draft-input-failure-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const backing = createInMemorySessionStoreDirectory<SessionRecord>();
+  const wrappedStores = new Map<string, SessionStore<SessionRecord>>();
+  const failingDirectory: SessionStoreDirectory<SessionRecord> = {
+    async create(sessionId) {
+      const store = await backing.create(sessionId);
+      const wrapped: SessionStore<SessionRecord> = {
+        async append(record) {
+          if (record.schemaVersion === 3 && record.record.type === "logical_run_started") {
+            throw new Error("Injected logical-input persistence failure.");
+          }
+          await store.append(record);
+        },
+        read: () => store.read(),
+      };
+      wrappedStores.set(sessionId, wrapped);
+      return wrapped;
+    },
+    listSessionIds: () => backing.listSessionIds(),
+    async open(sessionId) {
+      return (await backing.open(sessionId)) === undefined
+        ? undefined
+        : wrappedStores.get(sessionId);
+    },
+  };
+  const modelTargets = settledModelTargets("The model must not run after persistence failure.");
+  const lifecycle = createSessionLifecycle({
+    modelTargets,
+    workspaceRoot,
+    [sessionStoreDirectory]: failingDirectory,
+  });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      openProject: true,
+      projectLabel: "workspace",
+      workspaceRoot,
+    });
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+
+    await expect(
+      presentation.dispatch({
+        type: "submit_draft_prompt",
+        text: "Keep this draft after persistence failure",
+        skills: [],
+      }),
+    ).resolves.toMatchObject({ status: "rejected", code: "persistence_failed" });
+    expect(presentation.getState()).toMatchObject({
+      draft: { targetId: targetIdentity.targetId },
+      authoritative: { active: null, sessions: { items: [] } },
+    });
+    await expect(lifecycle.listProjectSessions()).resolves.toMatchObject({ items: [] });
 
     await presentation.close();
   } finally {
@@ -448,7 +1002,7 @@ test("PresentationSession saves one exact default target through a distinct sema
   }
 });
 
-test("PresentationSession creates a session only from an exact available launch target", async () => {
+test("PresentationSession begins a draft only from an exact available launch target", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-target-create-"));
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
@@ -484,14 +1038,11 @@ test("PresentationSession creates a session only from an exact available launch 
     await expect(
       presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId }),
     ).resolves.toMatchObject({ status: "admitted", resource: null });
-    expect(presentation.getState().authoritative.active?.session).toMatchObject({
-      targetId: targetIdentity.targetId,
-      label: "New session",
-      status: "idle",
+    expect(presentation.getState()).toMatchObject({
+      draft: { targetId: targetIdentity.targetId },
+      authoritative: { active: null, sessions: { items: [] } },
     });
-    await expect(lifecycle.listProjectSessions()).resolves.toMatchObject({
-      items: [expect.objectContaining({ targetIdentity })],
-    });
+    await expect(lifecycle.listProjectSessions()).resolves.toMatchObject({ items: [] });
 
     await presentation.close();
   } finally {
@@ -500,16 +1051,33 @@ test("PresentationSession creates a session only from an exact available launch 
   }
 });
 
-test("PresentationSession opens a real new session as authoritative empty project history", async () => {
+test("PresentationSession opens an exact target as a process-local draft", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-open-"));
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
 
-  const lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      throw new Error("Opening an exact target draft must not resolve a model driver.");
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
   try {
-    const presentation = await createPresentationSession({
+    const presentation = await createProductPresentationSession({
       lifecycle,
+      modelTargets,
       projectLabel: "workspace",
       stateRoot,
       targetIdentity,
@@ -523,68 +1091,27 @@ test("PresentationSession opens a real new session as authoritative empty projec
         schemaVersion: 1,
         continuity: {
           status: "current",
-          sessionThroughSequence: 1,
+          sessionThroughSequence: 0,
           operationThrough: [],
         },
         project: { id: state.authoritative.project.id, label: "workspace" },
-        targets: { items: [], defaultTargetId: null, diagnostic: null },
-        sessions: {
-          items: [
-            {
-              id: state.authoritative.active?.session.id,
-              label: "New session",
-              targetId: "deepseek-v4-flash.direct",
-              status: "idle",
-              naming: {
-                manualName: null,
-                generatedTitle: null,
-                fallbackTitle: null,
-                displayLabel: "New session",
-                generation: { status: "not_started" },
-              },
-            },
-          ],
-          nextCursor: null,
+        targets: {
+          items: [expect.objectContaining({ targetId: targetIdentity.targetId })],
+          defaultTargetId: null,
+          diagnostic: null,
         },
-        active: {
-          session: {
-            id: state.authoritative.active?.session.id,
-            label: "New session",
-            targetId: "deepseek-v4-flash.direct",
-            status: "idle",
-            naming: {
-              manualName: null,
-              generatedTitle: null,
-              fallbackTitle: null,
-              displayLabel: "New session",
-              generation: { status: "not_started" },
-            },
-          },
-          transcript: { items: [], olderCursor: null },
-          context: null,
-          pendingInteractions: [],
-          repositoryInstructions: {
-            revision: 1,
-            activeScopes: ["."],
-            sources: [],
-            diagnostics: [],
-            effectiveDigest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
-            reloadAvailable: true,
-          },
-          skills: {
-            revision: 1,
-            items: [],
-            diagnostics: [],
-            overflow: { omittedCount: 0, shortenedCount: 0 },
-            reloadAvailable: true,
-          },
-          projectPaths: { items: [], omittedCount: 0, diagnostic: null },
-          mcp: null,
-        },
+        sessions: { items: [], nextCursor: null },
+        active: null,
+      },
+      draft: {
+        targetId: targetIdentity.targetId,
+        projectPaths: expect.objectContaining({ items: [], omittedCount: 0 }),
+        skills: expect.objectContaining({ items: [], reloadAvailable: false }),
       },
       transient: null,
     });
     expect(state.authoritative.project.id).toMatch(/^sha256:[0-9a-f]{64}$/u);
+    await expect(lifecycle.listProjectSessions()).resolves.toMatchObject({ items: [] });
 
     await presentation.close();
   } finally {
@@ -4371,25 +4898,28 @@ test("SessionLifecycle rejects a preview reference whose provenance no longer ma
   }
 });
 
-test("PresentationSession creates and selects sessions through semantic commands", async () => {
+test("PresentationSession starts a draft and selects admitted sessions through semantic commands", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-create-select-"));
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
-  const lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+  const modelTargets = settledModelTargets();
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
 
   try {
+    const first = await lifecycle.create({ targetIdentity });
+    await lifecycle.continue({
+      sessionId: first.sessionId,
+      input: { text: "First admitted project session" },
+    });
     const presentation = await createPresentationSession({
       lifecycle,
+      modelTargets,
+      openProject: true,
       projectLabel: "workspace",
-      targetIdentity,
       stateRoot,
       workspaceRoot,
     });
-    const firstSessionId = presentation.getState().authoritative.active?.session.id;
-    if (firstSessionId === undefined) {
-      throw new Error("Expected an initial session.");
-    }
 
     await expect(
       presentation.dispatch({
@@ -4397,22 +4927,29 @@ test("PresentationSession creates and selects sessions through semantic commands
         targetId: "deepseek-v4-flash.direct",
       }),
     ).resolves.toMatchObject({ status: "admitted", resource: null });
-    const secondSessionId = presentation.getState().authoritative.active?.session.id;
-    expect(secondSessionId).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
-    );
-    expect(secondSessionId).not.toBe(firstSessionId);
-    expect(presentation.getState().authoritative.sessions.items).toHaveLength(2);
+    expect(presentation.getState()).toMatchObject({
+      draft: { targetId: targetIdentity.targetId },
+      authoritative: {
+        active: null,
+        sessions: { items: [{ id: first.sessionId }] },
+      },
+    });
 
     await expect(
-      presentation.dispatch({ type: "select_session", sessionId: firstSessionId }),
+      presentation.dispatch({ type: "select_session", sessionId: first.sessionId }),
     ).resolves.toMatchObject({ status: "admitted", resource: null });
     expect(presentation.getState()).toMatchObject({
+      draft: null,
       authoritative: {
-        continuity: { status: "current", sessionThroughSequence: 1 },
         active: {
-          session: { id: firstSessionId, label: "New session" },
-          transcript: { items: [], olderCursor: null },
+          session: { id: first.sessionId },
+          transcript: {
+            items: [
+              { type: "user_message", text: "First admitted project session" },
+              { type: "assistant_message", text: "Presentation fixture answer." },
+            ],
+            olderCursor: null,
+          },
         },
       },
     });
@@ -4429,11 +4966,14 @@ test("PresentationSession discovers and selects cold sibling project sessions", 
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
-  const lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+  const modelTargets = settledModelTargets("Cold catalog answer.");
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
 
   try {
     const first = await lifecycle.create({ targetIdentity });
     const second = await lifecycle.create({ targetIdentity });
+    await lifecycle.continue({ sessionId: first.sessionId, input: { text: "Cold first" } });
+    await lifecycle.continue({ sessionId: second.sessionId, input: { text: "Cold second" } });
     const presentation = await createPresentationSession({
       lifecycle,
       projectLabel: "workspace",
@@ -4466,13 +5006,21 @@ test("PresentationSession consumes the opaque project catalog cursor", async () 
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
-  const lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+  const modelTargets = settledModelTargets("Catalog page answer.");
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
 
   try {
     const created = [
       await lifecycle.create({ targetIdentity }),
       await lifecycle.create({ targetIdentity }),
-    ].sort((left, right) => left.sessionId.localeCompare(right.sessionId));
+    ];
+    for (const [index, session] of created.entries()) {
+      await lifecycle.continue({
+        sessionId: session.sessionId,
+        input: { text: `Catalog page ${index + 1}` },
+      });
+    }
+    created.sort((left, right) => left.sessionId.localeCompare(right.sessionId));
     const first = created[0];
     if (first === undefined) {
       throw new Error("Expected a project session.");
@@ -4512,11 +5060,20 @@ test("PresentationSession rejects a failed catalog page inside CommandReceipt", 
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
-  const lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+  const modelTargets = settledModelTargets("Catalog failure answer.");
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
 
   try {
     const first = await lifecycle.create({ targetIdentity });
-    await lifecycle.create({ targetIdentity });
+    const second = await lifecycle.create({ targetIdentity });
+    await lifecycle.continue({
+      sessionId: first.sessionId,
+      input: { text: "Catalog failure first" },
+    });
+    await lifecycle.continue({
+      sessionId: second.sessionId,
+      input: { text: "Catalog failure second" },
+    });
     const presentationLifecycle: SessionLifecycle = {
       ...lifecycle,
       async listProjectSessions(input) {
@@ -5300,6 +5857,9 @@ test("PresentationSession keeps an active run bound to its source session", asyn
       await modelStarted.promise;
       await expect(
         presentation.dispatch({ type: "select_session", sessionId: sibling.sessionId }),
+      ).resolves.toMatchObject({ status: "rejected", code: "conflict" });
+      await expect(
+        presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId }),
       ).resolves.toMatchObject({ status: "rejected", code: "conflict" });
       expect(presentation.getState().authoritative.active?.session.id).toBe(source.sessionId);
       await expect(

--- a/packages/testkit/src/session-lifecycle.test.ts
+++ b/packages/testkit/src/session-lifecycle.test.ts
@@ -26,6 +26,7 @@ import {
   preparedDirectDeepSeekV2ContextProfile,
   type SessionRecord,
   sessionAutomaticTitlesEnabled,
+  sessionLogicalRunStartedBarrier,
 } from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
 import { createInMemorySessionLifecycleHarness, FakeModelDriver } from "./index.js";
@@ -274,18 +275,377 @@ test("SessionLifecycle creates durable new-schema genesis for an exact project a
   }
 });
 
-test("SessionLifecycle catalogs shared in-memory sessions through public pagination", async () => {
+test("SessionLifecycle rejects an unavailable draft Skill before allocating durable session identity", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-lifecycle-draft-skill-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "available-sibling");
+  await mkdir(skillDirectory, { recursive: true });
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: available-sibling\ndescription: Proves rejected admission leaves discovered Skills staged.\n---\nDo not persist this sibling before admission.\n",
+    "utf8",
+  );
+  const harness = createInMemorySessionLifecycleHarness();
+  const driver = new FakeModelDriver(() => {
+    throw new Error("The model must not run when draft Skill resolution fails.");
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Use a missing Skill", skills: ["skill:v1:user:missing"] },
+      }),
+    ).rejects.toMatchObject({ code: "session_skill_unavailable" });
+    await expect(harness.sessions.listSessionIds()).resolves.toEqual([]);
+    await expect(stat(join(stateRoot, "artifacts"))).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects denied draft Skill policy before allocating durable session identity", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-lifecycle-draft-policy-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "draft-policy");
+  await mkdir(skillDirectory, { recursive: true });
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: draft-policy\ndescription: Exercises draft admission policy.\n---\nUse only after read permission is admitted.\n",
+    "utf8",
+  );
+  const harness = createInMemorySessionLifecycleHarness();
+  const driver = new FakeModelDriver(() => {
+    throw new Error("The model must not run when draft Skill policy denies admission.");
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = harness.createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: [] }),
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: {
+          text: "Use the policy Skill",
+          skills: ["skill:v1:project:.:draft-policy"],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "session_skill_policy_rejected" });
+    await expect(harness.sessions.listSessionIds()).resolves.toEqual([]);
+    await expect(stat(join(stateRoot, "artifacts"))).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects asked draft Skill policy before allocating durable session identity", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-lifecycle-draft-ask-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "draft-ask");
+  await mkdir(skillDirectory, { recursive: true });
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: draft-ask\ndescription: Requires confirmation before admission.\n---\nDo not admit this draft before confirmation.\n",
+    "utf8",
+  );
+  const harness = createInMemorySessionLifecycleHarness();
+  const driver = new FakeModelDriver(() => {
+    throw new Error("The model must not run when draft Skill policy needs confirmation.");
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = harness.createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["read"] }),
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Use the asked Skill", skills: ["skill:v1:project:.:draft-ask"] },
+      }),
+    ).rejects.toMatchObject({ code: "session_skill_confirmation_required" });
+    await expect(harness.sessions.listSessionIds()).resolves.toEqual([]);
+    await expect(stat(join(stateRoot, "artifacts"))).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle cancels after target resolution before persisting draft resources", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-lifecycle-draft-cancel-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "draft-cancel");
+  await mkdir(skillDirectory, { recursive: true });
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: draft-cancel\ndescription: Must remain staged when admission is cancelled.\n---\nNever persist this cancelled draft.\n",
+    "utf8",
+  );
+  const harness = createInMemorySessionLifecycleHarness();
+  const controller = new AbortController();
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      controller.abort();
+      return {
+        identity: targetIdentity,
+        driver: new FakeModelDriver(() => {
+          throw new Error("The model must not run after draft admission cancellation.");
+        }),
+        contextProfile: testContextProfile,
+      };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = harness.createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: {
+          text: "Cancel after resolving the target",
+          skills: ["skill:v1:project:.:draft-cancel"],
+        },
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    await expect(harness.sessions.listSessionIds()).resolves.toEqual([]);
+    await expect(stat(join(stateRoot, "artifacts"))).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle freezes draft Skill resources before allocating durable session identity", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-lifecycle-draft-resource-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "draft-resource");
+  const resourcePath = join(skillDirectory, "references", "guide.txt");
+  await mkdir(join(skillDirectory, "references"), { recursive: true });
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: draft-resource\ndescription: Freezes resources before admission.\n---\nRead references/guide.txt.\n",
+    "utf8",
+  );
+  await writeFile(resourcePath, "before admission\n", "utf8");
+  const originalSize = (await stat(resourcePath, { bigint: true })).size.toString();
+  const harness = createInMemorySessionLifecycleHarness();
+  const driver = new FakeModelDriver(() => [
+    { type: "text_delta", text: "Draft resource admitted." },
+    { type: "finish", reason: "stop" },
+  ]);
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  let policyDecision: "allow" | "deny" = "allow";
+  const lifecycle = harness.createLifecycle({
+    modelTargets,
+    permissions: {
+      decide() {
+        return policyDecision;
+      },
+    },
+    workspaceRoot,
+    [sessionLogicalRunStartedBarrier]: {
+      async afterDurableRecord() {
+        await writeFile(resourcePath, "changed after durable logical input\n", "utf8");
+        policyDecision = "deny";
+      },
+    },
+  });
+
+  try {
+    const admitted = await lifecycle.admit({
+      targetIdentity,
+      input: {
+        text: "Use the frozen resource Skill",
+        skills: ["skill:v1:project:.:draft-resource"],
+      },
+    });
+    const manifestEntry = admitted.snapshot.skillContext?.active[0]?.manifest.entries.find(
+      (entry) => entry.path === "references/guide.txt",
+    );
+
+    expect(admitted.result).toMatchObject({ status: "completed" });
+    expect(manifestEntry?.identity.size).toBe(originalSize);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects invalid draft run limits before allocating durable session identity", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-lifecycle-draft-limits-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const harness = createInMemorySessionLifecycleHarness();
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return {
+        identity: targetIdentity,
+        driver: new FakeModelDriver([]),
+        contextProfile: testContextProfile,
+      };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = harness.createLifecycle({ modelTargets, workspaceRoot });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Reject invalid limits before genesis" },
+        limits: { maxTurns: 0 },
+      }),
+    ).rejects.toMatchObject({ code: "session_invalid" });
+    await expect(harness.sessions.listSessionIds()).resolves.toEqual([]);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle paginates prompt-admitted sessions while hiding genesis-only history", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-lifecycle-memory-catalog-"));
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
   const harness = createInMemorySessionLifecycleHarness();
-  const lifecycle = harness.createLifecycle({ workspaceRoot });
+  const driver = new FakeModelDriver(() => [
+    { type: "text_delta", text: "Cataloged answer." },
+    { type: "finish", reason: "stop" },
+  ]);
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = harness.createLifecycle({ modelTargets, workspaceRoot });
 
   try {
-    const created = [
+    const genesisOnly = await lifecycle.create({ targetIdentity });
+    const admitted = [
       await lifecycle.create({ targetIdentity }),
       await lifecycle.create({ targetIdentity }),
     ];
+    for (const [index, session] of admitted.entries()) {
+      await lifecycle.continue({
+        sessionId: session.sessionId,
+        input: { text: `Catalog prompt ${index + 1}` },
+      });
+    }
     const firstPage = await lifecycle.listProjectSessions({ limit: 1 });
     if (firstPage.nextCursor === null) {
       throw new Error("The first in-memory catalog page requires a continuation cursor.");
@@ -296,7 +656,10 @@ test("SessionLifecycle catalogs shared in-memory sessions through public paginat
     });
 
     expect([...firstPage.items, ...secondPage.items].map((item) => item.sessionId)).toEqual(
-      created.map((item) => item.sessionId).sort(),
+      admitted.map((item) => item.sessionId).sort(),
+    );
+    expect([...firstPage.items, ...secondPage.items]).not.toContainEqual(
+      expect.objectContaining({ sessionId: genesisOnly.sessionId }),
     );
     expect({ first: firstPage.nextCursor, second: secondPage.nextCursor }).toEqual({
       first: expect.any(String),


### PR DESCRIPTION
## Summary

- Keep a new project session process-local until its first non-empty prompt reaches durable logical admission.
- Hide legacy genesis-only sessions from the project catalog without deleting historical data.
- Preserve draft target, Skill, Help, Resume, path-completion, and cancellation behavior without allocating durable session identity.
- Pin a full-width New Session choice in the project session picker.
- Preflight exact targets, Skill resources, permission policy, run limits, and cancellation before persistence, with caller-visible typed failures.
- Use the same first-prompt admission boundary from the CLI and TUI.

## Verification

- `pnpm quality:check`
- 30 test files passed, 2 skipped
- 910 tests passed, 10 skipped
- Focused draft admission, cancellation, catalog, CLI, TUI, and real durability tracers
- Independent frozen-contract and test-hardening reviews report zero blockers