### PR TITLE
Fix TUI viewport rendering and add tool previews

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -6,6 +6,8 @@ Adam Agent uses the terminal mechanics package
 [`@earendil-works/pi-tui`](https://github.com/earendil-works/pi/tree/914cf1472e715297caa30db4b9535d534a9eb718/packages/tui),
 licensed under the MIT License.
 
+Adam Agent's bounded tool-preview interaction and syntax-projection strategy is independently adapted from [`badlogic/pi-mono`](https://github.com/badlogic/pi-mono/tree/dcd461925db2edf69a43c8135db1180d418afd54/packages/coding-agent), also licensed under the MIT License.
+
 Copyright (c) Mario Zechner and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -24,6 +26,20 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## `highlight.js` 11.11.1
+
+Adam Agent uses [`highlight.js`](https://github.com/highlightjs/highlight.js/tree/11.11.1), licensed under the BSD 3-Clause License.
+
+Copyright (c) 2006, Ivan Sagalaev. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+- Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ## `pi-catppuccin` Catppuccin Mocha theme
 

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@adam-agent/agent": "workspace:*",
     "@adam-agent/presentation": "workspace:*",
-    "@earendil-works/pi-tui": "0.84.2"
+    "@earendil-works/pi-tui": "0.84.2",
+    "highlight.js": "11.11.1"
   }
 }

--- a/apps/tui/src/applied-viewport-terminal.test-support.ts
+++ b/apps/tui/src/applied-viewport-terminal.test-support.ts
@@ -1,0 +1,342 @@
+import { StdinBuffer, type Terminal, visibleWidth } from "@earendil-works/pi-tui";
+
+const missingFrameFailureMilliseconds = 30_000;
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+type FrameWaiter = {
+  readonly after: number;
+  readonly guard: ReturnType<typeof setTimeout>;
+  readonly reject: (error: Error) => void;
+  readonly resolve: () => void;
+};
+
+export class AppliedViewportTerminal implements Terminal {
+  readonly #commitPendingWrapAtFrameEnd: boolean;
+  readonly #graphemeWidths: ReadonlyMap<string, number>;
+  readonly #input = new StdinBuffer();
+  readonly #waiters = new Set<FrameWaiter>();
+  #column = 0;
+  #columns: number;
+  #frame = 0;
+  #inputHandler: ((data: string) => void) | undefined;
+  #output = "";
+  #row = 0;
+  #rows: number;
+  #screen: string[][];
+  #started = false;
+
+  constructor(options: {
+    readonly columns: number;
+    readonly commitPendingWrapAtFrameEnd?: boolean;
+    readonly rows: number;
+    readonly graphemeWidths?: ReadonlyMap<string, number>;
+  }) {
+    this.#columns = options.columns;
+    this.#commitPendingWrapAtFrameEnd = options.commitPendingWrapAtFrameEnd ?? false;
+    this.#rows = options.rows;
+    this.#graphemeWidths = options.graphemeWidths ?? new Map();
+    this.#screen = this.#createBlankScreen();
+    this.#input.on("data", (sequence) => this.#inputHandler?.(sequence));
+    this.#input.on("paste", (content) => this.#inputHandler?.(`\u001b[200~${content}\u001b[201~`));
+  }
+
+  get columns(): number {
+    return this.#columns;
+  }
+
+  get frame(): number {
+    return this.#frame;
+  }
+
+  get kittyProtocolActive(): boolean {
+    return false;
+  }
+
+  get rows(): number {
+    return this.#rows;
+  }
+
+  start(onInput: (data: string) => void, _onResize: () => void): void {
+    this.#inputHandler = onInput;
+    this.#started = true;
+  }
+
+  stop(): void {
+    this.#started = false;
+    this.#input.destroy();
+    this.#inputHandler = undefined;
+    for (const waiter of this.#waiters) {
+      clearTimeout(waiter.guard);
+      waiter.reject(new Error(`Terminal stopped before synchronized frame ${waiter.after + 1}.`));
+    }
+    this.#waiters.clear();
+  }
+
+  async drainInput(): Promise<void> {}
+
+  write(data: string): void {
+    this.#output += data;
+    let index = 0;
+    while (index < data.length) {
+      const codePoint = data.codePointAt(index);
+      if (codePoint === undefined) {
+        break;
+      }
+      const character = String.fromCodePoint(codePoint);
+      if (character === "\u001b") {
+        const parsedEscape = this.#consumeEscape(data, index);
+        index = parsedEscape.nextIndex;
+        if (parsedEscape.synchronizedFrameEnded) {
+          if (this.#commitPendingWrapAtFrameEnd && this.#column >= this.#columns) {
+            this.#column = 0;
+            this.#lineFeed();
+          }
+          this.#completeFrame();
+        }
+        continue;
+      }
+      if (character === "\r") {
+        this.#column = 0;
+      } else if (character === "\n") {
+        this.#lineFeed();
+      } else if (character === "\b") {
+        this.#column = Math.max(0, this.#column - 1);
+      } else if (codePoint >= 0x20 && codePoint !== 0x7f) {
+        const plainTextEnd = this.#nextControlIndex(data, index);
+        for (const { segment } of graphemeSegmenter.segment(data.slice(index, plainTextEnd))) {
+          this.#putGrapheme(segment);
+        }
+        index = plainTextEnd;
+        continue;
+      }
+      index += character.length;
+    }
+  }
+
+  input(data: string): void {
+    if (!this.#started || this.#inputHandler === undefined) {
+      throw new Error("AppliedViewportTerminal accepts input only while started.");
+    }
+    this.#input.process(data);
+  }
+
+  lines(): readonly string[] {
+    return this.#screen.map((line) => line.join("").replace(/ +$/u, ""));
+  }
+
+  output(): string {
+    return this.#output;
+  }
+
+  running(): boolean {
+    return this.#started;
+  }
+
+  nextFrame(after = this.#frame): Promise<void> {
+    if (this.#frame > after) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve, reject) => {
+      const waiter: FrameWaiter = {
+        after,
+        guard: setTimeout(() => {
+          this.#waiters.delete(waiter);
+          reject(new Error(`No synchronized frame was rendered after frame ${after}.`));
+        }, missingFrameFailureMilliseconds),
+        reject,
+        resolve,
+      };
+      waiter.guard.unref();
+      this.#waiters.add(waiter);
+    });
+  }
+
+  moveBy(lines: number): void {
+    this.#row = clamp(this.#row + lines, 0, this.#rows - 1);
+  }
+
+  hideCursor(): void {}
+
+  showCursor(): void {}
+
+  clearLine(): void {
+    this.#eraseLine(0);
+  }
+
+  clearFromCursor(): void {
+    this.#eraseDisplay(0);
+  }
+
+  clearScreen(): void {
+    this.#eraseDisplay(2);
+    this.#row = 0;
+    this.#column = 0;
+  }
+
+  setTitle(): void {}
+
+  setProgress(): void {}
+
+  #completeFrame(): void {
+    this.#frame += 1;
+    for (const waiter of this.#waiters) {
+      if (this.#frame > waiter.after) {
+        clearTimeout(waiter.guard);
+        this.#waiters.delete(waiter);
+        waiter.resolve();
+      }
+    }
+  }
+
+  #consumeEscape(
+    data: string,
+    startIndex: number,
+  ): { readonly nextIndex: number; readonly synchronizedFrameEnded: boolean } {
+    const kind = data[startIndex + 1];
+    if (kind === "[") {
+      let endIndex = startIndex + 2;
+      while (endIndex < data.length && !/[\x40-\x7e]/u.test(data[endIndex] as string)) {
+        endIndex += 1;
+      }
+      if (endIndex >= data.length) {
+        throw new Error("AppliedViewportTerminal received a partial CSI sequence.");
+      }
+      const final = data[endIndex] as string;
+      const rawParameters = data.slice(startIndex + 2, endIndex);
+      const parameters = rawParameters
+        .replace(/^[?>]/u, "")
+        .split(";")
+        .map((value) => (value === "" ? 0 : Number(value)));
+      const amount = parameters[0] || 1;
+      if (final === "A") {
+        this.#row = clamp(this.#row - amount, 0, this.#rows - 1);
+      } else if (final === "B") {
+        this.#row = clamp(this.#row + amount, 0, this.#rows - 1);
+      } else if (final === "C") {
+        this.#column = clamp(this.#column + amount, 0, this.#columns - 1);
+      } else if (final === "D") {
+        this.#column = clamp(this.#column - amount, 0, this.#columns - 1);
+      } else if (final === "G") {
+        this.#column = clamp(amount - 1, 0, this.#columns - 1);
+      } else if (final === "H" || final === "f") {
+        this.#row = clamp((parameters[0] || 1) - 1, 0, this.#rows - 1);
+        this.#column = clamp((parameters[1] || 1) - 1, 0, this.#columns - 1);
+      } else if (final === "J") {
+        this.#eraseDisplay(parameters[0] || 0);
+      } else if (final === "K") {
+        this.#eraseLine(parameters[0] || 0);
+      }
+      return {
+        nextIndex: endIndex + 1,
+        synchronizedFrameEnded: rawParameters === "?2026" && final === "l",
+      };
+    }
+    if (kind === "]" || kind === "_") {
+      let endIndex = startIndex + 2;
+      while (
+        endIndex < data.length &&
+        data[endIndex] !== "\u0007" &&
+        !(data[endIndex] === "\u001b" && data[endIndex + 1] === "\\")
+      ) {
+        endIndex += 1;
+      }
+      if (endIndex >= data.length) {
+        throw new Error("AppliedViewportTerminal received a partial string escape sequence.");
+      }
+      return {
+        nextIndex: data[endIndex] === "\u0007" ? endIndex + 1 : endIndex + 2,
+        synchronizedFrameEnded: false,
+      };
+    }
+    return { nextIndex: Math.min(data.length, startIndex + 2), synchronizedFrameEnded: false };
+  }
+
+  #createBlankScreen(): string[][] {
+    return Array.from({ length: this.#rows }, () => Array<string>(this.#columns).fill(" "));
+  }
+
+  #nextControlIndex(data: string, startIndex: number): number {
+    let index = startIndex;
+    while (index < data.length) {
+      const codePoint = data.codePointAt(index);
+      if (codePoint === undefined || codePoint < 0x20 || codePoint === 0x7f) {
+        break;
+      }
+      index += String.fromCodePoint(codePoint).length;
+    }
+    return index;
+  }
+
+  #putGrapheme(grapheme: string): void {
+    const width = this.#graphemeWidths.get(grapheme) ?? visibleWidth(grapheme);
+    if (width <= 0) {
+      return;
+    }
+    if (this.#column >= this.#columns) {
+      this.#column = 0;
+      this.#lineFeed();
+    }
+    const line = this.#line(this.#row);
+    line[this.#column] = grapheme;
+    for (
+      let continuation = 1;
+      continuation < width && this.#column + continuation < this.#columns;
+      continuation += 1
+    ) {
+      line[this.#column + continuation] = " ";
+    }
+    this.#column += width;
+  }
+
+  #lineFeed(): void {
+    if (this.#row < this.#rows - 1) {
+      this.#row += 1;
+      return;
+    }
+    this.#screen.shift();
+    this.#screen.push(Array<string>(this.#columns).fill(" "));
+  }
+
+  #eraseLine(mode: number): void {
+    const line = this.#line(this.#row);
+    if (mode === 2) {
+      line.fill(" ");
+    } else if (mode === 1) {
+      line.fill(" ", 0, this.#column + 1);
+    } else {
+      line.fill(" ", this.#column);
+    }
+  }
+
+  #eraseDisplay(mode: number): void {
+    if (mode === 2 || mode === 3) {
+      for (const line of this.#screen) {
+        line.fill(" ");
+      }
+      return;
+    }
+    if (mode === 1) {
+      for (let row = 0; row < this.#row; row += 1) {
+        this.#line(row).fill(" ");
+      }
+      this.#line(this.#row).fill(" ", 0, this.#column + 1);
+      return;
+    }
+    this.#line(this.#row).fill(" ", this.#column);
+    for (let row = this.#row + 1; row < this.#rows; row += 1) {
+      this.#line(row).fill(" ");
+    }
+  }
+
+  #line(row: number): string[] {
+    const line = this.#screen[row];
+    if (line === undefined) {
+      throw new RangeError(`AppliedViewportTerminal row ${row} is outside the viewport.`);
+    }
+    return line;
+  }
+}
+
+function clamp(value: number, lower: number, upper: number): number {
+  return Math.max(lower, Math.min(value, upper));
+}

--- a/apps/tui/src/fixture-scenario.ts
+++ b/apps/tui/src/fixture-scenario.ts
@@ -35,6 +35,7 @@ export const fixtureScenarios = [
   "tool-artifact",
   "unsafe-history",
   "unsafe-output",
+  "write",
 ] as const;
 
 export type FixtureScenario = (typeof fixtureScenarios)[number];

--- a/apps/tui/src/highlight-js.d.ts
+++ b/apps/tui/src/highlight-js.d.ts
@@ -1,0 +1,13 @@
+declare module "highlight.js/lib/core" {
+  import type { HLJSApi } from "highlight.js";
+
+  const hljs: HLJSApi;
+  export default hljs;
+}
+
+declare module "highlight.js/lib/languages/*" {
+  import type { LanguageFn } from "highlight.js";
+
+  const language: LanguageFn;
+  export default language;
+}

