### PR TITLE
B9-H1a: define the public portfolio contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,55 @@
 
 Adam Agent is a lightweight, inspectable TypeScript coding agent for local software-engineering work.
 
+> **Status:** Adam is a Linux-supported source-checkout portfolio checkpoint. The root application and CLI/TUI packages remain private `0.0.0` workspace packages; this is not an npm package, standalone binary, or production release. The separately published `@adam-agent/extension-api` follows its own versioned release lifecycle.
+
+## Quick start
+
+Adam supports Linux with Node.js 24 and pnpm 11. Clone the source, enable the package manager declared by the repository, install the frozen lockfile, and launch the TUI:
+
+```bash
+git clone https://github.com/DrEden33773/adam-agent.git
+cd adam-agent
+corepack enable
+pnpm install --frozen-lockfile
+pnpm tui
+```
+
+The TUI lists durable sessions first and otherwise offers an explicit target picker. For a deterministic local headless check with no provider credential, use an isolated state root:
+
+```bash
+ADAM_AGENT_STATE_ROOT="$(mktemp -d)" ADAM_AGENT_TARGET=fake.local pnpm --silent adam "What is this repository?"
+```
+
+Run `pnpm tui --help` or `pnpm --silent adam --help` for copyable entry and lifecycle commands. Live Direct DeepSeek setup remains below.
+
+## Evidence
+
+Adam keeps four evidence classes separate so a deterministic fixture is never presented as a live-model or production claim.
+
+| Label | Meaning |
+| --- | --- |
+| Deterministically tested | Credential-free behavior exercised through public runtime, lifecycle, Presentation, CLI, or TUI seams. |
+| Real OS/PTY tested | Linux process, PTY, signal, stdio, terminal-restoration, filesystem, or transport behavior exercised at its irreducible external boundary. |
+| Live-provider observed | One bounded credentialed request or workflow observed against an exact named model target; this does not prove general model quality. |
+| Human walkthrough observed | One retained end-to-end manual workflow whose Git, test, session, approval, and terminal outcomes were independently checked. |
+
+See [Portfolio acceptance and walkthrough](docs/portfolio-acceptance.md) for the reproducible command matrix, public fixture contract, security boundary, and exact closeout evidence.
+
+## Security model
+
+Adam is intended for trusted local foreground work. Permission decisions, first-party path checks, process lifecycle controls, and code-loading trust are separate controls.
+
+| Surface | Active control | Explicit non-guarantee |
+| --- | --- | --- |
+| Built-in files | Lexical traversal and symlink escape are rejected beneath the canonical workspace root. | No protection from every hostile same-user race or mount-namespace change. |
+| Writes and commands | Write and execute effects require exact call-scoped approval by default. | Approval is not containment and does not make an unreviewed command safe. |
+| Shell and MCP | Processes use bounded inputs, environment disclosure, deadlines, process groups, and causal cleanup. | Approved processes retain the invoking user's authority and may use the network; there is no OS, process, or network sandbox. |
+| Extensions | Only exact Owner-configured, identity/version-checked packages are activated through bounded Host contracts. | Extensions are trusted in-process JavaScript, not isolated plugins. |
+| Credentials and state | Credentials remain external; durable state, artifacts, and configuration use owner-only local paths where specified. | `.env` remains plaintext local input, and local permissions do not defend against every same-user process or backup. |
+
+## Architecture and behavior
+
 The repository contains a provider-neutral Agent kernel with four model-facing coding tools (`read_file`, `write_file`, `edit_file`, and `run_shell`) plus two Agent Skill tools (`activate_skill` and `read_skill_resource`), call-scoped permission requests, canonical event persistence through caller-supplied in-memory and durable project-scoped JSONL stores, cancellation, bounded shell output with durable content-addressed overflow artifacts, and per-run turn/token limits. `write_file` is create-only, while `edit_file` accepts one bounded operations-only patch containing declarative create, exact update, ordinary-text delete, and move operations. Adam binds the normalized patch to one multi-path write approval with a SHA-256 digest, completes all semantic preflight before commit, and uses same-filesystem staging plus compensating rollback for ordinary in-process I/O failures. A rollback failure is reported as `patch_state_uncertain` with affected paths and an opaque reference to owner-only recovery data. A recovery-cleanup failure instead reports whether the workspace is known to be committed or rolled back and tells the caller not to retry automatically; neither result is a crash-safe or cross-path atomic filesystem guarantee.
 
 Every headless CLI run requires an explicit model target. The TUI instead lists existing project sessions first, then resolves an explicit target, a valid saved default, or an exact target picker only after the user chooses New Session. `fake.local` keeps deterministic development available, while the Certified Direct targets `deepseek-v4-flash.direct` and `deepseek-v4-pro.direct` use an exact-pinned Vercel Provider V4 adapter. Adam still owns the Agent loop, tools, permissions, retries, cancellation, deadlines, and canonical state; no SDK Agent or high-level tool loop is used. Filesystem path confinement rejects traversal and symlink escape, while approved shell commands run from the project root with a minimal environment and mandatory timeout/process-group cleanup. Neither mechanism is an OS sandbox or network isolation boundary, and the shell must only be used for trusted local work after reviewing each command. The accepted runtime is Node.js 24 LTS with pnpm 11; Bun is reserved for a later compatibility-tested distribution experiment.
