### PR TITLE
refactor: extract session naming history fold

### DIFF
--- a/packages/agent/src/session-history-folds.ts
+++ b/packages/agent/src/session-history-folds.ts
@@ -14,6 +14,7 @@ import {
 } from "./prompt-assembly.js";
 import { modelMessagesFromCanonicalRecords } from "./session-history-replay.js";
 import { SessionLifecycleError } from "./session-lifecycle-error.js";
+import { sessionTitleFallback } from "./session-naming.js";
 import type {
   CurrentSessionSnapshot,
   SessionContextSnapshot,
@@ -240,6 +241,32 @@ export type ModelResponseArtifactInspection = {
 
 export function isGenesisRecord(record: SessionRecord): record is SessionGenesisRecord {
   return record.schemaVersion === 3 && record.record.type === "session_genesis";
+}
+
+export function sessionDisplayLabelFromRecords(records: readonly SessionRecord[]): string {
+  const genesis = records[0];
+  let fallbackTitle =
+    genesis?.schemaVersion === 3 && genesis.record.type === "session_genesis"
+      ? (genesis.record.naming?.fallbackTitle ?? null)
+      : null;
+  let manualName: string | null = null;
+  let generatedTitle: string | null = null;
+  for (const entry of records) {
+    if (entry.schemaVersion !== 3) {
+      continue;
+    }
+    if (entry.record.type === "logical_run_started" && fallbackTitle === null) {
+      fallbackTitle =
+        entry.record.naming?.fallbackTitle ?? sessionTitleFallback(entry.record.userMessage);
+    } else if (entry.record.type === "session_manual_name_set") {
+      manualName = entry.record.name;
+    } else if (entry.record.type === "session_manual_name_cleared") {
+      manualName = null;
+    } else if (entry.record.type === "session_title_generation_completed") {
+      generatedTitle = entry.record.title;
+    }
+  }
+  return manualName ?? generatedTitle ?? fallbackTitle ?? "New session";
 }
 
 export function attemptStatus(

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -106,6 +106,7 @@ import {
   type ModelResponseArtifactDegradation,
   type ModelResponseArtifactInspection,
   promptContextRecordFromRecords,
+  sessionDisplayLabelFromRecords,
   skillContextRecordFromRecords,
   snapshotFromGenesis,
   snapshotFromRecords,
@@ -3739,32 +3740,6 @@ function boundedTitleInput(input: string): string {
     bounded += character;
   }
   return bounded;
-}
-
-function sessionDisplayLabelFromRecords(records: readonly SessionRecord[]): string {
-  const genesis = records[0];
-  let fallbackTitle =
-    genesis?.schemaVersion === 3 && genesis.record.type === "session_genesis"
-      ? (genesis.record.naming?.fallbackTitle ?? null)
-      : null;
-  let manualName: string | null = null;
-  let generatedTitle: string | null = null;
-  for (const entry of records) {
-    if (entry.schemaVersion !== 3) {
-      continue;
-    }
-    if (entry.record.type === "logical_run_started" && fallbackTitle === null) {
-      fallbackTitle =
-        entry.record.naming?.fallbackTitle ?? sessionTitleFallback(entry.record.userMessage);
-    } else if (entry.record.type === "session_manual_name_set") {
-      manualName = entry.record.name;
-    } else if (entry.record.type === "session_manual_name_cleared") {
-      manualName = null;
-    } else if (entry.record.type === "session_title_generation_completed") {
-      generatedTitle = entry.record.title;
-    }
-  }
-  return manualName ?? generatedTitle ?? fallbackTitle ?? "New session";
 }
 
 function mcpWorkspaceConfirmationFromRecords(

--- a/packages/testkit/src/public-product-contract.test.ts
+++ b/packages/testkit/src/public-product-contract.test.ts
@@ -265,6 +265,7 @@ test("SessionLifecycle canonical history projections have package-internal owner
     modelMessagesFromCanonicalRecords: ["session-history-replay.ts"],
     modelMessagesFromCompleteRecords: ["session-history-replay.ts"],
     promptContextRecordFromRecords: ["session-history-folds.ts"],
+    sessionDisplayLabelFromRecords: ["session-history-folds.ts"],
     skillContextRecordFromRecords: ["session-history-folds.ts"],
     snapshotFromGenesis: ["session-history-folds.ts"],
     snapshotFromRecords: ["session-history-folds.ts"],


### PR DESCRIPTION
Moves the unchanged canonical-record-to-display-label fold from SessionLifecycle into the existing package-internal history-fold owner. Keeps title scheduling, provider I/O, persistence, metadata, Presentation projection, public exports, and branch fallback behavior unchanged. Extends the existing structural owner guard. Local quality: 43 test files passed, 2 skipped; 1074 tests passed, 10 skipped. Lifecycle plus Presentation: 168/168. Three independent reviews reported 0 findings.