### PR TITLE
B9 R2c: Skill compatibility and prompt mentions

### DIFF
--- a/apps/tui/src/command-autocomplete.ts
+++ b/apps/tui/src/command-autocomplete.ts
@@ -9,10 +9,12 @@ import { safeTerminalText } from "./safe-terminal-text.js";
 
 type SkillCompletion = {
   readonly description: string;
+  readonly name: string;
   readonly qualifiedId: string;
 };
 
 export class AdamAutocompleteProvider implements AutocompleteProvider {
+  readonly triggerCharacters = ["$"];
   readonly #getProjectPaths: () => readonly string[];
   readonly #getRunActive: () => boolean;
   readonly #getSkills: () => readonly SkillCompletion[];
@@ -94,6 +96,21 @@ export class AdamAutocompleteProvider implements AutocompleteProvider {
         }));
       return Promise.resolve(
         skillItems.length === 0 ? null : { items: skillItems, prefix: skillPrefix },
+      );
+    }
+    const mention = /(?:^|[^A-Za-z0-9_$\\])(\$([a-z0-9-]*))$/u.exec(beforeCursor);
+    const mentionPrefix = mention?.[1];
+    const mentionNamePrefix = mention?.[2];
+    if (mentionPrefix !== undefined && mentionNamePrefix !== undefined) {
+      const skillItems = this.#getSkills()
+        .filter((skill) => skill.name.startsWith(mentionNamePrefix))
+        .map<AutocompleteItem>((skill) => ({
+          value: `$${skill.name}`,
+          label: `$${skill.name}`,
+          description: safeTerminalText(`${skill.qualifiedId} · ${skill.description}`),
+        }));
+      return Promise.resolve(
+        skillItems.length === 0 ? null : { items: skillItems, prefix: mentionPrefix },
       );
     }
     if (options.force !== true) {

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -1659,6 +1659,39 @@ test("Tab completes an exact qualified Skill argument from authoritative catalog
   }
 });
 
