### PR TITLE
refactor(agent): extract operation presentation projector

### DIFF
--- a/packages/agent/src/presentation-operation-projection.ts
+++ b/packages/agent/src/presentation-operation-projection.ts
@@ -1,0 +1,139 @@
+import type { OperationArtifactDisplay, OperationDisplay } from "@adam-agent/presentation";
+import type { OperationSnapshot } from "./operation-host.js";
+
+export type ProjectedOperation = {
+  readonly display: OperationDisplay;
+  readonly throughSequence: number;
+};
+
+export function projectLinkedOperation(snapshot: OperationSnapshot): ProjectedOperation | null {
+  if (snapshot.origin === null) {
+    return null;
+  }
+  const base = {
+    artifacts: projectOperationArtifacts(snapshot),
+    operationId: snapshot.operationId,
+    origin: snapshot.origin,
+    provenance: {
+      contributionId: snapshot.contributionId,
+      extensionId: snapshot.extensionId,
+      extensionVersion: snapshot.extensionVersion,
+      presentation: snapshot.presentation.kind,
+      title: snapshot.presentation.title,
+    },
+    progress: projectOperationProgress(snapshot.progress),
+  };
+  const display: OperationDisplay =
+    snapshot.status === "running"
+      ? { ...base, status: "running", actions: ["cancel"], settlement: null }
+      : snapshot.status === "cancel_requested"
+        ? { ...base, status: "cancel_requested", actions: [], settlement: null }
+        : snapshot.status === "completed"
+          ? {
+              ...base,
+              status: "completed",
+              actions: [],
+              settlement: { summary: null },
+            }
+          : snapshot.status === "failed"
+            ? {
+                ...base,
+                status: "failed",
+                actions: [],
+                settlement: snapshot.error,
+              }
+            : snapshot.status === "cancelled"
+              ? {
+                  ...base,
+                  status: "cancelled",
+                  actions: [],
+                  settlement: { reason: snapshot.reason },
+                }
+              : snapshot.status === "inspection_required"
+                ? {
+                    ...base,
+                    status: "inspection_required",
+                    actions: [],
+                    settlement: { message: snapshot.message },
+                  }
+                : projectRecoveryRequiredOperation(base, snapshot);
+  return {
+    display,
+    throughSequence: snapshot.throughSequence,
+  };
+}
+
+function projectOperationProgress(
+  progress: OperationSnapshot["progress"],
+): OperationDisplay["progress"] {
+  if (progress === undefined || progress === null) {
+    return null;
+  }
+  const serialized = typeof progress === "string" ? progress : JSON.stringify(progress);
+  const maximumBytes = 240;
+  const encoded = new TextEncoder().encode(serialized);
+  if (encoded.byteLength <= maximumBytes) {
+    return { summary: serialized };
+  }
+  const prefix = encoded.subarray(0, maximumBytes - 3);
+  for (let trim = 0; trim <= 3; trim += 1) {
+    try {
+      return {
+        summary: `${new TextDecoder("utf-8", { fatal: true }).decode(
+          prefix.subarray(0, prefix.byteLength - trim),
+        )}…`,
+      };
+    } catch {
+      // The byte bound may split one UTF-8 scalar; retry without its partial bytes.
+    }
+  }
+  throw new TypeError("The operation progress summary could not be bounded.");
+}
+
+function projectOperationArtifacts(
+  snapshot: OperationSnapshot,
+): readonly OperationArtifactDisplay[] {
+  const terminal = "artifacts" in snapshot ? (snapshot.artifacts ?? []) : [];
+  const evidence =
+    snapshot.status === "inspection_required"
+      ? (snapshot.evidence ?? []).flatMap((reference) =>
+          reference.type === "artifact" ? [reference.artifact] : [],
+        )
+      : [];
+  const evidenceIds = new Set(evidence.map((artifact) => artifact.id));
+  const unique = new Map([...terminal, ...evidence].map((artifact) => [artifact.id, artifact]));
+  return [...unique.values()].map((artifact) => ({
+    contract: artifact.contract,
+    reference: {
+      id: artifact.id,
+      mediaType: artifact.mediaType,
+      byteCount: artifact.byteCount,
+      source: "operation",
+    },
+    role:
+      artifact.contract.id === snapshot.presentation.report?.id &&
+      artifact.contract.version === snapshot.presentation.report.version
+        ? "report"
+        : evidenceIds.has(artifact.id)
+          ? "evidence"
+          : "artifact",
+  }));
+}
+
+function projectRecoveryRequiredOperation(
+  base: Omit<
+    Extract<OperationDisplay, { readonly status: "running" }>,
+    "actions" | "settlement" | "status"
+  >,
+  snapshot: OperationSnapshot,
+): OperationDisplay {
+  if (snapshot.status !== "recovery_required") {
+    throw new TypeError("The operation status could not be projected.");
+  }
+  return {
+    ...base,
+    status: "recovery_required",
+    actions: snapshot.recoverable ? ["recover"] : [],
+    settlement: snapshot.error,
+  };
+}

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -5,7 +5,6 @@ import type {
   AuthoritativePresentationSnapshot,
   CommandReceipt,
   McpDisplay,
-  OperationDisplay,
   PresentationCommand,
   PresentationDisplayState,
   PresentationSession,
@@ -33,6 +32,10 @@ import {
   sameModelTargetIdentity,
 } from "./model-targets.js";
 import type { OperationHost, OperationSnapshot } from "./operation-host.js";
+import {
+  type ProjectedOperation,
+  projectLinkedOperation,
+} from "./presentation-operation-projection.js";
 import type { PresentationPreferences } from "./presentation-preferences.js";
 import { listProjectPaths } from "./project-path-catalog.js";
 import {
@@ -2564,11 +2567,6 @@ export async function createPresentationSession(
   }
 }
 
-type ProjectedOperation = {
-  readonly display: OperationDisplay;
-  readonly throughSequence: number;
-};
-
 async function settleOwnedOperationForClose(
   operations: OperationHost,
   operationId: string,
@@ -2675,138 +2673,6 @@ async function listLinkedOperationPrefix(
     }
     cursor = page.nextCursor;
   }
-}
-
-function projectLinkedOperation(snapshot: OperationSnapshot): ProjectedOperation | null {
-  if (snapshot.origin === null) {
-    return null;
-  }
-  const base = {
-    artifacts: projectOperationArtifacts(snapshot),
-    operationId: snapshot.operationId,
-    origin: snapshot.origin,
-    provenance: {
-      contributionId: snapshot.contributionId,
-      extensionId: snapshot.extensionId,
-      extensionVersion: snapshot.extensionVersion,
-      presentation: snapshot.presentation.kind,
-      title: snapshot.presentation.title,
-    },
-    progress: projectOperationProgress(snapshot.progress),
-  };
-  const display: OperationDisplay =
-    snapshot.status === "running"
-      ? { ...base, status: "running", actions: ["cancel"], settlement: null }
-      : snapshot.status === "cancel_requested"
-        ? { ...base, status: "cancel_requested", actions: [], settlement: null }
-        : snapshot.status === "completed"
-          ? {
-              ...base,
-              status: "completed",
-              actions: [],
-              settlement: { summary: null },
-            }
-          : snapshot.status === "failed"
-            ? {
-                ...base,
-                status: "failed",
-                actions: [],
-                settlement: snapshot.error,
-              }
-            : snapshot.status === "cancelled"
-              ? {
-                  ...base,
-                  status: "cancelled",
-                  actions: [],
-                  settlement: { reason: snapshot.reason },
-                }
-              : snapshot.status === "inspection_required"
-                ? {
-                    ...base,
-                    status: "inspection_required",
-                    actions: [],
-                    settlement: { message: snapshot.message },
-                  }
-                : projectRecoveryRequiredOperation(base, snapshot);
-  return {
-    display,
-    throughSequence: snapshot.throughSequence,
-  };
-}
-
-function projectOperationProgress(
-  progress: OperationSnapshot["progress"],
-): OperationDisplay["progress"] {
-  if (progress === undefined || progress === null) {
-    return null;
-  }
-  const serialized = typeof progress === "string" ? progress : JSON.stringify(progress);
-  const maximumBytes = 240;
-  const encoded = new TextEncoder().encode(serialized);
-  if (encoded.byteLength <= maximumBytes) {
-    return { summary: serialized };
-  }
-  const prefix = encoded.subarray(0, maximumBytes - 3);
-  for (let trim = 0; trim <= 3; trim += 1) {
-    try {
-      return {
-        summary: `${new TextDecoder("utf-8", { fatal: true }).decode(
-          prefix.subarray(0, prefix.byteLength - trim),
-        )}…`,
-      };
-    } catch {
-      // The byte bound may split one UTF-8 scalar; retry without its partial bytes.
-    }
-  }
-  throw new TypeError("The operation progress summary could not be bounded.");
-}
-
-function projectOperationArtifacts(
-  snapshot: OperationSnapshot,
-): readonly import("@adam-agent/presentation").OperationArtifactDisplay[] {
-  const terminal = "artifacts" in snapshot ? (snapshot.artifacts ?? []) : [];
-  const evidence =
-    snapshot.status === "inspection_required"
-      ? (snapshot.evidence ?? []).flatMap((reference) =>
-          reference.type === "artifact" ? [reference.artifact] : [],
-        )
-      : [];
-  const evidenceIds = new Set(evidence.map((artifact) => artifact.id));
-  const unique = new Map([...terminal, ...evidence].map((artifact) => [artifact.id, artifact]));
-  return [...unique.values()].map((artifact) => ({
-    contract: artifact.contract,
-    reference: {
-      id: artifact.id,
-      mediaType: artifact.mediaType,
-      byteCount: artifact.byteCount,
-      source: "operation",
-    },
-    role:
-      artifact.contract.id === snapshot.presentation.report?.id &&
-      artifact.contract.version === snapshot.presentation.report.version
-        ? "report"
-        : evidenceIds.has(artifact.id)
-          ? "evidence"
-          : "artifact",
-  }));
-}
-
-function projectRecoveryRequiredOperation(
-  base: Omit<
-    Extract<OperationDisplay, { readonly status: "running" }>,
-    "actions" | "settlement" | "status"
-  >,
-  snapshot: OperationSnapshot,
-): OperationDisplay {
-  if (snapshot.status !== "recovery_required") {
-    throw new TypeError("The operation status could not be projected.");
-  }
-  return {
-    ...base,
-    status: "recovery_required",
-    actions: snapshot.recoverable ? ["recover"] : [],
-    settlement: snapshot.error,
-  };
 }
 
 function decodeArtifactPage(

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -3518,6 +3518,169 @@ test("PresentationSession preserves linked operation truth through session and r
   }
 });
 