@@ -34,7 +83,7 @@ pnpm install --frozen-lockfile
 pnpm hooks:install
 pnpm quality:check
 ADAM_AGENT_TARGET=fake.local pnpm --silent adam "What is this repository?"
-DEEPSEEK_API_KEY=<credential> pnpm tui
+pnpm tui --target fake.local
 ```
 
 For the headless CLI, the explicit `fake.local` target exercises deterministic read, edit, and shell scenarios. Omitting a target fails with copy-pastable guidance, and a credential never selects a target implicitly. Adam asks on stderr before write or execute effects. Session and operation JSONL, overflow and extension artifacts, immutable extension records, extension lifecycle state, and private patch recovery data are written under `ADAM_AGENT_STATE_ROOT` when set, otherwise under `~/.local/state/adam-agent`. Recovery data is normally removed after a successful patch or complete rollback. If removal fails, Adam returns `patch_recovery_cleanup_failed` with the known `committed` or `rolled_back` settlement and an opaque reference to the cleanup attempt; because recursive removal may have partially completed, any remaining bundle is not guaranteed to be complete. Inspect the reference and workspace state before any retry. Recovery data is retained intact when Adam stops cleanup because it cannot confirm the workspace state, and this first version deliberately provides no automatic restart recovery.

--- a/apps/cli/src/main.os.test.ts
+++ b/apps/cli/src/main.os.test.ts
@@ -1,0 +1,123 @@
+import { spawn } from "node:child_process";
+import { access, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const cliPath = fileURLToPath(new URL("../dist/main.js", import.meta.url));
+
+interface CliResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number | null;
+  readonly signal: NodeJS.Signals | null;
+}
+
+describe("one-shot CLI process help", () => {
+  test("prints public help without creating session state", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-help-"));
+    const workspaceRoot = join(testRoot, "workspace");
+    const stateRoot = join(testRoot, "state");
+    await mkdir(workspaceRoot);
+
+    try {
+      const result = await runCliArguments({ args: ["--help"], cwd: workspaceRoot, stateRoot });
+
+      expect({ result, statePersisted: await pathExists(stateRoot) }).toEqual({
+        result: {
+          stdout: expect.stringContaining("Usage: adam-agent <prompt>"),
+          stderr: "",
+          exitCode: 0,
+          signal: null,
+        },
+        statePersisted: false,
+      });
+      expect(result.stdout).toContain("Linux source checkout");
+      expect(result.stdout).toContain('ADAM_AGENT_TARGET=fake.local pnpm --silent adam "<prompt>"');
+      expect(result.stdout).toContain("pnpm tui");
+      expect(result.stdout).toContain("--resume without --continue hydrates only");
+      expect(result.stdout).toContain("Final answers use stdout; approvals and errors use stderr");
+      expect(result.stdout).toContain(
+        "Approvals and built-in path confinement are not an OS, process, or network sandbox",
+      );
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("prints identical short help before reading project environment", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-short-help-"));
+    const workspaceRoot = join(testRoot, "workspace");
+    const stateRoot = join(testRoot, "state");
+    await mkdir(join(workspaceRoot, ".env"), { recursive: true });
+
+    try {
+      const shortResult = await runCliArguments({ args: ["-h"], cwd: workspaceRoot, stateRoot });
+      const longResult = await runCliArguments({ args: ["--help"], cwd: workspaceRoot, stateRoot });
+
+      expect({ result: shortResult, statePersisted: await pathExists(stateRoot) }).toEqual({
+        result: {
+          stdout: expect.stringContaining("Usage: adam-agent <prompt>"),
+          stderr: "",
+          exitCode: 0,
+          signal: null,
+        },
+        statePersisted: false,
+      });
+      expect(shortResult).toEqual(longResult);
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+async function runCliArguments(input: {
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly stateRoot: string;
+}): Promise<CliResult> {
+  const child = spawn(process.execPath, [cliPath, ...input.args], {
+    cwd: input.cwd,
+    env: {
+      ...process.env,
+      ADAM_AGENT_STATE_ROOT: input.stateRoot,
+      ADAM_AGENT_TARGET: "fake.local",
+      NO_COLOR: "1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  let spawnError: Error | undefined;
+  child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+  child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+
+  return await new Promise<CliResult>((resolve, reject) => {
+    child.once("error", (error) => {
+      spawnError = error;
+    });
+    child.once("close", (exitCode, signal) => {
+      if (spawnError !== undefined) {
+        reject(spawnError);
+        return;
+      }
+      resolve({
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        exitCode,
+        signal,
+      });
+    });
+  });
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -34,7 +34,7 @@ import {
 import { FakeModelDriver } from "@adam-agent/testkit";
 
 const command = parseCliCommand(process.argv.slice(2));
-if (command.type !== "recover_operation") {
+if (command.type !== "help" && command.type !== "recover_operation") {
   loadProjectEnvironment();
 }
 const workspaceRoot = process.cwd();
@@ -376,6 +376,7 @@ function writeText(fileDescriptor: number, text: string): void {
 }
 
 type CliCommand =
+  | { readonly type: "help" }
   | { readonly type: "prompt"; readonly prompt: string; readonly skills?: readonly string[] }
   | { readonly type: "recover_operation"; readonly operationId: string }
   | { readonly type: "resume"; readonly sessionId: string; readonly continue: boolean }
@@ -388,6 +389,10 @@ type CliCommand =
 
 async function runCliCommand(activeCommand: CliCommand): Promise<void> {
   try {
+    if (activeCommand.type === "help") {
+      writeText(1, `${cliUsage()}\n`);
+      return;
+    }
     if (activeCommand.type === "recover_operation") {
       const extensions = await loadExtensionConfiguration(process.env);
       const artifactStore = await createFileArtifactStore({ root: join(stateRoot, "artifacts") });
@@ -586,6 +591,9 @@ function createCliModelTargets(): ModelTargets {
 }
 
 function parseCliCommand(arguments_: readonly string[]): CliCommand {
+  if (arguments_.length === 1 && (arguments_[0] === "--help" || arguments_[0] === "-h")) {
+    return { type: "help" };
+  }
   if (arguments_[0] === "--recover-operation") {
     const operationId = arguments_[1];
     if (
@@ -668,6 +676,29 @@ function parseCliCommand(arguments_: readonly string[]): CliCommand {
     prompt: arguments_.slice(promptStart).join(" "),
     ...(skills.length === 0 ? {} : { skills }),
   };
+}
+
+function cliUsage(): string {
+  return [
+    "Adam Agent headless CLI",
+    "Status: Linux source checkout; application packages are private and not an npm or binary distribution.",
+    "",
+    "Usage: adam-agent <prompt>",
+    "       adam-agent [--skill <id-or-unique-short-name>]... <prompt>",
+    "       adam-agent --resume <session-id> [--continue]",
+    "       adam-agent --branch <parent-session-id> --at <event-position> [--target <target-id>]",
+    "       adam-agent --recover-operation <operation-id>",
+    "       adam-agent --help | -h",
+    "",
+    "From a source checkout:",
+    '  ADAM_AGENT_TARGET=fake.local pnpm --silent adam "<prompt>"',
+    "  pnpm tui",
+    "",
+    "--resume without --continue hydrates only; --continue explicitly starts another attempt.",
+    "Final answers use stdout; approvals and errors use stderr.",
+    "Approvals and built-in path confinement are not an OS, process, or network sandbox.",
+    "Review every shell command before approving it.",
+  ].join("\n");
 }
 
 function failConfiguration(message: string): never {

--- a/apps/tui/src/command-registry.ts
+++ b/apps/tui/src/command-registry.ts
@@ -58,7 +58,7 @@ export type AdamKeybindingDefinition = {
 };
 
 export type AdamHelpTopicDefinition = {
-  readonly id: "commands" | "editor" | "hotkeys";
+  readonly id: "commands" | "editor" | "hotkeys" | "safety";
   readonly label: string;
   readonly summary: string;
 };
@@ -533,6 +533,7 @@ const fixedHelpTopics: readonly AdamHelpTopicDefinition[] = [
   { id: "commands", label: "Commands", summary: "Command names, arguments, and aliases" },
   { id: "hotkeys", label: "Hotkeys", summary: "Fixed effective keyboard bindings" },
   { id: "editor", label: "Editor", summary: "Pi Editor navigation and editing bindings" },
+  { id: "safety", label: "Safety", summary: "Permissions, trust, and isolation boundaries" },
 ];
 
 function rankSuggestions<Entry>(

--- a/apps/tui/src/help-navigator.ts
+++ b/apps/tui/src/help-navigator.ts
@@ -14,7 +14,7 @@ import {
 } from "./command-registry.js";
 import type { AdamTuiTheme } from "./theme.js";
 
-export type HelpPage = "commands" | "editor" | "hotkeys" | "root";
+export type HelpPage = "commands" | "editor" | "hotkeys" | "root" | "safety";
 
 export class HelpNavigator implements Component, Focusable {
   focused = false;
@@ -134,6 +134,23 @@ function helpContent(
       ...keybindings
         .filter((binding) => binding.section === "editor")
         .map((binding) => `${theme.toolTitle(binding.keys)}  ${binding.description}`),
+      "",
+      theme.muted("Esc back"),
+    ];
+  }
+  if (page === "safety") {
+    return [
+      theme.toolTitle("Safety and Trust"),
+      "",
+      "Default built-in policy:",
+      "  Write/execute: exact-call approval.",
+      "Built-in file tools:",
+      "  Reject traversal/symlink escape.",
+      "Shell/MCP: same-user authority.",
+      "Extensions: trusted in-process code.",
+      "Credentials: external plaintext.",
+      "State/artifacts: owner-only local.",
+      "No OS/process/network sandbox.",
       "",
       theme.muted("Esc back"),
     ];

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -1,5 +1,5 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readFile, realpath, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, realpath, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -307,15 +307,27 @@ test("the production TUI entry exposes its usage contract", async () => {
 
   try {
     const fixture = startFixture({
-      program: { arguments: ["--help"], cwd: workspaceRoot, entrypoint: productionPath },
+      program: {
+        arguments: ["--help"],
+        cwd: workspaceRoot,
+        entrypoint: productionPath,
+        environment: { ADAM_AGENT_STATE_ROOT: stateRoot },
+      },
       stateRoot,
       workspaceRoot,
     });
     const result = await fixture.closed;
     expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain("Adam Agent TUI");
+    expect(result.stdout).toContain("pnpm tui --target fake.local");
+    expect(result.stdout).toContain("pnpm tui --resume <session-id>");
     expect(result.stdout).toContain(
-      "Usage: adam-agent-tui [--target <exact-target-id> | --resume <session-id>]",
+      "Under the default policy, built-in write and execute tools require call-scoped approval.",
     );
+    expect(result.stdout).toContain("Credentials remain external plaintext inputs.");
+    expect(result.stdout).toContain("Session state and artifacts are owner-only local files.");
+    expect(result.stdout).toContain("Adam does not provide an OS, process, or network sandbox.");
+    await expect(stat(stateRoot)).rejects.toMatchObject({ code: "ENOENT" });
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -1145,6 +1145,42 @@ test("the real TUI opens slash Help locally without submitting it to the model",
   }
 });
 
+test("the real TUI explains its safety and trust boundary locally", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-safety-help-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ scenario: "review-unavailable", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    const beforeHelp = fixture.output().length;
+    fixture.write("/help safety\r");
+    const outcome = await Promise.race([
+      fixture
+        .waitForCompleteFrameAfter("Safety and Trust", beforeHelp)
+        .then(() => "safety" as const),
+      fixture.waitForAfter("Unknown Help topic safety", beforeHelp).then(() => "unknown" as const),
+    ]);
+    expect(outcome).toBe("safety");
+    const frame = fixture.output().slice(beforeHelp);
+    expect(frame).toContain("Default built-in policy");
+    expect(frame).toContain("Write/execute: exact-call approval");
+    expect(frame).toContain("Built-in file tools");
+    expect(frame).toContain("Reject traversal/symlink escape");
+    expect(frame).toContain("Shell/MCP: same-user authority");
+    expect(frame).toContain("Extensions: trusted in-process code");
+    expect(frame).toContain("Credentials: external plaintext");
+    expect(frame).toContain("State/artifacts: owner-only local");
+    expect(frame).toContain("No OS/process/network sandbox");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(await readFilesRecursively(stateRoot)).not.toContain('"text":"/help safety"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("Escape closes the Help root and restores editor focus", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-help-escape-"));
   const workspaceRoot = join(testRoot, "workspace");

--- a/apps/tui/src/main.ts
+++ b/apps/tui/src/main.ts
@@ -225,5 +225,22 @@ function parseCommand(arguments_: readonly string[]): TuiCommand {
 }
 
 function usage(): string {
-  return "Usage: adam-agent-tui [--target <exact-target-id> | --resume <session-id>] [--state-root <path>]";
+  return [
+    "Adam Agent TUI",
+    "",
+    "Usage: adam-agent-tui [--target <exact-target-id> | --resume <session-id>] [--state-root <path>]",
+    "",
+    "From a source checkout:",
+    "  pnpm tui",
+    "  pnpm tui --target fake.local",
+    "  pnpm tui --resume <session-id>",
+    "",
+    "Under the default policy, built-in write and execute tools require call-scoped approval.",
+    "Built-in file tools reject lexical traversal and symlink escape from the workspace.",
+    "Approved shell commands and trusted MCP servers run with the invoking user's authority.",
+    "Extensions are trusted in-process code.",
+    "Credentials remain external plaintext inputs.",
+    "Session state and artifacts are owner-only local files.",
+    "Adam does not provide an OS, process, or network sandbox.",
+  ].join("\n");
 }

--- a/docs/portfolio-acceptance.md
+++ b/docs/portfolio-acceptance.md
@@ -1,0 +1,104 @@
+# Portfolio acceptance and walkthrough
+
+Adam is a Linux-supported source-checkout portfolio checkpoint. The application workspace and CLI/TUI packages are private `0.0.0` packages, not an npm or standalone-binary distribution, and this document does not claim production readiness or semantic release compatibility.
+
+## Evidence vocabulary
+
+| Label | Certifies | Does not certify |
+| --- | --- | --- |
+| Deterministically tested | Repeatable credential-free behavior at an Adam public or caller-visible seam. | Live provider availability, model quality, or an external OS contract. |
+| Real OS/PTY tested | A distinct Linux process, PTY, signal, transport, filesystem, or terminal-restoration contract. | Every terminal emulator, cross-platform behavior, or model quality. |
+| Live-provider observed | One bounded run against the recorded exact target and profile. | Universal reliability, comparative quality, or future provider behavior. |
+| Human walkthrough observed | One retained end-to-end workflow with independently checked repository and terminal outcomes. | Unattended autonomy, hostile-workspace safety, or statistical quality. |
+
+`Supported` means the current Linux source-checkout path is part of the required Quality contract. `Experimental` identifies an explicit path that is excluded from certification. `Not implemented` is used for absent behavior rather than implying future compatibility. Certified is an Adam code-level conformance status, not a provider endorsement.
+
+## Acceptance matrix
+
+| Claim | Certifying evidence | Supplementary evidence | Failure meaning |
+| --- | --- | --- | --- |
+| Source checkout builds and tests | `pnpm quality:check` passes from an exact clean candidate commit on the required Ubuntu 24.04 hosted runner. | Focused workspace tests and locally recorded toolchain versions make diagnosis reproducible. | The portfolio checkpoint is not reproducible and cannot close. |
+| TUI terminal lifecycle is reliable | The required real-process and PTY suite passes through Quality and `pnpm test:tui:os` on Linux. | `pnpm test:tui:behavior` isolates renderer-neutral lifecycle and presentation behavior. | A terminal, signal, transport, or restoration failure blocks the claim and merge. |
+| Headless CLI is composable | The CLI process and deterministic coding-flow tests pass through Quality with stdout, stderr, exit, and persisted-state assertions. | A disposable-repository transcript may illustrate the same contract. | Stream separation, terminal status, or coding-flow behavior is not accepted. |
+| Permissions match the documented trust boundary | Approval, built-in path-confinement, shell, MCP, extension, credential, and owner-only state tests pass through Quality. | `/help safety` and the security table make the tested boundary caller-visible. | The affected boundary must be corrected or narrowed before publication. |
+| Sessions resume without implicit continuation | Deterministic CLI and TUI tests prove cold hydration, explicit continuation, and immutable-prefix branching through Quality. | The live walkthrough repeats cold hydration and read-only continuation against one retained public session ID. | Resume semantics are not accepted if hydration invokes a model or effect, or continuation corrupts history. |
+| Live provider completes the bounded walkthrough | One retained exact-candidate run uses `deepseek-v4-flash.direct`, the public fixture, exact-call approvals, a passing focused test, cold resume, and read-only verification. | The credential-free fixture and deterministic target/profile conformance tests constrain interpretation. | The live-provider and human-walkthrough labels remain unobserved; deterministic evidence alone cannot close B9-H1. |
+| Public claims remain bounded | The public-product contract guard and independent review pass on the exact candidate, and hosted Quality passes before merge. | Manual inspection compares README, runbook, CLI help, TUI process help, and `/help safety`. | Any unsupported distribution, platform, sandbox, parity, effects, API-stability, or model-quality claim blocks publication. |
+
+## Reproduce the deterministic and terminal gates
+
+Use Node.js 24 and the exact pnpm 11 release declared by `packageManager`. Start from a clean exact commit, retain the reported SHA with the evidence, and do not set `NODE_TLS_REJECT_UNAUTHORIZED=0`.
+
+```bash
+git rev-parse HEAD
+git status --porcelain=v1
+uname -a
+cat /etc/os-release
+node --version
+corepack pnpm --version
+pnpm install --frozen-lockfile
+pnpm quality:check
+pnpm exec vitest run packages/testkit/src/public-product-contract.test.ts
+pnpm test:tui:behavior
+pnpm test:tui:os
+```
+
+The complete Quality command is the certifying deterministic regression gate. The two TUI commands are focused diagnostic and acceptance views of the same required suite; they are not optional substitutes for Quality.
+
+## Headless acceptance
+
+The headless process contract keeps final answers on stdout, approval requests and failures on stderr, and terminal status in the exit code. `--resume` without `--continue` hydrates only; explicit continuation and immutable-prefix branching are separate operations. Focused repeatable evidence is available with:
+
+```bash
+pnpm exec vitest run apps/cli/src/main.test.ts -t "answers a repository question through one read-only tool turn"
+pnpm exec vitest run apps/cli/src/main.test.ts -t "edits, verifies, and persists one approved coding task"
+pnpm exec vitest run apps/cli/src/main.test.ts -t "continues an interrupted logical run in a new attempt without duplicating its user message"
+pnpm exec vitest run apps/cli/src/main.test.ts -t "branches an immutable complete parent boundary into an independently hydratable child"
+```
+
+Manual CLI transcripts must use a disposable working repository and an explicit temporary `ADAM_AGENT_STATE_ROOT`; they must not write acceptance state into the user's normal Adam state root.
+
+## Security and trust boundary
+
+| Boundary | Active statement |
+| --- | --- |
+| Exact-call approval | Write and execute effects require a decision for the exact prepared call under the default policy. Approval does not contain the resulting code or process. |
+| Built-in file path confinement | First-party file tools reject lexical traversal and symlink escape from the canonical workspace under the documented trusted-local threat model. |
+| Same-user shell and MCP processes | Approved shell commands and trusted MCP servers run with the invoking user's authority; deadlines, environment bounds, process groups, and cleanup are lifecycle controls. |
+| Trusted in-process extensions | Exact Owner-configured extension packages are validated before activation but execute as trusted JavaScript in the Adam process. |
+| External plaintext credentials | Provider credentials remain external environment or owner-managed `.env` input; `.env` is plaintext and must never enter transcripts, model context, or committed evidence. |
+| Owner-only local state | Session logs, artifacts, configuration, and operation data use documented owner-only local locations, but local modes are not protection from every same-user process or backup. |
+| No OS, process, or network sandbox | Adam does not provide hostile-code confinement or network isolation; review every command, MCP server, extension package, and repository before granting authority. |
+
+Adam does not claim safe unreviewed shell execution, exactly-once external effects, hostile same-user concurrency protection, cross-platform support, full Pi/Codex/Claude parity, stable public application APIs, or model-quality improvement.
+
+## Live coding walkthrough contract
+
+The retained walkthrough uses `deepseek-v4-flash.direct` and the public [`examples/portfolio-walkthrough`](../examples/portfolio-walkthrough) fixture. The fixture has two TypeScript source files, one intentionally failing focused test, a repository `AGENTS.md`, no third-party dependency, and one permitted source file to repair. Never edit the committed fixture in place; prepare a clean disposable Git repository:
+
+```bash
+ADAM_CHECKOUT="$(pwd)"
+WALKTHROUGH_ROOT="$(mktemp -d)"
+WALKTHROUGH_STATE="$(mktemp -d)"
+cp -R examples/portfolio-walkthrough/. "$WALKTHROUGH_ROOT/"
+git -C "$WALKTHROUGH_ROOT" init -q
+git -C "$WALKTHROUGH_ROOT" add .
+git -C "$WALKTHROUGH_ROOT" -c user.name=Adam -c user.email=adam@example.invalid commit -qm fixture
+pnpm --dir "$WALKTHROUGH_ROOT" test
+pnpm build
+```
+
+The initial test command must fail with an actual total of 2,000 cents and an expected total of 2,700 cents. Start the production entry from the fixture root without copying credentials or state into it:
+
+```bash
+cd "$WALKTHROUGH_ROOT"
+node --env-file-if-exists="$ADAM_CHECKOUT/.env" "$ADAM_CHECKOUT/apps/tui/dist/main.js" --target deepseek-v4-flash.direct --state-root "$WALKTHROUGH_STATE"
+```
+
+Use this task prompt: `Repair the quantity-discount bug. Follow AGENTS.md, run the focused test, inspect the resulting diff, and report the verified result.` The task must make Adam inspect the repository, read the applicable instructions and files, request exact approval for one bounded structured edit, request separate execute approval for `pnpm test`, expose the canonical diff, explain the verified result, and leave only the expected source change. Open `/session` and record the public session ID, exit normally, then restart the same production entry with `--resume <session-id> --state-root "$WALKTHROUGH_STATE"`. Hydration must perform no model request or effect. Explicitly submit `Without changing files, verify which file changed and whether the focused test passed.` and approve no mutation; the answer must agree with Git and the retained test result.
+
+Only a bounded summary may be public: exact Adam commit, exact target/profile, public fixture digest or contents, prompts, approval subjects and decisions, selected verification commands, exit statuses, Git diff summary/digest, cold-hydration result, continuation result, and terminal restoration. Credentials, `.env`, raw session JSONL, owner-only artifacts, private absolute paths, raw provider reasoning, and unredacted transcripts remain private.
+
+## Current closeout
+
+B9-H1 remains open until the deterministic and terminal gates pass on the exact candidate commit, the public fixture is present, the retained live walkthrough satisfies the contract above, public claims are independently reviewed, hosted Quality passes, and the exact merged `main` commit is verified. A successful fixture or live request alone is not completion evidence.

--- a/examples/portfolio-walkthrough/AGENTS.md
+++ b/examples/portfolio-walkthrough/AGENTS.md
@@ -1,0 +1,7 @@
+# Walkthrough fixture instructions
+
+Repair the quantity-discount calculation while preserving integer-cent arithmetic and the exported API.
+
+- Change only `src/order-total.ts`.
+- Do not change the test or discount policy.
+- Run `pnpm test` and report the result.

--- a/examples/portfolio-walkthrough/package.json
+++ b/examples/portfolio-walkthrough/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "adam-portfolio-walkthrough-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=24.0.0 <25"
+  },
+  "scripts": {
+    "test": "node test/order-total.test.ts"
+  }
+}

--- a/examples/portfolio-walkthrough/src/discounts.ts
+++ b/examples/portfolio-walkthrough/src/discounts.ts
@@ -1,0 +1,6 @@
+export function quantityDiscountBasisPoints(quantity: number): number {
+  if (!Number.isSafeInteger(quantity) || quantity <= 0) {
+    throw new RangeError("Quantity must be a positive integer.");
+  }
+  return quantity >= 3 ? 1_000 : 0;
+}

--- a/examples/portfolio-walkthrough/src/order-total.ts
+++ b/examples/portfolio-walkthrough/src/order-total.ts
@@ -1,0 +1,10 @@
+import { quantityDiscountBasisPoints } from "./discounts.ts";
+
+export function calculateOrderTotalCents(unitPriceCents: number, quantity: number): number {
+  if (!Number.isSafeInteger(unitPriceCents) || unitPriceCents < 0) {
+    throw new RangeError("Unit price must be a non-negative integer number of cents.");
+  }
+  const subtotalCents = unitPriceCents * quantity;
+  const discountBasisPoints = quantityDiscountBasisPoints(quantity);
+  return subtotalCents - discountBasisPoints;
+}

--- a/examples/portfolio-walkthrough/test/order-total.test.ts
+++ b/examples/portfolio-walkthrough/test/order-total.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+
+import { calculateOrderTotalCents } from "../src/order-total.ts";
+
+const testName = "applies the quantity discount to the subtotal in integer cents";
+
+try {
+  assert.equal(calculateOrderTotalCents(1_000, 3), 2_700);
+  process.stdout.write(`✔ ${testName}\n`);
+} catch (error) {
+  process.stdout.write(`✖ ${testName}\n${formatError(error)}\n`, () => {
+    process.exitCode = 1;
+  });
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/testkit/src/public-product-contract.os.test.ts
+++ b/packages/testkit/src/public-product-contract.os.test.ts
@@ -1,0 +1,52 @@
+import { spawn } from "node:child_process";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "vitest";
+
+const productRoot = fileURLToPath(new URL("../../..", import.meta.url));
+
+test("the public walkthrough starts from one diagnostic failing test", async () => {
+  const fixtureRoot = join(productRoot, "examples", "portfolio-walkthrough");
+  const result = await runFixtureTest(fixtureRoot);
+
+  expect(result).toMatchObject({ exitCode: 1, signal: null, stderr: "" });
+  expect(result.stdout).toContain("applies the quantity discount to the subtotal in integer cents");
+  expect(result.stdout).toContain("2000 !== 2700");
+});
+
+function runFixtureTest(cwd: string): Promise<{
+  readonly exitCode: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stderr: string;
+  readonly stdout: string;
+}> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(process.execPath, ["test/order-total.test.ts"], {
+      cwd,
+      env: { ...process.env, NODE_NO_WARNINGS: "1", NO_COLOR: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let spawnError: Error | undefined;
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", (error) => {
+      spawnError = error;
+    });
+    child.once("close", (exitCode, signal) => {
+      if (spawnError !== undefined) {
+        rejectPromise(spawnError);
+        return;
+      }
+      resolvePromise({ exitCode, signal, stderr, stdout });
+    });
+  });
+}

--- a/packages/testkit/src/public-product-contract.test.ts
+++ b/packages/testkit/src/public-product-contract.test.ts
@@ -1,0 +1,172 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "vitest";
+
+const productRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const forbiddenPublicClaimPatterns: readonly RegExp[] = [
+  /\bproduction[- ]ready(?:\s+(?:agent|product|release))?\b/iu,
+  /\b(?:provides|includes|enforces|uses)\s+(?:an?\s+)?(?:OS(?:-level)?|process|network)\s+sandbox\b/iu,
+  /\bAdam (?:provides|includes|enforces|uses|offers|has) (?:an?\s+)?OS(?:-level)?,\s*process,\s*(?:and|or)\s+network sandbox\b/iu,
+  /\bnetwork[- ]isolated\b/iu,
+  /\bAdam (?:provides|includes|enforces|uses|offers|has) network isolation\b/iu,
+  /\b(?:supports|runs on)\s+(?:macOS|Windows)\b/iu,
+  /\bAdam (?:is|provides|offers|supports) (?:a )?cross[- ]platform\b/iu,
+  /\b(?:npm (?:install|i)(?: -g)?|npx)\s+adam-agent\b/iu,
+  /\b(?:full|complete)\s+(?:Pi|Codex|Claude Code)\s+parity\b/iu,
+  /\bAdam (?:provides|offers|has|achieves) (?:full |complete )?(?:Pi|Codex|Claude Code)(?:[- ]level)? parity\b/iu,
+  /\bexactly[- ]once effects (?:are|is) guaranteed\b/iu,
+  /\bAdam (?:provides|offers|has|guarantees) exactly[- ]once (?:external )?effects\b/iu,
+  /\bAdam (?:contains|confines|protects against) (?:a )?(?:hostile|untrusted) workspace\b/iu,
+  /\bAdam makes unreviewed shell (?:execution )?safe\b/iu,
+  /\bAdam (?:provides|offers|has) stable public (?:app|application) APIs?\b/iu,
+  /\bAdam (?:improves|increases|guarantees) (?:model|provider) quality\b/iu,
+  /\bAdam (?:ships|provides|offers) (?:an? )?installable (?:npm )?(?:CLI|application|app)\b/iu,
+];
+
+test("the public entry describes a source-checkout portfolio checkpoint", async () => {
+  const [readme, rootPackage, cliPackage, tuiPackage] = await Promise.all([
+    readFile(join(productRoot, "README.md"), "utf8"),
+    readPackageJson(join(productRoot, "package.json")),
+    readPackageJson(join(productRoot, "apps", "cli", "package.json")),
+    readPackageJson(join(productRoot, "apps", "tui", "package.json")),
+  ]);
+
+  expect({ rootPackage, cliPackage, tuiPackage }).toMatchObject({
+    rootPackage: { private: true, version: "0.0.0" },
+    cliPackage: { private: true, version: "0.0.0" },
+    tuiPackage: { private: true, version: "0.0.0" },
+  });
+  expect(readme).toContain("Linux-supported source-checkout portfolio checkpoint");
+  expect(readme).toContain("not an npm package, standalone binary, or production release");
+  expect(readme).toContain("pnpm install --frozen-lockfile");
+  expect(readme).toContain("pnpm tui");
+  expect(readme).not.toMatch(/npm (?:install|i) (?:-g )?adam-agent/u);
+  expect(readme).not.toContain("npx adam-agent");
+});
+
+test("the public entry separates acceptance evidence from security guarantees", async () => {
+  const [readme, acceptance, qualityWorkflow, cliEntry, tuiEntry, tuiHelp, tuiCommands] =
+    await Promise.all([
+      readFile(join(productRoot, "README.md"), "utf8"),
+      readFile(join(productRoot, "docs", "portfolio-acceptance.md"), "utf8"),
+      readFile(join(productRoot, ".github", "workflows", "quality.yml"), "utf8"),
+      readFile(join(productRoot, "apps", "cli", "src", "main.ts"), "utf8"),
+      readFile(join(productRoot, "apps", "tui", "src", "main.ts"), "utf8"),
+      readFile(join(productRoot, "apps", "tui", "src", "help-navigator.ts"), "utf8"),
+      readFile(join(productRoot, "apps", "tui", "src", "command-registry.ts"), "utf8"),
+    ]);
+
+  const evidenceIndex = readme.indexOf("## Evidence");
+  const securityIndex = readme.indexOf("## Security model");
+  const architectureIndex = readme.indexOf("## Architecture and behavior");
+  expect(evidenceIndex).toBeGreaterThan(0);
+  expect(securityIndex).toBeGreaterThan(evidenceIndex);
+  expect(architectureIndex).toBeGreaterThan(securityIndex);
+  expect(readme).toContain("[Portfolio acceptance and walkthrough](docs/portfolio-acceptance.md)");
+
+  for (const evidenceClass of [
+    "Deterministically tested",
+    "Real OS/PTY tested",
+    "Live-provider observed",
+    "Human walkthrough observed",
+  ]) {
+    expect(acceptance).toContain(evidenceClass);
+  }
+  for (const command of ["pnpm quality:check", "pnpm test:tui:behavior", "pnpm test:tui:os"]) {
+    expect(acceptance).toContain(command);
+  }
+  for (const boundary of [
+    "Exact-call approval",
+    "Built-in file path confinement",
+    "Same-user shell and MCP processes",
+    "Trusted in-process extensions",
+    "External plaintext credentials",
+    "Owner-only local state",
+    "No OS, process, or network sandbox",
+  ]) {
+    expect(acceptance).toContain(boundary);
+  }
+  expect(acceptance).toContain(
+    "Certified is an Adam code-level conformance status, not a provider endorsement.",
+  );
+  expect(acceptance).toContain(
+    "| Claim | Certifying evidence | Supplementary evidence | Failure meaning |",
+  );
+  for (const acceptanceClaim of [
+    "Source checkout builds and tests",
+    "TUI terminal lifecycle is reliable",
+    "Headless CLI is composable",
+    "Permissions match the documented trust boundary",
+    "Sessions resume without implicit continuation",
+    "Live provider completes the bounded walkthrough",
+    "Public claims remain bounded",
+  ]) {
+    expect(acceptance).toContain(acceptanceClaim);
+  }
+  expect(qualityWorkflow).toContain("ubuntu-24.04");
+  const publicClaims = [readme, acceptance, cliEntry, tuiEntry, tuiHelp, tuiCommands].join("\n");
+  expect(isForbiddenPublicClaim(publicClaims)).toBe(false);
+});
+
+test("the public claim guard recognizes representative positive inversions", () => {
+  const representativeOverclaims = [
+    "Adam is a production-ready product.",
+    "Adam provides an OS, process, or network sandbox.",
+    "Adam provides network isolation.",
+    "Adam is network isolated.",
+    "Adam is cross-platform.",
+    "npm install -g adam-agent",
+    "Adam has Codex parity.",
+    "Adam guarantees exactly-once external effects.",
+    "Adam contains a hostile workspace.",
+    "Adam makes unreviewed shell execution safe.",
+    "Adam provides stable public application APIs.",
+    "Adam improves model quality.",
+    "Adam ships an installable CLI.",
+  ];
+
+  expect(representativeOverclaims.filter((claim) => !isForbiddenPublicClaim(claim))).toEqual([]);
+});
+
+test("the public walkthrough fixture is structurally bounded", async () => {
+  const fixtureRoot = join(productRoot, "examples", "portfolio-walkthrough");
+  const [instructions, fixturePackage, fixtureEntries, acceptance] = await Promise.all([
+    readFile(join(fixtureRoot, "AGENTS.md"), "utf8"),
+    readPackageJson(join(fixtureRoot, "package.json")),
+    readdir(fixtureRoot, { recursive: true }),
+    readFile(join(productRoot, "docs", "portfolio-acceptance.md"), "utf8"),
+  ]);
+
+  expect(fixturePackage).toEqual({
+    name: "adam-portfolio-walkthrough-fixture",
+    version: "0.0.0",
+    private: true,
+    type: "module",
+    engines: { node: ">=24.0.0 <25" },
+    scripts: { test: "node test/order-total.test.ts" },
+  });
+  expect([...fixtureEntries].sort()).toEqual(
+    [
+      "AGENTS.md",
+      "package.json",
+      "src",
+      "src/discounts.ts",
+      "src/order-total.ts",
+      "test",
+      "test/order-total.test.ts",
+    ].sort(),
+  );
+  expect(instructions).toContain("Change only `src/order-total.ts`");
+  expect(instructions).toContain("Run `pnpm test`");
+  expect(acceptance).toContain("examples/portfolio-walkthrough");
+});
+
+async function readPackageJson(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+function isForbiddenPublicClaim(text: string): boolean {
+  return forbiddenPublicClaimPatterns.some((pattern) => pattern.test(text));
+}


### PR DESCRIPTION
## Summary
- expose bounded source-checkout status, evidence classes, and security boundaries in README and CLI/TUI help
- add the public walkthrough fixture and claim-to-evidence acceptance runbook
- enforce distribution and trust-boundary claims with mutation-sensitive public-contract tests

## Verification
- pnpm quality:check
- 41 test files passed, 2 skipped; 1064 tests passed, 10 skipped
- independent specification review: PASS
- independent test-standards review: PASS