+test("Tab completes and admits a Skill mention from the current first-draft catalog", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-draft-skill-mention-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "first");
+  await mkdir(skillDirectory, { recursive: true });
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: first\ndescription: First mention completion procedure.\n---\nFIRST_MENTION_BODY\n",
+    "utf8",
+  );
+
+  try {
+    const fixture = startFixture({ scenario: "skill-selection", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Use $fir");
+    await fixture.waitFor("$first");
+    fixture.write("\t");
+    await fixture.waitFor("Use $first");
+    fixture.write("\r");
+    await fixture.waitFor("Skill selection complete.");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+
+    const durableState = await readFilesRecursively(stateRoot);
+    expect(durableState).toContain('"qualifiedId":"skill:v1:project:.:first"');
+    expect(durableState).toContain('"reason":"user_explicit"');
+    expect(durableState).toContain('"userMessage":"Use $first"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("Tab completes a Help topic argument from the Registry", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-help-topic-completion-"));
   const workspaceRoot = join(testRoot, "workspace");
@@ -2392,9 +2425,13 @@ test("the Skill palette renders untrusted metadata and diagnostic identities as 
   const stateRoot = join(testRoot, "state");
   const validDirectory = join(workspaceRoot, ".agents", "skills", "safe-name");
   const invalidDirectory = join(workspaceRoot, ".agents", "skills", "wrong-file");
+  const oversizedDirectory = join(workspaceRoot, ".agents", "skills", "oversized-frontmatter");
+  const oversizedFileDirectory = join(workspaceRoot, ".agents", "skills", "oversized-file");
   const unsafeSequence = "\u001b]52;c;c2NvcGU=\u0007";
   await mkdir(validDirectory, { recursive: true });
   await mkdir(invalidDirectory, { recursive: true });
+  await mkdir(oversizedDirectory, { recursive: true });
+  await mkdir(oversizedFileDirectory, { recursive: true });
   await writeFile(
     join(validDirectory, "SKILL.md"),
     `---\nname: safe-name\ndescription: Safe ${unsafeSequence} description.\n---\nPrivate body.\n`,
@@ -2405,6 +2442,12 @@ test("the Skill palette renders untrusted metadata and diagnostic identities as 
     "---\nname: wrong-file\ndescription: Wrong filename.\n---\n",
     "utf8",
   );
+  await writeFile(
+    join(oversizedDirectory, "SKILL.md"),
+    `---\nname: oversized-frontmatter\ndescription: Must expose its rejected frontmatter bound.\nvendor: ${"x".repeat(16_400)}\n---\n`,
+    "utf8",
+  );
+  await writeFile(join(oversizedFileDirectory, "SKILL.md"), "x".repeat(65_537), "utf8");
 
   try {
     const fixture = startFixture({ scenario: "skill-selection", stateRoot, workspaceRoot });
@@ -2415,6 +2458,10 @@ test("the Skill palette renders untrusted metadata and diagnostic identities as 
     const result = await fixture.closed;
     expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
     expect(result.stdout).toContain("wrong-file");
+    expect(result.stdout).toContain("field skill.md");
+    expect(result.stdout).toContain("maximum 16384 bytes");
+    expect(result.stdout).toContain("oversized-file");
+    expect(result.stdout).toContain("maximum 65536 bytes");
     expect(result.stdout).not.toContain(unsafeSequence);
   } finally {
     await rm(testRoot, { recursive: true, force: true });

--- a/apps/tui/src/skill-palette.ts
+++ b/apps/tui/src/skill-palette.ts
@@ -76,20 +76,51 @@ export class SkillPalette implements Component {
       this.#theme.muted(
         `Catalog r${this.#catalog.revision} · ${this.#catalog.overflow.omittedCount} omitted · ${this.#catalog.overflow.shortenedCount} shortened · ${this.#catalog.diagnostics.length} diagnostics`,
       ),
-      ...this.#catalog.diagnostics.map((diagnostic) =>
-        this.#theme.muted(
-          safeTerminalText(
-            `${diagnostic.code} · ${diagnostic.source}${
-              diagnostic.scope === undefined ? "" : `:${diagnostic.scope}`
-            } · ${diagnostic.packagePath}`,
+      ...this.#catalog.diagnostics.flatMap((diagnostic) => {
+        const detail = [
+          diagnostic.field === undefined ? undefined : `field ${diagnostic.field}`,
+          diagnostic.bound === undefined
+            ? undefined
+            : `maximum ${diagnostic.bound.maximum} ${diagnosticBoundUnit(diagnostic.bound.unit)}`,
+        ].filter((part): part is string => part !== undefined);
+        return [
+          this.#theme.muted(
+            safeTerminalText(
+              `${diagnostic.code} · ${diagnosticSourceLabel(diagnostic)}${
+                diagnostic.scope === undefined ? "" : `:${diagnostic.scope}`
+              } · ${diagnostic.packagePath}`,
+            ),
           ),
-        ),
-      ),
+          ...(detail.length === 0
+            ? []
+            : [this.#theme.muted(safeTerminalText(`  ${detail.join(" · ")}`))]),
+        ];
+      }),
       ...(this.#notice === null ? [] : ["", this.#theme.muted(this.#notice)]),
       "",
       this.#theme.muted("Enter toggle · Esc close · exact qualified IDs only"),
     ];
   }
+}
+
+function diagnosticSourceLabel(diagnostic: SkillCatalogDisplay["diagnostics"][number]): string {
+  if (diagnostic.source !== "extension") {
+    return diagnostic.source;
+  }
+  const identity = diagnostic.extensionId ?? "unknown-extension";
+  const packageIdentity =
+    diagnostic.packageName === undefined
+      ? ""
+      : `:${diagnostic.packageName}${
+          diagnostic.packageVersion === undefined ? "" : `@${diagnostic.packageVersion}`
+        }`;
+  return `extension:${identity}${packageIdentity}`;
+}
+
+function diagnosticBoundUnit(
+  unit: NonNullable<SkillCatalogDisplay["diagnostics"][number]["bound"]>["unit"],
+): string {
+  return unit === "estimated_tokens" ? "estimated tokens" : unit;
 }
 
 function sourceLabel(source: SkillDisplay["source"]): string {

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -115,10 +115,15 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           );
         },
         getSkills: () =>
-          options.presentation.getState().authoritative.active?.skills?.items.map((skill) => ({
+          (
+            options.presentation.getState().authoritative.active?.skills?.items ??
+            options.presentation.getState().draft?.skills.items ??
+            []
+          ).map((skill) => ({
             description: skill.description,
+            name: skill.name,
             qualifiedId: skill.qualifiedId,
-          })) ?? [],
+          })),
       }),
     );
     for (const prompt of authoritativePromptHistory(active)) {
@@ -1877,6 +1882,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           editor.setText("");
           selectedSkills.clear();
         } else {
+          statusMessage = receipt.message;
           editor.disableSubmit = false;
         }
       })

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -17,6 +17,7 @@ import type {
 import {
   presentationArtifactPageMaximumBytes,
   reconcilePresentationUpdate,
+  resolveSkillMentions,
 } from "@adam-agent/presentation";
 import { readFileArtifact, readFileArtifactRange } from "./artifact-store.js";
 import { maximumModelResponseContentBytes } from "./durable-model-response-policy.js";
@@ -903,6 +904,14 @@ export async function createPresentationSession(
             message: "The active session already has a running command.",
           };
         }
+        const skillResolution = resolveSkillMentions({
+          text: command.text,
+          explicitQualifiedIds: command.skills,
+          catalog: state.authoritative.active.skills,
+        });
+        if (skillResolution.status === "ambiguous") {
+          return ambiguousSkillMentionRejection(skillResolution);
+        }
         const controller = new AbortController();
         const commandId = randomUUID();
         const admission = Promise.withResolvers<void>();
