### PR TITLE
refactor: centralize TUI project runtime

### DIFF
--- a/apps/tui/src/lifecycle-close.test.ts
+++ b/apps/tui/src/lifecycle-close.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "vitest";
+
+import { findMcpShutdownUnconfirmedError, McpShutdownUnconfirmedError } from "./lifecycle-close.js";
+
+test("MCP shutdown diagnosis survives an aggregate of independent cleanup failures", () => {
+  const shutdownFailure = new McpShutdownUnconfirmedError("MCP shutdown could not be confirmed.");
+  const failure = new AggregateError(
+    [new Error("terminal restoration failed"), new AggregateError([shutdownFailure])],
+    "cleanup failed",
+  );
+
+  expect(findMcpShutdownUnconfirmedError(failure)).toBe(shutdownFailure);
+});
+
+test("unrelated aggregate failures do not become MCP shutdown failures", () => {
+  expect(findMcpShutdownUnconfirmedError(new AggregateError([new Error("clipboard failed")]))).toBe(
+    undefined,
+  );
+});

--- a/apps/tui/src/lifecycle-close.ts
+++ b/apps/tui/src/lifecycle-close.ts
@@ -2,6 +2,24 @@ import type { McpCloseResult } from "@adam-agent/agent";
 
 export class McpShutdownUnconfirmedError extends Error {}
 
+export function findMcpShutdownUnconfirmedError(
+  error: unknown,
+): McpShutdownUnconfirmedError | undefined {
+  const pending = [error];
+  const visited = new Set<unknown>();
+  while (pending.length > 0) {
+    const candidate = pending.shift();
+    if (candidate instanceof McpShutdownUnconfirmedError) {
+      return candidate;
+    }
+    if (candidate instanceof AggregateError && !visited.has(candidate)) {
+      visited.add(candidate);
+      pending.push(...candidate.errors);
+    }
+  }
+  return undefined;
+}
+
 export function requireConfirmedLifecycleClose(result: McpCloseResult): void {
   if (result.status === "mcp_shutdown_unconfirmed") {
     throw new McpShutdownUnconfirmedError("MCP shutdown could not be confirmed.");

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -1020,13 +1020,15 @@ test("the production TUI resumes and explicitly reactivates one committed MCP pr
   }
 });
 
