### PR TITLE
fix: expose extension skills in TUI drafts

### DIFF
--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -466,6 +466,55 @@ test("the production TUI entry reaches a credentialed exact-target session witho
   }
 });
 
+test("the production TUI exposes one enabled extension Skill in the first-prompt draft", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-extension-skill-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const configRoot = join(testRoot, "config");
+  const configDirectory = join(configRoot, "adam-agent");
+  const packageRoot = join(testRoot, "extension-package");
+  const skillDirectory = join(packageRoot, "skills", "extension-procedure");
+  await mkdir(workspaceRoot);
+  await writeRecoverableReviewPackage(packageRoot);
+  await mkdir(skillDirectory, { recursive: true });
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: extension-procedure\ndescription: Runs only from one enabled production extension.\n---\nExtension procedure body.\n",
+    "utf8",
+  );
+  await writeReviewExtensionConfiguration(configDirectory, packageRoot, { block: false });
+
+  try {
+    const fixture = startFixture({
+      program: {
+        arguments: ["--target", "deepseek-v4-flash.direct", "--state-root", stateRoot],
+        cwd: workspaceRoot,
+        entrypoint: productionPath,
+        environment: {
+          DEEPSEEK_API_KEY: "deterministic-non-network-fixture",
+          XDG_CONFIG_HOME: configRoot,
+        },
+      },
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    const beforePalette = fixture.output().length;
+    fixture.write("/skills\r");
+    await fixture.waitForCompleteFrameAfter("Select next-turn Skills", beforePalette);
+    const paletteFrame = fixture.output().slice(beforePalette);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+
+    expect(paletteFrame).toContain("extension-procedure ·");
+    expect(paletteFrame).toContain("Runs only from one enabled production extension.");
+    expect(paletteFrame).toContain("extension:fixture.recoverable-review@1.0.0 · available");
+    expect(paletteFrame).not.toContain("No matching commands");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("the production TUI reviews real Git changes through the exact public Eve adapter and survives restart", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-eve-registry-"));
   const workspaceRoot = join(testRoot, "workspace");

--- a/apps/tui/src/main.ts
+++ b/apps/tui/src/main.ts
@@ -103,7 +103,13 @@ try {
       : rejectedExtensions === 0
         ? undefined
         : `${rejectedExtensions} configured extension${rejectedExtensions === 1 ? " is" : "s are"} unavailable.`;
-    lifecycle = createSessionLifecycle({ modelTargets, permissions, stateRoot, workspaceRoot });
+    lifecycle = createSessionLifecycle({
+      extensionHost: host,
+      modelTargets,
+      permissions,
+      stateRoot,
+      workspaceRoot,
+    });
     try {
       if (command.resumeSessionId !== undefined && command.targetId !== undefined) {
         throw new TuiConfigurationError("--resume and --target cannot be combined.");

--- a/packages/agent/src/extension-host.ts
+++ b/packages/agent/src/extension-host.ts
@@ -578,6 +578,14 @@ export function createExtensionHost(options: ExtensionHostOptions): ExtensionHos
       if (loadInFlight !== undefined) {
         return loadInFlight;
       }
+      const existing = options.extensions.map(({ extensionId }) =>
+        loadedSnapshots.get(extensionId),
+      );
+      if (
+        existing.every((snapshot): snapshot is ExtensionStateSnapshot => snapshot !== undefined)
+      ) {
+        return Promise.resolve({ extensions: existing });
+      }
       const operation = projectLifecycleOwner
         .run(async () => {
           const availableCapabilities = new Map(


### PR DESCRIPTION
## Summary
- pass the already-loaded ExtensionHost into the production TUI SessionLifecycle
- reuse completed extension-load snapshots before reacquiring the non-reentrant project owner
- prove an enabled extension Skill appears in the real first-prompt /skills palette

## TDD evidence
- RED: production palette rendered Catalog r1 with zero candidates and no extension Skill
- GREEN: focused production PTY tracer and existing SessionLifecycle extension-Skill contract passed
- focused TUI OS matrix: 24/24 passed with full Linux OS authority
- focused Skills/Operation/Extension set: 121/121 passed
- final pnpm quality:check: 41 files passed, 2 opt-in skipped; 1067 tests passed, 10 opt-in skipped
- independent specification and engineering-standards reviews: clean

## Scope
- ordinary CLI behavior is unchanged
- no new public API, package, registry, capability, persistence format, or B9.5 restructuring