### PR TITLE
B9-H1b: align TUI help with production targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ pnpm install --frozen-lockfile
 pnpm hooks:install
 pnpm quality:check
 ADAM_AGENT_TARGET=fake.local pnpm --silent adam "What is this repository?"
-pnpm tui --target fake.local
+pnpm tui --target deepseek-v4-flash.direct
 ```
 
 For the headless CLI, the explicit `fake.local` target exercises deterministic read, edit, and shell scenarios. Omitting a target fails with copy-pastable guidance, and a credential never selects a target implicitly. Adam asks on stderr before write or execute effects. Session and operation JSONL, overflow and extension artifacts, immutable extension records, extension lifecycle state, and private patch recovery data are written under `ADAM_AGENT_STATE_ROOT` when set, otherwise under `~/.local/state/adam-agent`. Recovery data is normally removed after a successful patch or complete rollback. If removal fails, Adam returns `patch_recovery_cleanup_failed` with the known `committed` or `rolled_back` settlement and an opaque reference to the cleanup attempt; because recursive removal may have partially completed, any remaining bundle is not guaranteed to be complete. Inspect the reference and workspace state before any retry. Recovery data is retained intact when Adam stops cleanup because it cannot confirm the workspace state, and this first version deliberately provides no automatic restart recovery.

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -319,7 +319,8 @@ test("the production TUI entry exposes its usage contract", async () => {
     const result = await fixture.closed;
     expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
     expect(result.stdout).toContain("Adam Agent TUI");
-    expect(result.stdout).toContain("pnpm tui --target fake.local");
+    expect(result.stdout).toContain("pnpm tui --target deepseek-v4-flash.direct");
+    expect(result.stdout).not.toContain("pnpm tui --target fake.local");
     expect(result.stdout).toContain("pnpm tui --resume <session-id>");
     expect(result.stdout).toContain(
       "Under the default policy, built-in write and execute tools require call-scoped approval.",

--- a/apps/tui/src/main.ts
+++ b/apps/tui/src/main.ts
@@ -232,7 +232,7 @@ function usage(): string {
     "",
     "From a source checkout:",
     "  pnpm tui",
-    "  pnpm tui --target fake.local",
+    "  pnpm tui --target deepseek-v4-flash.direct",
     "  pnpm tui --resume <session-id>",
     "",
     "Under the default policy, built-in write and execute tools require call-scoped approval.",

--- a/packages/testkit/src/public-product-contract.test.ts
+++ b/packages/testkit/src/public-product-contract.test.ts
@@ -42,6 +42,8 @@ test("the public entry describes a source-checkout portfolio checkpoint", async 
   expect(readme).toContain("not an npm package, standalone binary, or production release");
   expect(readme).toContain("pnpm install --frozen-lockfile");
   expect(readme).toContain("pnpm tui");
+  expect(readme).toContain("pnpm tui --target deepseek-v4-flash.direct");
+  expect(readme).not.toContain("pnpm tui --target fake.local");
   expect(readme).not.toMatch(/npm (?:install|i) (?:-g )?adam-agent/u);
   expect(readme).not.toContain("npx adam-agent");
 });


### PR DESCRIPTION
## Summary
- replace the unsupported fake.local TUI example with deepseek-v4-flash.direct
- keep fake.local explicitly bounded to the headless deterministic CLI
- guard README and production process help with positive Direct and negative fake TUI assertions

## Acceptance defect
The published pnpm tui --target fake.local command opened an unavailable-target picker because fake.local is CLI-local test infrastructure, not a production TUI model target.

## Verification
- public-contract and production-process RED tracers reproduced the misleading command
- focused GREEN: 2 passed
- complete public-contract plus TUI OS regression: 27 passed
- pnpm quality:check: 41 files passed, 2 skipped; 1065 tests passed, 10 skipped
- independent specification review: PASS
- independent test-standards review: PASS