-test("the TUI process fails visibly when MCP shutdown cannot be confirmed", async () => {
+test("the TUI process preserves the MCP shutdown diagnosis across a terminal cleanup failure", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-mcp-close-unconfirmed-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
   const spawnMarker = join(testRoot, "mcp-spawned");
   const closeMarker = join(testRoot, "mcp-closed");
   await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
   await writeFile(
     join(workspaceRoot, ".mcp.json"),
     JSON.stringify({
@@ -1042,6 +1044,7 @@ test("the TUI process fails visibly when MCP shutdown cannot be confirmed", asyn
 
   try {
     const fixture = startFixture({
+      controlRoot,
       external: true,
       scenario: "mcp-close-unconfirmed",
       stateRoot,
@@ -1070,7 +1073,9 @@ test("the TUI process fails visibly when MCP shutdown cannot be confirmed", asyn
     fixture.write("\u0011");
     const result = await fixture.closed;
     expect(result).toMatchObject({ code: 1, signal: null });
-    expect(`${result.stdout}${result.stderr}`).toContain("MCP shutdown could not be confirmed.");
+    const output = `${result.stdout}${result.stderr}`;
+    expect(output).toContain("MCP shutdown could not be confirmed.");
+    await waitForPath(join(controlRoot, "terminal-restoration-failed"));
     await waitForPath(closeMarker);
   } finally {
     await rm(testRoot, { recursive: true, force: true });

--- a/apps/tui/src/main.ts
+++ b/apps/tui/src/main.ts
@@ -4,31 +4,19 @@ import { homedir } from "node:os";
 import { basename, join } from "node:path";
 
 import {
-  createBiomeExecutionAdapter,
-  createExtensionHost,
-  createFileArtifactStore,
-  createJsonlOperationStore,
   createModelTargets,
   createPermissionPolicy,
   createPresentationPreferences,
-  createPresentationSession,
-  createSessionLifecycle,
-  ExtensionConfigurationError,
-  loadExtensionConfiguration,
-  ModelTargetError,
-  type SessionLifecycle,
-  SessionLifecycleError,
   selectModelTargetId,
 } from "@adam-agent/agent";
 import {
   adamCommandRegistry,
   createAdamCommandRegistryFromContributions,
 } from "./command-registry.js";
-import { McpShutdownUnconfirmedError, requireConfirmedLifecycleClose } from "./lifecycle-close.js";
 import { createLinuxClipboardAdapter } from "./linux-clipboard.js";
+import { createProductionProjectRuntime } from "./project-runtime.js";
 import { runTui } from "./tui-app.js";
-
-class TuiConfigurationError extends Error {}
+import { TuiConfigurationError, tuiProcessFailureMessage } from "./tui-process-failure.js";
 
 try {
   const command = parseCommand(process.argv.slice(2));
@@ -47,91 +35,45 @@ try {
       askedEffects: ["write", "execute", "network", "delegate", "administrative"],
     });
     const extensionPermissions = createPermissionPolicy({ allowedEffects: ["execute"] });
-    let extensionConfigurationUnavailable = false;
-    const extensions = await loadExtensionConfiguration(process.env, { allowMissing: true }).catch(
-      (error: unknown) => {
-        if (
-          error instanceof ExtensionConfigurationError &&
-          error.code === "extension_configuration_unavailable"
-        ) {
-          extensionConfigurationUnavailable = true;
-          return [];
-        }
-        throw error;
-      },
-    );
-    const artifactStore = await createFileArtifactStore({ root: join(stateRoot, "artifacts") });
-    const operationStore = await createJsonlOperationStore({ stateRoot, workspaceRoot });
-    let lifecycle: SessionLifecycle | undefined;
-    const host = createExtensionHost({
-      artifactStore,
-      biomeExecution: createBiomeExecutionAdapter(),
-      capabilities: [
-        { id: "adam.analyzer-execution.biome@1", version: "1.0.0" },
-        { id: "adam.artifact.publish@1", version: "1.0.0" },
-        { id: "adam.storage.records@1", version: "1.0.0" },
-      ],
-      extensions,
-      operationOriginAuthority: {
-        async validateBoundary({ origin, projectId }) {
-          if (lifecycle === undefined) {
-            return false;
-          }
-          const snapshot = await lifecycle.inspect({ sessionId: origin.sessionId });
-          return (
-            snapshot.schemaVersion === 3 &&
-            snapshot.projectId === projectId &&
-            origin.sourceSequence <= snapshot.lastSequence
-          );
-        },
-      },
-      operationStore,
-      permissions: extensionPermissions,
-      projectRoot: workspaceRoot,
+    const runtime = await createProductionProjectRuntime({
+      environment: process.env,
+      extensionPermissions,
+      modelTargets,
+      permissions,
+      preferences,
+      projectLabel: basename(workspaceRoot),
       reservedCommandNames: adamCommandRegistry
         .entries()
         .flatMap((entry) => [entry.name, ...entry.aliases]),
       stateRoot,
-    });
-    const extensionSnapshot = await host.loadConfiguredExtensions();
-    const commandRegistry = createAdamCommandRegistryFromContributions(host.listContributions());
-    const rejectedExtensions = extensionSnapshot.extensions.filter(
-      (extension) => extension.status === "rejected",
-    ).length;
-    const startupNotice = extensionConfigurationUnavailable
-      ? "Configured extension packages are unavailable; new extension commands are disabled."
-      : rejectedExtensions === 0
-        ? undefined
-        : `${rejectedExtensions} configured extension${rejectedExtensions === 1 ? " is" : "s are"} unavailable.`;
-    lifecycle = createSessionLifecycle({
-      extensionHost: host,
-      modelTargets,
-      permissions,
-      stateRoot,
       workspaceRoot,
     });
+    const commandRegistry = createAdamCommandRegistryFromContributions(runtime.contributions);
+    const startupNotice = runtime.extensionAvailability.configurationUnavailable
+      ? "Configured extension packages are unavailable; new extension commands are disabled."
+      : runtime.extensionAvailability.rejectedCount === 0
+        ? undefined
+        : `${runtime.extensionAvailability.rejectedCount} configured extension${runtime.extensionAvailability.rejectedCount === 1 ? " is" : "s are"} unavailable.`;
+    let runtimeCloseAttempted = false;
+    const closeRuntime = async () => {
+      runtimeCloseAttempted = true;
+      await runtime.close();
+    };
     try {
       if (command.resumeSessionId !== undefined && command.targetId !== undefined) {
         throw new TuiConfigurationError("--resume and --target cannot be combined.");
       }
       if (command.resumeSessionId !== undefined) {
-        const snapshot = await lifecycle.inspect({ sessionId: command.resumeSessionId });
+        const snapshot = await runtime.inspectSession(command.resumeSessionId);
         if (snapshot.schemaVersion !== 3) {
           throw new TuiConfigurationError("The selected session cannot be opened by this TUI.");
         }
-        const presentation = await createPresentationSession({
-          lifecycle,
-          modelTargets,
-          operations: host.operations,
-          preferences,
-          projectChanges: host,
-          projectLabel: basename(workspaceRoot),
+        const presentation = await runtime.createPresentation({
           sessionId: command.resumeSessionId,
-          stateRoot,
-          workspaceRoot,
         });
         await runTui({
           clipboard,
+          closeRuntime,
           commandRegistry,
           presentation,
           ...(startupNotice === undefined ? {} : { startupNotice }),
@@ -155,19 +97,12 @@ try {
         const startupTargetId = hasConfiguredTargetSelector
           ? (command.targetId ?? selectModelTargetId(process.env))
           : undefined;
-        const presentation = await createPresentationSession({
-          lifecycle,
-          modelTargets,
+        const presentation = await runtime.createPresentation({
           openProject: true,
-          operations: host.operations,
-          preferences,
-          projectChanges: host,
-          projectLabel: basename(workspaceRoot),
-          stateRoot,
-          workspaceRoot,
         });
         await runTui({
           clipboard,
+          closeRuntime,
           commandRegistry,
           presentation,
           ...(startupNotice === undefined ? {} : { startupNotice }),
@@ -175,19 +110,13 @@ try {
         });
       }
     } finally {
-      requireConfirmedLifecycleClose(await lifecycle.close());
+      if (!runtimeCloseAttempted) {
+        await runtime.close();
+      }
     }
   }
 } catch (error) {
-  const message =
-    error instanceof TuiConfigurationError ||
-    error instanceof ExtensionConfigurationError ||
-    error instanceof McpShutdownUnconfirmedError ||
-    error instanceof ModelTargetError ||
-    error instanceof SessionLifecycleError
-      ? error.message
-      : "The Adam TUI could not start safely.";
-  process.stderr.write(`${message}\n${usage()}\n`);
+  process.stderr.write(`${tuiProcessFailureMessage(error)}\n${usage()}\n`);
   process.exitCode = 1;
 }
 

--- a/apps/tui/src/project-runtime.test.ts
+++ b/apps/tui/src/project-runtime.test.ts
@@ -1,0 +1,56 @@
+import { mkdir, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createModelTargets,
+  createPermissionPolicy,
+  createPresentationPreferences,
+} from "@adam-agent/agent";
+import { expect, test } from "vitest";
+import { createProductionProjectRuntime } from "./project-runtime.js";
+import { removeTuiFixtureRoot as rm } from "./tui-filesystem.test-support.js";
+
+test("the project runtime owns only one Presentation across a concurrent close", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-project-runtime-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const environment = {
+      DEEPSEEK_API_KEY: "deterministic-non-network-fixture",
+      XDG_CONFIG_HOME: join(testRoot, "config"),
+    };
+    const runtime = await createProductionProjectRuntime({
+      environment,
+      extensionPermissions: createPermissionPolicy({ allowedEffects: ["execute"] }),
+      modelTargets: createModelTargets({ environment }),
+      permissions: createPermissionPolicy({
+        allowedEffects: ["read"],
+        askedEffects: ["write", "execute", "network", "delegate", "administrative"],
+      }),
+      preferences: createPresentationPreferences({ environment }),
+      projectLabel: "runtime-fixture",
+      reservedCommandNames: [],
+      stateRoot,
+      workspaceRoot,
+    });
+
+    const presentation = runtime.createPresentation({ openProject: true });
+    await expect(runtime.createPresentation({ openProject: true })).rejects.toThrow(
+      "The production project runtime already owns its Presentation.",
+    );
+    const closing = runtime.close();
+    await expect(runtime.createPresentation({ openProject: true })).rejects.toThrow(
+      "The production project runtime is closing or closed.",
+    );
+    await expect(presentation).resolves.toBeDefined();
+    await expect(closing).resolves.toBeUndefined();
+    await expect(runtime.createPresentation({ openProject: true })).rejects.toThrow(
+      "The production project runtime is closing or closed.",
+    );
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});

--- a/apps/tui/src/project-runtime.ts
+++ b/apps/tui/src/project-runtime.ts
@@ -1,0 +1,171 @@
+import { join } from "node:path";
+
+import {
+  createBiomeExecutionAdapter,
+  createExtensionHost,
+  createFileArtifactStore,
+  createJsonlOperationStore,
+  createPresentationSession,
+  createSessionLifecycle,
+  ExtensionConfigurationError,
+  type ExtensionContributionSummary,
+  loadExtensionConfiguration,
+  type ModelTargets,
+  type PermissionPolicy,
+  type PresentationPreferences,
+  type SessionSnapshot,
+} from "@adam-agent/agent";
+import type { PresentationSession } from "@adam-agent/presentation";
+import { requireConfirmedLifecycleClose } from "./lifecycle-close.js";
+
+export type ProductionProjectRuntimeOptions = {
+  readonly environment: NodeJS.ProcessEnv;
+  readonly extensionPermissions: PermissionPolicy;
+  readonly modelTargets: ModelTargets;
+  readonly permissions: PermissionPolicy;
+  readonly preferences: PresentationPreferences;
+  readonly projectLabel: string;
+  readonly reservedCommandNames: readonly string[];
+  readonly stateRoot: string;
+  readonly workspaceRoot: string;
+};
+
+export type ProductionProjectRuntime = {
+  readonly contributions: readonly ExtensionContributionSummary[];
+  readonly extensionAvailability: {
+    readonly configurationUnavailable: boolean;
+    readonly rejectedCount: number;
+  };
+  close(): Promise<void>;
+  createPresentation(
+    input: { readonly openProject: true } | { readonly sessionId: string },
+  ): Promise<PresentationSession>;
+  inspectSession(sessionId: string): Promise<SessionSnapshot>;
+};
+
+export async function createProductionProjectRuntime(
+  options: ProductionProjectRuntimeOptions,
+): Promise<ProductionProjectRuntime> {
+  let configurationUnavailable = false;
+  const extensions = await loadExtensionConfiguration(options.environment, {
+    allowMissing: true,
+  }).catch((error: unknown) => {
+    if (
+      error instanceof ExtensionConfigurationError &&
+      error.code === "extension_configuration_unavailable"
+    ) {
+      configurationUnavailable = true;
+      return [];
+    }
+    throw error;
+  });
+  const artifactStore = await createFileArtifactStore({
+    root: join(options.stateRoot, "artifacts"),
+  });
+  const operationStore = await createJsonlOperationStore({
+    stateRoot: options.stateRoot,
+    workspaceRoot: options.workspaceRoot,
+  });
+  let lifecycle: ReturnType<typeof createSessionLifecycle> | undefined;
+  const host = createExtensionHost({
+    artifactStore,
+    biomeExecution: createBiomeExecutionAdapter(),
+    capabilities: [
+      { id: "adam.analyzer-execution.biome@1", version: "1.0.0" },
+      { id: "adam.artifact.publish@1", version: "1.0.0" },
+      { id: "adam.storage.records@1", version: "1.0.0" },
+    ],
+    extensions,
+    operationOriginAuthority: {
+      async validateBoundary({ origin, projectId }) {
+        if (lifecycle === undefined) {
+          return false;
+        }
+        const snapshot = await lifecycle.inspect({ sessionId: origin.sessionId });
+        return (
+          snapshot.schemaVersion === 3 &&
+          snapshot.projectId === projectId &&
+          origin.sourceSequence <= snapshot.lastSequence
+        );
+      },
+    },
+    operationStore,
+    permissions: options.extensionPermissions,
+    projectRoot: options.workspaceRoot,
+    reservedCommandNames: options.reservedCommandNames,
+    stateRoot: options.stateRoot,
+  });
+  const extensionSnapshot = await host.loadConfiguredExtensions();
+  lifecycle = createSessionLifecycle({
+    extensionHost: host,
+    modelTargets: options.modelTargets,
+    permissions: options.permissions,
+    stateRoot: options.stateRoot,
+    workspaceRoot: options.workspaceRoot,
+  });
+  let presentationPromise: Promise<PresentationSession> | undefined;
+  let closePromise: Promise<void> | undefined;
+
+  return {
+    contributions: host.listContributions(),
+    extensionAvailability: {
+      configurationUnavailable,
+      rejectedCount: extensionSnapshot.extensions.filter(
+        (extension) => extension.status === "rejected",
+      ).length,
+    },
+    close() {
+      closePromise ??= closeProjectRuntime(presentationPromise, lifecycle);
+      return closePromise;
+    },
+    createPresentation(input) {
+      if (closePromise !== undefined) {
+        return Promise.reject(new Error("The production project runtime is closing or closed."));
+      }
+      if (presentationPromise !== undefined) {
+        return Promise.reject(
+          new Error("The production project runtime already owns its Presentation."),
+        );
+      }
+      presentationPromise = createPresentationSession({
+        lifecycle,
+        modelTargets: options.modelTargets,
+        operations: host.operations,
+        preferences: options.preferences,
+        projectChanges: host,
+        projectLabel: options.projectLabel,
+        stateRoot: options.stateRoot,
+        workspaceRoot: options.workspaceRoot,
+        ...input,
+      });
+      return presentationPromise;
+    },
+    inspectSession(sessionId) {
+      return lifecycle.inspect({ sessionId });
+    },
+  };
+}
+
+async function closeProjectRuntime(
+  presentationPromise: Promise<PresentationSession> | undefined,
+  lifecycle: ReturnType<typeof createSessionLifecycle>,
+): Promise<void> {
+  let presentationFailure: unknown;
+  let presentation: PresentationSession | undefined;
+  try {
+    presentation = await presentationPromise;
+  } catch (error) {
+    presentationFailure = error;
+  }
+  if (presentation !== undefined) {
+    try {
+      await presentation.close();
+    } catch (error) {
+      presentationFailure = error;
+    }
+  }
+  requireConfirmedLifecycleClose(await lifecycle.close());
+  if (presentationFailure !== undefined) {
+    throw presentationFailure;
+  }
+}

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
 import { access, mkdir, watch, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -25,11 +26,12 @@ import {
   presentationHistoryPageSize,
 } from "@adam-agent/agent/internal-testing";
 import type { PresentationSession } from "@adam-agent/presentation";
-import type { Terminal } from "@earendil-works/pi-tui";
+import { ProcessTerminal, type Terminal } from "@earendil-works/pi-tui";
 import { createAdamCommandRegistry } from "./command-registry.js";
 import { type FixtureScenario, isFixtureScenario } from "./fixture-scenario.js";
 import { requireConfirmedLifecycleClose } from "./lifecycle-close.js";
 import { type ClipboardAdapter, type DeadlineScheduler, runTui } from "./tui-app.js";
+import { tuiProcessFailureMessage } from "./tui-process-failure.js";
 
 const targetIdentity: ModelTargetIdentity = {
   targetId: "fake.local",
@@ -140,6 +142,23 @@ export type TuiFixtureOptions = {
   readonly workspaceRoot: string;
 };
 
+class TerminalRestorationFailure extends ProcessTerminal {
+  readonly #failureMarker: string | undefined;
+
+  constructor(failureMarker: string | undefined) {
+    super();
+    this.#failureMarker = failureMarker;
+  }
+
+  override stop(): void {
+    super.stop();
+    if (this.#failureMarker !== undefined) {
+      writeFileSync(this.#failureMarker, "failed\n", "utf8");
+    }
+    throw new Error("Injected terminal stop failure after restoration.");
+  }
+}
+
 export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
   if (options.terminalProcessMarker !== undefined) {
     await writeFile(options.terminalProcessMarker, `${process.pid}\n`, "utf8");
@@ -177,6 +196,7 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
           options.scenario,
         )
       : undefined;
+  let lifecycleCloseAttempted = false;
 
   try {
     const previewBarrier = previewReadBarrier(options);
@@ -335,8 +355,33 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
     const clipboard = options.clipboard ?? clipboardAdapter(options);
     const deadlineScheduler = controlledDeadlineScheduler(options);
     const tuiPresentation = observeTuiDispatch(presentation, options);
+    const closeRuntime = async () => {
+      let presentationFailure: unknown;
+      try {
+        await tuiPresentation.close();
+      } catch (error) {
+        presentationFailure = error;
+      }
+      if (options.scenario === "mcp-close-unconfirmed") {
+        lifecycleCloseAttempted = true;
+        requireConfirmedLifecycleClose(await lifecycle.close());
+      }
+      if (presentationFailure !== undefined) {
+        throw presentationFailure;
+      }
+    };
+    const terminal =
+      options.terminal ??
+      (options.scenario === "mcp-close-unconfirmed"
+        ? new TerminalRestorationFailure(
+            options.controlRoot === undefined
+              ? undefined
+              : join(options.controlRoot, "terminal-restoration-failed"),
+          )
+        : undefined);
     await runTui({
       ...(clipboard === undefined ? {} : { clipboard }),
+      closeRuntime,
       ...(options.scenario === "review-unavailable" || reviewFixture !== undefined
         ? {
             commandRegistry: createAdamCommandRegistry(
@@ -369,11 +414,13 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
         : options.launch.startupTargetId === undefined
           ? {}
           : { startupTargetId: options.launch.startupTargetId }),
-      ...(options.terminal === undefined ? {} : { terminal: options.terminal }),
+      ...(terminal === undefined ? {} : { terminal }),
     });
   } finally {
     reviewFixture?.releaseExecution();
-    requireConfirmedLifecycleClose(await lifecycle.close());
+    if (!lifecycleCloseAttempted) {
+      requireConfirmedLifecycleClose(await lifecycle.close());
+    }
     if (options.controlRoot !== undefined) {
       await writeFile(join(options.controlRoot, "tui-fixture-closed"), "closed\n", "utf8");
     }
@@ -669,7 +716,16 @@ function parseArguments(arguments_: readonly string[]): {
 }
 
 if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
-  await runTuiFixture(parseArguments(process.argv.slice(2)));
+  const options = parseArguments(process.argv.slice(2));
+  try {
+    await runTuiFixture(options);
+  } catch (error) {
+    if (options.scenario !== "mcp-close-unconfirmed") {
+      throw error;
+    }
+    process.stderr.write(`${tuiProcessFailureMessage(error)}\n`);
+    process.exitCode = 1;
+  }
 }
 
 function optionValue(arguments_: readonly string[], option: string): string | undefined {

--- a/apps/tui/src/test-topology.test.ts
+++ b/apps/tui/src/test-topology.test.ts
@@ -1,11 +1,15 @@
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { expect, test } from "vitest";
 
 const behaviorSuitePath = fileURLToPath(new URL("./main.test.ts", import.meta.url));
 const operatingSystemSuitePath = fileURLToPath(new URL("./main.os.test.ts", import.meta.url));
+const tuiSourceRoot = fileURLToPath(new URL(".", import.meta.url));
+const productionEntryPath = fileURLToPath(new URL("./main.ts", import.meta.url));
 const productionTuiPath = fileURLToPath(new URL("./tui-app.ts", import.meta.url));
+const cliEntryPath = fileURLToPath(new URL("../../cli/src/main.ts", import.meta.url));
 const packagePath = fileURLToPath(new URL("../../../package.json", import.meta.url));
 const qualityWorkflowPath = fileURLToPath(
   new URL("../../../.github/workflows/quality.yml", import.meta.url),
@@ -84,6 +88,104 @@ test("every production overlay family enters Pi through the shared Adam frame", 
     expect(source).toContain(`new ${family}`);
   }
 });
+
+test("the production TUI has one app-private project runtime composition owner", async () => {
+  const [productionSources, entrySource, rendererSource, cliSource] = await Promise.all([
+    readProductionTuiSources(tuiSourceRoot),
+    readFile(productionEntryPath, "utf8"),
+    readFile(productionTuiPath, "utf8"),
+    readFile(cliEntryPath, "utf8"),
+  ]);
+  const runtimeSource = productionSources.get("project-runtime.ts");
+  expect(runtimeSource).toBeDefined();
+
+  for (const assemblyCall of [
+    "createExtensionHost",
+    "createFileArtifactStore",
+    "createJsonlOperationStore",
+    "createSessionLifecycle",
+    "createPresentationSession",
+  ]) {
+    expect(
+      [...productionSources]
+        .filter(([, source]) => importsFactoryFromAgent(source, assemblyCall))
+        .map(([path]) => path),
+    ).toEqual(["project-runtime.ts"]);
+  }
+  expect(
+    importsFactoryFromAgent(
+      'import { createExtensionHost as buildHost } from "@adam-agent/agent";',
+      "createExtensionHost",
+    ),
+  ).toBe(true);
+  expect(
+    importsFactoryFromAgent(
+      'import * as agent from "@adam-agent/agent";',
+      "createSessionLifecycle",
+    ),
+  ).toBe(true);
+  expect([...entrySource.matchAll(/\bcreateProductionProjectRuntime\(/gu)]).toHaveLength(1);
+  expect([...entrySource.matchAll(/\btuiProcessFailureMessage\(error\)/gu)]).toHaveLength(1);
+  expect(rendererSource).not.toContain("options.presentation.close()");
+  expect(rendererSource).toContain("options.closeRuntime()");
+  expect(cliSource).not.toContain("project-runtime.js");
+  const presentationClose = (runtimeSource as string).indexOf("await presentation.close();");
+  const lifecycleClose = (runtimeSource as string).indexOf(
+    "requireConfirmedLifecycleClose(await lifecycle.close());",
+  );
+  expect(presentationClose).toBeGreaterThan(-1);
+  expect(lifecycleClose).toBeGreaterThan(presentationClose);
+});
+
+async function readProductionTuiSources(root: string): Promise<ReadonlyMap<string, string>> {
+  const sources = new Map<string, string>();
+  await visit(root);
+  return new Map([...sources].sort(([left], [right]) => left.localeCompare(right)));
+
+  async function visit(directory: string): Promise<void> {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await visit(path);
+      } else if (entry.isFile() && isProductionTuiSource(entry.name)) {
+        sources.set(relative(root, path), await readFile(path, "utf8"));
+      }
+    }
+  }
+}
+
+function isProductionTuiSource(filename: string): boolean {
+  return (
+    filename.endsWith(".ts") &&
+    !filename.endsWith(".test.ts") &&
+    !filename.endsWith(".test-support.ts") &&
+    !filename.endsWith(".fixture.ts") &&
+    filename !== "fixture-scenario.ts" &&
+    filename !== "test-fixture.ts"
+  );
+}
+
+function importsFactoryFromAgent(source: string, factory: string): boolean {
+  if (/import\s+\*\s+as\s+\w+\s+from\s+["']@adam-agent\/agent["']/u.test(source)) {
+    return true;
+  }
+  for (const declaration of source.matchAll(
+    /import\s*\{([^}]*)\}\s*from\s*["']@adam-agent\/agent["']/gu,
+  )) {
+    const bindings = declaration[1] ?? "";
+    const importedNames = bindings.split(",").map((binding) =>
+      binding
+        .trim()
+        .replace(/^type\s+/u, "")
+        .split(/\s+as\s+/u)[0]
+        ?.trim(),
+    );
+    if (importedNames.includes(factory)) {
+      return true;
+    }
+  }
+  return false;
+}
 
 function topLevelTestBlocks(source: string): readonly string[] {
   const starts = [...source.matchAll(/^test\(/gmu)].map((match) => match.index);

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -77,6 +77,7 @@ export type TuiTargetStatus = {
 };
 
 export type RunTuiOptions = {
+  readonly closeRuntime: () => Promise<void>;
   readonly commandRegistry?: AdamCommandRegistry;
   readonly presentation: PresentationSession;
   readonly startupNotice?: string;
@@ -2310,7 +2311,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       failures.push(error);
     }
     try {
-      await options.presentation.close();
+      await options.closeRuntime();
     } catch (error) {
       failures.push(error);
     }

--- a/apps/tui/src/tui-process-failure.ts
+++ b/apps/tui/src/tui-process-failure.ts
@@ -1,0 +1,20 @@
+import {
+  ExtensionConfigurationError,
+  ModelTargetError,
+  SessionLifecycleError,
+} from "@adam-agent/agent";
+import { findMcpShutdownUnconfirmedError } from "./lifecycle-close.js";
+
+export class TuiConfigurationError extends Error {}
+
+export function tuiProcessFailureMessage(error: unknown): string {
+  if (
+    error instanceof TuiConfigurationError ||
+    error instanceof ExtensionConfigurationError ||
+    error instanceof ModelTargetError ||
+    error instanceof SessionLifecycleError
+  ) {
+    return error.message;
+  }
+  return findMcpShutdownUnconfirmedError(error)?.message ?? "The Adam TUI could not start safely.";
+}


### PR DESCRIPTION
## Summary

- centralize the production TUI ExtensionHost, OperationHost, stores, SessionLifecycle, Presentation construction, and shutdown order in one app-private ProjectRuntime
- keep the CLI extension-free harness unchanged and keep process, terminal, clipboard, policy, and command adaptation ownership in the TUI entry
- enforce one Presentation owner across concurrent create/close, preserve MCP shutdown diagnosis across aggregate cleanup failures, and recursively guard the production composition topology

## Verification

- focused semantic TUI/runtime/topology: 142 passed
- full TUI PTY/OS suite: 24 passed
- pnpm quality:check: 43 test files passed, 2 skipped; 1073 tests passed, 10 skipped
- independent specification review: clean
- independent engineering-standards review: clean