+test("PresentationSession projects linked-operation status, progress, and artifact variants from Host truth", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-operation-projection-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({
+    modelTargets: settledModelTargets(),
+    stateRoot,
+    workspaceRoot,
+  });
+  const created = await lifecycle.create({ targetIdentity });
+  const origin = {
+    invocation: {
+      id: "review" as const,
+      kind: "presentation_command" as const,
+      version: 1 as const,
+    },
+    sessionId: created.sessionId,
+    sourceSequence: created.lastSequence,
+  };
+  const base = {
+    budget: {
+      inputBytes: 32,
+      outputBytesRemaining: 1_024,
+      progressBytesRemaining: 1_024,
+      progressRecordsRemaining: 8,
+    },
+    contributionId: "fixture.review",
+    deadlineAt: "2030-01-01T00:00:00.000Z",
+    extensionId: "fixture.extension",
+    extensionVersion: "1.0.0",
+    presentation: { kind: "descriptor" as const, report: null, title: "Review changes" },
+    startedAt: "2026-01-01T00:00:00.000Z",
+  };
+  const artifact = (id: string, operationId: string) => ({
+    byteCount: 17,
+    contract: { id: `fixture.${id}`, version: 1 },
+    id,
+    mediaType: "application/json",
+    provenance: {
+      contributionId: base.contributionId,
+      extensionId: base.extensionId,
+      extensionVersion: base.extensionVersion,
+      operationId,
+      projectId: "fixture-project",
+    },
+  });
+  const genericArtifact = artifact("failure-log", "operation-failed");
+  const inspectionEvidence = artifact("inspection-evidence", "operation-inspection");
+  const snapshots: readonly OperationSnapshot[] = [
+    {
+      ...base,
+      operationId: "operation-unlinked",
+      origin: null,
+      output: { ignored: true },
+      status: "completed",
+      throughSequence: 2,
+    },
+    {
+      ...base,
+      operationId: "operation-cancel-requested",
+      origin,
+      status: "cancel_requested",
+      throughSequence: 2,
+    },
+    {
+      ...base,
+      artifacts: [genericArtifact],
+      error: { code: "extension_execution_failed", message: "Review execution failed." },
+      operationId: "operation-failed",
+      origin,
+      progress: "Collected partial evidence.",
+      status: "failed",
+      throughSequence: 3,
+    },
+    {
+      ...base,
+      evidence: [
+        { type: "artifact", artifact: inspectionEvidence },
+        {
+          type: "record",
+          record: {
+            byteCount: 19,
+            contract: { id: "fixture.inspection-record", version: 1 },
+            digest: "fixture-record-digest",
+            key: "operations/operation-inspection",
+            provenance: inspectionEvidence.provenance,
+          },
+        },
+      ],
+      message: "Human inspection is required.",
+      operationId: "operation-inspection",
+      origin,
+      progress: null,
+      status: "inspection_required",
+      throughSequence: 4,
+    },
+  ];
+  const snapshotsById = new Map(snapshots.map((snapshot) => [snapshot.operationId, snapshot]));
+  const operations = presentationOperationHost({
+    async listLinked() {
+      return {
+        items: snapshots.map(({ operationId }) => ({ operationId })),
+        nextCursor: null,
+      };
+    },
+    async query(operationId) {
+      const snapshot = snapshotsById.get(operationId);
+      if (snapshot === undefined) {
+        throw new Error(`Unexpected operation query: ${operationId}`);
+      }
+      return snapshot;
+    },
+  });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets: settledModelTargets(),
+      operations,
+      projectLabel: "workspace",
+      sessionId: created.sessionId,
+      stateRoot,
+      workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    });
+    const projected = presentation.getState().authoritative.active?.linkedOperations ?? [];
+    const projectedById = new Map(projected.map((operation) => [operation.operationId, operation]));
+
+    expect([...projectedById.keys()].sort()).toEqual([
+      "operation-cancel-requested",
+      "operation-failed",
+      "operation-inspection",
+    ]);
+    expect(projectedById.get("operation-cancel-requested")).toMatchObject({
+      actions: [],
+      artifacts: [],
+      progress: null,
+      settlement: null,
+      status: "cancel_requested",
+    });
+    expect(projectedById.get("operation-failed")).toMatchObject({
+      actions: [],
+      artifacts: [{ role: "artifact" }],
+      progress: { summary: "Collected partial evidence." },
+      settlement: { code: "extension_execution_failed", message: "Review execution failed." },
+      status: "failed",
+    });
+    expect(projectedById.get("operation-inspection")).toMatchObject({
+      actions: [],
+      artifacts: [{ role: "evidence" }],
+      progress: null,
+      settlement: { message: "Human inspection is required." },
+      status: "inspection_required",
+    });
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("PresentationSession publishes linked operation progress and replaces it with durable completion", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-operation-progress-"));
   const stateRoot = join(testRoot, "state");

--- a/packages/testkit/src/public-product-contract.test.ts
+++ b/packages/testkit/src/public-product-contract.test.ts
@@ -463,6 +463,119 @@ test("SessionLifecycle canonical history projections have package-internal owner
   }
 });
 