@@ -925,7 +934,9 @@ export async function createPresentationSession(
           sessionId: command.sessionId,
           input: {
             text: command.text,
-            ...(command.skills.length === 0 ? {} : { skills: command.skills }),
+            ...(skillResolution.qualifiedIds.length === 0
+              ? {}
+              : { skills: skillResolution.qualifiedIds }),
           },
           runId: commandId,
           signal: controller.signal,
@@ -997,6 +1008,14 @@ export async function createPresentationSession(
             message: "The exact draft target is no longer available.",
           };
         }
+        const skillResolution = resolveSkillMentions({
+          text: command.text,
+          explicitQualifiedIds: command.skills,
+          catalog: draft.skills,
+        });
+        if (skillResolution.status === "ambiguous") {
+          return ambiguousSkillMentionRejection(skillResolution);
+        }
         const controller = new AbortController();
         const commandId = randomUUID();
         const admission = Promise.withResolvers<string>();
@@ -1011,7 +1030,9 @@ export async function createPresentationSession(
           targetIdentity,
           input: {
             text: command.text,
-            ...(command.skills.length === 0 ? {} : { skills: command.skills }),
+            ...(skillResolution.qualifiedIds.length === 0
+              ? {}
+              : { skills: skillResolution.qualifiedIds }),
           },
           runId: commandId,
           signal: controller.signal,
@@ -2725,13 +2746,34 @@ function projectSkillContext(
       code: diagnostic.code,
       source: diagnostic.source,
       ...(diagnostic.scope === undefined ? {} : { scope: diagnostic.scope }),
+      ...(diagnostic.extensionId === undefined ? {} : { extensionId: diagnostic.extensionId }),
+      ...(diagnostic.packageName === undefined ? {} : { packageName: diagnostic.packageName }),
+      ...(diagnostic.packageVersion === undefined
+        ? {}
+        : { packageVersion: diagnostic.packageVersion }),
       packagePath: diagnostic.packagePath,
+      ...(diagnostic.field === undefined ? {} : { field: diagnostic.field }),
+      ...(diagnostic.bound === undefined ? {} : { bound: diagnostic.bound }),
     })),
     overflow: {
       omittedCount: skills.catalog.omittedCount,
       shortenedCount: skills.catalog.shortenedCount,
     },
     reloadAvailable,
+  };
+}
+
+function ambiguousSkillMentionRejection(
+  resolution: Extract<ReturnType<typeof resolveSkillMentions>, { readonly status: "ambiguous" }>,
+): Extract<CommandReceipt, { readonly status: "rejected" }> {
+  const candidates = resolution.candidateQualifiedIds
+    .slice(0, 3)
+    .map((qualifiedId) => qualifiedId.slice(0, 160))
+    .join(", ");
+  return {
+    status: "rejected",
+    code: "invalid_command",
+    message: `Skill $${resolution.name} is ambiguous. Select one exact qualified ID with /skills: ${candidates}`,
   };
 }
 

