### PR TITLE
refactor: extract session snapshot folds

### DIFF
--- a/packages/agent/src/session-history-folds.ts
+++ b/packages/agent/src/session-history-folds.ts
@@ -1,8 +1,35 @@
+import type { ContextUsageTotals } from "./agent-session-contracts.js";
+import { createContextProjectionMessage, estimateActiveContextTokens } from "./durable-context.js";
+import type { ModelTargetIdentity } from "./model-targets.js";
+import {
+  commitMcpToolProfileV3,
+  hasSkillPromptContext,
+  isPromptContextRecordValid,
+  type PromptContextRecordV2,
+  type PromptContextRecordV3,
+  type PromptContextSnapshot,
+  promptContextSnapshot,
+  replacePromptRepositoryV1,
+  replacePromptSkillsV2,
+} from "./prompt-assembly.js";
+import { modelMessagesFromCanonicalRecords } from "./session-history-replay.js";
+import { SessionLifecycleError } from "./session-lifecycle-error.js";
 import type {
+  CurrentSessionSnapshot,
+  SessionContextSnapshot,
+  SessionContextUsageSnapshot,
+} from "./session-snapshot-contracts.js";
+import type {
+  SessionGenesisRecord,
   SessionLogicalRunStartedRecord,
+  SessionRecord,
   SessionSkillActivationBatchCommittedRecord,
 } from "./session-store.js";