+test("PresentationSession linked-operation projection has one package-internal owner", async () => {
+  const agentSourceRoot = join(productRoot, "packages", "agent", "src");
+  const sourceFiles = (await readdir(agentSourceRoot, { recursive: true }))
+    .filter((entry) => entry.endsWith(".ts"))
+    .sort();
+  const sources = await Promise.all(
+    sourceFiles.map(async (sourceFile) => ({
+      path: sourceFile,
+      source: await readFile(join(agentSourceRoot, sourceFile), "utf8"),
+    })),
+  );
+  const expectedOwners = {
+    projectLinkedOperation: ["presentation-operation-projection.ts"],
+  } as const;
+  const actualOwners = Object.fromEntries(
+    Object.keys(expectedOwners).map((symbol) => [
+      symbol,
+      sources
+        .filter(({ source }) => new RegExp(`\\bfunction\\s+${symbol}\\s*\\(`, "u").test(source))
+        .map(({ path }) => path),
+    ]),
+  );
+  const expectedTypeOwners = {
+    ProjectedOperation: ["presentation-operation-projection.ts"],
+  } as const;
+  const actualTypeOwners = Object.fromEntries(
+    Object.keys(expectedTypeOwners).map((symbol) => [
+      symbol,
+      sources
+        .filter(({ source }) => new RegExp(`\\bexport\\s+type\\s+${symbol}\\b`, "u").test(source))
+        .map(({ path }) => path),
+    ]),
+  );
+  const projectionSource =
+    sources.find(({ path }) => path === "presentation-operation-projection.ts")?.source ?? "";
+  const projectionConsumers = sources
+    .filter(({ source }) =>
+      moduleSpecifiers(source).includes("./presentation-operation-projection.js"),
+    )
+    .map(({ path }) => path);
+  const projectionDependencies = [...moduleSpecifiers(projectionSource)].sort();
+  const testSourceRoots = (
+    await Promise.all(
+      ["apps", "packages"].map(async (root) =>
+        (
+          await readdir(join(productRoot, root), { withFileTypes: true })
+        )
+          .filter((entry) => entry.isDirectory())
+          .map((entry) => join(productRoot, root, entry.name, "src")),
+      ),
+    )
+  ).flat();
+  const testSources = (
+    await Promise.all(
+      testSourceRoots.map(async (sourceRoot) => {
+        try {
+          return (await readdir(sourceRoot, { recursive: true }))
+            .filter((entry) => entry.endsWith(".test.ts"))
+            .map((entry) => join(sourceRoot, entry));
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            return [];
+          }
+          throw error;
+        }
+      }),
+    )
+  ).flat();
+  const directTestImports = (
+    await Promise.all(
+      testSources
+        .filter((testPath) => testPath !== fileURLToPath(import.meta.url))
+        .map(async (testPath) =>
+          moduleSpecifiers(await readFile(testPath, "utf8"))
+            .filter((specifier) => /presentation-operation-projection\.js$/u.test(specifier))
+            .map((specifier) => ({
+              path: relative(productRoot, testPath),
+              specifier,
+            })),
+        ),
+    )
+  ).flat();
+
+  expect.soft(actualOwners).toEqual(expectedOwners);
+  expect.soft(actualTypeOwners).toEqual(expectedTypeOwners);
+  expect.soft(projectionConsumers).toEqual(["presentation-session.ts"]);
+  expect.soft(projectionDependencies).toEqual(["./operation-host.js", "@adam-agent/presentation"]);
+  expect
+    .soft({
+      operationHostReferences: moduleSpecifiers(projectionSource).filter(
+        (specifier) => specifier === "./operation-host.js",
+      ).length,
+      operationHostTypeImport:
+        /import\s+type\s+\{[^}]*OperationSnapshot[^}]*\}\s+from\s+"\.\/operation-host\.js";/su.test(
+          projectionSource,
+        ),
+      presentationReferences: moduleSpecifiers(projectionSource).filter(
+        (specifier) => specifier === "@adam-agent/presentation",
+      ).length,
+      presentationTypeImport:
+        /import\s+type\s+\{[^}]*OperationDisplay[^}]*\}\s+from\s+"@adam-agent\/presentation";/su.test(
+          projectionSource,
+        ),
+    })
+    .toEqual({
+      operationHostReferences: 1,
+      operationHostTypeImport: true,
+      presentationReferences: 1,
+      presentationTypeImport: true,
+    });
+  expect.soft(directTestImports).toEqual([]);
+});
+
 async function readPackageJson(path: string): Promise<unknown> {
   return JSON.parse(await readFile(path, "utf8"));
 }


### PR DESCRIPTION
## Summary

- move linked-operation display projection into one package-private deep module
- freeze its single consumer and exact type-only dependency direction with a structural guard
- cover the moved status, progress, and artifact variants through the public PresentationSession seam

## Verification

- pnpm quality:check
- 43 test files passed, 2 skipped; 1076 tests passed, 10 skipped
- three independent final reviews: 0 blocker/high/medium findings