### PR TITLE
test: synchronize complete TUI effects

### DIFF
--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -12,7 +12,11 @@ import {
   createSessionLifecycle,
 } from "@adam-agent/agent";
 import { afterEach, expect, test } from "vitest";
-import { removeTuiFixtureRoot as rm, waitForPath } from "./tui-filesystem.test-support.js";
+import {
+  removeTuiFixtureRoot as rm,
+  waitForFileContents,
+  waitForPath,
+} from "./tui-filesystem.test-support.js";
 import {
   cleanupActiveTuiFixtures,
   startTuiFixture as startFixture,
@@ -428,8 +432,7 @@ test("the production TUI composes the Linux clipboard adapter for copy commands"
         .then(() => "unavailable" as const),
     ]);
     expect(copyStatus).toBe("copied");
-    await waitForPath(clipboardMarker);
-    await expect(readFile(clipboardMarker, "utf8")).resolves.toBe(assistantText);
+    await expect(waitForFileContents(clipboardMarker, assistantText)).resolves.toBe(assistantText);
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -8,6 +8,7 @@ import { runTuiFixture } from "./test-fixture.js";
 import {
   readFilesRecursively,
   removeTuiFixtureRoot as rm,
+  waitForFileContents,
   waitForPath,
 } from "./tui-filesystem.test-support.js";
 import {
@@ -3572,12 +3573,18 @@ test("slash Copy copies the last inline assistant response without persisting a 
   try {
     const fixture = startFixture({ controlRoot, scenario: "read", stateRoot, workspaceRoot });
     await fixture.waitFor("Adam · New session");
+    const beforePrompt = fixture.output().length;
     fixture.write("Read the README\r");
-    await fixture.waitFor("Read complete");
+    await fixture.waitForCompleteFrameAfter("Read complete", beforePrompt);
+    const resultOccurrence = fixture.output().lastIndexOf("Read complete");
+    expect(resultOccurrence).toBeGreaterThanOrEqual(beforePrompt);
+    await fixture.waitForCompleteFrameAfter(" · idle", resultOccurrence);
     const beforeCopy = fixture.output().length;
     fixture.write("/copy \r");
     const outcome = await Promise.race([
-      waitForPath(join(controlRoot, "clipboard.txt")).then(() => "copied" as const),
+      waitForFileContents(join(controlRoot, "clipboard.txt"), "Read complete.").then(
+        () => "copied" as const,
+      ),
       fixture.waitForAfter("Unknown command /copy", beforeCopy).then(() => "unknown" as const),
     ]);
     expect(outcome).toBe("copied");
@@ -3607,12 +3614,16 @@ test("slash Copy never truncates a large inline assistant response", async () =>
       workspaceRoot,
     });
     await fixture.waitFor("Adam · New session");
+    const beforePrompt = fixture.output().length;
     fixture.write("Produce a large inline response\r");
-    await fixture.waitFor("Exact copy tail.");
+    await fixture.waitForCompleteFrameAfter("Exact copy tail.", beforePrompt);
+    const resultOccurrence = fixture.output().lastIndexOf("Exact copy tail.");
+    expect(resultOccurrence).toBeGreaterThanOrEqual(beforePrompt);
+    await fixture.waitForCompleteFrameAfter(" · idle", resultOccurrence);
+    const expected = `${"c".repeat(65 * 1024)}\nExact copy tail.`;
     fixture.write("/copy \r");
-    await waitForPath(join(controlRoot, "clipboard.txt"));
-    expect(await readFile(join(controlRoot, "clipboard.txt"), "utf8")).toBe(
-      `${"c".repeat(65 * 1024)}\nExact copy tail.`,
+    await expect(waitForFileContents(join(controlRoot, "clipboard.txt"), expected)).resolves.toBe(
+      expected,
     );
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
@@ -3637,11 +3648,15 @@ test("slash Copy reads and copies the complete last artifact-backed assistant re
       workspaceRoot,
     });
     await fixture.waitFor("Adam · New session");
+    const beforePrompt = fixture.output().length;
     fixture.write("Produce an artifact-backed answer\r");
-    await fixture.waitFor("Assistant response stored as artifact");
+    await fixture.waitForCompleteFrameAfter("Assistant response stored as artifact", beforePrompt);
+    const resultOccurrence = fixture.output().lastIndexOf("Assistant response stored as artifact");
+    expect(resultOccurrence).toBeGreaterThanOrEqual(beforePrompt);
+    await fixture.waitForCompleteFrameAfter(" · idle", resultOccurrence);
+    const expected = `Assistant artifact page one\n${"a".repeat(20_000)}\nAssistant artifact page two\n${"b".repeat(250_000)}`;
     fixture.write("/copy \r");
-    await waitForPath(join(controlRoot, "clipboard.txt"));
-    const copied = await readFile(join(controlRoot, "clipboard.txt"), "utf8");
+    const copied = await waitForFileContents(join(controlRoot, "clipboard.txt"), expected);
     expect(Buffer.byteLength(copied, "utf8")).toBe(270_057);
     expect(copied).toMatch(/^Assistant artifact page one/u);
     expect(copied).toContain("Assistant artifact page two");
@@ -3672,12 +3687,17 @@ test("slash Copy loads older active chronology to find the last assistant respon
       stateRoot,
       workspaceRoot,
     });
-    await fixture.waitFor("Later copy prompt two");
+    await fixture.waitForCompleteFrameAfter("Later copy prompt two", 0);
+    const resultOccurrence = fixture.output().lastIndexOf("Later copy prompt two");
+    expect(resultOccurrence).toBeGreaterThanOrEqual(0);
+    await fixture.waitForCompleteFrameAfter(" · idle", resultOccurrence);
     expect(fixture.output()).not.toContain("Older copy answer.");
     const beforeCopy = fixture.output().length;
     fixture.write("/copy \r");
     const outcome = await Promise.race([
-      waitForPath(join(controlRoot, "clipboard.txt")).then(() => "copied" as const),
+      waitForFileContents(join(controlRoot, "clipboard.txt"), "Older copy answer.").then(
+        () => "copied" as const,
+      ),
       fixture
         .waitForAfter("No assistant response is available to copy.", beforeCopy)
         .then(() => "missing" as const),
@@ -3849,8 +3869,12 @@ test("PageDown reads the next bounded assistant artifact page", async () => {
       workspaceRoot,
     });
     await fixture.waitFor("Adam · New session");
+    const beforePrompt = fixture.output().length;
     fixture.write("Produce an artifact-backed answer\r");
-    await fixture.waitFor("Assistant response stored as artifact");
+    await fixture.waitForCompleteFrameAfter("Assistant response stored as artifact", beforePrompt);
+    const resultOccurrence = fixture.output().lastIndexOf("Assistant response stored as artifact");
+    expect(resultOccurrence).toBeGreaterThanOrEqual(beforePrompt);
+    await fixture.waitForCompleteFrameAfter(" · idle", resultOccurrence);
     fixture.write("/artifacts \r");
     await fixture.waitFor("Session artifacts");
     fixture.write("\r");
@@ -3858,14 +3882,16 @@ test("PageDown reads the next bounded assistant artifact page", async () => {
     await fixture.waitFor("1-16384 of 270057 bytes");
     const beforeNextPage = fixture.output().length;
     fixture.write("\u001b[6~");
-    await waitForPath(join(controlRoot, "artifact-read-2"));
-    expect(await readFile(join(controlRoot, "artifact-read-2"), "utf8")).toBe("16384\n");
+    await expect(
+      waitForFileContents(join(controlRoot, "artifact-read-2"), "16384\n"),
+    ).resolves.toBe("16384\n");
     await fixture.waitForAfter("16385-32768 of 270057 bytes", beforeNextPage);
     await fixture.waitForAfter("Assistant artifact page two", beforeNextPage);
     const beforePreviousPage = fixture.output().length;
     fixture.write("\u001b[5~");
-    await waitForPath(join(controlRoot, "artifact-read-3"));
-    expect(await readFile(join(controlRoot, "artifact-read-3"), "utf8")).toBe("0\n");
+    await expect(waitForFileContents(join(controlRoot, "artifact-read-3"), "0\n")).resolves.toBe(
+      "0\n",
+    );
     await fixture.waitForAfter("1-16384 of 270057 bytes", beforePreviousPage);
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });

--- a/apps/tui/src/tui-filesystem.test-support.ts
+++ b/apps/tui/src/tui-filesystem.test-support.ts
@@ -14,36 +14,65 @@ export async function removeTuiFixtureRoot(
 }
 
 export async function waitForPath(path: string): Promise<void> {
+  await waitForFilesystemEffect(
+    path,
+    async () =>
+      access(path).then(
+        () => true,
+        () => undefined,
+      ),
+    "create",
+  );
+}
+
+export async function waitForFileContents(path: string, expected: string): Promise<string> {
+  return await waitForFilesystemEffect(
+    path,
+    async () => {
+      try {
+        const contents = await readFile(path, "utf8");
+        return contents === expected ? contents : undefined;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          return undefined;
+        }
+        throw error;
+      }
+    },
+    "publish the expected contents for",
+  );
+}
+
+async function waitForFilesystemEffect<T>(
+  path: string,
+  observe: () => Promise<T | undefined>,
+  action: string,
+): Promise<T> {
   const directory = join(path, "..");
   const filename = path.slice(directory.length + 1);
   const watcher = watch(directory);
   const failure = Promise.withResolvers<never>();
   const guard = setTimeout(
-    () => failure.reject(new Error(`The fixture did not create ${filename}.`)),
+    () => failure.reject(new Error(`The fixture did not ${action} ${filename}.`)),
     missingFilesystemEffectFailureMilliseconds,
   );
   guard.unref();
   try {
-    if (
-      await access(path).then(
-        () => true,
-        () => false,
-      )
-    ) {
-      return;
+    const initial = await observe();
+    if (initial !== undefined) {
+      return initial;
     }
-    await Promise.race([
+    return await Promise.race([
       (async () => {
         for await (const _event of watcher) {
-          if (
-            await access(path).then(
-              () => true,
-              () => false,
-            )
-          ) {
-            return;
+          const observed = await observe();
+          if (observed !== undefined) {
+            return observed;
           }
         }
+        throw new Error(
+          `The filesystem watcher closed before the fixture could ${action} ${filename}.`,
+        );
       })(),
       failure.promise,
     ]);


### PR DESCRIPTION
## Summary

- wait for each exact response result in a complete synchronized frame, then bind the idle precondition to that result's actual output occurrence before exercising slash Copy or artifact navigation
- distinguish path creation from exact file-content publication with one fs.watch-based causal helper
- migrate Copy, artifact paging, and production clipboard assertions that immediately consume marker contents

## Acceptance-discovered RED evidence

- main run 32955306057: PageDown read an already-created artifact marker before its offset content was complete
- main run 32956426265: slash Copy timed out after input raced the final response lifecycle
- first PR run 32959915283: the older-chronology Copy case exposed one remaining pre-result idle synchronization seam
- no timeout, sleep, polling, worker, or assertion relaxation was introduced

## Verification

- focused semantic Copy/PageDown set: 5/5 passed
- four concurrent focused sets: 4/4 processes passed, 5/5 tests each
- focused production clipboard OS contract: 1/1 passed
- `pnpm quality:check`: 41 test files passed, 2 skipped; 1066 tests passed, 10 skipped
- independent specification and test-architecture reviews: PASS, no blocker/high/medium findings