-import type { SkillContextRecordV1 } from "./skills.js";
+import {
+  isSkillContextRecordV1Valid,
+  type SkillContextRecordV1,
+  skillContextSnapshot,
+} from "./skills.js";
 
 export function isSkillContextCatalogSuccessor(
   previous: SkillContextRecordV1,
@@ -200,4 +227,680 @@ function resolvePersistedSkillSelection(
     (candidate) => candidate.name === selection,
   );
   return shortMatches.length === 1 ? shortMatches[0]?.qualifiedId : undefined;
+}
+
+export type ModelResponseArtifactDegradation = NonNullable<CurrentSessionSnapshot["degradation"]>;
+
+export type ModelResponseArtifactInspection = {
+  readonly contents: ReadonlyMap<number, { readonly text: string; readonly reasoning?: string }>;
+  readonly degradation?: ModelResponseArtifactDegradation;
+  readonly logicalReferencedBytes: number;
+  readonly records: readonly SessionRecord[];
+};
+
+export function isGenesisRecord(record: SessionRecord): record is SessionGenesisRecord {
+  return record.schemaVersion === 3 && record.record.type === "session_genesis";
+}
+
+export function attemptStatus(
+  records: readonly Extract<SessionRecord, { readonly schemaVersion: 3 }>[],
+  attempt: {
+    readonly runId: string;
+    readonly turn: number;
+    readonly attempt: number;
+  },
+): "started" | "interrupted" | "completed" {
+  const matching = records.filter(
+    (record) =>
+      "runId" in record.record &&
+      record.record.runId === attempt.runId &&
+      "turn" in record.record &&
+      record.record.turn === attempt.turn &&
+      "attempt" in record.record &&
+      record.record.attempt === attempt.attempt,
+  );
+  if (matching.some((record) => record.record.type === "model_response_completed")) {
+    return "completed";
+  }
+  if (matching.some((record) => record.record.type === "provider_attempt_interrupted")) {
+    return "interrupted";
+  }
+  return "started";
+}
+
+export function isCompleteBranchBoundary(records: readonly SessionRecord[]): boolean {
+  const currentRecords = records.filter((record) => record.schemaVersion === 3);
+  if (currentRecords.length !== records.length || currentRecords.length === 0) {
+    return false;
+  }
+  const latestRun = currentRecords.findLast(
+    (record) => record.record.type === "logical_run_started",
+  );
+  if (latestRun === undefined) {
+    const first = records[0];
+    return (
+      first !== undefined &&
+      isGenesisRecord(first) &&
+      currentRecords
+        .slice(1)
+        .every(
+          (entry) =>
+            ((entry.record.type === "repository_instructions_committed" ||
+              entry.record.type === "repository_instructions_failed") &&
+              entry.record.trigger === undefined) ||
+            entry.record.type === "skill_catalog_committed" ||
+            entry.record.type === "skill_catalog_failed" ||
+            entry.record.type === "skill_revoked" ||
+            entry.record.type === "mcp_workspace_confirmed" ||
+            entry.record.type === "mcp_server_definition_approved" ||
+            entry.record.type === "mcp_activation_started" ||
+            entry.record.type === "mcp_activation_settled" ||
+            entry.record.type === "mcp_tool_profile_committed",
+        )
+    );
+  }
+  if (latestRun.record.type !== "logical_run_started") {
+    return false;
+  }
+  const runId = latestRun.record.runId;
+  const lastAttempt = currentRecords.findLast(
+    (record) => record.record.type === "provider_attempt_started" && record.record.runId === runId,
+  );
+  if (
+    lastAttempt?.record.type === "provider_attempt_started" &&
+    attemptStatus(currentRecords, lastAttempt.record) === "started"
+  ) {
+    return false;
+  }
+  const lastResponse = currentRecords.findLast(
+    (record) => record.record.type === "model_response_completed" && record.record.runId === runId,
+  );
+  if (
+    lastResponse?.record.type !== "model_response_completed" ||
+    lastResponse.record.response.finishReason !== "tool_calls"
+  ) {
+    return true;
+  }
+  return lastResponse.record.response.toolCalls.every((call) =>
+    currentRecords.some(
+      (candidate) =>
+        candidate.sequence > lastResponse.sequence &&
+        candidate.record.type === "runtime_event" &&
+        candidate.record.runId === runId &&
+        (candidate.record.event.type === "tool_completed" ||
+          candidate.record.event.type === "tool_failed") &&
+        candidate.record.event.callId === call.id &&
+        candidate.record.event.name === call.name,
+    ),
+  );
+}
+
+export function areReplayProfilesCompatible(
+  left: ModelTargetIdentity,
+  right: ModelTargetIdentity,
+): boolean {
+  return (
+    left.vendor === right.vendor &&
+    left.route === right.route &&
+    left.upstreamProviderId === right.upstreamProviderId &&
+    left.profileVersion === right.profileVersion
+  );
+}
+
+export function snapshotFromGenesis(
+  genesis: SessionGenesisRecord,
+  lastSequence: number,
+): CurrentSessionSnapshot {
+  return {
+    schemaVersion: 3,
+    sessionId: genesis.record.sessionId,
+    projectId: genesis.record.projectId,
+    targetIdentity: genesis.record.targetIdentity,
+    status: "idle",
+    lastSequence,
+    ...(genesis.record.promptContext === undefined
+      ? {}
+      : { promptContext: promptContextSnapshot(genesis.record.promptContext) }),
+    ...(genesis.record.skillContext === undefined
+      ? {}
+      : { skillContext: skillContextSnapshot(genesis.record.skillContext) }),
+    ...(genesis.record.lineage === undefined ? {} : { lineage: genesis.record.lineage }),
+  };
+}
+
+function promptContextSnapshotFromRecords(
+  genesis: SessionGenesisRecord,
+  records: readonly SessionRecord[],
+): PromptContextSnapshot | undefined {
+  const context = promptContextRecordFromRecords(genesis, records);
+  if (context === undefined) {
+    return undefined;
+  }
+  const snapshot = promptContextSnapshot(context);
+  const latestProjection = records.findLast(
+    (entry) =>
+      entry.schemaVersion === 3 &&
+      entry.record.type === "provider_attempt_started" &&
+      entry.record.promptProjection !== undefined,
+  );
+  return latestProjection?.schemaVersion === 3 &&
+    latestProjection.record.type === "provider_attempt_started" &&
+    latestProjection.record.promptProjection !== undefined
+    ? {
+        ...snapshot,
+        lastRequestProjectionDigest:
+          latestProjection.record.promptProjection.requestProjectionDigest,
+      }
+    : snapshot;
+}
+
+export function promptContextRecordFromRecords(
+  genesis: SessionGenesisRecord,
+  records: readonly SessionRecord[],
+): SessionGenesisRecord["record"]["promptContext"] {
+  let context = genesis.record.promptContext;
+  for (const entry of records) {
+    if (entry.schemaVersion !== 3) {
+      continue;
+    }
+    if (entry.record.type === "repository_instructions_committed") {
+      if (
+        context === undefined ||
+        entry.record.previousRevision !== context.repository.revision ||
+        entry.record.previousEffectiveDigest !== context.repository.effectiveDigest ||
+        entry.record.repository.revision !== context.repository.revision + 1
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      const next = replacePromptRepositoryV1(context, entry.record.repository);
+      if (
+        next.assemblyIdentityDigest !== entry.record.assemblyIdentityDigest ||
+        !isPromptContextRecordValid(next)
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      context = next;
+      continue;
+    }
+    if (entry.record.type === "mcp_tool_profile_committed") {
+      if (
+        context?.recordVersion !== 3 ||
+        context.mcp !== undefined ||
+        entry.record.previousAssemblyIdentityDigest !== context.assemblyIdentityDigest
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      const next = commitMcpToolProfileV3(context, entry.record.profile);
+      if (
+        next.assemblyIdentityDigest !== entry.record.assemblyIdentityDigest ||
+        !isPromptContextRecordValid(next)
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      context = next;
+      continue;
+    }
+    if (entry.record.type === "path_context_committed") {
+      if (
+        !hasSkillPromptContext(context) ||
+        entry.record.previousRepositoryRevision !== context.repository.revision ||
+        entry.record.previousRepositoryDigest !== context.repository.effectiveDigest ||
+        entry.record.repository.revision !== context.repository.revision + 1
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      let next = replacePromptRepositoryV1(context, entry.record.repository) as
+        | PromptContextRecordV2
+        | PromptContextRecordV3;
+      next = replacePromptSkillsV2(next, entry.record.skillContext);
+      if (
+        next.assemblyIdentityDigest !== entry.record.assemblyIdentityDigest ||
+        !isPromptContextRecordValid(next)
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      context = next;
+      continue;
+    }
+    if (entry.record.type === "skill_activation_batch_committed") {
+      if (!hasSkillPromptContext(context)) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      const next = replacePromptSkillsV2(context, entry.record.skillContext);
+      if (
+        next.assemblyIdentityDigest !== entry.record.assemblyIdentityDigest ||
+        !isPromptContextRecordValid(next)
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      context = next;
+    }
+    if (entry.record.type === "skill_catalog_committed") {
+      if (!hasSkillPromptContext(context)) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      const next = replacePromptSkillsV2(context, entry.record.skillContext);
+      if (
+        next.assemblyIdentityDigest !== entry.record.assemblyIdentityDigest ||
+        !isPromptContextRecordValid(next)
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      context = next;
+    }
+  }
+  return context;
+}
+
+export function skillContextRecordFromRecords(
+  genesis: SessionGenesisRecord,
+  records: readonly SessionRecord[],
+): SkillContextRecordV1 | undefined {
+  let context = genesis.record.skillContext;
+  for (const entry of records) {
+    if (
+      entry.schemaVersion !== 3 ||
+      (entry.record.type !== "skill_activation_batch_committed" &&
+        entry.record.type !== "skill_catalog_committed" &&
+        entry.record.type !== "path_context_committed")
+    ) {
+      continue;
+    }
+    if (entry.record.type === "skill_catalog_committed") {
+      if (
+        context === undefined ||
+        entry.record.previousRevision !== context.registry.revision ||
+        entry.record.previousRegistryDigest !== context.registry.digest ||
+        !isSkillContextRecordV1Valid(entry.record.skillContext) ||
+        !isSkillContextCatalogSuccessor(context, entry.record.skillContext)
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      context = entry.record.skillContext;
+      continue;
+    }
+    if (entry.record.type === "path_context_committed") {
+      if (
+        context === undefined ||
+        entry.record.previousSkillRevision !== context.registry.revision ||
+        entry.record.previousSkillRegistryDigest !== context.registry.digest ||
+        !isSkillContextRecordV1Valid(entry.record.skillContext) ||
+        !isSkillContextPathSuccessor(context, entry.record.skillContext)
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      context = entry.record.skillContext;
+      continue;
+    }
+    if (
+      context === undefined ||
+      entry.record.previousActivationDigest !== context.activationDigest ||
+      !isSkillContextRecordV1Valid(entry.record.skillContext) ||
+      !isSkillActivationBatchTransitionValid(context, entry.record.skillContext, entry.record)
+    ) {
+      throw new SessionLifecycleError("session_invalid");
+    }
+    context = entry.record.skillContext;
+  }
+  return context;
+}
+
+export function contextSnapshotFromRecords(
+  records: readonly SessionRecord[],
+): SessionContextSnapshot | undefined {
+  const currentRecords = records.filter((record) => record.schemaVersion === 3);
+  const checkpoint = currentRecords.findLast(
+    (record) => record.record.type === "context_compaction_committed",
+  );
+  const started = currentRecords.findLast(
+    (record) => record.record.type === "context_compaction_started",
+  );
+  const checkpointRecord =
+    checkpoint?.record.type === "context_compaction_committed" ? checkpoint.record : undefined;
+  const startedRecord =
+    started?.record.type === "context_compaction_started" ? started.record : undefined;
+  if (checkpointRecord === undefined && startedRecord === undefined) {
+    return undefined;
+  }
+  const compactionUsage = compactionContextUsageFromRecords(currentRecords);
+  const ordinaryUsage = ordinaryContextUsageFromRecords(currentRecords);
+  const lastTerminal =
+    startedRecord === undefined
+      ? undefined
+      : currentRecords.findLast(
+          (record) =>
+            record.sequence > (started?.sequence ?? 0) &&
+            (record.record.type === "context_compaction_committed" ||
+              record.record.type === "context_compaction_failed" ||
+              record.record.type === "context_compaction_interrupted") &&
+            record.record.attemptId === startedRecord.attemptId,
+        );
+  const terminalRecord =
+    lastTerminal?.record.type === "context_compaction_committed" ||
+    lastTerminal?.record.type === "context_compaction_failed" ||
+    lastTerminal?.record.type === "context_compaction_interrupted"
+      ? lastTerminal.record
+      : undefined;
+  const lastAttemptUsage =
+    terminalRecord?.usage === undefined ? ({ status: "unknown" } as const) : terminalRecord.usage;
+  const lastAttemptStatus =
+    terminalRecord?.type === "context_compaction_committed"
+      ? ("committed" as const)
+      : terminalRecord?.type === "context_compaction_failed"
+        ? ("failed" as const)
+        : terminalRecord?.type === "context_compaction_interrupted"
+          ? ("interrupted" as const)
+          : ("started" as const);
+  const latestResponse = currentRecords.findLast(
+    (record) =>
+      record.sequence > (checkpoint?.sequence ?? Number.MAX_SAFE_INTEGER) &&
+      record.record.type === "model_response_completed",
+  );
+  const active =
+    latestResponse?.record.type === "model_response_completed" &&
+    latestResponse.record.response.usage !== undefined
+      ? {
+          source: "provider_reported" as const,
+          tokens: latestResponse.record.response.usage.inputTokens,
+        }
+      : checkpointRecord !== undefined
+        ? {
+            source: "estimated" as const,
+            tokens: estimateActiveContextTokens(
+              [
+                createContextProjectionMessage(checkpointRecord.summary, checkpointRecord.evidence),
+                ...modelMessagesFromCanonicalRecords(
+                  currentRecords.filter(
+                    (record) =>
+                      record.sequence >= checkpointRecord.retainedFrom &&
+                      record.sequence <= checkpointRecord.sourceThrough,
+                  ),
+                ),
+              ],
+              checkpointRecord.contextProfile,
+            ),
+          }
+        : { source: "unknown" as const };
+  return {
+    profile:
+      startedRecord?.contextProfile ??
+      (checkpointRecord as NonNullable<typeof checkpointRecord>).contextProfile,
+    ...(checkpointRecord === undefined || checkpoint === undefined
+      ? {}
+      : {
+          checkpoint: {
+            checkpointId: checkpointRecord.checkpointId,
+            sequence: checkpoint.sequence,
+            windowNumber: checkpointRecord.windowNumber,
+            status: "committed" as const,
+            sourceThrough: checkpointRecord.sourceThrough,
+            retainedFrom: checkpointRecord.retainedFrom,
+          },
+        }),
+    lastAttempt: {
+      attemptId:
+        startedRecord?.attemptId ??
+        (checkpointRecord as NonNullable<typeof checkpointRecord>).attemptId,
+      attemptNumber:
+        startedRecord?.attemptNumber ??
+        (checkpointRecord as NonNullable<typeof checkpointRecord>).attemptNumber,
+      windowNumber:
+        startedRecord?.windowNumber ??
+        (checkpointRecord as NonNullable<typeof checkpointRecord>).windowNumber,
+      status: lastAttemptStatus,
+      ...(terminalRecord?.type === "context_compaction_failed" ||
+      terminalRecord?.type === "context_compaction_interrupted"
+        ? { reason: terminalRecord.reason }
+        : {}),
+      usage: lastAttemptUsage,
+    },
+    ordinaryUsage,
+    compactionUsage,
+    active,
+  };
+}
+
+export function contextUsageSnapshotFromRecords(
+  records: readonly SessionRecord[],
+): SessionContextUsageSnapshot | undefined {
+  const currentRecords = records.filter((record) => record.schemaVersion === 3);
+  if (
+    !currentRecords.some(
+      ({ record }) =>
+        record.type === "provider_attempt_started" ||
+        record.type === "context_compaction_started" ||
+        record.type === "context_compaction_committed" ||
+        record.type === "context_compaction_failed" ||
+        record.type === "context_compaction_interrupted",
+    )
+  ) {
+    return undefined;
+  }
+  const latestAttemptBoundary = currentRecords.findLast(
+    ({ record }) =>
+      record.type === "provider_attempt_started" ||
+      record.type === "model_response_completed" ||
+      record.type === "provider_attempt_interrupted",
+  );
+  return {
+    ordinaryUsage: ordinaryContextUsageFromRecords(currentRecords),
+    compactionUsage: compactionContextUsageFromRecords(currentRecords),
+    active:
+      latestAttemptBoundary?.record.type === "model_response_completed" &&
+      latestAttemptBoundary.record.response.usage !== undefined
+        ? {
+            source: "provider_reported",
+            tokens: latestAttemptBoundary.record.response.usage.inputTokens,
+          }
+        : { source: "unknown" },
+  };
+}
+
+function compactionContextUsageFromRecords(
+  records: readonly Extract<SessionRecord, { readonly schemaVersion: 3 }>[],
+): ContextUsageTotals {
+  return records.reduce<ContextUsageTotals>((totals, entry) => {
+    if (
+      entry.record.type !== "context_compaction_committed" &&
+      entry.record.type !== "context_compaction_failed" &&
+      entry.record.type !== "context_compaction_interrupted"
+    ) {
+      return totals;
+    }
+    const usage = entry.record.usage;
+    if (usage === undefined || "status" in usage) {
+      return incrementUnknownContextUsage(totals);
+    }
+    return {
+      inputTokens: totals.inputTokens + usage.inputTokens,
+      outputTokens: totals.outputTokens + usage.outputTokens,
+      reasoningTokens: totals.reasoningTokens + (usage.reasoningTokens ?? 0),
+      cachedInputTokens: totals.cachedInputTokens + (usage.cachedInputTokens ?? 0),
+      cacheMissInputTokens: totals.cacheMissInputTokens + (usage.cacheMissInputTokens ?? 0),
+      unknownCalls: totals.unknownCalls,
+    };
+  }, emptyContextUsageTotals());
+}
+
+export function addContextUsageTotals(
+  left: ContextUsageTotals,
+  right: ContextUsageTotals,
+): ContextUsageTotals {
+  return {
+    inputTokens: left.inputTokens + right.inputTokens,
+    outputTokens: left.outputTokens + right.outputTokens,
+    reasoningTokens: left.reasoningTokens + right.reasoningTokens,
+    cachedInputTokens: left.cachedInputTokens + right.cachedInputTokens,
+    cacheMissInputTokens: left.cacheMissInputTokens + right.cacheMissInputTokens,
+    unknownCalls: left.unknownCalls + right.unknownCalls,
+  };
+}
+
+function emptyContextUsageTotals(): ContextUsageTotals {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    cachedInputTokens: 0,
+    cacheMissInputTokens: 0,
+    unknownCalls: 0,
+  };
+}
+
+function incrementUnknownContextUsage(totals: ContextUsageTotals): ContextUsageTotals {
+  return {
+    inputTokens: totals.inputTokens,
+    outputTokens: totals.outputTokens,
+    reasoningTokens: totals.reasoningTokens,
+    cachedInputTokens: totals.cachedInputTokens,
+    cacheMissInputTokens: totals.cacheMissInputTokens,
+    unknownCalls: totals.unknownCalls + 1,
+  };
+}
+
+function ordinaryContextUsageFromRecords(
+  records: readonly Extract<SessionRecord, { readonly schemaVersion: 3 }>[],
+): ContextUsageTotals {
+  let totals: ContextUsageTotals = {
+    inputTokens: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    cachedInputTokens: 0,
+    cacheMissInputTokens: 0,
+    unknownCalls: 0,
+  };
+  let attemptStarted = false;
+  let usageSeen = false;
+  for (const entry of records) {
+    const record = entry.record;
+    if (record.type === "provider_attempt_started") {
+      attemptStarted = true;
+      usageSeen = false;
+      continue;
+    }
+    if (record.type === "runtime_event" && record.event.type === "model_usage" && attemptStarted) {
+      usageSeen = true;
+      totals = {
+        inputTokens: totals.inputTokens + record.event.inputTokens,
+        outputTokens: totals.outputTokens + record.event.outputTokens,
+        reasoningTokens: totals.reasoningTokens + (record.event.reasoningTokens ?? 0),
+        cachedInputTokens: totals.cachedInputTokens + (record.event.cachedInputTokens ?? 0),
+        cacheMissInputTokens:
+          totals.cacheMissInputTokens + (record.event.cacheMissInputTokens ?? 0),
+        unknownCalls: totals.unknownCalls,
+      };
+      continue;
+    }
+    if (
+      attemptStarted &&
+      (record.type === "model_response_completed" || record.type === "provider_attempt_interrupted")
+    ) {
+      if (!usageSeen) {
+        totals = incrementUnknownContextUsage(totals);
+      }
+      attemptStarted = false;
+      usageSeen = false;
+    }
+  }
+  return totals;
+}
+
+export function snapshotFromRecords(
+  genesis: SessionGenesisRecord,
+  records: readonly SessionRecord[],
+  artifactInspection?: ModelResponseArtifactInspection,
+): CurrentSessionSnapshot {
+  if (records.some((record) => record.schemaVersion !== 3)) {
+    throw new SessionLifecycleError("session_invalid");
+  }
+  const currentRecords = records.filter((record) => record.schemaVersion === 3);
+  const context = contextSnapshotFromRecords(records);
+  const latestRun = currentRecords.findLast(
+    (record) => record.record.type === "logical_run_started",
+  );
+  if (latestRun === undefined || latestRun.record.type !== "logical_run_started") {
+    const promptContext = promptContextSnapshotFromRecords(genesis, records);
+    const skillContext = skillContextRecordFromRecords(genesis, records);
+    return {
+      ...snapshotFromGenesis(genesis, records.length),
+      ...(promptContext === undefined ? {} : { promptContext }),
+      ...(skillContext === undefined ? {} : { skillContext: skillContextSnapshot(skillContext) }),
+      ...(context === undefined ? {} : { context }),
+      ...(artifactInspection?.degradation === undefined
+        ? {}
+        : { degradation: artifactInspection.degradation }),
+    };
+  }
+  const runId = latestRun.record.runId;
+  const lastResponse = currentRecords.findLast(
+    (record) => record.record.type === "model_response_completed" && record.record.runId === runId,
+  );
+  const settlement = currentRecords.findLast(
+    (record) =>
+      record.record.type === "runtime_event" &&
+      record.record.runId === runId &&
+      record.record.event.type === "session_settled",
+  );
+  const linkedSettlement = currentRecords.findLast(
+    (record) => record.record.type === "run_settled" && record.record.runId === runId,
+  );
+  const lastAttemptStarted = currentRecords.findLast(
+    (record) => record.record.type === "provider_attempt_started" && record.record.runId === runId,
+  );
+  const lastAttempt =
+    lastAttemptStarted?.record.type !== "provider_attempt_started"
+      ? undefined
+      : {
+          turn: lastAttemptStarted.record.turn,
+          attempt: lastAttemptStarted.record.attempt,
+          status: attemptStatus(currentRecords, lastAttemptStarted.record),
+        };
+  const result =
+    settlement?.record.type === "runtime_event" &&
+    settlement.record.event.type === "session_settled"
+      ? settlement.record.event.result
+      : linkedSettlement?.record.type === "run_settled"
+        ? artifactInspection?.contents.get(linkedSettlement.record.responseSequence) === undefined
+          ? undefined
+          : linkedSettlement.record.status === "completed"
+            ? {
+                status: "completed" as const,
+                answer: artifactInspection.contents.get(linkedSettlement.record.responseSequence)
+                  ?.text as string,
+              }
+            : {
+                status: "incomplete" as const,
+                reason: linkedSettlement.record.reason,
+                answer: artifactInspection.contents.get(linkedSettlement.record.responseSequence)
+                  ?.text as string,
+              }
+        : undefined;
+  const isSettled = settlement !== undefined || linkedSettlement !== undefined;
+  const promptContext = promptContextSnapshotFromRecords(genesis, records);
+  const skillContext = skillContextRecordFromRecords(genesis, records);
+  return {
+    ...snapshotFromGenesis(genesis, records.length),
+    ...(promptContext === undefined ? {} : { promptContext }),
+    ...(skillContext === undefined ? {} : { skillContext: skillContextSnapshot(skillContext) }),
+    ...(context === undefined ? {} : { context }),
+    ...(artifactInspection?.degradation === undefined
+      ? {}
+      : { degradation: artifactInspection.degradation }),
+    status: isSettled ? "settled" : "interrupted",
+    run: {
+      runId,
+      status: isSettled ? "settled" : "interrupted",
+      ...(result === undefined ? {} : { result }),
+      ...(lastAttempt === undefined ? {} : { lastAttempt }),
+      ...(lastResponse?.record.type !== "model_response_completed"
+        ? {}
+        : {
+            lastCompletedResponse: {
+              turn: lastResponse.record.turn,
+              attempt: lastResponse.record.attempt,
+              finishReason: lastResponse.record.response.finishReason,
+            },
+          }),
+    },
+  };
 }

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -6,7 +6,6 @@ import { isDeepStrictEqual } from "node:util";
 import { z } from "zod";
 import { AgentSession } from "./agent-session.js";
 import type {
-  ContextUsageTotals,
   ModelMessage,
   PermissionDecisionCommand,
   PermissionDecisionCommandResult,
@@ -22,11 +21,9 @@ import {
   createFileArtifactStore,
   readFileArtifact,
 } from "./artifact-store.js";
-import { type ContextProfile, isContextProfileSupported } from "./context-profile.js";
+import { isContextProfileSupported } from "./context-profile.js";
 import {
   type ContextEvidenceV1,
-  createContextProjectionMessage,
-  estimateActiveContextTokens,
   mergeContextEvidence,
   reduceContextEvidence,
 } from "./durable-context.js";
@@ -82,12 +79,8 @@ import {
   hasSkillPromptContext,
   isPromptContextCompatible,
   isPromptContextRecordCompatible,
-  isPromptContextRecordValid,
   type PromptContextRecordV1,
-  type PromptContextRecordV2,
   type PromptContextRecordV3,
-  type PromptContextSnapshot,
-  promptContextSnapshot,
   replacePromptRepositoryV1,
   replacePromptSkillsV2,
 } from "./prompt-assembly.js";
@@ -103,13 +96,22 @@ import {
   sessionDurableOutputLimits,
 } from "./session-durable-context.js";
 import {
-  isSkillActivationBatchTransitionValid,
-  isSkillContextCatalogSuccessor,
-  isSkillContextPathSuccessor,
+  addContextUsageTotals,
+  areReplayProfilesCompatible,
+  attemptStatus,
+  contextSnapshotFromRecords,
+  contextUsageSnapshotFromRecords,
+  isCompleteBranchBoundary,
+  isGenesisRecord,
+  type ModelResponseArtifactDegradation,
+  type ModelResponseArtifactInspection,
+  promptContextRecordFromRecords,
+  skillContextRecordFromRecords,
+  snapshotFromGenesis,
+  snapshotFromRecords,
 } from "./session-history-folds.js";
 import {
   inlineModelResponseField,
-  modelMessagesFromCanonicalRecords,
   modelMessagesFromCompleteRecords,
 } from "./session-history-replay.js";
 import {
@@ -118,6 +120,13 @@ import {
 } from "./session-history-validation.js";
 import { SessionLifecycleError } from "./session-lifecycle-error.js";
 import { normalizedSessionTitle, sessionTitleFallback } from "./session-naming.js";
+import type {
+  CurrentSessionSnapshot,
+  SessionContextSnapshot,
+  SessionContextUsageSnapshot,
+  SessionResumeResult,
+  SessionSnapshot,
+} from "./session-snapshot-contracts.js";
 import {
   createJsonlSessionStoreDirectory,
   type SessionGenesisRecord,
@@ -131,7 +140,6 @@ import {
   buildSkillResourceManifestV1,
   createInitialSkillContextV1,
   type ExtensionSkillSourceV1,
-  isSkillContextRecordV1Valid,
   reconcileExtensionSkillContextV1,
   reloadSkillContextV1,
   type SkillContextRecordV1,
@@ -154,106 +162,14 @@ import {
 
 export type { McpSessionSnapshot } from "./mcp-host.js";
 export { SessionLifecycleError } from "./session-lifecycle-error.js";
-
-export type CurrentSessionSnapshot = {
-  readonly schemaVersion: 3;
-  readonly sessionId: string;
-  readonly projectId: string;
-  readonly targetIdentity: ModelTargetIdentity;
-  readonly status: "idle" | "interrupted" | "settled";
-  readonly lastSequence: number;
-  readonly mcp?: McpSessionSnapshot;
-  readonly promptContext?: PromptContextSnapshot;
-  readonly skillContext?: SkillContextSnapshot;
-  readonly context?: SessionContextSnapshot;
-  readonly degradation?: {
-    readonly code: "model_response_artifact_corrupt" | "model_response_artifact_missing";
-    readonly artifactId: string;
-    readonly field: "reasoning" | "text";
-    readonly responseSequence: number;
-  };
-  readonly lineage?: SessionGenesisRecord["record"]["lineage"];
-  readonly run?: {
-    readonly runId: string;
-    readonly status: "interrupted" | "settled";
-    readonly result?: RunResult;
-    readonly lastAttempt?: {
-      readonly turn: number;
-      readonly attempt: number;
-      readonly status: "started" | "interrupted" | "completed";
-    };
-    readonly lastCompletedResponse?: {
-      readonly turn: number;
-      readonly attempt: number;
-      readonly finishReason: "length" | "stop" | "tool_calls";
-    };
-  };
-};
-
-export type SessionContextSnapshot = {
-  readonly profile: ContextProfile;
-  readonly checkpoint?: {
-    readonly checkpointId: string;
-    readonly sequence: number;
-    readonly windowNumber: number;
-    readonly status: "committed";
-    readonly sourceThrough: number;
-    readonly retainedFrom: number;
-  };
-  readonly lastAttempt: {
-    readonly attemptId: string;
-    readonly attemptNumber: number;
-    readonly windowNumber: number;
-    readonly status: "started" | "committed" | "failed" | "interrupted";
-    readonly reason?: string;
-    readonly usage:
-      | { readonly status: "unknown" }
-      | {
-          readonly inputTokens: number;
-          readonly outputTokens: number;
-          readonly reasoningTokens?: number;
-          readonly cachedInputTokens?: number;
-          readonly cacheMissInputTokens?: number;
-        };
-  };
-  readonly ordinaryUsage: ContextUsageTotals;
-  readonly compactionUsage: ContextUsageTotals;
-  readonly active:
-    | { readonly source: "provider_reported"; readonly tokens: number }
-    | { readonly source: "estimated"; readonly tokens: number }
-    | { readonly source: "unknown" };
-};
-
-export type SessionContextUsageSnapshot = Pick<
+export type {
+  CurrentSessionSnapshot,
+  LegacySessionSnapshot,
   SessionContextSnapshot,
-  "active" | "compactionUsage" | "ordinaryUsage"
->;
-
-export type LegacySessionSnapshot = {
-  readonly schemaVersion: 1 | 2;
-  readonly sessionId: string;
-  readonly projectId: string;
-  readonly status: "legacy";
-  readonly lastSequence: number;
-};
-
-export type SessionSnapshot = CurrentSessionSnapshot | LegacySessionSnapshot;
-
-export type SessionResumeResult =
-  | { readonly status: "ready"; readonly snapshot: CurrentSessionSnapshot }
-  | {
-      readonly status: "rejected";
-      readonly snapshot: SessionSnapshot;
-      readonly error: {
-        readonly code:
-          | "model_target_incompatible"
-          | "model_target_unavailable"
-          | "prompt_profile_incompatible"
-          | "non_resumable_legacy_session"
-          | "session_replay_unavailable";
-        readonly message: string;
-      };
-    };
+  SessionContextUsageSnapshot,
+  SessionResumeResult,
+  SessionSnapshot,
+} from "./session-snapshot-contracts.js";
 
 /** Tests only. Production activation settlement has no artificial publication barrier. */
 export const mcpActivationSettlementBarrier = Symbol(
@@ -3808,10 +3724,6 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
   };
 }
 
-function isGenesisRecord(record: SessionRecord): record is SessionGenesisRecord {
-  return record.schemaVersion === 3 && record.record.type === "session_genesis";
-}
-
 function boundedTitleInput(input: string): string {
   let normalized = "";
   for (const character of input) {
@@ -4600,643 +4512,6 @@ async function readValidatedLineagePrefix(
   return { parentGenesis, prefixRecords };
 }
 
-function isCompleteBranchBoundary(records: readonly SessionRecord[]): boolean {
-  const currentRecords = records.filter((record) => record.schemaVersion === 3);
-  if (currentRecords.length !== records.length || currentRecords.length === 0) {
-    return false;
-  }
-  const latestRun = currentRecords.findLast(
-    (record) => record.record.type === "logical_run_started",
-  );
-  if (latestRun === undefined) {
-    const first = records[0];
-    return (
-      first !== undefined &&
-      isGenesisRecord(first) &&
-      currentRecords
-        .slice(1)
-        .every(
-          (entry) =>
-            ((entry.record.type === "repository_instructions_committed" ||
-              entry.record.type === "repository_instructions_failed") &&
-              entry.record.trigger === undefined) ||
-            entry.record.type === "skill_catalog_committed" ||
-            entry.record.type === "skill_catalog_failed" ||
-            entry.record.type === "skill_revoked" ||
-            entry.record.type === "mcp_workspace_confirmed" ||
-            entry.record.type === "mcp_server_definition_approved" ||
-            entry.record.type === "mcp_activation_started" ||
-            entry.record.type === "mcp_activation_settled" ||
-            entry.record.type === "mcp_tool_profile_committed",
-        )
-    );
-  }
-  if (latestRun.record.type !== "logical_run_started") {
-    return false;
-  }
-  const runId = latestRun.record.runId;
-  const lastAttempt = currentRecords.findLast(
-    (record) => record.record.type === "provider_attempt_started" && record.record.runId === runId,
-  );
-  if (
-    lastAttempt?.record.type === "provider_attempt_started" &&
-    attemptStatus(currentRecords, lastAttempt.record) === "started"
-  ) {
-    return false;
-  }
-  const lastResponse = currentRecords.findLast(
-    (record) => record.record.type === "model_response_completed" && record.record.runId === runId,
-  );
-  if (
-    lastResponse?.record.type !== "model_response_completed" ||
-    lastResponse.record.response.finishReason !== "tool_calls"
-  ) {
-    return true;
-  }
-  return lastResponse.record.response.toolCalls.every((call) =>
-    currentRecords.some(
-      (candidate) =>
-        candidate.sequence > lastResponse.sequence &&
-        candidate.record.type === "runtime_event" &&
-        candidate.record.runId === runId &&
-        (candidate.record.event.type === "tool_completed" ||
-          candidate.record.event.type === "tool_failed") &&
-        candidate.record.event.callId === call.id &&
-        candidate.record.event.name === call.name,
-    ),
-  );
-}
-
-function areReplayProfilesCompatible(
-  left: ModelTargetIdentity,
-  right: ModelTargetIdentity,
-): boolean {
-  return (
-    left.vendor === right.vendor &&
-    left.route === right.route &&
-    left.upstreamProviderId === right.upstreamProviderId &&
-    left.profileVersion === right.profileVersion
-  );
-}
-
-function snapshotFromGenesis(
-  genesis: SessionGenesisRecord,
-  lastSequence: number,
-): CurrentSessionSnapshot {
-  return {
-    schemaVersion: 3,
-    sessionId: genesis.record.sessionId,
-    projectId: genesis.record.projectId,
-    targetIdentity: genesis.record.targetIdentity,
-    status: "idle",
-    lastSequence,
-    ...(genesis.record.promptContext === undefined
-      ? {}
-      : { promptContext: promptContextSnapshot(genesis.record.promptContext) }),
-    ...(genesis.record.skillContext === undefined
-      ? {}
-      : { skillContext: skillContextSnapshot(genesis.record.skillContext) }),
-    ...(genesis.record.lineage === undefined ? {} : { lineage: genesis.record.lineage }),
-  };
-}
-
-function promptContextSnapshotFromRecords(
-  genesis: SessionGenesisRecord,
-  records: readonly SessionRecord[],
-): PromptContextSnapshot | undefined {
-  const context = promptContextRecordFromRecords(genesis, records);
-  if (context === undefined) {
-    return undefined;
-  }
-  const snapshot = promptContextSnapshot(context);
-  const latestProjection = records.findLast(
-    (entry) =>
-      entry.schemaVersion === 3 &&
-      entry.record.type === "provider_attempt_started" &&
-      entry.record.promptProjection !== undefined,
-  );
-  return latestProjection?.schemaVersion === 3 &&
-    latestProjection.record.type === "provider_attempt_started" &&
-    latestProjection.record.promptProjection !== undefined
-    ? {
-        ...snapshot,
-        lastRequestProjectionDigest:
-          latestProjection.record.promptProjection.requestProjectionDigest,
-      }
-    : snapshot;
-}
-
-function promptContextRecordFromRecords(
-  genesis: SessionGenesisRecord,
-  records: readonly SessionRecord[],
-): SessionGenesisRecord["record"]["promptContext"] {
-  let context = genesis.record.promptContext;
-  for (const entry of records) {
-    if (entry.schemaVersion !== 3) {
-      continue;
-    }
-    if (entry.record.type === "repository_instructions_committed") {
-      if (
-        context === undefined ||
-        entry.record.previousRevision !== context.repository.revision ||
-        entry.record.previousEffectiveDigest !== context.repository.effectiveDigest ||
-        entry.record.repository.revision !== context.repository.revision + 1
-      ) {
-        throw new SessionLifecycleError("session_invalid");
-      }
-      const next = replacePromptRepositoryV1(context, entry.record.repository);
-      if (
-        next.assemblyIdentityDigest !== entry.record.assemblyIdentityDigest ||
-        !isPromptContextRecordValid(next)
-      ) {
-        throw new SessionLifecycleError("session_invalid");
-      }
-      context = next;
-      continue;
-    }
-    if (entry.record.type === "mcp_tool_profile_committed") {
-      if (
-        context?.recordVersion !== 3 ||
-        context.mcp !== undefined ||
-        entry.record.previousAssemblyIdentityDigest !== context.assemblyIdentityDigest
-      ) {
-        throw new SessionLifecycleError("session_invalid");
-      }
-      const next = commitMcpToolProfileV3(context, entry.record.profile);
-      if (
-        next.assemblyIdentityDigest !== entry.record.assemblyIdentityDigest ||
-        !isPromptContextRecordValid(next)
-      ) {
-        throw new SessionLifecycleError("session_invalid");
-      }
-      context = next;
-      continue;
-    }
-    if (entry.record.type === "path_context_committed") {
-      if (
-        !hasSkillPromptContext(context) ||
-        entry.record.previousRepositoryRevision !== context.repository.revision ||
-        entry.record.previousRepositoryDigest !== context.repository.effectiveDigest ||
-        entry.record.repository.revision !== context.repository.revision + 1
-      ) {
-        throw new SessionLifecycleError("session_invalid");
-      }
-      let next = replacePromptRepositoryV1(context, entry.record.repository) as
-        | PromptContextRecordV2
-        | PromptContextRecordV3;
-      next = replacePromptSkillsV2(next, entry.record.skillContext);
-      if (
-        next.assemblyIdentityDigest !== entry.record.assemblyIdentityDigest ||
-        !isPromptContextRecordValid(next)
-      ) {
-        throw new SessionLifecycleError("session_invalid");
-      }
-      context = next;
-      continue;
-    }
-    if (entry.record.type === "skill_activation_batch_committed") {
-      if (!hasSkillPromptContext(context)) {
-        throw new SessionLifecycleError("session_invalid");
-      }
-      const next = replacePromptSkillsV2(context, entry.record.skillContext);
-      if (
-        next.assemblyIdentityDigest !== entry.record.assemblyIdentityDigest ||
-        !isPromptContextRecordValid(next)
-      ) {
-        throw new SessionLifecycleError("session_invalid");
-      }
-      context = next;
-    }
-    if (entry.record.type === "skill_catalog_committed") {
-      if (!hasSkillPromptContext(context)) {
-        throw new SessionLifecycleError("session_invalid");
-      }
-      const next = replacePromptSkillsV2(context, entry.record.skillContext);
-      if (
-        next.assemblyIdentityDigest !== entry.record.assemblyIdentityDigest ||
-        !isPromptContextRecordValid(next)
-      ) {
-        throw new SessionLifecycleError("session_invalid");
-      }
-      context = next;
-    }
-  }
-  return context;
-}
-
-function skillContextRecordFromRecords(
-  genesis: SessionGenesisRecord,
-  records: readonly SessionRecord[],
-): SkillContextRecordV1 | undefined {
-  let context = genesis.record.skillContext;
-  for (const entry of records) {
-    if (
-      entry.schemaVersion !== 3 ||
-      (entry.record.type !== "skill_activation_batch_committed" &&
-        entry.record.type !== "skill_catalog_committed" &&
-        entry.record.type !== "path_context_committed")
-    ) {
-      continue;
-    }
-    if (entry.record.type === "skill_catalog_committed") {
-      if (
-        context === undefined ||
-        entry.record.previousRevision !== context.registry.revision ||
-        entry.record.previousRegistryDigest !== context.registry.digest ||
-        !isSkillContextRecordV1Valid(entry.record.skillContext) ||
-        !isSkillContextCatalogSuccessor(context, entry.record.skillContext)
-      ) {
-        throw new SessionLifecycleError("session_invalid");
-      }
-      context = entry.record.skillContext;
-      continue;
-    }
-    if (entry.record.type === "path_context_committed") {
-      if (
-        context === undefined ||
-        entry.record.previousSkillRevision !== context.registry.revision ||
-        entry.record.previousSkillRegistryDigest !== context.registry.digest ||
-        !isSkillContextRecordV1Valid(entry.record.skillContext) ||
-        !isSkillContextPathSuccessor(context, entry.record.skillContext)
-      ) {
-        throw new SessionLifecycleError("session_invalid");
-      }
-      context = entry.record.skillContext;
-      continue;
-    }
-    if (
-      context === undefined ||
-      entry.record.previousActivationDigest !== context.activationDigest ||
-      !isSkillContextRecordV1Valid(entry.record.skillContext) ||
-      !isSkillActivationBatchTransitionValid(context, entry.record.skillContext, entry.record)
-    ) {
-      throw new SessionLifecycleError("session_invalid");
-    }
-    context = entry.record.skillContext;
-  }
-  return context;
-}
-
-function contextSnapshotFromRecords(
-  records: readonly SessionRecord[],
-): SessionContextSnapshot | undefined {
-  const currentRecords = records.filter((record) => record.schemaVersion === 3);
-  const checkpoint = currentRecords.findLast(
-    (record) => record.record.type === "context_compaction_committed",
-  );
-  const started = currentRecords.findLast(
-    (record) => record.record.type === "context_compaction_started",
-  );
-  const checkpointRecord =
-    checkpoint?.record.type === "context_compaction_committed" ? checkpoint.record : undefined;
-  const startedRecord =
-    started?.record.type === "context_compaction_started" ? started.record : undefined;
-  if (checkpointRecord === undefined && startedRecord === undefined) {
-    return undefined;
-  }
-  const compactionUsage = compactionContextUsageFromRecords(currentRecords);
-  const ordinaryUsage = ordinaryContextUsageFromRecords(currentRecords);
-  const lastTerminal =
-    startedRecord === undefined
-      ? undefined
-      : currentRecords.findLast(
-          (record) =>
-            record.sequence > (started?.sequence ?? 0) &&
-            (record.record.type === "context_compaction_committed" ||
-              record.record.type === "context_compaction_failed" ||
-              record.record.type === "context_compaction_interrupted") &&
-            record.record.attemptId === startedRecord.attemptId,
-        );
-  const terminalRecord =
-    lastTerminal?.record.type === "context_compaction_committed" ||
-    lastTerminal?.record.type === "context_compaction_failed" ||
-    lastTerminal?.record.type === "context_compaction_interrupted"
-      ? lastTerminal.record
-      : undefined;
-  const lastAttemptUsage =
-    terminalRecord?.usage === undefined ? ({ status: "unknown" } as const) : terminalRecord.usage;
-  const lastAttemptStatus =
-    terminalRecord?.type === "context_compaction_committed"
-      ? ("committed" as const)
-      : terminalRecord?.type === "context_compaction_failed"
-        ? ("failed" as const)
-        : terminalRecord?.type === "context_compaction_interrupted"
-          ? ("interrupted" as const)
-          : ("started" as const);
-  const latestResponse = currentRecords.findLast(
-    (record) =>
-      record.sequence > (checkpoint?.sequence ?? Number.MAX_SAFE_INTEGER) &&
-      record.record.type === "model_response_completed",
-  );
-  const active =
-    latestResponse?.record.type === "model_response_completed" &&
-    latestResponse.record.response.usage !== undefined
-      ? {
-          source: "provider_reported" as const,
-          tokens: latestResponse.record.response.usage.inputTokens,
-        }
-      : checkpointRecord !== undefined
-        ? {
-            source: "estimated" as const,
-            tokens: estimateActiveContextTokens(
-              [
-                createContextProjectionMessage(checkpointRecord.summary, checkpointRecord.evidence),
-                ...modelMessagesFromCanonicalRecords(
-                  currentRecords.filter(
-                    (record) =>
-                      record.sequence >= checkpointRecord.retainedFrom &&
-                      record.sequence <= checkpointRecord.sourceThrough,
-                  ),
-                ),
-              ],
-              checkpointRecord.contextProfile,
-            ),
-          }
-        : { source: "unknown" as const };
-  return {
-    profile:
-      startedRecord?.contextProfile ??
-      (checkpointRecord as NonNullable<typeof checkpointRecord>).contextProfile,
-    ...(checkpointRecord === undefined || checkpoint === undefined
-      ? {}
-      : {
-          checkpoint: {
-            checkpointId: checkpointRecord.checkpointId,
-            sequence: checkpoint.sequence,
-            windowNumber: checkpointRecord.windowNumber,
-            status: "committed" as const,
-            sourceThrough: checkpointRecord.sourceThrough,
-            retainedFrom: checkpointRecord.retainedFrom,
-          },
-        }),
-    lastAttempt: {
-      attemptId:
-        startedRecord?.attemptId ??
-        (checkpointRecord as NonNullable<typeof checkpointRecord>).attemptId,
-      attemptNumber:
-        startedRecord?.attemptNumber ??
-        (checkpointRecord as NonNullable<typeof checkpointRecord>).attemptNumber,
-      windowNumber:
-        startedRecord?.windowNumber ??
-        (checkpointRecord as NonNullable<typeof checkpointRecord>).windowNumber,
-      status: lastAttemptStatus,
-      ...(terminalRecord?.type === "context_compaction_failed" ||
-      terminalRecord?.type === "context_compaction_interrupted"
-        ? { reason: terminalRecord.reason }
-        : {}),
-      usage: lastAttemptUsage,
-    },
-    ordinaryUsage,
-    compactionUsage,
-    active,
-  };
-}
-
-function contextUsageSnapshotFromRecords(
-  records: readonly SessionRecord[],
-): SessionContextUsageSnapshot | undefined {
-  const currentRecords = records.filter((record) => record.schemaVersion === 3);
-  if (
-    !currentRecords.some(
-      ({ record }) =>
-        record.type === "provider_attempt_started" ||
-        record.type === "context_compaction_started" ||
-        record.type === "context_compaction_committed" ||
-        record.type === "context_compaction_failed" ||
-        record.type === "context_compaction_interrupted",
-    )
-  ) {
-    return undefined;
-  }
-  const latestAttemptBoundary = currentRecords.findLast(
-    ({ record }) =>
-      record.type === "provider_attempt_started" ||
-      record.type === "model_response_completed" ||
-      record.type === "provider_attempt_interrupted",
-  );
-  return {
-    ordinaryUsage: ordinaryContextUsageFromRecords(currentRecords),
-    compactionUsage: compactionContextUsageFromRecords(currentRecords),
-    active:
-      latestAttemptBoundary?.record.type === "model_response_completed" &&
-      latestAttemptBoundary.record.response.usage !== undefined
-        ? {
-            source: "provider_reported",
-            tokens: latestAttemptBoundary.record.response.usage.inputTokens,
-          }
-        : { source: "unknown" },
-  };
-}
-
-function compactionContextUsageFromRecords(
-  records: readonly Extract<SessionRecord, { readonly schemaVersion: 3 }>[],
-): ContextUsageTotals {
-  return records.reduce<ContextUsageTotals>((totals, entry) => {
-    if (
-      entry.record.type !== "context_compaction_committed" &&
-      entry.record.type !== "context_compaction_failed" &&
-      entry.record.type !== "context_compaction_interrupted"
-    ) {
-      return totals;
-    }
-    const usage = entry.record.usage;
-    if (usage === undefined || "status" in usage) {
-      return incrementUnknownContextUsage(totals);
-    }
-    return {
-      inputTokens: totals.inputTokens + usage.inputTokens,
-      outputTokens: totals.outputTokens + usage.outputTokens,
-      reasoningTokens: totals.reasoningTokens + (usage.reasoningTokens ?? 0),
-      cachedInputTokens: totals.cachedInputTokens + (usage.cachedInputTokens ?? 0),
-      cacheMissInputTokens: totals.cacheMissInputTokens + (usage.cacheMissInputTokens ?? 0),
-      unknownCalls: totals.unknownCalls,
-    };
-  }, emptyContextUsageTotals());
-}
-
-function addContextUsageTotals(
-  left: ContextUsageTotals,
-  right: ContextUsageTotals,
-): ContextUsageTotals {
-  return {
-    inputTokens: left.inputTokens + right.inputTokens,
-    outputTokens: left.outputTokens + right.outputTokens,
-    reasoningTokens: left.reasoningTokens + right.reasoningTokens,
-    cachedInputTokens: left.cachedInputTokens + right.cachedInputTokens,
-    cacheMissInputTokens: left.cacheMissInputTokens + right.cacheMissInputTokens,
-    unknownCalls: left.unknownCalls + right.unknownCalls,
-  };
-}
-
-function emptyContextUsageTotals(): ContextUsageTotals {
-  return {
-    inputTokens: 0,
-    outputTokens: 0,
-    reasoningTokens: 0,
-    cachedInputTokens: 0,
-    cacheMissInputTokens: 0,
-    unknownCalls: 0,
-  };
-}
-
-function incrementUnknownContextUsage(totals: ContextUsageTotals): ContextUsageTotals {
-  return {
-    inputTokens: totals.inputTokens,
-    outputTokens: totals.outputTokens,
-    reasoningTokens: totals.reasoningTokens,
-    cachedInputTokens: totals.cachedInputTokens,
-    cacheMissInputTokens: totals.cacheMissInputTokens,
-    unknownCalls: totals.unknownCalls + 1,
-  };
-}
-
-function ordinaryContextUsageFromRecords(
-  records: readonly Extract<SessionRecord, { readonly schemaVersion: 3 }>[],
-): ContextUsageTotals {
-  let totals: ContextUsageTotals = {
-    inputTokens: 0,
-    outputTokens: 0,
-    reasoningTokens: 0,
-    cachedInputTokens: 0,
-    cacheMissInputTokens: 0,
-    unknownCalls: 0,
-  };
-  let attemptStarted = false;
-  let usageSeen = false;
-  for (const entry of records) {
-    const record = entry.record;
-    if (record.type === "provider_attempt_started") {
-      attemptStarted = true;
-      usageSeen = false;
-      continue;
-    }
-    if (record.type === "runtime_event" && record.event.type === "model_usage" && attemptStarted) {
-      usageSeen = true;
-      totals = {
-        inputTokens: totals.inputTokens + record.event.inputTokens,
-        outputTokens: totals.outputTokens + record.event.outputTokens,
-        reasoningTokens: totals.reasoningTokens + (record.event.reasoningTokens ?? 0),
-        cachedInputTokens: totals.cachedInputTokens + (record.event.cachedInputTokens ?? 0),
-        cacheMissInputTokens:
-          totals.cacheMissInputTokens + (record.event.cacheMissInputTokens ?? 0),
-        unknownCalls: totals.unknownCalls,
-      };
-      continue;
-    }
-    if (
-      attemptStarted &&
-      (record.type === "model_response_completed" || record.type === "provider_attempt_interrupted")
-    ) {
-      if (!usageSeen) {
-        totals = incrementUnknownContextUsage(totals);
-      }
-      attemptStarted = false;
-      usageSeen = false;
-    }
-  }
-  return totals;
-}
-
-function snapshotFromRecords(
-  genesis: SessionGenesisRecord,
-  records: readonly SessionRecord[],
-  artifactInspection?: ModelResponseArtifactInspection,
-): CurrentSessionSnapshot {
-  if (records.some((record) => record.schemaVersion !== 3)) {
-    throw new SessionLifecycleError("session_invalid");
-  }
-  const currentRecords = records.filter((record) => record.schemaVersion === 3);
-  const context = contextSnapshotFromRecords(records);
-  const latestRun = currentRecords.findLast(
-    (record) => record.record.type === "logical_run_started",
-  );
-  if (latestRun === undefined || latestRun.record.type !== "logical_run_started") {
-    const promptContext = promptContextSnapshotFromRecords(genesis, records);
-    const skillContext = skillContextRecordFromRecords(genesis, records);
-    return {
-      ...snapshotFromGenesis(genesis, records.length),
-      ...(promptContext === undefined ? {} : { promptContext }),
-      ...(skillContext === undefined ? {} : { skillContext: skillContextSnapshot(skillContext) }),
-      ...(context === undefined ? {} : { context }),
-      ...(artifactInspection?.degradation === undefined
-        ? {}
-        : { degradation: artifactInspection.degradation }),
-    };
-  }
-  const runId = latestRun.record.runId;
-  const lastResponse = currentRecords.findLast(
-    (record) => record.record.type === "model_response_completed" && record.record.runId === runId,
-  );
-  const settlement = currentRecords.findLast(
-    (record) =>
-      record.record.type === "runtime_event" &&
-      record.record.runId === runId &&
-      record.record.event.type === "session_settled",
-  );
-  const linkedSettlement = currentRecords.findLast(
-    (record) => record.record.type === "run_settled" && record.record.runId === runId,
-  );
-  const lastAttemptStarted = currentRecords.findLast(
-    (record) => record.record.type === "provider_attempt_started" && record.record.runId === runId,
-  );
-  const lastAttempt =
-    lastAttemptStarted?.record.type !== "provider_attempt_started"
-      ? undefined
-      : {
-          turn: lastAttemptStarted.record.turn,
-          attempt: lastAttemptStarted.record.attempt,
-          status: attemptStatus(currentRecords, lastAttemptStarted.record),
-        };
-  const result =
-    settlement?.record.type === "runtime_event" &&
-    settlement.record.event.type === "session_settled"
-      ? settlement.record.event.result
-      : linkedSettlement?.record.type === "run_settled"
-        ? artifactInspection?.contents.get(linkedSettlement.record.responseSequence) === undefined
-          ? undefined
-          : linkedSettlement.record.status === "completed"
-            ? {
-                status: "completed" as const,
-                answer: artifactInspection.contents.get(linkedSettlement.record.responseSequence)
-                  ?.text as string,
-              }
-            : {
-                status: "incomplete" as const,
-                reason: linkedSettlement.record.reason,
-                answer: artifactInspection.contents.get(linkedSettlement.record.responseSequence)
-                  ?.text as string,
-              }
-        : undefined;
-  const isSettled = settlement !== undefined || linkedSettlement !== undefined;
-  const promptContext = promptContextSnapshotFromRecords(genesis, records);
-  const skillContext = skillContextRecordFromRecords(genesis, records);
-  return {
-    ...snapshotFromGenesis(genesis, records.length),
-    ...(promptContext === undefined ? {} : { promptContext }),
-    ...(skillContext === undefined ? {} : { skillContext: skillContextSnapshot(skillContext) }),
-    ...(context === undefined ? {} : { context }),
-    ...(artifactInspection?.degradation === undefined
-      ? {}
-      : { degradation: artifactInspection.degradation }),
-    status: isSettled ? "settled" : "interrupted",
-    run: {
-      runId,
-      status: isSettled ? "settled" : "interrupted",
-      ...(result === undefined ? {} : { result }),
-      ...(lastAttempt === undefined ? {} : { lastAttempt }),
-      ...(lastResponse?.record.type !== "model_response_completed"
-        ? {}
-        : {
-            lastCompletedResponse: {
-              turn: lastResponse.record.turn,
-              attempt: lastResponse.record.attempt,
-              finishReason: lastResponse.record.response.finishReason,
-            },
-          }),
-    },
-  };
-}
-
 async function appendDanglingAttemptInterruption(
   options: SessionLifecycleOptions,
   snapshot: CurrentSessionSnapshot,
@@ -5854,32 +5129,6 @@ function isExactToolIntent(
   );
 }
 
-function attemptStatus(
-  records: readonly Extract<SessionRecord, { readonly schemaVersion: 3 }>[],
-  attempt: {
-    readonly runId: string;
-    readonly turn: number;
-    readonly attempt: number;
-  },
-): "started" | "interrupted" | "completed" {
-  const matching = records.filter(
-    (record) =>
-      "runId" in record.record &&
-      record.record.runId === attempt.runId &&
-      "turn" in record.record &&
-      record.record.turn === attempt.turn &&
-      "attempt" in record.record &&
-      record.record.attempt === attempt.attempt,
-  );
-  if (matching.some((record) => record.record.type === "model_response_completed")) {
-    return "completed";
-  }
-  if (matching.some((record) => record.record.type === "provider_attempt_interrupted")) {
-    return "interrupted";
-  }
-  return "started";
-}
-
 function createAgentResumeState(
   records: readonly SessionRecord[],
   options: SessionLifecycleOptions,
@@ -6327,15 +5576,6 @@ async function resolveExtensionSkillSources(
     lifecycleDigest: source.lifecycleDigest,
   }));
 }
-
-type ModelResponseArtifactDegradation = NonNullable<CurrentSessionSnapshot["degradation"]>;
-
-type ModelResponseArtifactInspection = {
-  readonly contents: ReadonlyMap<number, { readonly text: string; readonly reasoning?: string }>;
-  readonly degradation?: ModelResponseArtifactDegradation;
-  readonly logicalReferencedBytes: number;
-  readonly records: readonly SessionRecord[];
-};
 
 type ResolvedModelResponseArtifact =
   | { readonly byteCount: number; readonly text: string }

--- a/packages/agent/src/session-snapshot-contracts.ts
+++ b/packages/agent/src/session-snapshot-contracts.ts
@@ -1,0 +1,107 @@
+import type { ContextUsageTotals, RunResult } from "./agent-session-contracts.js";
+import type { ContextProfile } from "./context-profile.js";
+import type { McpSessionSnapshot } from "./mcp-host.js";
+import type { ModelTargetIdentity } from "./model-targets.js";
+import type { PromptContextSnapshot } from "./prompt-assembly.js";
+import type { SessionGenesisRecord } from "./session-store.js";
+import type { SkillContextSnapshot } from "./skills.js";
+
+export type CurrentSessionSnapshot = {
+  readonly schemaVersion: 3;
+  readonly sessionId: string;
+  readonly projectId: string;
+  readonly targetIdentity: ModelTargetIdentity;
+  readonly status: "idle" | "interrupted" | "settled";
+  readonly lastSequence: number;
+  readonly mcp?: McpSessionSnapshot;
+  readonly promptContext?: PromptContextSnapshot;
+  readonly skillContext?: SkillContextSnapshot;
+  readonly context?: SessionContextSnapshot;
+  readonly degradation?: {
+    readonly code: "model_response_artifact_corrupt" | "model_response_artifact_missing";
+    readonly artifactId: string;
+    readonly field: "reasoning" | "text";
+    readonly responseSequence: number;
+  };
+  readonly lineage?: SessionGenesisRecord["record"]["lineage"];
+  readonly run?: {
+    readonly runId: string;
+    readonly status: "interrupted" | "settled";
+    readonly result?: RunResult;
+    readonly lastAttempt?: {
+      readonly turn: number;
+      readonly attempt: number;
+      readonly status: "started" | "interrupted" | "completed";
+    };
+    readonly lastCompletedResponse?: {
+      readonly turn: number;
+      readonly attempt: number;
+      readonly finishReason: "length" | "stop" | "tool_calls";
+    };
+  };
+};
+
+export type SessionContextSnapshot = {
+  readonly profile: ContextProfile;
+  readonly checkpoint?: {
+    readonly checkpointId: string;
+    readonly sequence: number;
+    readonly windowNumber: number;
+    readonly status: "committed";
+    readonly sourceThrough: number;
+    readonly retainedFrom: number;
+  };
+  readonly lastAttempt: {
+    readonly attemptId: string;
+    readonly attemptNumber: number;
+    readonly windowNumber: number;
+    readonly status: "started" | "committed" | "failed" | "interrupted";
+    readonly reason?: string;
+    readonly usage:
+      | { readonly status: "unknown" }
+      | {
+          readonly inputTokens: number;
+          readonly outputTokens: number;
+          readonly reasoningTokens?: number;
+          readonly cachedInputTokens?: number;
+          readonly cacheMissInputTokens?: number;
+        };
+  };
+  readonly ordinaryUsage: ContextUsageTotals;
+  readonly compactionUsage: ContextUsageTotals;
+  readonly active:
+    | { readonly source: "provider_reported"; readonly tokens: number }
+    | { readonly source: "estimated"; readonly tokens: number }
+    | { readonly source: "unknown" };
+};
+
+export type SessionContextUsageSnapshot = Pick<
+  SessionContextSnapshot,
+  "active" | "compactionUsage" | "ordinaryUsage"
+>;
+
+export type LegacySessionSnapshot = {
+  readonly schemaVersion: 1 | 2;
+  readonly sessionId: string;
+  readonly projectId: string;
+  readonly status: "legacy";
+  readonly lastSequence: number;
+};
+
+export type SessionSnapshot = CurrentSessionSnapshot | LegacySessionSnapshot;
+
+export type SessionResumeResult =
+  | { readonly status: "ready"; readonly snapshot: CurrentSessionSnapshot }
+  | {
+      readonly status: "rejected";
+      readonly snapshot: SessionSnapshot;
+      readonly error: {
+        readonly code:
+          | "model_target_incompatible"
+          | "model_target_unavailable"
+          | "prompt_profile_incompatible"
+          | "non_resumable_legacy_session"
+          | "session_replay_unavailable";
+        readonly message: string;
+      };
+    };

--- a/packages/testkit/src/public-product-contract.test.ts
+++ b/packages/testkit/src/public-product-contract.test.ts
@@ -236,7 +236,7 @@ test("the agent root facade detector covers relative and package self-references
   expect(moduleSpecifiers('export * as facade from "./index.js";')).toEqual(["./index.js"]);
 });
 
-test("SessionLifecycle canonical validation and replay have package-internal owners", async () => {
+test("SessionLifecycle canonical history projections have package-internal owners", async () => {
   const agentSourceRoot = join(productRoot, "packages", "agent", "src");
   const sourceFiles = (await readdir(agentSourceRoot, { recursive: true }))
     .filter((entry) => entry.endsWith(".ts"))
@@ -249,14 +249,25 @@ test("SessionLifecycle canonical validation and replay have package-internal own
   );
   const expectedOwners = {
     SessionLifecycleError: ["session-lifecycle-error.ts"],
+    addContextUsageTotals: ["session-history-folds.ts"],
+    areReplayProfilesCompatible: ["session-history-folds.ts"],
+    attemptStatus: ["session-history-folds.ts"],
+    contextSnapshotFromRecords: ["session-history-folds.ts"],
+    contextUsageSnapshotFromRecords: ["session-history-folds.ts"],
     hasSuccessfullySettledAssistant: ["session-history-validation.ts"],
     inlineModelResponseField: ["session-history-replay.ts"],
+    isCompleteBranchBoundary: ["session-history-folds.ts"],
+    isGenesisRecord: ["session-history-folds.ts"],
     isSkillActivationBatchValid: ["session-history-folds.ts"],
     isSkillActivationBatchTransitionValid: ["session-history-folds.ts"],
     isSkillContextCatalogSuccessor: ["session-history-folds.ts"],
     isSkillContextPathSuccessor: ["session-history-folds.ts"],
     modelMessagesFromCanonicalRecords: ["session-history-replay.ts"],
     modelMessagesFromCompleteRecords: ["session-history-replay.ts"],
+    promptContextRecordFromRecords: ["session-history-folds.ts"],
+    skillContextRecordFromRecords: ["session-history-folds.ts"],
+    snapshotFromGenesis: ["session-history-folds.ts"],
+    snapshotFromRecords: ["session-history-folds.ts"],
     validateCurrentSessionHistory: ["session-history-validation.ts"],
   } as const;
   const actualOwners = Object.fromEntries(
@@ -277,12 +288,34 @@ test("SessionLifecycle canonical validation and replay have package-internal own
 
   expect.soft(actualOwners).toEqual(expectedOwners);
 
+  const expectedTypeOwners = {
+    CurrentSessionSnapshot: ["session-snapshot-contracts.ts"],
+    LegacySessionSnapshot: ["session-snapshot-contracts.ts"],
+    ModelResponseArtifactDegradation: ["session-history-folds.ts"],
+    ModelResponseArtifactInspection: ["session-history-folds.ts"],
+    SessionContextSnapshot: ["session-snapshot-contracts.ts"],
+    SessionContextUsageSnapshot: ["session-snapshot-contracts.ts"],
+    SessionResumeResult: ["session-snapshot-contracts.ts"],
+    SessionSnapshot: ["session-snapshot-contracts.ts"],
+  } as const;
+  const actualTypeOwners = Object.fromEntries(
+    Object.keys(expectedTypeOwners).map((symbol) => [
+      symbol,
+      sources
+        .filter(({ source }) => new RegExp(`\\bexport\\s+type\\s+${symbol}\\b`, "u").test(source))
+        .map(({ path }) => path),
+    ]),
+  );
+
+  expect.soft(actualTypeOwners).toEqual(expectedTypeOwners);
+
   const extractedSources = sources.filter(({ path }) =>
     [
       "session-history-folds.ts",
       "session-history-replay.ts",
       "session-history-validation.ts",
       "session-lifecycle-error.ts",
+      "session-snapshot-contracts.ts",
     ].includes(path),
   );
   const forbiddenImports = extractedSources.flatMap(({ path, source }) =>
@@ -339,10 +372,11 @@ test("SessionLifecycle canonical validation and replay have package-internal own
         .filter((testPath) => testPath !== fileURLToPath(import.meta.url))
         .map(async (testPath) =>
           moduleSpecifiers(await readFile(testPath, "utf8"))
-            .filter((specifier) =>
-              /(?:session-history-(?:folds|replay|validation)|session-lifecycle-error)\.js$/u.test(
-                specifier,
-              ),
+            .filter(
+              (specifier) =>
+                /(?:session-history-(?:folds|replay|validation)|session-lifecycle-error)\.js$/u.test(
+                  specifier,
+                ) || /session-snapshot-contracts\.js$/u.test(specifier),
             )
             .map((specifier) => ({
               path: relative(productRoot, testPath),
@@ -361,12 +395,16 @@ test("SessionLifecycle canonical validation and replay have package-internal own
         'export { SessionLifecycleError } from "./session-lifecycle-error.js";',
       ),
       replayImport: lifecycleSource.includes('from "./session-history-replay.js"'),
+      snapshotContractReferences: moduleSpecifiers(lifecycleSource).filter(
+        (specifier) => specifier === "./session-snapshot-contracts.js",
+      ).length,
       validationImport: lifecycleSource.includes('from "./session-history-validation.js"'),
     })
     .toEqual({
       errorImport: true,
       errorReexport: true,
       replayImport: true,
+      snapshotContractReferences: 2,
       validationImport: true,
     });
   for (const facadeSource of [publicFacadeSource, testingFacadeSource]) {
@@ -374,6 +412,7 @@ test("SessionLifecycle canonical validation and replay have package-internal own
     expect.soft(moduleSpecifiers(facadeSource)).not.toContain("./session-history-replay.js");
     expect.soft(moduleSpecifiers(facadeSource)).not.toContain("./session-history-validation.js");
     expect.soft(moduleSpecifiers(facadeSource)).not.toContain("./session-lifecycle-error.js");
+    expect.soft(moduleSpecifiers(facadeSource)).not.toContain("./session-snapshot-contracts.js");
   }
 });
 


### PR DESCRIPTION
Moves canonical session state, branch-boundary, prompt/Skill context, context-usage, and current-snapshot projections from SessionLifecycle into one package-internal history-fold owner. Moves the unchanged public snapshot/resume type contracts into a type-only internal owner while preserving their existing SessionLifecycle re-export path. Adds a structural guard for unique owners, facade boundaries, and direct-test imports. Public behavior, JSONL persistence, and package exports are unchanged. Local quality: 43 test files passed, 2 skipped; 1074 tests passed, 10 skipped. Three independent reviews reported 0 findings.