--- a/packages/agent/src/skills.ts
+++ b/packages/agent/src/skills.ts
@@ -60,6 +60,12 @@ export type SkillDiagnosticV1 = {
   readonly packageVersion?: string | undefined;
   readonly packagePath: string;
   readonly field?: string | undefined;
+  readonly bound?:
+    | {
+        readonly maximum: number;
+        readonly unit: "bytes" | "estimated_tokens" | "fields";
+      }
+    | undefined;
 };
 
 export type SkillCandidateRecordV1 = {
@@ -284,6 +290,16 @@ const diagnosticSchema = z.strictObject({
     .string()
     .min(1)
     .refine((value) => scalarLength(value) <= 128)
+    .optional(),
+  bound: z
+    .strictObject({
+      maximum: z
+        .number()
+        .int()
+        .positive()
+        .max(64 * 1024 * 1024),
+      unit: z.enum(["bytes", "estimated_tokens", "fields"]),
+    })
     .optional(),
 }) as z.ZodType<SkillDiagnosticV1>;
 const catalogEntrySchema = z.strictObject({
@@ -1350,17 +1366,25 @@ async function loadCandidate(
       return quarantine(input, packagePath, "skill_symlink_escape");
     }
     const metadata = await stat(resolvedSkillPath);
-    if (
-      !metadata.isFile() ||
-      metadata.size <= 0 ||
-      metadata.size > skillLimitsV1.maximumSkillMdBytes
-    ) {
+    if (!metadata.isFile() || metadata.size <= 0) {
       return quarantine(input, packagePath, "skill_file_invalid");
+    }
+    if (metadata.size > skillLimitsV1.maximumSkillMdBytes) {
+      return quarantine(input, packagePath, "skill_file_too_large", "SKILL.md", {
+        maximum: skillLimitsV1.maximumSkillMdBytes,
+        unit: "bytes",
+      });
     }
     const bytes = await readFile(resolvedSkillPath);
     const parsed = parseSkillMd(bytes, basename(directory));
     if (!parsed.success) {
-      return quarantine(input, packagePath, parsed.code, parsed.field);
+      return quarantine(
+        input,
+        packagePath,
+        parsed.code,
+        parsed.field,
+        skillDiagnosticBound(parsed.code, parsed.field),
+      );
     }
     const qualifiedId = qualifiedIdFor(input.locator, parsed.name);
     if (!isAscii(qualifiedId) || Buffer.byteLength(qualifiedId, "utf8") > 16_384) {
@@ -1368,11 +1392,13 @@ async function loadCandidate(
     }
     const skillMdDigest = digestBytes(bytes);
     for (const diagnostic of parsed.diagnostics) {
+      const bound = skillDiagnosticBound(diagnostic.code, diagnostic.field);
       input.diagnostics.push({
         code: diagnostic.code,
         ...diagnosticLocator(input.locator),
         packagePath,
         field: diagnostic.field,
+        ...(bound === undefined ? {} : { bound }),
       });
     }
     const artifact = await input.artifactStore.write({
@@ -1501,7 +1527,7 @@ function parseSkillMd(bytes: Uint8Array, directoryName: string): ParsedSkillMd {
     return { success: false, code: "skill_body_too_large" };
   }
   const diagnostics = unknownFields.map((field) => ({ code: "skill_unknown_field", field }));
-  if (typeof value["allowed-tools"] === "string") {
+  if (value["allowed-tools"] !== undefined) {
     diagnostics.push({ code: "skill_allowed_tools_ignored", field: "allowed-tools" });
   }
   return { success: true, name, description, metadata: value, bodyBytes, diagnostics };
@@ -1539,7 +1565,6 @@ function validateOptionalFields(value: Readonly<Record<string, unknown>>): strin
   for (const [field, maximum] of [
     ["license", 1_024],
     ["compatibility", 500],
-    ["allowed-tools", 4_096],
   ] as const) {
     const entry = value[field];
     if (
@@ -1548,6 +1573,17 @@ function validateOptionalFields(value: Readonly<Record<string, unknown>>): strin
     ) {
       return field;
     }
+  }
+  const allowedTools = value["allowed-tools"];
+  if (
+    allowedTools !== undefined &&
+    !isBoundedStringOrStringList(allowedTools, {
+      maximumEntries: 64,
+      maximumEntryScalars: 256,
+      maximumTotalScalars: 4_096,
+    })
+  ) {
+    return "allowed-tools";
   }
   const metadata = (value as RawSkillFrontmatter).metadata;
   if (metadata === undefined) {
@@ -1559,14 +1595,42 @@ function validateOptionalFields(value: Readonly<Record<string, unknown>>): strin
   for (const [key, entry] of Object.entries(metadata)) {
     if (
       scalarLength(key) > 128 ||
-      typeof entry !== "string" ||
-      scalarLength(entry) < 1 ||
-      scalarLength(entry) > 1_024
+      !isBoundedStringOrStringList(entry, {
+        maximumEntries: 64,
+        maximumEntryScalars: 1_024,
+        maximumTotalScalars: 4_096,
+      })
     ) {
-      return "metadata";
+      return `metadata.${key}`;
     }
   }
   return Buffer.byteLength(canonicalJson(metadata), "utf8") > 16 * 1024 ? "metadata" : undefined;
+}
+
+function isBoundedStringOrStringList(
+  value: unknown,
+  bounds: {
+    readonly maximumEntries: number;
+    readonly maximumEntryScalars: number;
+    readonly maximumTotalScalars: number;
+  },
+): boolean {
+  const entries = typeof value === "string" ? [value] : Array.isArray(value) ? value : undefined;
+  return (
+    entries !== undefined &&
+    entries.length > 0 &&
+    entries.length <= bounds.maximumEntries &&
+    entries.every(
+      (entry) =>
+        typeof entry === "string" &&
+        scalarLength(entry) > 0 &&
+        scalarLength(entry) <= bounds.maximumEntryScalars,
+    ) &&
+    entries.reduce(
+      (total, entry) => total + (typeof entry === "string" ? scalarLength(entry) : 0),
+      0,
+    ) <= bounds.maximumTotalScalars
+  );
 }
 
 interface RawSkillFrontmatter extends Readonly<Record<string, unknown>> {
@@ -1580,15 +1644,33 @@ function quarantine(
   packagePath: string,
   code: string,
   field?: string,
+  bound?: NonNullable<SkillDiagnosticV1["bound"]>,
 ): undefined {
   input.diagnostics.push({
     code,
     ...diagnosticLocator(input.locator),
     packagePath,
     ...(field === undefined ? {} : { field }),
+    ...(bound === undefined ? {} : { bound }),
   });
   if (input.diagnostics.length > skillLimitsV1.maximumDiagnostics) {
     throw new SkillsError("skill_catalog_unavailable");
+  }
+  return undefined;
+}
+
+function skillDiagnosticBound(
+  code: string,
+  field: string | undefined,
+): NonNullable<SkillDiagnosticV1["bound"]> | undefined {
+  if (code === "skill_frontmatter_too_large") {
+    return { maximum: skillLimitsV1.maximumFrontmatterBytes, unit: "bytes" };
+  }
+  if (code === "skill_body_too_large") {
+    return { maximum: skillLimitsV1.maximumSkillMdTokens, unit: "estimated_tokens" };
+  }
+  if (code === "skill_unknown_field_invalid" && field === "unknown-fields") {
+    return { maximum: 64, unit: "fields" };
   }
   return undefined;
 }
@@ -1913,7 +1995,7 @@ function resolveIdentityCollisions(
 
 function diagnosticLocator(
   locator: SkillLocatorV1,
-): Omit<SkillDiagnosticV1, "code" | "packagePath" | "field"> {
+): Omit<SkillDiagnosticV1, "code" | "packagePath" | "field" | "bound"> {
   if (locator.source === "project") {
     return { source: "project", scope: locator.scope };
   }

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -325,7 +325,15 @@ export type SkillCatalogDisplay = {
     readonly code: string;
     readonly source: "project" | "user" | "extension";
     readonly scope?: string;
+    readonly extensionId?: string;
+    readonly packageName?: string;
+    readonly packageVersion?: string;
     readonly packagePath: string;
+    readonly field?: string;
+    readonly bound?: {
+      readonly maximum: number;
+      readonly unit: "bytes" | "estimated_tokens" | "fields";
+    };
   }[];
   readonly overflow: {
     readonly omittedCount: number;
@@ -333,6 +341,69 @@ export type SkillCatalogDisplay = {
   };
   readonly reloadAvailable: boolean;
 };
+
+export type SkillMentionResolution =
+  | {
+      readonly status: "resolved";
+      readonly text: string;
+      readonly qualifiedIds: readonly string[];
+    }
+  | {
+      readonly status: "ambiguous";
+      readonly text: string;
+      readonly name: string;
+      readonly candidateQualifiedIds: readonly string[];
+    };
+
+export function resolveSkillMentions(input: {
+  readonly text: string;
+  readonly explicitQualifiedIds: readonly string[];
+  readonly catalog: SkillCatalogDisplay | null;
+}): SkillMentionResolution {
+  const resolved = [...new Set(input.explicitQualifiedIds)];
+  if (input.catalog === null) {
+    return { status: "resolved", text: input.text, qualifiedIds: resolved };
+  }
+  const candidatesByName = Map.groupBy(input.catalog.items, (item) => item.name);
+  for (const match of input.text.matchAll(/\$([a-z0-9]+(?:-[a-z0-9]+)*)/gu)) {
+    const name = match[1];
+    const offset = match.index;
+    const preceding = offset === 0 ? undefined : input.text[offset - 1];
+    const following = input.text[offset + match[0].length];
+    if (
+      name === undefined ||
+      (preceding !== undefined && /[A-Za-z0-9_$\\]/u.test(preceding)) ||
+      (following !== undefined && /[A-Za-z0-9_-]/u.test(following))
+    ) {
+      continue;
+    }
+    const candidates = candidatesByName.get(name) ?? [];
+    if (candidates.length === 0) {
+      continue;
+    }
+    const explicitlySelected = candidates.filter((candidate) =>
+      resolved.includes(candidate.qualifiedId),
+    );
+    const selected =
+      candidates.length === 1
+        ? candidates[0]
+        : explicitlySelected.length === 1
+          ? explicitlySelected[0]
+          : undefined;
+    if (selected === undefined) {
+      return {
+        status: "ambiguous",
+        text: input.text,
+        name,
+        candidateQualifiedIds: candidates.map((candidate) => candidate.qualifiedId),
+      };
+    }
+    if (!resolved.includes(selected.qualifiedId)) {
+      resolved.push(selected.qualifiedId);
+    }
+  }
+  return { status: "resolved", text: input.text, qualifiedIds: resolved };
+}
 
 export type RepositoryInstructionsDisplay = {
   readonly revision: number;

--- a/packages/presentation/src/presentation.test.ts
+++ b/packages/presentation/src/presentation.test.ts
@@ -3,6 +3,7 @@ import {
   type AuthoritativePresentationSnapshot,
   type PresentationDisplayState,
   reconcilePresentationUpdate,
+  resolveSkillMentions,
 } from "./index.js";
 
 const emptySnapshot: AuthoritativePresentationSnapshot = {
@@ -166,6 +167,140 @@ describe("presentation reconciliation", () => {
       },
       draft: null,
       transient: null,
+    });
+  });
+});
+
+describe("Skill mention resolution", () => {
+  it("keeps canonical prompt text while resolving one exact Skill mention", () => {
+    const text = "Please use $project-review before changing the code.";
+
+    expect(
+      resolveSkillMentions({
+        text,
+        explicitQualifiedIds: [],
+        catalog: {
+          revision: 1,
+          items: [
+            {
+              qualifiedId: "skill:v1:project:.:project-review",
+              name: "project-review",
+              description: "Reviews exact project state.",
+              source: { type: "project", scope: "." },
+              active: false,
+            },
+          ],
+          diagnostics: [],
+          overflow: { omittedCount: 0, shortenedCount: 0 },
+          reloadAvailable: false,
+        },
+      }),
+    ).toEqual({
+      status: "resolved",
+      text,
+      qualifiedIds: ["skill:v1:project:.:project-review"],
+    });
+  });
+
+  it("recognizes token boundaries while leaving escaped dollar text literal", () => {
+    const text = String.raw`Keep \$escaped-skill and prefix$embedded-skill literal; use $valid-skill.`;
+    const item = (name: string) => ({
+      qualifiedId: `skill:v1:user:${name}`,
+      name,
+      description: `${name} fixture.`,
+      source: { type: "user" as const },
+      active: false,
+    });
+
+    expect(
+      resolveSkillMentions({
+        text,
+        explicitQualifiedIds: [],
+        catalog: {
+          revision: 1,
+          items: [item("escaped-skill"), item("embedded-skill"), item("valid-skill")],
+          diagnostics: [],
+          overflow: { omittedCount: 0, shortenedCount: 0 },
+          reloadAvailable: false,
+        },
+      }),
+    ).toEqual({
+      status: "resolved",
+      text,
+      qualifiedIds: ["skill:v1:user:valid-skill"],
+    });
+  });
+
+  it("requires one explicit qualified choice for an ambiguous short mention", () => {
+    const text = "Use $shared-name.";
+    const catalog: Parameters<typeof resolveSkillMentions>[0]["catalog"] = {
+      revision: 1,
+      items: [
+        {
+          qualifiedId: "skill:v1:project:.:shared-name",
+          name: "shared-name",
+          description: "Project procedure.",
+          source: { type: "project", scope: "." },
+          active: false,
+        },
+        {
+          qualifiedId: "skill:v1:user:shared-name",
+          name: "shared-name",
+          description: "User procedure.",
+          source: { type: "user" },
+          active: false,
+        },
+      ],
+      diagnostics: [],
+      overflow: { omittedCount: 0, shortenedCount: 0 },
+      reloadAvailable: false,
+    };
+
+    expect(resolveSkillMentions({ text, explicitQualifiedIds: [], catalog })).toEqual({
+      status: "ambiguous",
+      text,
+      name: "shared-name",
+      candidateQualifiedIds: ["skill:v1:project:.:shared-name", "skill:v1:user:shared-name"],
+    });
+    expect(
+      resolveSkillMentions({
+        text,
+        explicitQualifiedIds: ["skill:v1:user:shared-name"],
+        catalog,
+      }),
+    ).toEqual({
+      status: "resolved",
+      text,
+      qualifiedIds: ["skill:v1:user:shared-name"],
+    });
+  });
+
+  it("deduplicates multiple exact mentions in first-appearance order", () => {
+    const text = "$alpha then $beta then $alpha.";
+    const item = (name: string) => ({
+      qualifiedId: `skill:v1:user:${name}`,
+      name,
+      description: `${name} fixture.`,
+      source: { type: "user" as const },
+      active: false,
+    });
+
+    expect(
+      resolveSkillMentions({
+        text,
+        explicitQualifiedIds: [],
+        catalog: {
+          revision: 1,
+          items: [item("alpha"), item("beta")],
+          diagnostics: [],
+          overflow: { omittedCount: 0, shortenedCount: 0 },
+          reloadAvailable: false,
+        },
+      }),
+    ).toEqual({
+      status: "resolved",
+      text,
+      qualifiedIds: ["skill:v1:user:alpha", "skill:v1:user:beta"],
     });
   });
 });

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -290,7 +290,11 @@ test("PresentationSession projects exact target identity and readiness for proje
   };
 
   const harness = createInMemorySessionLifecycleHarness();
-  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const lifecycle = harness.createLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+  });
   try {
     const presentation = await createPresentationSession({
       lifecycle,
@@ -446,6 +450,356 @@ test("PresentationSession previews the draft Skill catalog without creating dura
     await presentation.close();
   } finally {
     await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession resolves a first-prompt Skill mention through atomic draft admission", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-draft-skill-mention-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const isolatedHome = join(testRoot, "home");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "draft-review");
+  const previousHome = testEnvironment.HOME;
+  await mkdir(skillDirectory, { recursive: true });
+  await mkdir(isolatedHome);
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: draft-review\ndescription: Reviews the first mentioned draft.\n---\nMENTIONED_DRAFT_SKILL\n",
+    "utf8",
+  );
+  testEnvironment.HOME = isolatedHome;
+  const modelTargets = settledModelTargets("Mention admission complete.");
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      openProject: true,
+      projectLabel: "workspace",
+      stateRoot,
+      workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    });
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+    const completed = Promise.withResolvers<void>();
+    const unsubscribe = presentation.subscribe(() => {
+      if (
+        presentation
+          .getState()
+          .authoritative.active?.transcript.items.some(
+            (item) =>
+              item.type === "assistant_message" && item.text === "Mention admission complete.",
+          )
+      ) {
+        completed.resolve();
+      }
+    });
+    const text = "Use $draft-review before answering.";
+    try {
+      await expect(
+        presentation.dispatch({ type: "submit_draft_prompt", text, skills: [] }),
+      ).resolves.toMatchObject({ status: "admitted" });
+      await completed.promise;
+    } finally {
+      unsubscribe();
+    }
+
+    const listed = await lifecycle.listProjectSessions();
+    expect(listed.items).toHaveLength(1);
+    const sessionId = listed.items[0]?.sessionId;
+    if (sessionId === undefined) {
+      throw new Error("Expected one admitted session.");
+    }
+    const records = await readInMemoryPresentationRecords(harness.sessions)(sessionId);
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          record: expect.objectContaining({
+            type: "skill_activation_batch_committed",
+            outcomes: [
+              expect.objectContaining({
+                qualifiedId: "skill:v1:project:.:draft-review",
+              }),
+            ],
+            skillContext: expect.objectContaining({
+              active: [expect.objectContaining({ reason: "user_explicit" })],
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          record: expect.objectContaining({ type: "logical_run_started", userMessage: text }),
+        }),
+      ]),
+    );
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    if (previousHome === undefined) {
+      delete testEnvironment.HOME;
+    } else {
+      testEnvironment.HOME = previousHome;
+    }
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession resolves a Skill mention for an existing session through durable admission", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-active-skill-mention-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const isolatedHome = join(testRoot, "home");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "active-review");
+  const previousHome = testEnvironment.HOME;
+  await mkdir(skillDirectory, { recursive: true });
+  await mkdir(isolatedHome);
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: active-review\ndescription: Reviews a mentioned active-session prompt.\n---\nACTIVE_MENTION_SKILL\n",
+    "utf8",
+  );
+  testEnvironment.HOME = isolatedHome;
+  const modelTargets = settledModelTargets("Active mention admission complete.");
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      projectLabel: "workspace",
+      stateRoot,
+      targetIdentity,
+      workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    });
+    const sessionId = presentation.getState().authoritative.active?.session.id;
+    if (sessionId === undefined) {
+      throw new Error("Expected an existing active session.");
+    }
+    const completed = Promise.withResolvers<void>();
+    const unsubscribe = presentation.subscribe(() => {
+      if (
+        presentation
+          .getState()
+          .authoritative.active?.transcript.items.some(
+            (item) =>
+              item.type === "assistant_message" &&
+              item.text === "Active mention admission complete.",
+          )
+      ) {
+        completed.resolve();
+      }
+    });
+    const text = "Use $active-review before answering this follow-up.";
+    try {
+      await expect(
+        presentation.dispatch({ type: "submit_prompt", sessionId, text, skills: [] }),
+      ).resolves.toMatchObject({ status: "admitted" });
+      await completed.promise;
+    } finally {
+      unsubscribe();
+    }
+
+    const records = await readInMemoryPresentationRecords(harness.sessions)(sessionId);
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          record: expect.objectContaining({
+            type: "skill_activation_batch_committed",
+            outcomes: [
+              expect.objectContaining({
+                qualifiedId: "skill:v1:project:.:active-review",
+              }),
+            ],
+            skillContext: expect.objectContaining({
+              active: [expect.objectContaining({ reason: "user_explicit" })],
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          record: expect.objectContaining({ type: "logical_run_started", userMessage: text }),
+        }),
+      ]),
+    );
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    if (previousHome === undefined) {
+      delete testEnvironment.HOME;
+    } else {
+      testEnvironment.HOME = previousHome;
+    }
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession rejects an ambiguous Skill mention before extending an existing session", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-active-skill-collision-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const userHome = join(testRoot, "home");
+  const previousHome = testEnvironment.HOME;
+  for (const directory of [
+    join(workspaceRoot, ".agents", "skills", "shared-name"),
+    join(userHome, ".agents", "skills", "shared-name"),
+  ]) {
+    await mkdir(directory, { recursive: true });
+    await writeFile(
+      join(directory, "SKILL.md"),
+      "---\nname: shared-name\ndescription: Collides across exact Skill scopes.\n---\nCollision body.\n",
+      "utf8",
+    );
+  }
+  testEnvironment.HOME = userHome;
+  let providerResolutions = 0;
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      providerResolutions += 1;
+      throw new Error("An ambiguous Skill mention must fail before target resolution.");
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      projectLabel: "workspace",
+      stateRoot,
+      targetIdentity,
+      workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    });
+    const sessionId = presentation.getState().authoritative.active?.session.id;
+    if (sessionId === undefined) {
+      throw new Error("Expected an existing active session.");
+    }
+    const before = await readInMemoryPresentationRecords(harness.sessions)(sessionId);
+
+    await expect(
+      presentation.dispatch({
+        type: "submit_prompt",
+        sessionId,
+        text: "Use $shared-name without guessing.",
+        skills: [],
+      }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      code: "invalid_command",
+      message: expect.stringContaining("skill:v1:project:.:shared-name"),
+    });
+
+    expect(providerResolutions).toBe(0);
+    await expect(readInMemoryPresentationRecords(harness.sessions)(sessionId)).resolves.toEqual(
+      before,
+    );
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    if (previousHome === undefined) {
+      delete testEnvironment.HOME;
+    } else {
+      testEnvironment.HOME = previousHome;
+    }
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession keeps an ambiguous first-prompt Skill mention outside persistence", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-draft-skill-collision-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const userHome = join(testRoot, "home");
+  const previousHome = testEnvironment.HOME;
+  for (const directory of [
+    join(workspaceRoot, ".agents", "skills", "shared-name"),
+    join(userHome, ".agents", "skills", "shared-name"),
+  ]) {
+    await mkdir(directory, { recursive: true });
+    await writeFile(
+      join(directory, "SKILL.md"),
+      "---\nname: shared-name\ndescription: Collides across exact Skill scopes.\n---\nCollision body.\n",
+      "utf8",
+    );
+  }
+  testEnvironment.HOME = userHome;
+  let providerResolutions = 0;
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      providerResolutions += 1;
+      throw new Error("An ambiguous Skill mention must fail before target resolution.");
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      openProject: true,
+      projectLabel: "workspace",
+      stateRoot,
+      workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    });
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+    const text = "Use $shared-name without guessing.";
+
+    await expect(
+      presentation.dispatch({ type: "submit_draft_prompt", text, skills: [] }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      code: "invalid_command",
+      message: expect.stringContaining("skill:v1:project:.:shared-name"),
+    });
+    expect(presentation.getState()).toMatchObject({ draft: { targetId: targetIdentity.targetId } });
+    await expect(lifecycle.listProjectSessions()).resolves.toMatchObject({ items: [] });
+    expect(providerResolutions).toBe(0);
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    if (previousHome === undefined) {
+      delete testEnvironment.HOME;
+    } else {
+      testEnvironment.HOME = previousHome;
+    }
     await rm(testRoot, { recursive: true, force: true });
   }
 });