--- a/apps/tui/src/main-screen-viewport.test.ts
+++ b/apps/tui/src/main-screen-viewport.test.ts
@@ -1,0 +1,68 @@
+import { type Component, TuiMainScreen } from "@earendil-works/pi-tui";
+import { expect, test } from "vitest";
+import { AppliedViewportTerminal } from "./applied-viewport-terminal.test-support.js";
+import { RightEdgeGuardTerminal } from "./right-edge-guard-terminal.js";
+
+class MutableLines implements Component {
+  lines: string[];
+
+  constructor(lines: readonly string[]) {
+    this.lines = [...lines];
+  }
+
+  invalidate(): void {}
+
+  render(): string[] {
+    return [...this.lines];
+  }
+}
+
+test("main-screen viewport rewinds when transient rows disappear", () => {
+  const physicalTerminal = new AppliedViewportTerminal({ columns: 120, rows: 30 });
+  const terminal = new RightEdgeGuardTerminal(physicalTerminal);
+  const baseLines = Array.from({ length: 56 }, (_, index) => `base-${index}`);
+  const content = new MutableLines(baseLines);
+  const tui = new TuiMainScreen(terminal, false);
+  tui.addChild(content);
+  tui.start();
+
+  try {
+    for (const transientRows of [6, 3, 1, 0]) {
+      content.lines = [
+        ...baseLines.slice(0, 36),
+        ...Array.from({ length: transientRows }, (_, index) => `completion-${index}`),
+        ...baseLines.slice(36),
+      ];
+      tui.renderNow();
+    }
+    content.lines = baseLines.with(37, "TREE TITLE");
+    tui.renderNow();
+
+    expect(physicalTerminal.lines().findIndex((line) => line.includes("TREE TITLE"))).toBe(11);
+  } finally {
+    tui.stop();
+  }
+});
+
+test("main-screen changes above the viewport preserve scrollback", () => {
+  const physicalTerminal = new AppliedViewportTerminal({ columns: 120, rows: 30 });
+  const terminal = new RightEdgeGuardTerminal(physicalTerminal);
+  const baseLines = Array.from({ length: 56 }, (_, index) => `base-${index}`);
+  const content = new MutableLines(baseLines);
+  const tui = new TuiMainScreen(terminal, false);
+  tui.addChild(content);
+  tui.start();
+
+  try {
+    const interactionOutputOffset = physicalTerminal.output().length;
+    content.lines = baseLines.with(0, "updated-above-viewport");
+    tui.renderNow();
+
+    const visibleLines = physicalTerminal.lines();
+    expect(visibleLines.at(0)).toContain("base-26");
+    expect(visibleLines.at(-1)).toContain("base-55");
+    expect(physicalTerminal.output().slice(interactionOutputOffset)).not.toContain("\u001b[3J");
+  } finally {
+    tui.stop();
+  }
+});

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -546,11 +546,11 @@ test("the production TUI reviews real Git changes through the exact public Eve a
 
     let beforeResize = fixture.output().length;
     await fixture.resize(40, 24);
-    await fixture.waitForCompleteFrameAfter("Completed", beforeResize);
+    await fixture.waitForCompleteFrameAfter("/artifacts inspect report", beforeResize);
     expect(fixture.output().slice(beforeResize)).toContain("/artifacts inspect report");
     beforeResize = fixture.output().length;
     await fixture.resize(80, 24);
-    await fixture.waitForCompleteFrameAfter("Completed", beforeResize);
+    await fixture.waitForCompleteFrameAfter("/artifacts inspect report", beforeResize);
     beforeResize = fixture.output().length;
     await fixture.resize(120, 40);
     await fixture.waitForCompleteFrameAfter("eve-reviewer.local-worktree-review@1", beforeResize);
@@ -746,6 +746,7 @@ test("the production TUI rehydrates and explicitly recovers one operation after 
     const resumed = startFixture({ program, stateRoot, terminalProcessMarker, workspaceRoot });
     await resumed.waitFor("Recovery required");
     await resumed.waitFor("Ctrl+R recover");
+    await resumed.resize(120, 40);
     const beforeRecovery = resumed.output().length;
     resumed.write("\u0012");
     await resumed.waitForCompleteFrameAfter("Completed", beforeRecovery);

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -195,6 +195,10 @@ test("real PTY streams Ctrl+T provider reasoning without taking terminal mouse s
     expect(result.stdout).toContain("\u001b[?2004h");
     expect(result.stdout).toContain("\u001b[?2004l");
     expect(result.stdout).toContain("\u001b[?25h");
+    expect(result.stdout).toContain("╭");
+    expect(result.stdout).toContain("╮");
+    expect(result.stdout).toContain("╰");
+    expect(result.stdout).toContain("╯");
     expect(result.stdout).not.toContain("\u001b[?1000h");
     expect(result.stdout).not.toContain("\u001b[?1006h");
   } finally {

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -3412,13 +3412,15 @@ test("a real read tool is rendered as a bounded Pi-style tool card", async () =>
   await writeFile(join(workspaceRoot, "README.md"), "# Fixture\n\nReadable content.\n", "utf8");
 
   try {
-    const fixture = startFixture({ scenario: "read", stateRoot, workspaceRoot });
+    const fixture = startFixture({ noColor: true, scenario: "read", stateRoot, workspaceRoot });
     await fixture.waitForCompleteFrameAfter("Adam · New session", 0);
     await fixture.waitForCompleteFrameAfter(" · idle", 0);
     fixture.write("Read README\r");
     await fixture.waitFor("read README.md");
     await fixture.waitFor("29 bytes");
     await fixture.waitFor("Read complete");
+    await fixture.waitFor("1 │ # Fixture");
+    await fixture.waitFor("3 │ Readable content.");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
@@ -3431,16 +3433,25 @@ test("Ctrl+O toggles bounded authoritative tool details", async () => {
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
   await mkdir(workspaceRoot);
-  await writeFile(join(workspaceRoot, "README.md"), "alpha\nbeta\n", "utf8");
+  await writeFile(
+    join(workspaceRoot, "README.md"),
+    `${Array.from({ length: 12 }, (_, index) => `line${String(index + 1).padStart(2, "0")}`).join(
+      "\n",
+    )}\n`,
+    "utf8",
+  );
 
   try {
-    const fixture = startFixture({ scenario: "read", stateRoot, workspaceRoot });
+    const fixture = startFixture({ noColor: true, scenario: "read", stateRoot, workspaceRoot });
     await fixture.waitFor("Adam · New session");
     fixture.write("Read the README\r");
     await fixture.waitFor("Read complete");
+    expect(fixture.output()).toContain("10 │ line10");
+    expect(fixture.output()).not.toContain("11 │ line11");
     expect(fixture.output()).not.toContain("provider model response");
     const beforeExpand = fixture.output().length;
     fixture.write("\u000f");
+    await fixture.waitForAfter("12 │ line12", beforeExpand);
     await fixture.waitForAfter("read_file · read · completed · replay safe", beforeExpand);
     await fixture.waitForAfter("provider model response", beforeExpand);
     await fixture.waitForAfter("duration unavailable", beforeExpand);
@@ -3450,8 +3461,62 @@ test("Ctrl+O toggles bounded authoritative tool details", async () => {
     await fixture.waitForAfter("provider model response", beforeRestore);
     const beforeCollapse = fixture.output().length;
     fixture.write("\u000f");
-    await fixture.waitForAfter("11 bytes", beforeCollapse);
+    await fixture.waitForAfter("84 bytes", beforeCollapse);
     expect(fixture.output().slice(beforeCollapse)).not.toContain("provider model response");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a settled write card previews numbered content from its canonical change artifact", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-write-preview-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ noColor: true, scenario: "write", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Create a TypeScript file\r");
+    await fixture.waitFor("Permission required");
+    await fixture.waitFor("+export const value12 = 12;");
+    const beforeAllow = fixture.output().length;
+    fixture.write("\r");
+    await fixture.waitForAfter("Write complete.", beforeAllow);
+    await fixture.waitForAfter(" 1 │ export const value01 = 1;", beforeAllow);
+    await fixture.waitForAfter("10 │ export const value10 = 10;", beforeAllow);
+    expect(fixture.output().slice(beforeAllow)).not.toContain("11 │ export const value11");
+    await expect(readFile(join(workspaceRoot, "created.ts"), "utf8")).resolves.toContain(
+      "export const value12 = 12;",
+    );
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a settled edit card previews its canonical diff without inventing line coordinates", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-edit-preview-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "edit.txt"), "before\n", "utf8");
+
+  try {
+    const fixture = startFixture({ noColor: true, scenario: "mutation", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Edit the file\r");
+    await fixture.waitFor("Permission required");
+    await fixture.waitFor("+after");
+    const beforeAllow = fixture.output().length;
+    fixture.write("\r");
+    await fixture.waitForAfter("Edit complete.", beforeAllow);
+    await fixture.waitForAfter("  - │ before", beforeAllow);
+    await fixture.waitForAfter("  + │ after", beforeAllow);
+    await expect(readFile(join(workspaceRoot, "edit.txt"), "utf8")).resolves.toBe("after\n");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
@@ -3598,10 +3663,13 @@ test("a shell tool card uses the accepted dollar-command grammar", async () => {
   await mkdir(workspaceRoot);
 
   try {
-    const fixture = startFixture({ scenario: "shell", stateRoot, workspaceRoot });
+    const fixture = startFixture({ noColor: true, scenario: "shell", stateRoot, workspaceRoot });
     await fixture.waitFor("Adam · New session");
     fixture.write("Show shell card\r");
     await fixture.waitFor("$ printf shell-card-fixture");
+    await fixture.waitFor("Shell card complete.");
+    await fixture.waitFor("stdout");
+    expect(fixture.output()).not.toContain("stderr");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
@@ -3628,9 +3696,13 @@ test("tool subjects keep their full bounded value only in the 120-column layout"
 
     beforeResize = fixture.output().length;
     await fixture.resize(80, 24);
-    frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    const frameLines = latestSynchronizedFrame(fixture.output().slice(beforeResize));
+    frame = frameLines.join("\n");
     expect(frame).toContain("$ printf shell-card-fixture");
-    expect(frame).not.toContain("bounded-secondary-provenance-and-wide-tail");
+    expect(frameLines.find((line) => line.includes("$ printf"))).not.toContain(
+      "bounded-secondary-provenance-and-wide-tail",
+    );
+    expect(frame).toContain("shell-card-fixture-with-bounded-secondary-provenance-and-wide-tail");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { afterEach, expect, test } from "vitest";
+import { AppliedViewportTerminal } from "./applied-viewport-terminal.test-support.js";
 import { runTuiFixture } from "./test-fixture.js";
 import {
   readFilesRecursively,
@@ -447,10 +448,35 @@ function latestSynchronizedFrame(output: string): readonly string[] {
   if (start < 0 || end < 0) {
     throw new Error("The TUI did not emit one complete synchronized frame.");
   }
-  return output
+  const frame = output
     .slice(start + "\u001b[?2026h".length, end)
-    .replace("\u001b[2J\u001b[H\u001b[3J", "")
-    .split("\r\n");
+    .replace("\u001b[2J\u001b[H\u001b[3J", "");
+  const absoluteRows = [...frame.matchAll(new RegExp(`${"\u001b"}\\[(\\d+);1H`, "gu"))];
+  if (absoluteRows.length === 0) {
+    return frame.split("\r\n");
+  }
+  const lines: string[] = [];
+  for (const [index, match] of absoluteRows.entries()) {
+    const row = Number(match[1]) - 1;
+    const contentStart = (match.index ?? 0) + match[0].length;
+    const contentEnd = absoluteRows[index + 1]?.index ?? frame.length;
+    const content = frame.slice(contentStart, contentEnd);
+    if (content === "\u001b[2K") {
+      lines[row] = "";
+    } else if (content.length > 0) {
+      lines[row] = content.startsWith("\u001b[2K") ? content.slice("\u001b[2K".length) : content;
+    }
+  }
+  return lines.map((line) => line ?? "");
+}
+
+async function inputAndWaitForPhysicalFrame(
+  terminal: AppliedViewportTerminal,
+  input: string,
+): Promise<void> {
+  const frame = terminal.frame;
+  terminal.input(input);
+  await terminal.nextFrame(frame);
 }
 
 function expectFramedOverlay(output: string, title: string): void {
@@ -1387,7 +1413,7 @@ test("an active operation card keeps its status, action, identity, and draft thr
     let operationId: string | undefined;
     for (const columns of [120, 80, 40]) {
       const beforeResize = fixture.output().length;
-      await fixture.resize(columns, 24);
+      await fixture.resize(columns, 40);
       await fixture.waitForCompleteFrameAfter("Ctrl+C cancel", beforeResize);
       const lines = latestSynchronizedFrame(fixture.output().slice(beforeResize));
       const frame = lines.join("\n");
@@ -1432,7 +1458,7 @@ test("a 40-column operation card keeps exact long provenance identities reachabl
     fixture.write("/review\r");
     await fixture.waitFor("Ctrl+C cancel");
     const beforeResize = fixture.output().length;
-    await fixture.resize(40, 24);
+    await fixture.resize(40, 60);
     await fixture.waitForCompleteFrameAfter("Ctrl+C cancel", beforeResize);
     const lines = latestSynchronizedFrame(fixture.output().slice(beforeResize));
     const compactFrame = lines
@@ -2968,6 +2994,83 @@ test("the real TUI opens exact next-turn Skill metadata instead of submitting a 
     expect(fixture.output()).toContain("skill:v1:project:.:project-review");
     expect(fixture.output()).toContain("Reviews exact project state.");
   } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("repeated Skill navigation leaves the physical viewport and the next overlay clean", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-skill-viewport-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const skillRoot = join(workspaceRoot, ".agents", "skills");
+  await mkdir(skillRoot, { recursive: true });
+  await Promise.all(
+    Array.from({ length: 64 }, async (_, index) => {
+      const name = `viewport-${String(index).padStart(2, "0")}`;
+      const directory = join(skillRoot, name);
+      await mkdir(directory);
+      await writeFile(
+        join(directory, "SKILL.md"),
+        `---\nname: ${name}\ndescription: Deterministic viewport Skill ${index}.\n---\nBody.\n`,
+        "utf8",
+      );
+    }),
+  );
+  const terminal = new AppliedViewportTerminal({
+    columns: 120,
+    commitPendingWrapAtFrameEnd: true,
+    rows: 30,
+  });
+  const execution = runTuiFixture({
+    scenario: "history",
+    stateRoot,
+    terminal,
+    workspaceRoot,
+  });
+
+  try {
+    await terminal.nextFrame(0);
+    const interactionOutputOffset = terminal.output().length;
+    await inputAndWaitForPhysicalFrame(terminal, "/skills");
+    await inputAndWaitForPhysicalFrame(terminal, "\r");
+    expect(terminal.lines().join("\n")).toContain("Select next-turn Skills");
+    let maximumSkillRows = 0;
+    let minimumUniqueSkillRows = Number.POSITIVE_INFINITY;
+    for (let step = 0; step < 56; step += 1) {
+      await inputAndWaitForPhysicalFrame(terminal, "\u001b[B");
+      const skillRows = terminal.lines().filter((line) => line.includes("skill:v1:"));
+      maximumSkillRows = Math.max(maximumSkillRows, skillRows.length);
+      minimumUniqueSkillRows = Math.min(minimumUniqueSkillRows, new Set(skillRows).size);
+    }
+
+    await inputAndWaitForPhysicalFrame(terminal, "\u001b");
+    const afterSkills = terminal.lines().join("\n");
+    await inputAndWaitForPhysicalFrame(terminal, "/tree");
+    await inputAndWaitForPhysicalFrame(terminal, "\r");
+    const treeViewport = terminal.lines().join("\n");
+
+    expect({
+      maximumSkillRows,
+      minimumUniqueSkillRows,
+      skillsRemainAfterClose:
+        afterSkills.includes("Select next-turn Skills") || afterSkills.includes("skill:v1:"),
+      treeOpened: treeViewport.includes("Active chronology"),
+      skillsLeakIntoTree:
+        treeViewport.includes("Select next-turn Skills") || treeViewport.includes("skill:v1:"),
+      scrollbackWasCleared: terminal.output().slice(interactionOutputOffset).includes("\u001b[3J"),
+    }).toEqual({
+      maximumSkillRows: 8,
+      minimumUniqueSkillRows: 8,
+      skillsRemainAfterClose: false,
+      treeOpened: true,
+      skillsLeakIntoTree: false,
+      scrollbackWasCleared: false,
+    });
+  } finally {
+    if (terminal.running()) {
+      terminal.input("\u0011");
+    }
+    await execution.catch(() => undefined);
     await rm(testRoot, { recursive: true, force: true });
   }
 });

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -2529,6 +2529,7 @@ test("Ctrl+T expands cumulative live provider reasoning and preserves disclosure
     let frame = latestSynchronizedFrame(fixture.output().slice(beforeFrame)).join("\n");
     expect(frame).not.toContain("Inspect ");
     expect(frame).not.toContain("Working");
+    expect(frame).not.toContain("╭");
 
     fixture.write("\u0014");
     await fixture.waitFor("Inspect ");
@@ -2537,6 +2538,10 @@ test("Ctrl+T expands cumulative live provider reasoning and preserves disclosure
     await fixture.resize(79, 24);
     frame = latestSynchronizedFrame(fixture.output().slice(beforeFrame)).join("\n");
     expect(frame).toContain("Inspect ");
+    expect(frame).toContain("╭");
+    expect(frame).toContain("╮");
+    expect(frame).toContain("╰");
+    expect(frame).toContain("╯");
     beforeFrame = fixture.output().length;
     fixture.write("\u001b[116;5:3u");
     await fixture.resize(40, 12);
@@ -2558,6 +2563,7 @@ test("Ctrl+T expands cumulative live provider reasoning and preserves disclosure
     await fixture.waitFor("Thinking done · adam");
     await fixture.waitFor("Reasoning answer.");
     await fixture.waitForAfter(" · idle", beforeCompletion);
+    await fixture.waitForAfter("Adam · Streaming session", beforeCompletion);
     beforeFrame = fixture.output().length;
     await fixture.resize(80, 24);
     frame = latestSynchronizedFrame(fixture.output().slice(beforeFrame)).join("\n");
@@ -2568,7 +2574,6 @@ test("Ctrl+T expands cumulative live provider reasoning and preserves disclosure
     await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe(
       "Reasoning answer.",
     );
-    await fixture.waitForAfter("Adam · Streaming session", beforeCompletion);
     fixture.write("/session\r");
     await fixture.waitFor("Session facts");
     beforeFrame = fixture.output().length;

--- a/apps/tui/src/responsive-root.ts
+++ b/apps/tui/src/responsive-root.ts
@@ -8,21 +8,25 @@ export function terminalSizeIsSupported(columns: number, rows: number): boolean 
 }
 
 export class ResponsiveRoot extends Container {
+  readonly #columns: () => number;
   readonly #rows: () => number;
 
-  constructor(rows: () => number) {
+  constructor(rows: () => number, columns?: () => number) {
     super();
     this.#rows = rows;
+    this.#columns = columns ?? (() => Number.NaN);
   }
 
   override render(width: number): string[] {
+    const physicalColumns = this.#columns();
+    const columns = Number.isFinite(physicalColumns) ? physicalColumns : width;
     const rows = this.#rows();
-    if (terminalSizeIsSupported(width, rows)) {
+    if (terminalSizeIsSupported(columns, rows)) {
       return super.render(width);
     }
     return [
       "Terminal too small",
-      `${width}×${rows} · resize to ${minimumTerminalColumns}×${minimumTerminalRows} or larger`,
+      `${columns}×${rows} · resize to ${minimumTerminalColumns}×${minimumTerminalRows} or larger`,
       "Ctrl+C abort/exit · Esc deny/close · Ctrl+Q exit",
     ].map((line) => truncateToWidth(line, Math.max(0, width)));
   }
@@ -35,7 +39,12 @@ export type ResponsiveTextContent = {
 };
 
 export class ResponsiveText implements Component {
+  readonly #columns: ((renderWidth: number) => number) | undefined;
   #content: ResponsiveTextContent = { narrow: "", standard: "", wide: "" };
+
+  constructor(columns?: (renderWidth: number) => number) {
+    this.#columns = columns;
+  }
 
   invalidate(): void {}
 
@@ -45,10 +54,11 @@ export class ResponsiveText implements Component {
   }
 
   render(width: number): string[] {
+    const columns = this.#columns?.(width) ?? width;
     const content =
-      width >= 120
+      columns >= 120
         ? this.#content.wide
-        : width >= 80
+        : columns >= 80
           ? this.#content.standard
           : this.#content.narrow;
     return new Text(content).render(width);

--- a/apps/tui/src/right-edge-guard-terminal.ts
+++ b/apps/tui/src/right-edge-guard-terminal.ts
@@ -1,0 +1,77 @@
+import type { Terminal } from "@earendil-works/pi-tui";
+
+/**
+ * Keeps Pi's renderer away from the terminal's autowrap-sensitive final cell.
+ *
+ * Pi composes overlays to the full reported width. If the terminal and Pi
+ * disagree about even one grapheme cell, writing that final cell can wrap the
+ * hardware cursor without advancing Pi's logical cursor. Reserving one cell at
+ * the public Terminal boundary keeps both cursor models aligned.
+ */
+export class RightEdgeGuardTerminal implements Terminal {
+  readonly #terminal: Terminal;
+
+  constructor(terminal: Terminal) {
+    this.#terminal = terminal;
+  }
+
+  get columns(): number {
+    return Math.max(1, this.#terminal.columns - 1);
+  }
+
+  get rows(): number {
+    return this.#terminal.rows;
+  }
+
+  get kittyProtocolActive(): boolean {
+    return this.#terminal.kittyProtocolActive;
+  }
+
+  start(onInput: (data: string) => void, onResize: () => void): void {
+    this.#terminal.start(onInput, onResize);
+  }
+
+  stop(): void {
+    this.#terminal.stop();
+  }
+
+  drainInput(maxMs?: number, idleMs?: number): Promise<void> {
+    return this.#terminal.drainInput(maxMs, idleMs);
+  }
+
+  write(data: string): void {
+    this.#terminal.write(data);
+  }
+
+  moveBy(lines: number): void {
+    this.#terminal.moveBy(lines);
+  }
+
+  hideCursor(): void {
+    this.#terminal.hideCursor();
+  }
+
+  showCursor(): void {
+    this.#terminal.showCursor();
+  }
+
+  clearLine(): void {
+    this.#terminal.clearLine();
+  }
+
+  clearFromCursor(): void {
+    this.#terminal.clearFromCursor();
+  }
+
+  clearScreen(): void {
+    this.#terminal.clearScreen();
+  }
+
+  setTitle(title: string): void {
+    this.#terminal.setTitle(title);
+  }
+
+  setProgress(active: boolean): void {
+    this.#terminal.setProgress(active);
+  }
+}

--- a/apps/tui/src/rounded-frame.test.ts
+++ b/apps/tui/src/rounded-frame.test.ts
@@ -1,0 +1,33 @@
+import { type Component, visibleWidth } from "@earendil-works/pi-tui";
+import { expect, test } from "vitest";
+
+import { RoundedFrame } from "./rounded-frame.js";
+
+class MutableLines implements Component {
+  lines: string[] = [];
+
+  invalidate(): void {}
+
+  render(): string[] {
+    return this.lines;
+  }
+}
+
+test("RoundedFrame grows with streaming content while preserving exact rounded bounds", () => {
+  const content = new MutableLines();
+  content.lines = ["alpha"];
+  const frame = new RoundedFrame(content, (text) => text);
+
+  expect(frame.render(12)).toEqual(["╭──────────╮", "│ alpha    │", "╰──────────╯"]);
+
+  content.lines = ["alpha", "beta", "gamma"];
+  const grown = frame.render(12);
+  expect(grown).toEqual([
+    "╭──────────╮",
+    "│ alpha    │",
+    "│ beta     │",
+    "│ gamma    │",
+    "╰──────────╯",
+  ]);
+  expect(grown.every((line) => visibleWidth(line) === 12)).toBe(true);
+});

--- a/apps/tui/src/rounded-frame.ts
+++ b/apps/tui/src/rounded-frame.ts
@@ -1,0 +1,30 @@
+import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+
+export class RoundedFrame implements Component {
+  readonly #content: Component;
+  readonly #styleBorder: (text: string) => string;
+
+  constructor(content: Component, styleBorder: (text: string) => string) {
+    this.#content = content;
+    this.#styleBorder = styleBorder;
+  }
+
+  invalidate(): void {
+    this.#content.invalidate();
+  }
+
+  render(width: number): string[] {
+    if (width < 4) {
+      return this.#content.render(width).map((line) => truncateToWidth(line, Math.max(0, width)));
+    }
+    const innerWidth = width - 4;
+    const lines = this.#content.render(innerWidth).map((line) => {
+      const bounded = truncateToWidth(line, innerWidth);
+      return `${this.#styleBorder("│")} ${bounded}${" ".repeat(
+        Math.max(0, innerWidth - visibleWidth(bounded)),
+      )} ${this.#styleBorder("│")}`;
+    });
+    const horizontal = "─".repeat(width - 2);
+    return [this.#styleBorder(`╭${horizontal}╮`), ...lines, this.#styleBorder(`╰${horizontal}╯`)];
+  }
+}

--- a/apps/tui/src/syntax-highlight.ts
+++ b/apps/tui/src/syntax-highlight.ts
@@ -1,0 +1,177 @@
+import hljs from "highlight.js/lib/core";
+import bash from "highlight.js/lib/languages/bash";
+import c from "highlight.js/lib/languages/c";
+import cpp from "highlight.js/lib/languages/cpp";
+import csharp from "highlight.js/lib/languages/csharp";
+import css from "highlight.js/lib/languages/css";
+import go from "highlight.js/lib/languages/go";
+import java from "highlight.js/lib/languages/java";
+import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
+import kotlin from "highlight.js/lib/languages/kotlin";
+import markdown from "highlight.js/lib/languages/markdown";
+import python from "highlight.js/lib/languages/python";
+import ruby from "highlight.js/lib/languages/ruby";
+import rust from "highlight.js/lib/languages/rust";
+import sql from "highlight.js/lib/languages/sql";
+import typescript from "highlight.js/lib/languages/typescript";
+import xml from "highlight.js/lib/languages/xml";
+import yaml from "highlight.js/lib/languages/yaml";
+
+import { safeTerminalText } from "./safe-terminal-text.js";
+import type { AdamTuiTheme } from "./theme.js";
+
+/**
+ * Bounded language registration and theme-scope projection are adapted from the observable
+ * strategy in badlogic/pi-mono commit dcd461925db2edf69a43c8135db1180d418afd54 (MIT).
+ * See THIRD_PARTY_NOTICES.md.
+ */
+const languages = {
+  bash,
+  c,
+  cpp,
+  csharp,
+  css,
+  go,
+  html: xml,
+  java,
+  javascript,
+  json,
+  kotlin,
+  markdown,
+  python,
+  ruby,
+  rust,
+  sql,
+  typescript,
+  yaml,
+};
+
+for (const [name, language] of Object.entries(languages)) {
+  hljs.registerLanguage(name, language);
+}
+
+export function highlightCodeLines(
+  lines: readonly string[],
+  language: string | null,
+  theme: AdamTuiTheme,
+): readonly string[] {
+  const safeLines = lines.map((line) => safeTerminalText(line));
+  if (language === null || language === "text" || hljs.getLanguage(language) === undefined) {
+    return safeLines.map((line) => theme.syntax.default(line));
+  }
+  try {
+    const html = hljs.highlight(safeLines.join("\n"), {
+      language,
+      ignoreIllegals: true,
+    }).value;
+    return renderHighlightedLines(html, theme);
+  } catch {
+    return safeLines.map((line) => theme.syntax.default(line));
+  }
+}
+
+function renderHighlightedLines(html: string, theme: AdamTuiTheme): readonly string[] {
+  const lines = [""];
+  const scopes: Array<string | undefined> = [];
+  let index = 0;
+  const append = (text: string) => {
+    const formatter = activeFormatter(scopes, theme);
+    const parts = text.split("\n");
+    for (const [partIndex, part] of parts.entries()) {
+      if (part.length > 0) {
+        lines[lines.length - 1] += formatter?.(part) ?? part;
+      }
+      if (partIndex < parts.length - 1) {
+        lines.push("");
+      }
+    }
+  };
+  while (index < html.length) {
+    if (html.startsWith("<span", index)) {
+      const end = html.indexOf(">", index + 5);
+      if (end >= 0) {
+        const tag = html.slice(index, end + 1);
+        scopes.push(/class=["']hljs-([^"']+)["']/u.exec(tag)?.[1]);
+        index = end + 1;
+        continue;
+      }
+    }
+    if (html.startsWith("</span>", index)) {
+      scopes.pop();
+      index += "</span>".length;
+      continue;
+    }
+    if (html[index] === "&") {
+      const entity = decodeEntity(html, index);
+      if (entity !== null) {
+        append(entity.text);
+        index += entity.length;
+        continue;
+      }
+    }
+    const nextTag = html.indexOf("<", index);
+    const nextEntity = html.indexOf("&", index);
+    const candidates = [nextTag, nextEntity].filter((candidate) => candidate >= 0);
+    const end = candidates.length === 0 ? html.length : Math.min(...candidates);
+    if (end === index) {
+      append(html[index] ?? "");
+      index += 1;
+      continue;
+    }
+    append(html.slice(index, end));
+    index = end;
+  }
+  return lines;
+}
+
+function activeFormatter(
+  scopes: readonly (string | undefined)[],
+  theme: AdamTuiTheme,
+): ((text: string) => string) | undefined {
+  for (let index = scopes.length - 1; index >= 0; index -= 1) {
+    const scope = scopes[index];
+    if (scope === undefined) {
+      continue;
+    }
+    const exact = theme.syntax[scope];
+    if (exact !== undefined) {
+      return exact;
+    }
+    const prefix = scope.split(/[.-]/u)[0];
+    if (prefix !== undefined && theme.syntax[prefix] !== undefined) {
+      return theme.syntax[prefix];
+    }
+  }
+  return theme.syntax.default;
+}
+
+function decodeEntity(
+  html: string,
+  index: number,
+): { readonly text: string; readonly length: number } | null {
+  const match = /^&(amp|lt|gt|quot|#39|#x[0-9a-f]+|#[0-9]+);/iu.exec(html.slice(index));
+  if (match === null) {
+    return null;
+  }
+  const entity = match[1];
+  if (entity === undefined) {
+    return null;
+  }
+  const named: Readonly<Record<string, string>> = {
+    amp: "&",
+    lt: "<",
+    gt: ">",
+    quot: '"',
+    "#39": "'",
+  };
+  const namedText = named[entity];
+  const codePoint = entity.startsWith("#x")
+    ? Number.parseInt(entity.slice(2), 16)
+    : Number.parseInt(entity.slice(1), 10);
+  const text = namedText ?? (Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : null);
+  if (text === null) {
+    return null;
+  }
+  return { text, length: match[0].length };
+}

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -157,7 +157,10 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
       : {}),
     ...(modelTargets === undefined ? {} : { modelTargets }),
     permissions: createPermissionPolicy({
-      allowedEffects: options.scenario === "tool-artifact" ? ["read", "execute"] : ["read"],
+      allowedEffects:
+        options.scenario === "tool-artifact" || options.scenario === "shell"
+          ? ["read", "execute"]
+          : ["read"],
       askedEffects: ["write"],
     }),
     stateRoot: options.stateRoot,
@@ -736,6 +739,24 @@ function createFixtureModelTargets(options: {
           return;
         }
         yield { type: "text_delta", text: "Read complete." };
+      } else if (options.scenario === "write") {
+        const latest = request.messages.at(-1);
+        if (latest?.role === "user") {
+          const content = Array.from(
+            { length: 12 },
+            (_, index) => `export const value${String(index + 1).padStart(2, "0")} = ${index + 1};`,
+          ).join("\n");
+          yield { type: "tool_call_start", id: "write-file", name: "write_file" };
+          yield {
+            type: "tool_call_delta",
+            id: "write-file",
+            json: JSON.stringify({ path: "created.ts", content: `${content}\n` }),
+          };
+          yield { type: "tool_call_end", id: "write-file" };
+          yield { type: "finish", reason: "tool_calls" };
+          return;
+        }
+        yield { type: "text_delta", text: "Write complete." };
       } else if (
         options.scenario === "mutation" ||
         options.scenario === "mutation-after-release" ||

--- a/apps/tui/src/theme.ts
+++ b/apps/tui/src/theme.ts
@@ -5,6 +5,12 @@ import type { EditorTheme, MarkdownTheme } from "@earendil-works/pi-tui";
  * commit cd09277df06621155d9c4c20e45309bce5341779 (MIT). See THIRD_PARTY_NOTICES.md.
  */
 
+export type AdamSyntaxTheme = Readonly<
+  Record<string, (text: string) => string> & {
+    readonly default: (text: string) => string;
+  }
+>;
+
 export type AdamTuiTheme = {
   readonly allow: (text: string) => string;
   readonly danger: (text: string) => string;
@@ -16,6 +22,10 @@ export type AdamTuiTheme = {
   readonly muted: (text: string) => string;
   readonly primary: (text: string) => string;
   readonly subject: (text: string) => string;
+  readonly syntax: AdamSyntaxTheme;
+  readonly lineNumber: (text: string) => string;
+  readonly diffAddition: (text: string) => string;
+  readonly diffDeletion: (text: string) => string;
   readonly toolBackground: (text: string) => string;
   readonly toolOutput: (text: string) => string;
   readonly toolTitle: (text: string) => string;
@@ -43,6 +53,9 @@ export function createAdamTuiTheme(noColor = noColorRequested()): AdamTuiTheme {
   const blue = color(137, 180, 250);
   const pink = color(245, 194, 231);
   const teal = color(148, 226, 213);
+  const peach = color(250, 179, 135);
+  const yellow = color(249, 226, 175);
+  const lavender = color(180, 190, 254);
   const overlay = color(108, 112, 134);
   const subtext = color(186, 194, 222);
   const crust = color(17, 17, 27);
@@ -52,6 +65,35 @@ export function createAdamTuiTheme(noColor = noColorRequested()): AdamTuiTheme {
     muted,
     keyword: bold(mauve),
     subject: blue,
+    lineNumber: overlay,
+    diffAddition: green,
+    diffDeletion: red,
+    syntax: {
+      default: subtext,
+      comment: overlay,
+      quote: overlay,
+      keyword: mauve,
+      literal: mauve,
+      "selector-tag": mauve,
+      string: green,
+      regexp: green,
+      attribute: green,
+      number: peach,
+      bullet: peach,
+      title: blue,
+      section: blue,
+      function: blue,
+      name: blue,
+      type: yellow,
+      class: yellow,
+      params: lavender,
+      variable: pink,
+      "template-variable": pink,
+      meta: teal,
+      doctag: teal,
+      addition: green,
+      deletion: red,
+    },
     danger: red,
     allow: green,
     deny: red,

--- a/apps/tui/src/tool-preview.test.ts
+++ b/apps/tui/src/tool-preview.test.ts
@@ -1,0 +1,98 @@
+import type { ToolPreviewDisplay } from "@adam-agent/presentation";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { expect, test } from "vitest";
+import { createAdamTuiTheme } from "./theme.js";
+import { ToolPreview } from "./tool-preview.js";
+
+test("ToolPreview shows ten numbered code lines before the global expansion", () => {
+  const preview: ToolPreviewDisplay = {
+    kind: "read_text",
+    language: "typescript",
+    lines: Array.from({ length: 12 }, (_, index) => ({
+      number: index + 1,
+      text: `const value${index + 1} = ${index + 1};`,
+    })),
+    omittedBytes: 0,
+    sourceTruncated: false,
+  };
+
+  const collapsed = new ToolPreview(preview, false, createAdamTuiTheme(true)).render(64);
+  expect(collapsed.join("\n")).toContain(" 1 │ const value1 = 1;");
+  expect(collapsed.join("\n")).toContain("10 │ const value10 = 10;");
+  expect(collapsed.join("\n")).not.toContain("value11");
+  expect(collapsed.join("\n")).toContain("2 more projected lines · Ctrl+O expand");
+
+  const expanded = new ToolPreview(preview, true, createAdamTuiTheme(true)).render(32);
+  expect(expanded.join("\n")).toContain("12 │ const value12 = 12;");
+  expect(expanded.every((line) => visibleWidth(line) <= 32)).toBe(true);
+});
+
+test("ToolPreview keeps separate shell streams and a five-line collapsed tail", () => {
+  const preview: ToolPreviewDisplay = {
+    kind: "shell_output",
+    termination: { type: "exited", exitCode: 0 },
+    stdout: {
+      text: "one\ntwo\nthree\nfour\nfive\nsix\nseven",
+      totalBytes: 33,
+      omittedBytes: 9,
+    },
+    stderr: { text: "warning", totalBytes: 7, omittedBytes: 0 },
+  };
+
+  const collapsed = new ToolPreview(preview, false, createAdamTuiTheme(true)).render(48);
+  expect(collapsed.join("\n")).toContain("stdout · 9 earlier bytes omitted");
+  expect(collapsed).not.toContain("one");
+  expect(collapsed).not.toContain("two");
+  expect(collapsed).toContain("three");
+  expect(collapsed).toContain("seven");
+  expect(collapsed).toContain("stderr");
+  expect(collapsed).toContain("warning");
+
+  const expanded = new ToolPreview(preview, true, createAdamTuiTheme(true)).render(48);
+  expect(expanded).toContain("one");
+  expect(expanded).toContain("two");
+});
+
+test("ToolPreview maps syntax and diff roles through Catppuccin Mocha", () => {
+  const code: ToolPreviewDisplay = {
+    kind: "write_text",
+    language: "typescript",
+    lines: [{ number: 1, text: "const answer: number = 42;" }],
+    omittedBytes: 0,
+  };
+  const diff: ToolPreviewDisplay = {
+    kind: "diff",
+    language: "text",
+    lines: [
+      { kind: "deletion", oldLineNumber: null, newLineNumber: null, text: "before" },
+      { kind: "addition", oldLineNumber: null, newLineNumber: null, text: "after" },
+    ],
+    omittedBytes: 0,
+  };
+  const theme = createAdamTuiTheme(false);
+
+  expect(new ToolPreview(code, false, theme).render(40).join("\n")).toContain(
+    "\u001b[38;2;203;166;247mconst",
+  );
+  expect(new ToolPreview(diff, false, theme).render(40).join("\n")).toContain(
+    "\u001b[38;2;243;139;168m-",
+  );
+  expect(new ToolPreview(diff, false, theme).render(40).join("\n")).toContain(
+    "\u001b[38;2;166;227;161m+",
+  );
+});
+
+test("ToolPreview keeps CJK width bounded and strips untrusted terminal controls", () => {
+  const preview: ToolPreviewDisplay = {
+    kind: "read_text",
+    language: "typescript",
+    lines: [{ number: 1, text: 'const 标题 = "\u001b[2J内容";' }],
+    omittedBytes: 0,
+    sourceTruncated: false,
+  };
+
+  const rendered = new ToolPreview(preview, false, createAdamTuiTheme(true)).render(20);
+  expect(rendered.join("\n")).toContain("const 标题");
+  expect(rendered.join("\n")).not.toContain("\u001b[2J");
+  expect(rendered.every((line) => visibleWidth(line) <= 20)).toBe(true);
+});

--- a/apps/tui/src/tool-preview.ts
+++ b/apps/tui/src/tool-preview.ts
@@ -1,0 +1,201 @@
+import type {
+  ToolDiffPreviewLine,
+  ToolPreviewDisplay,
+  ToolStreamPreview,
+  ToolTextPreviewLine,
+} from "@adam-agent/presentation";
+import {
+  type Component,
+  truncateToWidth,
+  visibleWidth,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+
+import { safeTerminalText } from "./safe-terminal-text.js";
+import { highlightCodeLines } from "./syntax-highlight.js";
+import type { AdamTuiTheme } from "./theme.js";
+
+const collapsedCodeLineCount = 10;
+const collapsedDiffLineCount = 12;
+const collapsedShellVisualLineCount = 5;
+const expandedShellVisualLineCount = 200;
+
+export class ToolPreview implements Component {
+  readonly #expanded: boolean;
+  readonly #preview: ToolPreviewDisplay;
+  readonly #theme: AdamTuiTheme;
+
+  constructor(preview: ToolPreviewDisplay, expanded: boolean, theme: AdamTuiTheme) {
+    this.#preview = preview;
+    this.#expanded = expanded;
+    this.#theme = theme;
+  }
+
+  invalidate(): void {}
+
+  render(width: number): string[] {
+    if (width <= 0) {
+      return [];
+    }
+    if (this.#preview.kind === "read_text" || this.#preview.kind === "write_text") {
+      return this.#renderText(this.#preview, width);
+    }
+    if (this.#preview.kind === "diff") {
+      return this.#renderDiff(this.#preview, width);
+    }
+    return [
+      ...(streamHasContent(this.#preview.stdout)
+        ? this.#renderShellStream("stdout", this.#preview.stdout, width)
+        : []),
+      ...(streamHasContent(this.#preview.stderr)
+        ? this.#renderShellStream("stderr", this.#preview.stderr, width)
+        : []),
+    ];
+  }
+
+  #renderText(
+    preview: Extract<ToolPreviewDisplay, { readonly kind: "read_text" | "write_text" }>,
+    width: number,
+  ): string[] {
+    const visible = this.#expanded ? preview.lines : preview.lines.slice(0, collapsedCodeLineCount);
+    const rendered = renderNumberedCode(visible, preview.language, width, this.#theme);
+    const hiddenLines = preview.lines.length - visible.length;
+    const notices = [
+      ...(hiddenLines > 0
+        ? [
+            this.#expanded
+              ? `${hiddenLines} projected lines omitted`
+              : `${hiddenLines} more projected lines · Ctrl+O expand`,
+          ]
+        : []),
+      ...(preview.omittedBytes > 0
+        ? [`${preview.omittedBytes} bytes omitted from bounded preview`]
+        : []),
+      ...(preview.kind === "read_text" && preview.sourceTruncated
+        ? ["tool output truncated at source"]
+        : []),
+    ];
+    return [
+      ...rendered,
+      ...notices.map((notice) => boundedLine(this.#theme.muted(`… ${notice}`), width)),
+    ];
+  }
+
+  #renderDiff(
+    preview: Extract<ToolPreviewDisplay, { readonly kind: "diff" }>,
+    width: number,
+  ): string[] {
+    const visible = this.#expanded ? preview.lines : preview.lines.slice(0, collapsedDiffLineCount);
+    const highlighted = highlightCodeLines(
+      visible.map((line) => line.text),
+      preview.language,
+      this.#theme,
+    );
+    const numberWidth = Math.max(
+      1,
+      ...visible.map((line) => String(diffLineNumber(line) ?? "").length),
+    );
+    const rendered = visible.map((line, index) => {
+      const number = diffLineNumber(line);
+      const numberText =
+        number === null ? " ".repeat(numberWidth) : String(number).padStart(numberWidth);
+      const marker =
+        line.kind === "addition"
+          ? this.#theme.diffAddition("+")
+          : line.kind === "deletion"
+            ? this.#theme.diffDeletion("-")
+            : this.#theme.lineNumber(line.kind === "meta" ? "@" : " ");
+      const gutter = `${this.#theme.lineNumber(numberText)} ${marker} │ `;
+      const contentWidth = Math.max(0, width - visibleWidth(gutter));
+      return `${gutter}${truncateToWidth(highlighted[index] ?? "", contentWidth)}`;
+    });
+    const hiddenLines = preview.lines.length - visible.length;
+    return [
+      ...rendered,
+      ...(hiddenLines > 0
+        ? [
+            boundedLine(
+              this.#theme.muted(
+                `… ${hiddenLines} more diff lines${this.#expanded ? " omitted" : " · Ctrl+O expand"}`,
+              ),
+              width,
+            ),
+          ]
+        : []),
+      ...(preview.omittedBytes > 0
+        ? [
+            boundedLine(
+              this.#theme.muted(`… ${preview.omittedBytes} diff bytes omitted from preview`),
+              width,
+            ),
+          ]
+        : []),
+    ];
+  }
+
+  #renderShellStream(
+    label: "stdout" | "stderr",
+    stream: ToolStreamPreview,
+    width: number,
+  ): string[] {
+    const safeText = safeTerminalText(stream.text);
+    const visualLines = safeText.length === 0 ? [] : wrapTextWithAnsi(safeText, width);
+    const limit = this.#expanded ? expandedShellVisualLineCount : collapsedShellVisualLineCount;
+    const visible = this.#expanded ? visualLines.slice(0, limit) : visualLines.slice(-limit);
+    const hiddenVisualLines = visualLines.length - visible.length;
+    const facts = [
+      ...(stream.omittedBytes > 0 ? [`${stream.omittedBytes} earlier bytes omitted`] : []),
+      ...(hiddenVisualLines > 0
+        ? [
+            this.#expanded
+              ? `${hiddenVisualLines} visual lines omitted`
+              : `${hiddenVisualLines} earlier visual lines hidden`,
+          ]
+        : []),
+    ];
+    return [
+      boundedLine(
+        this.#theme.muted(`${label}${facts.length === 0 ? "" : ` · ${facts.join(" · ")}`}`),
+        width,
+      ),
+      ...visible.map((line) => boundedLine(this.#theme.toolOutput(line), width)),
+    ];
+  }
+}
+
+function renderNumberedCode(
+  lines: readonly ToolTextPreviewLine[],
+  language: string | null,
+  width: number,
+  theme: AdamTuiTheme,
+): readonly string[] {
+  const highlighted = highlightCodeLines(
+    lines.map((line) => line.text),
+    language,
+    theme,
+  );
+  const numberWidth = Math.max(1, ...lines.map((line) => String(line.number).length));
+  return lines.map((line, index) => {
+    const gutter = theme.lineNumber(`${String(line.number).padStart(numberWidth)} │ `);
+    return `${gutter}${truncateToWidth(
+      highlighted[index] ?? "",
+      Math.max(0, width - visibleWidth(gutter)),
+    )}`;
+  });
+}
+
+function diffLineNumber(line: ToolDiffPreviewLine): number | null {
+  return line.kind === "deletion"
+    ? line.oldLineNumber
+    : line.kind === "addition"
+      ? line.newLineNumber
+      : (line.newLineNumber ?? line.oldLineNumber);
+}
+
+function boundedLine(line: string, width: number): string {
+  return truncateToWidth(line, Math.max(0, width));
+}
+
+function streamHasContent(stream: ToolStreamPreview): boolean {
+  return stream.totalBytes > 0 || stream.text.length > 0;
+}

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -59,6 +59,7 @@ import {
   terminalSizeIsSupported,
 } from "./responsive-root.js";
 import { RightEdgeGuardTerminal } from "./right-edge-guard-terminal.js";
+import { RoundedFrame } from "./rounded-frame.js";
 import { safeTerminalText } from "./safe-terminal-text.js";
 import { SessionInspector, type SessionRunStatus } from "./session-inspector.js";
 import { SessionPicker } from "./session-picker.js";
@@ -707,12 +708,14 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       if (reasoning.status === "active") {
         activeReasoningVisible = true;
         thinking.setMessage(title);
-        transcript.addChild(thinking);
-      } else {
-        transcript.addChild(new Spacer(1));
-        transcript.addChild(new ResponsiveLine(title));
       }
       if (!expanded) {
+        if (reasoning.status === "active") {
+          transcript.addChild(thinking);
+        } else {
+          transcript.addChild(new Spacer(1));
+          transcript.addChild(new ResponsiveLine(title));
+        }
         return;
       }
       const text =
@@ -725,7 +728,11 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           : reasoningArtifactReads.has(reasoning.id)
             ? "Loading provider reasoning…"
             : "Provider reasoning is available as an artifact · Ctrl+T to retry loading");
-      transcript.addChild(new Markdown(safeTerminalText(text), 0, 0, theme.markdown));
+      const content = new Container();
+      content.addChild(reasoning.status === "active" ? thinking : new ResponsiveLine(title));
+      content.addChild(new Markdown(safeTerminalText(text), 0, 0, theme.markdown));
+      transcript.addChild(new Spacer(1));
+      transcript.addChild(new RoundedFrame(content, theme.editor.borderColor));
     };
     let previousWasAssistant = false;
     for (const item of active?.transcript.items ?? []) {

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -67,6 +67,7 @@ import { SkillPalette } from "./skill-palette.js";
 import { TargetPicker } from "./target-picker.js";
 import { createAdamTuiTheme } from "./theme.js";
 import { ThinkingPicker } from "./thinking-picker.js";
+import { ToolPreview } from "./tool-preview.js";
 
 export type { ClipboardAdapter, DeadlineScheduler } from "./exit-policy.js";
 
@@ -777,6 +778,9 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
               ? label
               : `${label} ${safeTerminalText(subject)}`;
         tool.addChild(new ResponsiveLine(theme.toolTitle(title)));
+        if (item.preview !== null) {
+          tool.addChild(new ToolPreview(item.preview, toolDetailsExpanded, theme));
+        }
         const detail = item.resultSummary ?? toolStatusText(item.status, item.outcome?.status);
         if (detail !== null) {
           tool.addChild(new ResponsiveLine(theme.toolOutput(safeTerminalText(detail))));

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -58,6 +58,7 @@ import {
   ResponsiveText,
   terminalSizeIsSupported,
 } from "./responsive-root.js";
+import { RightEdgeGuardTerminal } from "./right-edge-guard-terminal.js";
 import { safeTerminalText } from "./safe-terminal-text.js";
 import { SessionInspector, type SessionRunStatus } from "./session-inspector.js";
 import { SessionPicker } from "./session-picker.js";
@@ -85,7 +86,8 @@ export type RunTuiOptions = {
 };
 
 export async function runTui(options: RunTuiOptions): Promise<void> {
-  const terminal = options.terminal ?? new ProcessTerminal();
+  const physicalTerminal = options.terminal ?? new ProcessTerminal();
+  const terminal = new RightEdgeGuardTerminal(physicalTerminal);
   const deadlineScheduler = options.deadlineScheduler ?? nodeDeadlineScheduler;
   const commandRegistry = options.commandRegistry ?? adamCommandRegistry;
   const startupTargetId =
@@ -95,17 +97,26 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     options.presentation.getState().authoritative.sessions.items.length === 0;
   const tui: TUI = new TuiMainScreen(terminal, true);
   const theme = createAdamTuiTheme();
-  const showOverlay = (component: Component, overlayOptions: OverlayOptions) =>
-    tui.showOverlay(
+  const showOverlay = (component: Component, overlayOptions: OverlayOptions) => {
+    const renderOptions = resolvePhysicalOverlayWidth(
+      overlayOptions,
+      physicalTerminal.columns,
+      terminal.columns,
+    );
+    return tui.showOverlay(
       new OverlayFrame(component, theme, () =>
         resolveOverlayMaximumHeight(overlayOptions, terminal.rows),
       ),
       {
-        ...overlayOptions,
-        visible: (columns, rows) => terminalSizeIsSupported(columns, rows),
+        ...renderOptions,
+        visible: () => terminalSizeIsSupported(physicalTerminal.columns, physicalTerminal.rows),
       },
     );
-  const root = new ResponsiveRoot(() => terminal.rows);
+  };
+  const root = new ResponsiveRoot(
+    () => physicalTerminal.rows,
+    () => physicalTerminal.columns,
+  );
   const header = new Text();
   const transcript = new Container();
   const editorSlot = new Container();
@@ -148,7 +159,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   );
   let projectedHistorySessionId = options.presentation.getState().authoritative.active?.session.id;
   const statusLine = new Text();
-  const footer = new ResponsiveText();
+  const footer = new ResponsiveText(() => physicalTerminal.columns);
   const working = new Loader(tui, theme.toolTitle, theme.muted, "Working", { intervalMs: 80 });
   const thinking = new Loader(tui, theme.keyword, theme.muted, "Thinking", { intervalMs: 80 });
   thinking.stop();
@@ -2316,7 +2327,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       return { consume: true };
     }
     if (
-      !terminalSizeIsSupported(terminal.columns, terminal.rows) &&
+      !terminalSizeIsSupported(physicalTerminal.columns, physicalTerminal.rows) &&
       !commandRegistry.matchesInput(data, "interrupt")
     ) {
       if (commandRegistry.matchesInput(data, "back")) {
@@ -2593,6 +2604,22 @@ function operationActionText(operation: OperationDisplay): string {
         : []),
   ];
   return actions.join(" · ");
+}
+
+function resolvePhysicalOverlayWidth(
+  options: OverlayOptions,
+  physicalColumns: number,
+  renderColumns: number,
+): OverlayOptions {
+  if (typeof options.width !== "string") {
+    return options;
+  }
+  const match = options.width.match(/^(\d+(?:\.\d+)?)%$/u);
+  if (match === null) {
+    return options;
+  }
+  const requested = Math.floor((physicalColumns * Number.parseFloat(match[1] as string)) / 100);
+  return { ...options, width: Math.max(1, Math.min(requested, renderColumns)) };
 }
 
 function resolveOverlayMaximumHeight(

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -14,6 +14,7 @@ import type {
   SessionSummary,
   SkillCatalogDisplay,
   ToolCallDisplay,
+  ToolPreviewDisplay,
   TranscriptItem,
 } from "@adam-agent/presentation";
 import {
@@ -125,6 +126,7 @@ export async function createPresentationSession(
   options: CreatePresentationSessionOptions,
 ): Promise<PresentationSession> {
   options.lifecycle.enableAutomaticTitles();
+  const changePreviewCache = new Map<string, ToolPreviewDisplay | null>();
   const bufferedEvents: SessionRuntimeNotification[] = [];
   const bufferedMetadata: SessionMetadataEvent[] = [];
   let handleRuntime: ((notification: SessionRuntimeNotification) => void) | undefined;
@@ -210,7 +212,15 @@ export async function createPresentationSession(
     const advanceSessionCursor = (sequence: number): void => {
       activeSessionThroughSequence = Math.max(activeSessionThroughSequence, sequence);
     };
-    let transcript: readonly TranscriptItem[] = projectTranscript(records, projectedOperations);
+    const initialPreviewHydration = hydrateChangePreviews(records, options, changePreviewCache);
+    if (initialPreviewHydration !== null) {
+      await initialPreviewHydration;
+    }
+    let transcript: readonly TranscriptItem[] = projectTranscript(
+      records,
+      projectedOperations,
+      changePreviewCache,
+    );
     const historyPageSize = boundedHistoryPageSize(options[presentationHistoryPageSize]);
     let loadedTranscriptStart = Math.max(0, transcript.length - historyPageSize);
     const naming =
@@ -766,7 +776,19 @@ export async function createPresentationSession(
       const activatedContextUsage = await options.lifecycle.inspectContextUsage({
         sessionId: snapshot.sessionId,
       });
-      const activatedTranscript = projectTranscript(activatedRecords, activatedOperations);
+      const activatedPreviewHydration = hydrateChangePreviews(
+        activatedRecords,
+        options,
+        changePreviewCache,
+      );
+      if (activatedPreviewHydration !== null) {
+        await activatedPreviewHydration;
+      }
+      const activatedTranscript = projectTranscript(
+        activatedRecords,
+        activatedOperations,
+        changePreviewCache,
+      );
       const activatedLoadedTranscriptStart = Math.max(
         0,
         activatedTranscript.length - historyPageSize,
@@ -1131,7 +1153,19 @@ export async function createPresentationSession(
             if (closed || current === null || current.session.id !== active.session.id) {
               return;
             }
-            transcript = projectTranscript(refreshedRecords, refreshedOperations);
+            const refreshedPreviewHydration = hydrateChangePreviews(
+              refreshedRecords,
+              options,
+              changePreviewCache,
+            );
+            if (refreshedPreviewHydration !== null) {
+              await refreshedPreviewHydration;
+            }
+            transcript = projectTranscript(
+              refreshedRecords,
+              refreshedOperations,
+              changePreviewCache,
+            );
             loadedTranscriptStart = Math.min(
               loadedTranscriptStart,
               Math.max(0, transcript.length - historyPageSize),
@@ -3006,9 +3040,10 @@ async function readPresentationSessionRecords(
 
 function projectTranscript(
   records: readonly SourcedSessionRecord[],
-  operations: readonly ProjectedOperation[] = [],
+  operations: readonly ProjectedOperation[],
+  changePreviewCache: ReadonlyMap<string, ToolPreviewDisplay | null>,
 ): readonly TranscriptItem[] {
-  const toolDisplays = collectToolDisplays(records);
+  const toolDisplays = collectToolDisplays(records, changePreviewCache);
   const attemptProviders = new Map<string, string>(
     records.flatMap(({ entry, sessionId }) =>
       entry.schemaVersion === 3 && entry.record.type === "provider_attempt_started"
@@ -3404,9 +3439,9 @@ type MutableToolDisplay = {
   changePreviewRef?: NonNullable<ToolCallDisplay["changePreviewRef"]>;
 };
 
-function collectToolDisplays(
+function collectMutableToolDisplays(
   records: readonly SourcedSessionRecord[],
-): ReadonlyMap<string, ToolCallDisplay> {
+): ReadonlyMap<string, MutableToolDisplay> {
   const tools = new Map<string, MutableToolDisplay>();
   const toolFor = (sessionId: string, callId: string): MutableToolDisplay => {
     const key = `${sessionId}:${callId}`;
@@ -3487,6 +3522,14 @@ function collectToolDisplays(
     }
   }
 
+  return tools;
+}
+
+function collectToolDisplays(
+  records: readonly SourcedSessionRecord[],
+  changePreviewCache: ReadonlyMap<string, ToolPreviewDisplay | null>,
+): ReadonlyMap<string, ToolCallDisplay> {
+  const tools = collectMutableToolDisplays(records);
   return new Map(
     [...tools.entries()].flatMap(([key, tool]) => {
       if (tool.sequence === undefined) {
@@ -3519,6 +3562,13 @@ function collectToolDisplays(
                 : `${tool.failure.code}: ${tool.failure.message}`,
             artifacts: toolArtifacts(tool.output),
             changePreviewRef: tool.changePreviewRef ?? null,
+            preview: toolPreview(
+              name,
+              tool.output,
+              subject,
+              tool.changePreviewRef,
+              changePreviewCache,
+            ),
           },
         ] as const,
       ];
@@ -3826,6 +3876,292 @@ function toolResultSummary(name: string, output: JsonValue | undefined): string 
   return output === undefined ? null : "Completed";
 }
 
+const toolTextPreviewMaximumBytes = 16 * 1024;
+const toolTextPreviewMaximumLines = 200;
+const toolShellStreamPreviewMaximumBytes = 8 * 1024;
+
+function hydrateChangePreviews(
+  records: readonly SourcedSessionRecord[],
+  options: PresentationSessionRecordOptions,
+  changePreviewCache: Map<string, ToolPreviewDisplay | null>,
+): Promise<void> | null {
+  const pending = [...collectMutableToolDisplays(records).values()].flatMap((tool) => {
+    const name = tool.name;
+    const reference = tool.changePreviewRef;
+    if (
+      (name !== "write_file" && name !== "edit_file") ||
+      reference === undefined ||
+      changePreviewCache.has(reference.id)
+    ) {
+      return [];
+    }
+    changePreviewCache.set(reference.id, null);
+    return [
+      projectChangePreview(name, reference, options).then((preview) => {
+        changePreviewCache.set(reference.id, preview);
+      }),
+    ];
+  });
+  return pending.length === 0 ? null : Promise.all(pending).then(() => undefined);
+}
+
+function toolPreview(
+  name: string,
+  output: JsonValue | undefined,
+  subject: ToolCallDisplay["subject"],
+  changePreviewRef: ToolCallDisplay["changePreviewRef"] | undefined,
+  changePreviewCache: ReadonlyMap<string, ToolPreviewDisplay | null>,
+): ToolCallDisplay["preview"] {
+  const outputRecord = jsonRecord(output);
+  if (name === "read_file" && typeof outputRecord?.content === "string") {
+    const bounded = boundedTextLines(
+      outputRecord.content,
+      toolTextPreviewMaximumBytes,
+      toolTextPreviewMaximumLines,
+    );
+    return {
+      kind: "read_text",
+      language: subject?.type === "path" ? languageForPath(subject.value) : null,
+      lines: bounded.lines.map((text, index) => ({ number: index + 1, text })),
+      omittedBytes: bounded.omittedBytes,
+      sourceTruncated: outputRecord.truncated === true,
+    };
+  }
+  if (
+    (name === "write_file" || name === "edit_file") &&
+    changePreviewRef !== undefined &&
+    changePreviewRef !== null
+  ) {
+    return changePreviewCache.get(changePreviewRef.id) ?? null;
+  }
+  if (name === "run_shell") {
+    const termination = jsonRecord(outputRecord?.termination);
+    const stdout = jsonRecord(outputRecord?.stdout);
+    const stderr = jsonRecord(outputRecord?.stderr);
+    const projectedTermination = shellTerminationPreview(termination);
+    const projectedStdout = shellStreamPreview(stdout);
+    const projectedStderr = shellStreamPreview(stderr);
+    return projectedTermination === null || projectedStdout === null || projectedStderr === null
+      ? null
+      : {
+          kind: "shell_output",
+          termination: projectedTermination,
+          stdout: projectedStdout,
+          stderr: projectedStderr,
+        };
+  }
+  return null;
+}
+
+async function projectChangePreview(
+  name: "write_file" | "edit_file",
+  reference: NonNullable<ToolCallDisplay["changePreviewRef"]>,
+  options: PresentationSessionRecordOptions,
+): Promise<ToolPreviewDisplay | null> {
+  if (
+    options.stateRoot === undefined ||
+    reference.byteCount <= 0 ||
+    !reference.mediaType.startsWith("text/x-diff")
+  ) {
+    return null;
+  }
+  try {
+    const page = await readFileArtifactRange({
+      root: join(options.stateRoot, "artifacts"),
+      id: reference.id,
+      expectedByteCount: reference.byteCount,
+      offset: 0,
+      maximumBytes: Math.min(reference.byteCount, presentationArtifactPageMaximumBytes),
+    });
+    if (page === undefined || page.totalByteCount !== reference.byteCount) {
+      return null;
+    }
+    const decoded = decodeArtifactPage(page.bytes, page.eof);
+    const bounded = boundedTextLines(
+      decoded.text,
+      toolTextPreviewMaximumBytes,
+      toolTextPreviewMaximumLines,
+    );
+    const omittedBytes =
+      Math.max(0, reference.byteCount - decoded.byteCount) + bounded.omittedBytes;
+    const path = bounded.lines.find((line) => line.startsWith("+++ b/"))?.slice("+++ b/".length);
+    if (name === "write_file") {
+      const lines = bounded.lines
+        .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+        .map((line, index) => ({ number: index + 1, text: line.slice(1) }));
+      return {
+        kind: "write_text",
+        language: path === undefined ? null : languageForPath(path),
+        lines,
+        omittedBytes,
+      };
+    }
+    return {
+      kind: "diff",
+      language: path === undefined ? null : languageForPath(path),
+      lines: bounded.lines.map((line) => {
+        const kind = diffLineKind(line);
+        return {
+          kind,
+          oldLineNumber: null,
+          newLineNumber: null,
+          text: kind === "addition" || kind === "deletion" ? line.slice(1) : line,
+        };
+      }),
+      omittedBytes,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function diffLineKind(line: string): "meta" | "context" | "addition" | "deletion" {
+  if (line.startsWith("+++") || line.startsWith("---") || line.startsWith("@@")) {
+    return "meta";
+  }
+  if (line.startsWith("+")) {
+    return "addition";
+  }
+  if (line.startsWith("-")) {
+    return "deletion";
+  }
+  return "context";
+}
+
+function boundedTextLines(
+  text: string,
+  maximumBytes: number,
+  maximumLines: number,
+): { readonly lines: readonly string[]; readonly omittedBytes: number } {
+  const sourceBytes = Buffer.byteLength(text, "utf8");
+  const sourceLines = text.split("\n");
+  if (sourceLines.at(-1) === "") {
+    sourceLines.pop();
+  }
+  const lines: string[] = [];
+  let consumedBytes = 0;
+  for (const [index, line] of sourceLines.entries()) {
+    if (lines.length >= maximumLines || consumedBytes >= maximumBytes) {
+      break;
+    }
+    const lineBytes = Buffer.byteLength(line, "utf8");
+    const newlineBytes = index < sourceLines.length - 1 || text.endsWith("\n") ? 1 : 0;
+    if (consumedBytes + lineBytes + newlineBytes <= maximumBytes) {
+      lines.push(line);
+      consumedBytes += lineBytes + newlineBytes;
+      continue;
+    }
+    const remainingBytes = maximumBytes - consumedBytes;
+    const prefix = boundedUtf8Prefix(line, remainingBytes);
+    if (prefix.byteCount > 0 || lines.length === 0) {
+      lines.push(prefix.text);
+      consumedBytes += prefix.byteCount;
+    }
+    break;
+  }
+  return { lines, omittedBytes: Math.max(0, sourceBytes - consumedBytes) };
+}
+
+function boundedUtf8Prefix(
+  text: string,
+  maximumBytes: number,
+): { readonly text: string; readonly byteCount: number } {
+  const bytes = Buffer.from(text, "utf8");
+  if (bytes.byteLength <= maximumBytes) {
+    return { text, byteCount: bytes.byteLength };
+  }
+  let end = Math.max(0, maximumBytes);
+  while (end > 0 && (bytes[end] ?? 0) >= 0x80 && (bytes[end] ?? 0) < 0xc0) {
+    end -= 1;
+  }
+  return { text: bytes.subarray(0, end).toString("utf8"), byteCount: end };
+}
+
+function boundedUtf8Tail(
+  text: string,
+  maximumBytes: number,
+): { readonly text: string; readonly byteCount: number } {
+  const bytes = Buffer.from(text, "utf8");
+  if (bytes.byteLength <= maximumBytes) {
+    return { text, byteCount: bytes.byteLength };
+  }
+  let start = bytes.byteLength - maximumBytes;
+  while (start < bytes.byteLength && (bytes[start] ?? 0) >= 0x80 && (bytes[start] ?? 0) < 0xc0) {
+    start += 1;
+  }
+  return {
+    text: bytes.subarray(start).toString("utf8"),
+    byteCount: bytes.byteLength - start,
+  };
+}
+
+function shellStreamPreview(value: KnownJsonRecord | undefined): {
+  readonly text: string;
+  readonly totalBytes: number;
+  readonly omittedBytes: number;
+} | null {
+  if (
+    typeof value?.tail !== "string" ||
+    typeof value.totalBytes !== "number" ||
+    typeof value.omittedBytes !== "number"
+  ) {
+    return null;
+  }
+  const bounded = boundedUtf8Tail(value.tail, toolShellStreamPreviewMaximumBytes);
+  const retainedBytes = Buffer.byteLength(value.tail, "utf8");
+  return {
+    text: bounded.text,
+    totalBytes: value.totalBytes,
+    omittedBytes: value.omittedBytes + retainedBytes - bounded.byteCount,
+  };
+}
+
+function shellTerminationPreview(
+  value: KnownJsonRecord | undefined,
+): Extract<ToolCallDisplay["preview"], { readonly kind: "shell_output" }>["termination"] | null {
+  if (value?.type === "exited" && typeof value.exitCode === "number") {
+    return { type: "exited", exitCode: value.exitCode };
+  }
+  if (value?.type === "timed_out" || value?.type === "interrupted") {
+    return { type: value.type };
+  }
+  return value?.type === "signalled" && typeof value.signal === "string"
+    ? { type: "signalled", signal: value.signal }
+    : null;
+}
+
+function languageForPath(path: string): string | null {
+  const extension = /\.([^./]+)$/u.exec(path)?.[1]?.toLowerCase();
+  const languages: Readonly<Record<string, string>> = {
+    bash: "bash",
+    c: "c",
+    cc: "cpp",
+    cpp: "cpp",
+    css: "css",
+    go: "go",
+    h: "c",
+    hpp: "cpp",
+    html: "html",
+    java: "java",
+    js: "javascript",
+    json: "json",
+    jsx: "javascript",
+    kt: "kotlin",
+    kts: "kotlin",
+    md: "markdown",
+    py: "python",
+    rb: "ruby",
+    rs: "rust",
+    sh: "bash",
+    sql: "sql",
+    ts: "typescript",
+    tsx: "typescript",
+    yaml: "yaml",
+    yml: "yaml",
+  };
+  return extension === undefined ? "text" : (languages[extension] ?? "text");
+}
+
 function boundedDisplayText(value: string): string {
   return [...value.replaceAll(/\s+/gu, " ").trim()].slice(0, 240).join("");
 }
@@ -3874,6 +4210,8 @@ type KnownJsonRecord = Readonly<Record<string, JsonValue>> & {
   readonly artifact?: JsonValue;
   readonly type?: JsonValue;
   readonly exitCode?: JsonValue;
+  readonly signal?: JsonValue;
+  readonly tail?: JsonValue;
   readonly totalBytes?: JsonValue;
   readonly omittedBytes?: JsonValue;
   readonly omittedContentBlocks?: JsonValue;

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -3355,9 +3355,13 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       }
       const afterSessionId = decodeProjectSessionCatalogCursor(input.cursor);
       const projectId = await canonicalProjectId(options.workspaceRoot);
-      const sessionIds: string[] = [];
-      for (const sessionId of [...(await storeDirectory.listSessionIds())].sort()) {
-        const records = await readSessionRecords(options, sessionId);
+      const directoryEntries = await storeDirectory.listSessionEntries();
+      const catalogEntries: Array<{
+        readonly sessionId: string;
+        readonly modifiedAtMilliseconds: number;
+      }> = [];
+      for (const entry of directoryEntries) {
+        const records = await readSessionRecords(options, entry.sessionId);
         if (
           records.some((entry) =>
             entry.schemaVersion === 3
@@ -3365,15 +3369,27 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
               : entry.event.type === "user_message",
           )
         ) {
-          sessionIds.push(sessionId);
+          catalogEntries.push(entry);
         }
       }
-      const afterIndex =
+      catalogEntries.sort(
+        (left, right) =>
+          right.modifiedAtMilliseconds - left.modifiedAtMilliseconds ||
+          (left.sessionId < right.sessionId ? -1 : left.sessionId > right.sessionId ? 1 : 0),
+      );
+      const cursorIndex =
+        afterSessionId === undefined
+          ? -1
+          : catalogEntries.findIndex((entry) => entry.sessionId === afterSessionId);
+      const start =
         afterSessionId === undefined
           ? 0
-          : sessionIds.findIndex((sessionId) => sessionId > afterSessionId);
-      const start = afterIndex < 0 ? sessionIds.length : afterIndex;
-      const selectedIds = sessionIds.slice(start, start + limit);
+          : cursorIndex < 0
+            ? catalogEntries.length
+            : cursorIndex + 1;
+      const selectedIds = catalogEntries
+        .slice(start, start + limit)
+        .map((entry) => entry.sessionId);
       const items = await Promise.all(
         selectedIds.map((sessionId) => inspectSession({ sessionId })),
       );
@@ -3382,7 +3398,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         projectId,
         items,
         nextCursor:
-          lastSessionId !== undefined && start + selectedIds.length < sessionIds.length
+          lastSessionId !== undefined && start + selectedIds.length < catalogEntries.length
             ? encodeProjectSessionCatalogCursor(lastSessionId)
             : null,
       };

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { chmod, type FileHandle, mkdir, open, readdir, realpath } from "node:fs/promises";
+import { chmod, type FileHandle, mkdir, open, readdir, realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -771,8 +771,14 @@ export interface SessionStore<RecordType extends SessionRecord = SessionEventRec
   read(): Promise<readonly RecordType[]>;
 }
 
+export interface SessionStoreDirectoryEntry {
+  readonly sessionId: string;
+  readonly modifiedAtMilliseconds: number;
+}
+
 export interface SessionStoreDirectory<RecordType extends SessionRecord = SessionRecord> {
   create(sessionId: string): Promise<SessionStore<RecordType>>;
+  listSessionEntries(): Promise<readonly SessionStoreDirectoryEntry[]>;
   listSessionIds(): Promise<readonly string[]>;
   open(sessionId: string): Promise<SessionStore<RecordType> | undefined>;
 }
@@ -2087,24 +2093,52 @@ export function createInMemorySessionStore<
 export function createInMemorySessionStoreDirectory<
   RecordType extends SessionRecord = SessionRecord,
 >(): SessionStoreDirectory<RecordType> {
-  const stores = new Map<string, SessionStore<RecordType>>();
+  const stores = new Map<
+    string,
+    { readonly store: SessionStore<RecordType>; modifiedAtMilliseconds: number }
+  >();
+  let lastModifiedAtMilliseconds = 0;
+  const nextModifiedAtMilliseconds = () => {
+    lastModifiedAtMilliseconds = Math.max(Date.now(), lastModifiedAtMilliseconds + 1);
+    return lastModifiedAtMilliseconds;
+  };
   return {
     async create(sessionId) {
       validateSessionId(sessionId);
       if (stores.has(sessionId)) {
         throw new SessionStoreError("session_log_exists");
       }
-      const store = createInMemorySessionStore<RecordType>();
-      stores.set(sessionId, store);
-      return store;
+      const backing = createInMemorySessionStore<RecordType>();
+      const entry = {
+        modifiedAtMilliseconds: nextModifiedAtMilliseconds(),
+        store: {
+          async append(record: RecordType) {
+            await backing.append(record);
+            entry.modifiedAtMilliseconds = nextModifiedAtMilliseconds();
+          },
+          read: () => backing.read(),
+        },
+      };
+      stores.set(sessionId, entry);
+      return entry.store;
+    },
+    async listSessionEntries() {
+      return [...stores.entries()]
+        .map(([sessionId, entry]) => ({
+          sessionId,
+          modifiedAtMilliseconds: entry.modifiedAtMilliseconds,
+        }))
+        .sort((left, right) =>
+          left.sessionId < right.sessionId ? -1 : left.sessionId > right.sessionId ? 1 : 0,
+        );
     },
     async listSessionIds() {
       return [...stores.keys()].sort();
     },
     async open(sessionId) {
       validateSessionId(sessionId);
-      const store = stores.get(sessionId);
-      return store !== undefined && (await store.read()).length > 0 ? store : undefined;
+      const entry = stores.get(sessionId);
+      return entry !== undefined && (await entry.store.read()).length > 0 ? entry.store : undefined;
     },
   };
 }
@@ -2118,6 +2152,41 @@ export function createJsonlSessionStoreDirectory<
   return {
     create(sessionId) {
       return createJsonlSessionStore<RecordType>({ ...options, sessionId });
+    },
+    async listSessionEntries() {
+      const { sessionsDirectory } = await resolveProjectSessionDirectories(options);
+      try {
+        const files = (await readdir(sessionsDirectory, { withFileTypes: true }))
+          .filter((entry) => entry.isFile() && /^[0-9a-f-]{36}\.jsonl$/u.test(entry.name))
+          .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
+        const entries = await Promise.all(
+          files.map(async (file) => {
+            try {
+              const metadata = await stat(join(sessionsDirectory, file.name));
+              return {
+                sessionId: file.name.slice(0, -".jsonl".length),
+                modifiedAtMilliseconds: metadata.mtimeMs,
+              };
+            } catch (error) {
+              if (isNodeError(error) && error.code === "ENOENT") {
+                return null;
+              }
+              throw error;
+            }
+          }),
+        );
+        return entries.filter(
+          (
+            entry,
+          ): entry is { readonly sessionId: string; readonly modifiedAtMilliseconds: number } =>
+            entry !== null,
+        );
+      } catch (error) {
+        if (isNodeError(error) && error.code === "ENOENT") {
+          return [];
+        }
+        throw error;
+      }
     },
     async listSessionIds() {
       const { sessionsDirectory } = await resolveProjectSessionDirectories(options);

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -164,6 +164,55 @@ export type SessionNoticeDisplay = {
   | { readonly status: "failed"; readonly code: string; readonly message: string }
 );
 
+export type ToolTextPreviewLine = {
+  readonly number: number;
+  readonly text: string;
+};
+
+export type ToolStreamPreview = {
+  readonly text: string;
+  readonly totalBytes: number;
+  readonly omittedBytes: number;
+};
+
+export type ToolDiffPreviewLine = {
+  readonly kind: "meta" | "context" | "addition" | "deletion";
+  readonly oldLineNumber: number | null;
+  readonly newLineNumber: number | null;
+  readonly text: string;
+};
+
+export type ToolPreviewDisplay =
+  | {
+      readonly kind: "read_text";
+      readonly language: string | null;
+      readonly lines: readonly ToolTextPreviewLine[];
+      readonly omittedBytes: number;
+      readonly sourceTruncated: boolean;
+    }
+  | {
+      readonly kind: "write_text";
+      readonly language: string | null;
+      readonly lines: readonly ToolTextPreviewLine[];
+      readonly omittedBytes: number;
+    }
+  | {
+      readonly kind: "diff";
+      readonly language: string | null;
+      readonly lines: readonly ToolDiffPreviewLine[];
+      readonly omittedBytes: number;
+    }
+  | {
+      readonly kind: "shell_output";
+      readonly termination:
+        | { readonly type: "exited"; readonly exitCode: number }
+        | { readonly type: "timed_out" }
+        | { readonly type: "interrupted" }
+        | { readonly type: "signalled"; readonly signal: string };
+      readonly stdout: ToolStreamPreview;
+      readonly stderr: ToolStreamPreview;
+    };
+
 export type ToolCallDisplay = {
   readonly type: "tool_call";
   readonly id: string;
@@ -217,6 +266,7 @@ export type ToolCallDisplay = {
   readonly resultSummary: string | null;
   readonly artifacts: readonly ArtifactReference[];
   readonly changePreviewRef: ArtifactReference | null;
+  readonly preview: ToolPreviewDisplay | null;
 };
 
 export type OperationLinkDisplay = {

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -7401,9 +7401,16 @@ test("PresentationSession normalizes a real read call without exposing raw argum
       resultSummary: "65536 bytes · output truncated",
       artifacts: [],
       changePreviewRef: null,
+      preview: {
+        kind: "read_text",
+        language: "text",
+        lines: [{ number: 1, text: expect.stringMatching(/^r+$/u) }],
+        omittedBytes: expect.any(Number),
+        sourceTruncated: true,
+      },
     });
     expect(JSON.stringify(tool)).not.toContain('{"path":"notes.txt"}');
-    expect(JSON.stringify(tool)).not.toContain("r".repeat(1_024));
+    expect(JSON.stringify(tool)).not.toContain("r".repeat(17 * 1_024));
 
     await presentation.close();
   } finally {
@@ -7506,6 +7513,16 @@ test("PresentationSession exposes a bounded shell summary and durable overflow a
           source: "tool_output",
         },
       ],
+      preview: {
+        kind: "shell_output",
+        termination: { type: "exited", exitCode: 0 },
+        stdout: { text: "", totalBytes: 0, omittedBytes: 0 },
+        stderr: {
+          text: expect.stringMatching(/x+$/u),
+          totalBytes: 70_000,
+          omittedBytes: expect.any(Number),
+        },
+      },
     });
     if (tool?.type !== "tool_call" || tool.artifacts[0] === undefined) {
       throw new Error("Expected one shell output artifact.");
@@ -7767,7 +7784,18 @@ test("PresentationSession publishes a durable change preview before write permis
           .authoritative.active?.transcript.items.find(
             (item) => item.type === "tool_call" && item.callId === "pending-write",
           ),
-      ).toMatchObject({ changePreviewRef: pending?.changePreviewRef });
+      ).toMatchObject({
+        changePreviewRef: pending?.changePreviewRef,
+        preview: {
+          kind: "write_text",
+          language: "text",
+          lines: [
+            { number: 1, text: "line one" },
+            { number: 2, text: "line two" },
+          ],
+          omittedBytes: 0,
+        },
+      });
       const previewId = pending?.changePreviewRef?.id;
       if (previewId === undefined || requestId === undefined) {
         throw new Error("Expected an actionable canonical preview.");
@@ -7896,6 +7924,23 @@ test("PresentationSession publishes a canonical structured-edit preview before p
         callId: "pending-edit",
         canAllow: true,
         changePreviewRef: { source: "change_preview" },
+      });
+      expect(
+        presentation
+          .getState()
+          .authoritative.active?.transcript.items.find(
+            (item) => item.type === "tool_call" && item.callId === "pending-edit",
+          ),
+      ).toMatchObject({
+        preview: {
+          kind: "diff",
+          language: "text",
+          lines: expect.arrayContaining([
+            { kind: "deletion", oldLineNumber: null, newLineNumber: null, text: "before" },
+            { kind: "addition", oldLineNumber: null, newLineNumber: null, text: "after" },
+          ]),
+          omittedBytes: 0,
+        },
       });
     } finally {
       if (failureGuard !== undefined) {

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -1,6 +1,16 @@
 import { createHash } from "node:crypto";
 import { rmSync } from "node:fs";
-import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -1960,6 +1970,7 @@ test("PresentationSession keeps its draft when logical input persistence fails",
       wrappedStores.set(sessionId, wrapped);
       return wrapped;
     },
+    listSessionEntries: () => backing.listSessionEntries(),
     listSessionIds: () => backing.listSessionIds(),
     async open(sessionId) {
       return (await backing.open(sessionId)) === undefined
@@ -8238,6 +8249,77 @@ test("PresentationSession discovers and selects cold sibling project sessions", 
   }
 });
 
+test("PresentationSession orders project sessions by durable modification time with a stable tie", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-session-mtime-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const modelTargets = settledModelTargets("Modification order answer.");
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    lifecycle.enableAutomaticTitles();
+    const created = [
+      await lifecycle.create({ targetIdentity }),
+      await lifecycle.create({ targetIdentity }),
+      await lifecycle.create({ targetIdentity }),
+    ];
+    for (const [index, session] of created.entries()) {
+      await lifecycle.setSessionManualName({
+        sessionId: session.sessionId,
+        name: `Modification order ${index + 1}`,
+      });
+      await lifecycle.continue({
+        sessionId: session.sessionId,
+        input: { text: `Modification order ${index + 1}` },
+      });
+    }
+    const sortedIds = created.map((session) => session.sessionId).sort();
+    const [oldestId, ...newestIds] = sortedIds;
+    if (oldestId === undefined || newestIds.length !== 2) {
+      throw new Error("Expected three durable sessions.");
+    }
+    const projectId = createHash("sha256").update(workspaceRoot).digest("hex");
+    const sessionPath = (sessionId: string) =>
+      join(stateRoot, "projects", projectId, "sessions", `${sessionId}.jsonl`);
+    const olderTime = new Date("2026-01-01T00:00:00.000Z");
+    const newerTime = new Date("2026-01-02T00:00:00.000Z");
+    await utimes(sessionPath(oldestId), olderTime, olderTime);
+    await Promise.all(
+      newestIds.map((sessionId) => utimes(sessionPath(sessionId), newerTime, newerTime)),
+    );
+    const [oldestMetadata, ...newestMetadata] = await Promise.all(
+      [oldestId, ...newestIds].map((sessionId) => stat(sessionPath(sessionId))),
+    );
+    expect(oldestMetadata?.mtimeMs).toBeLessThan(newestMetadata[0]?.mtimeMs ?? 0);
+    expect(newestMetadata.map((metadata) => metadata.mtimeMs)).toEqual([
+      newerTime.getTime(),
+      newerTime.getTime(),
+    ]);
+    expect(
+      (await lifecycle.listProjectSessions()).items.map((session) => session.sessionId),
+    ).toEqual([...newestIds, oldestId]);
+
+    const presentation = await createPresentationSession({
+      lifecycle,
+      projectLabel: "workspace",
+      sessionId: oldestId,
+      stateRoot,
+      workspaceRoot,
+    });
+    try {
+      expect(
+        presentation.getState().authoritative.sessions.items.map((session) => session.id),
+      ).toEqual([...newestIds, oldestId]);
+    } finally {
+      await presentation.close();
+    }
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("PresentationSession consumes the opaque project catalog cursor", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-catalog-page-"));
   const stateRoot = join(testRoot, "state");
@@ -8252,13 +8334,17 @@ test("PresentationSession consumes the opaque project catalog cursor", async () 
       await lifecycle.create({ targetIdentity }),
     ];
     for (const [index, session] of created.entries()) {
+      await lifecycle.setSessionManualName({
+        sessionId: session.sessionId,
+        name: `Catalog page ${index + 1}`,
+      });
       await lifecycle.continue({
         sessionId: session.sessionId,
         input: { text: `Catalog page ${index + 1}` },
       });
     }
-    created.sort((left, right) => left.sessionId.localeCompare(right.sessionId));
-    const first = created[0];
+    const expectedOrder = [...created].reverse();
+    const first = expectedOrder[0];
     if (first === undefined) {
       throw new Error("Expected a project session.");
     }
@@ -8280,7 +8366,7 @@ test("PresentationSession consumes the opaque project catalog cursor", async () 
         presentation.dispatch({ type: "load_more_sessions", after: cursor }),
       ).resolves.toMatchObject({ status: "admitted", resource: null });
       expect(presentation.getState().authoritative.sessions).toMatchObject({
-        items: [{ id: created[0]?.sessionId }, { id: created[1]?.sessionId }],
+        items: [{ id: expectedOrder[0]?.sessionId }, { id: expectedOrder[1]?.sessionId }],
         nextCursor: null,
       });
     } finally {

--- a/packages/testkit/src/session-lifecycle.test.ts
+++ b/packages/testkit/src/session-lifecycle.test.ts
@@ -1128,7 +1128,7 @@ test("SessionLifecycle paginates prompt-admitted sessions while hiding genesis-o
     });
 
     expect([...firstPage.items, ...secondPage.items].map((item) => item.sessionId)).toEqual(
-      admitted.map((item) => item.sessionId).sort(),
+      admitted.map((item) => item.sessionId).reverse(),
     );
     expect([...firstPage.items, ...secondPage.items]).not.toContainEqual(
       expect.objectContaining({ sessionId: genesisOnly.sessionId }),

--- a/packages/testkit/src/session-store.test.ts
+++ b/packages/testkit/src/session-store.test.ts
@@ -67,6 +67,7 @@ test("SessionStoreDirectory adapters create open and list isolated session store
 
   try {
     for (const [name, directory] of directories) {
+      expect(await directory.listSessionEntries(), name).toEqual([]);
       expect(await directory.listSessionIds(), name).toEqual([]);
       expect(await directory.open(sessionId), name).toBeUndefined();
       const created = await directory.create(sessionId);
@@ -78,6 +79,10 @@ test("SessionStoreDirectory adapters create open and list isolated session store
         code: "session_log_exists",
       });
       expect(await directory.listSessionIds(), name).toEqual([sessionId, secondSessionId]);
+      expect(await directory.listSessionEntries(), name).toEqual([
+        { sessionId, modifiedAtMilliseconds: expect.any(Number) },
+        { sessionId: secondSessionId, modifiedAtMilliseconds: expect.any(Number) },
+      ]);
       await expect(
         directory.open(sessionId).then((store) => store?.read()),
         name,

--- a/patches/@earendil-works__pi-tui@0.84.2.patch
+++ b/patches/@earendil-works__pi-tui@0.84.2.patch
@@ -1,0 +1,112 @@
+diff --git a/dist/tui-main-screen.js b/dist/tui-main-screen.js
+index 05279f4699c298ca345785dd2f896a33d8271f4a..499a30b92b1145b19f4b8021ee420f22321a792e 100644
+--- a/dist/tui-main-screen.js
++++ b/dist/tui-main-screen.js
+@@ -220,6 +220,38 @@ export class TuiMainScreen extends TuiBase {
+             this.previousWidth = width;
+             this.previousHeight = height;
+         };
++        // Repaint only the visible main-screen viewport. Absolute cursor
++        // positioning avoids CRLF at the bottom row, so this neither scrolls
++        // the viewport nor destroys the user's existing scrollback.
++        const repaintVisibleViewport = () => {
++            this.fullRedrawCount += 1;
++            const viewportTop = Math.max(0, newLines.length - height);
++            let buffer = "\x1b[?2026h";
++            buffer += this.deleteKittyImages(this.previousKittyImageIds);
++            for (let screenRow = 0; screenRow < height; screenRow++) {
++                buffer += `\x1b[${screenRow + 1};1H\x1b[2K`;
++            }
++            for (let screenRow = 0; screenRow < height; screenRow++) {
++                const line = newLines[viewportTop + screenRow];
++                if (line !== undefined) {
++                    buffer += `\x1b[${screenRow + 1};1H${line}`;
++                }
++            }
++            const lastLogicalRow = Math.max(0, newLines.length - 1);
++            const lastScreenRow = Math.max(0, lastLogicalRow - viewportTop);
++            buffer += `\x1b[${lastScreenRow + 1};1H`;
++            buffer += "\x1b[?2026l";
++            this.terminal.write(buffer);
++            this.cursorRow = lastLogicalRow;
++            this.hardwareCursorRow = lastLogicalRow;
++            this.maxLinesRendered = newLines.length;
++            this.previousViewportTop = viewportTop;
++            this.positionHardwareCursor(cursorPos, newLines.length);
++            this.previousLines = newLines;
++            this.previousKittyImageIds = this.collectKittyImageIds(newLines);
++            this.previousWidth = width;
++            this.previousHeight = height;
++        };
+         const debugRedraw = process.env.PI_DEBUG_REDRAW === "1";
+         const logRedraw = (reason) => {
+             if (!debugRedraw)
+@@ -238,7 +270,7 @@ export class TuiMainScreen extends TuiBase {
+         // Width changes always need a full re-render because wrapping changes.
+         if (widthChanged) {
+             logRedraw(`terminal width changed (${this.previousWidth} -> ${width})`);
+-            fullRender(true);
++            repaintVisibleViewport();
+             return;
+         }
+         // Height changes normally need a full re-render to keep the visible viewport aligned,
+@@ -246,7 +278,13 @@ export class TuiMainScreen extends TuiBase {
+         // In that environment, a full redraw causes the entire history to replay on every toggle.
+         if (heightChanged && !isTermuxSession()) {
+             logRedraw(`terminal height changed (${this.previousHeight} -> ${height})`);
+-            fullRender(true);
++            repaintVisibleViewport();
++            return;
++        }
++        const desiredViewportTop = Math.max(0, newLines.length - height);
++        if (desiredViewportTop < prevViewportTop) {
++            logRedraw(`viewport rewind (${prevViewportTop} -> ${desiredViewportTop})`);
++            repaintVisibleViewport();
+             return;
+         }
+         // Content shrunk below the working area and no overlays - re-render to clear empty rows
+@@ -254,7 +292,7 @@ export class TuiMainScreen extends TuiBase {
+         // Configurable via setClearOnShrink() or PI_CLEAR_ON_SHRINK=0 env var
+         if (this.getClearOnShrink() && newLines.length < this.maxLinesRendered && !this.hasOverlayEntries) {
+             logRedraw(`clearOnShrink (maxLinesRendered=${this.maxLinesRendered})`);
+-            fullRender(true);
++            repaintVisibleViewport();
+             return;
+         }
+         // Find first and last changed lines
+@@ -300,7 +338,7 @@ export class TuiMainScreen extends TuiBase {
+                 const targetRow = Math.max(0, newLines.length - 1);
+                 if (targetRow < prevViewportTop) {
+                     logRedraw(`deleted lines moved viewport up (${targetRow} < ${prevViewportTop})`);
+-                    fullRender(true);
++                    repaintVisibleViewport();
+                     return;
+                 }
+                 const lineDiff = computeLineDiff(targetRow);
+@@ -313,7 +351,7 @@ export class TuiMainScreen extends TuiBase {
+                 const extraLines = this.previousLines.length - newLines.length;
+                 if (extraLines > height) {
+                     logRedraw(`extraLines > height (${extraLines} > ${height})`);
+-                    fullRender(true);
++                    repaintVisibleViewport();
+                     return;
+                 }
+                 const clearStartOffset = newLines.length === 0 ? 0 : 1;
+@@ -346,7 +384,7 @@ export class TuiMainScreen extends TuiBase {
+         // If the first changed line is above the previous viewport, we need a full redraw.
+         if (firstChanged < prevViewportTop) {
+             logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
+-            fullRender(true);
++            repaintVisibleViewport();
+             return;
+         }
+         // Render from first changed line to end
+@@ -389,7 +427,7 @@ export class TuiMainScreen extends TuiBase {
+                 const imageStartScreenRow = i - viewportTop;
+                 if (imageStartScreenRow < 0 || imageStartScreenRow + imageReservedRows > height) {
+                     logRedraw(`kitty image pre-clear would scroll (${imageStartScreenRow} + ${imageReservedRows} > ${height})`);
+-                    fullRender(true);
++                    repaintVisibleViewport();
+                     return;
+                 }
+                 buffer += "\x1b[2K";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@earendil-works/pi-tui@0.84.2': bd1e6d9a618b183c8a4050a6754bcaa706661ded6882cfc6465a3775a0789a7f
+
 importers:
 
   .:
@@ -49,7 +52,7 @@ importers:
         version: link:../../packages/presentation
       '@earendil-works/pi-tui':
         specifier: 0.84.2
-        version: 0.84.2
+        version: 0.84.2(patch_hash=bd1e6d9a618b183c8a4050a6754bcaa706661ded6882cfc6465a3775a0789a7f)
 
   packages/agent:
     dependencies:
@@ -1293,7 +1296,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.8':
     optional: true
 
-  '@earendil-works/pi-tui@0.84.2':
+  '@earendil-works/pi-tui@0.84.2(patch_hash=bd1e6d9a618b183c8a4050a6754bcaa706661ded6882cfc6465a3775a0789a7f)':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@earendil-works/pi-tui':
         specifier: 0.84.2
         version: 0.84.2(patch_hash=bd1e6d9a618b183c8a4050a6754bcaa706661ded6882cfc6465a3775a0789a7f)
+      highlight.js:
+        specifier: 11.11.1
+        version: 11.11.1
 
   packages/agent:
     dependencies:
@@ -645,6 +648,10 @@ packages:
   globby@16.2.2:
     resolution: {integrity: sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==}
     engines: {node: '>=20'}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   ignore@7.0.6:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
@@ -1618,6 +1625,8 @@ snapshots:
       is-path-inside: 4.0.0
       slash: 5.1.0
       unicorn-magic: 0.4.0
+
+  highlight.js@11.11.1: {}
 
   ignore@7.0.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,5 @@ minimumReleaseAgeExclude:
   - '@adam-agent/extension-api@0.3.0'
   - '@eve-reviewer/adam-extension@0.3.0'
   - '@eve-reviewer/core@0.2.0'
+patchedDependencies:
+  '@earendil-works/pi-tui@0.84.2': patches/@earendil-works__pi-tui@0.84.2.patch


### PR DESCRIPTION
## Summary

- keep Pi main-screen overlays aligned with the physical viewport and preserve scrollback during viewport rewinds
- order session selection by durable modification time and frame expanded reasoning with a responsive rounded border
- add bounded Catppuccin syntax-highlighted previews for read, write, edit, and shell tool cards with Ctrl+O expansion

## Verification

- pnpm quality:check
- pnpm test:tui:behavior (137 passed)
- pnpm test:tui:os (23 passed)