--- a/packages/testkit/src/skills.test.ts
+++ b/packages/testkit/src/skills.test.ts
@@ -629,6 +629,68 @@ test("SessionLifecycle bounds unknown frontmatter fields and reports allowed-too
   }
 });
 
+test("SessionLifecycle admits audited Skill metadata arrays without granting listed tools", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-skill-common-frontmatter-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const isolatedHome = join(testRoot, "home");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "common-frontmatter");
+  const previousHome = testEnvironment.HOME;
+  await mkdir(skillDirectory, { recursive: true });
+  await mkdir(isolatedHome);
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    '---\nname: common-frontmatter\ndescription: Uses common skills.sh-compatible frontmatter collections.\nmetadata:\n  version: "3.2.0"\n  related_skills:\n    - deep-research\n    - academic-paper-reviewer\nallowed-tools:\n  - Read\n  - Bash\n---\nCommon body.\n',
+    "utf8",
+  );
+  testEnvironment.HOME = isolatedHome;
+
+  try {
+    const created = await createSessionLifecycle({ stateRoot, workspaceRoot }).create({
+      targetIdentity,
+    });
+
+    expect(created.skillContext).toMatchObject({
+      registry: {
+        candidateCount: 1,
+        diagnostics: [
+          {
+            code: "skill_allowed_tools_ignored",
+            packagePath: "common-frontmatter",
+            field: "allowed-tools",
+          },
+        ],
+      },
+      catalog: {
+        totalCount: 1,
+        entries: [
+          {
+            qualifiedId: "skill:v1:project:.:common-frontmatter",
+            name: "common-frontmatter",
+          },
+        ],
+      },
+    });
+    expect(
+      created.promptContext?.toolProfile.definitions.map((definition) => definition.name),
+    ).toEqual([
+      "read_file",
+      "write_file",
+      "edit_file",
+      "run_shell",
+      "activate_skill",
+      "read_skill_resource",
+    ]);
+  } finally {
+    if (previousHome === undefined) {
+      delete testEnvironment.HOME;
+    } else {
+      testEnvironment.HOME = previousHome;
+    }
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("SessionLifecycle persists an unknown frontmatter field bounded by Unicode scalar values", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-skill-scalar-unknown-field-"));
   const stateRoot = join(testRoot, "state");


### PR DESCRIPTION
## Summary

- admit bounded audited Skill frontmatter list forms without expanding tool authority
- surface source-aware quarantine diagnostics with exact fields and typed bounds in `/skills`
- resolve exact `$name` mentions at token boundaries while preserving canonical prompt text and requiring explicit qualified choices for collisions
- support first-draft and existing-session atomic Skill admission plus draft mention autocomplete

## Verification

- `pnpm quality:check`
- 30 test files passed, 2 skipped
- 920 tests passed, 10 skipped
- independent fresh-reader and standards reviews report zero blockers
