### PR TITLE
refactor(agent): unify durable session naming state

### DIFF
--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -10,6 +10,7 @@ import type {
   PresentationSession,
   PresentationTransientState,
   RepositoryInstructionsDisplay,
+  SessionNaming,
   SessionSummary,
   SkillCatalogDisplay,
   ToolCallDisplay,
@@ -39,6 +40,10 @@ import {
 import type { PresentationPreferences } from "./presentation-preferences.js";
 import { listProjectPaths } from "./project-path-catalog.js";
 import {
+  type SessionNamingHistoryState,
+  sessionNamingStateFromRecords,
+} from "./session-history-folds.js";
+import {
   type CurrentSessionSnapshot,
   type SessionContextUsageSnapshot,
   type SessionLifecycle,
@@ -46,7 +51,6 @@ import {
   type SessionMetadataEvent,
   type SessionRuntimeNotification,
 } from "./session-lifecycle.js";
-import { sessionTitleFallback } from "./session-naming.js";
 import { readJsonlSessionRecords, type SessionRecord } from "./session-store.js";
 import type { JsonValue, PermissionSubject, ToolEffect } from "./tool-runtime.js";
 
@@ -227,7 +231,7 @@ export async function createPresentationSession(
     const historyPageSize = boundedHistoryPageSize(options[presentationHistoryPageSize]);
     let loadedTranscriptStart = Math.max(0, transcript.length - historyPageSize);
     const naming =
-      created === undefined ? undefined : sessionNamingFromRecords(records, created.sessionId);
+      created === undefined ? undefined : projectSessionNaming(records, created.sessionId);
     const catalogPageSize = boundedCatalogPageSize(options[presentationCatalogPageSize]);
     const activeSummary: SessionSummary | undefined =
       created === undefined || naming === undefined
@@ -800,7 +804,7 @@ export async function createPresentationSession(
         activatedRecords,
         options,
       );
-      const activatedNaming = sessionNamingFromRecords(activatedRecords, snapshot.sessionId);
+      const activatedNaming = projectSessionNaming(activatedRecords, snapshot.sessionId);
       const activatedSummary: SessionSummary = {
         id: snapshot.sessionId,
         label: activatedNaming.displayLabel,
@@ -897,7 +901,7 @@ export async function createPresentationSession(
       if (closed || current === null || current.session.id !== sessionId) {
         return;
       }
-      const refreshedNaming = sessionNamingFromRecords(refreshedRecords, sessionId);
+      const refreshedNaming = projectSessionNaming(refreshedRecords, sessionId);
       const refreshedSummary: SessionSummary = {
         ...current.session,
         label: refreshedNaming.displayLabel,
@@ -2845,7 +2849,7 @@ function sessionSummaryFromSnapshot(
   snapshot: CurrentSessionSnapshot,
   records: readonly SourcedSessionRecord[],
 ): SessionSummary {
-  const naming = sessionNamingFromRecords(records, snapshot.sessionId);
+  const naming = projectSessionNaming(records, snapshot.sessionId);
   return {
     id: snapshot.sessionId,
     label: naming.displayLabel,
@@ -4335,87 +4339,49 @@ function projectMcp(snapshot: CurrentSessionSnapshot): McpDisplay | null {
   };
 }
 
-function sessionNamingFromRecords(
+function projectSessionNaming(
   records: readonly SourcedSessionRecord[],
   sessionId: string,
-): SessionSummary["naming"] {
-  const firstRun = records.find(
-    ({ entry, sessionId: sourceSessionId }) =>
-      sourceSessionId === sessionId &&
-      entry.schemaVersion === 3 &&
-      entry.record.type === "logical_run_started",
+): SessionNaming {
+  const naming = sessionNamingStateFromRecords(
+    records
+      .filter(({ sessionId: sourceSessionId }) => sourceSessionId === sessionId)
+      .map(({ entry }) => entry),
   );
-  const genesis = records.find(
-    ({ entry, sessionId: sourceSessionId }) =>
-      sourceSessionId === sessionId &&
-      entry.schemaVersion === 3 &&
-      entry.record.type === "session_genesis",
-  );
-  const genesisFallback =
-    genesis?.entry.schemaVersion === 3 && genesis.entry.record.type === "session_genesis"
-      ? (genesis.entry.record.naming?.fallbackTitle ?? null)
-      : null;
-  const fallbackTitle =
-    genesisFallback ??
-    (firstRun?.entry.schemaVersion === 3 && firstRun.entry.record.type === "logical_run_started"
-      ? (firstRun.entry.record.naming?.fallbackTitle ??
-        sessionTitleFallback(firstRun.entry.record.userMessage))
-      : null);
-  let manualName: string | null = null;
-  let generatedTitle: string | null = null;
-  let generation: SessionSummary["naming"]["generation"] = { status: "not_started" };
-  for (const { entry, sessionId: sourceSessionId } of records) {
-    if (
-      sourceSessionId === sessionId &&
-      entry.schemaVersion === 3 &&
-      (entry.record.type === "session_manual_name_set" ||
-        entry.record.type === "session_manual_name_cleared")
-    ) {
-      manualName = entry.record.type === "session_manual_name_set" ? entry.record.name : null;
-    }
-    if (
-      sourceSessionId === sessionId &&
-      entry.schemaVersion === 3 &&
-      entry.record.type === "session_title_generation_started"
-    ) {
-      generation = { status: "in_progress", generationId: entry.record.generationId };
-    }
-    if (
-      sourceSessionId === sessionId &&
-      entry.schemaVersion === 3 &&
-      entry.record.type === "session_title_generation_completed"
-    ) {
-      generatedTitle = entry.record.title;
-      generation = {
+  return {
+    manualName: naming.manualName,
+    generatedTitle: naming.generatedTitle,
+    fallbackTitle: naming.fallbackTitle,
+    displayLabel: naming.displayLabel,
+    generation: projectSessionTitleGeneration(naming.generation),
+  };
+}
+
+function projectSessionTitleGeneration(
+  generation: SessionNamingHistoryState["generation"],
+): SessionNaming["generation"] {
+  switch (generation.status) {
+    case "not_started":
+      return { status: "not_started" };
+    case "in_progress":
+      return { status: "in_progress", generationId: generation.generationId };
+    case "completed":
+      return {
         status: "completed",
-        generationId: entry.record.generationId,
-        usage: entry.record.usage,
+        generationId: generation.generationId,
+        usage: generation.usage,
       };
-    }
-    if (
-      sourceSessionId === sessionId &&
-      entry.schemaVersion === 3 &&
-      entry.record.type === "session_title_generation_skipped_manual"
-    ) {
-      generation = { status: "skipped_manual" };
-    }
-    if (
-      sourceSessionId === sessionId &&
-      entry.schemaVersion === 3 &&
-      entry.record.type === "session_title_generation_failed"
-    ) {
-      generation = {
+    case "failed":
+      return {
         status: "failed",
-        generationId: entry.record.generationId,
-        reason: entry.record.reason,
+        generationId: generation.generationId,
+        reason: generation.reason,
       };
+    case "skipped_manual":
+      return { status: "skipped_manual" };
+    default: {
+      const unreachable: never = generation;
+      return unreachable;
     }
   }
-  return {
-    manualName,
-    generatedTitle,
-    fallbackTitle,
-    displayLabel: manualName ?? generatedTitle ?? fallbackTitle ?? "New session",
-    generation,
-  };
 }

--- a/packages/agent/src/session-history-folds.ts
+++ b/packages/agent/src/session-history-folds.ts
@@ -243,7 +243,36 @@ export function isGenesisRecord(record: SessionRecord): record is SessionGenesis
   return record.schemaVersion === 3 && record.record.type === "session_genesis";
 }
 
-export function sessionDisplayLabelFromRecords(records: readonly SessionRecord[]): string {
+export type SessionNamingHistoryState = {
+  readonly manualName: string | null;
+  readonly generatedTitle: string | null;
+  readonly fallbackTitle: string | null;
+  readonly displayLabel: string;
+  readonly generation:
+    | { readonly status: "not_started" }
+    | { readonly status: "in_progress"; readonly generationId: string }
+    | {
+        readonly status: "completed";
+        readonly generationId: string;
+        readonly usage:
+          | { readonly status: "unknown" }
+          | {
+              readonly status: "known";
+              readonly inputTokens: number;
+              readonly outputTokens: number;
+            };
+      }
+    | {
+        readonly status: "failed";
+        readonly generationId: string;
+        readonly reason: "model_request_failed" | "invalid_title" | "process_restart";
+      }
+    | { readonly status: "skipped_manual" };
+};
+
+export function sessionNamingStateFromRecords(
+  records: readonly SessionRecord[],
+): SessionNamingHistoryState {
   const genesis = records[0];
   let fallbackTitle =
     genesis?.schemaVersion === 3 && genesis.record.type === "session_genesis"
@@ -251,6 +280,7 @@ export function sessionDisplayLabelFromRecords(records: readonly SessionRecord[]
       : null;
   let manualName: string | null = null;
   let generatedTitle: string | null = null;
+  let generation: SessionNamingHistoryState["generation"] = { status: "not_started" };
   for (const entry of records) {
     if (entry.schemaVersion !== 3) {
       continue;
@@ -262,11 +292,32 @@ export function sessionDisplayLabelFromRecords(records: readonly SessionRecord[]
       manualName = entry.record.name;
     } else if (entry.record.type === "session_manual_name_cleared") {
       manualName = null;
+    } else if (entry.record.type === "session_title_generation_started") {
+      generation = { status: "in_progress", generationId: entry.record.generationId };
     } else if (entry.record.type === "session_title_generation_completed") {
       generatedTitle = entry.record.title;
+      generation = {
+        status: "completed",
+        generationId: entry.record.generationId,
+        usage: entry.record.usage,
+      };
+    } else if (entry.record.type === "session_title_generation_skipped_manual") {
+      generation = { status: "skipped_manual" };
+    } else if (entry.record.type === "session_title_generation_failed") {
+      generation = {
+        status: "failed",
+        generationId: entry.record.generationId,
+        reason: entry.record.reason,
+      };
     }
   }
-  return manualName ?? generatedTitle ?? fallbackTitle ?? "New session";
+  return {
+    manualName,
+    generatedTitle,
+    fallbackTitle,
+    displayLabel: manualName ?? generatedTitle ?? fallbackTitle ?? "New session",
+    generation,
+  };
 }
 
 export function attemptStatus(

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -101,7 +101,7 @@ import {
   type ModelResponseArtifactDegradation,
   type ModelResponseArtifactInspection,
   promptContextRecordFromRecords,
-  sessionDisplayLabelFromRecords,
+  sessionNamingStateFromRecords,
   skillContextRecordFromRecords,
   snapshotFromGenesis,
   snapshotFromRecords,
@@ -1910,7 +1910,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         const store = await sessionStoreDirectoryFrom(options).create(sessionId);
         const prefix = `${parentPrefix.map((record) => JSON.stringify(record)).join("\n")}\n`;
         const branchFallback = sessionTitleFallback(
-          `Branch of ${sessionDisplayLabelFromRecords(parentRecords)}`,
+          `Branch of ${sessionNamingStateFromRecords(parentRecords).displayLabel}`,
         );
         const genesis: SessionGenesisRecord = {
           schemaVersion: 3,

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -7288,6 +7288,111 @@ test("PresentationSession explicitly regenerates and replaces the generated titl
   }
 });
 
+test("PresentationSession preserves the last completed title through regeneration progress and failure", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-title-preserved-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const regenerationStarted = Promise.withResolvers<void>();
+  const releaseRegenerationFailure = Promise.withResolvers<void>();
+  let titleCalls = 0;
+  const model: ModelDriver = {
+    async *stream(request) {
+      if (request.tools.length === 0) {
+        titleCalls += 1;
+        if (titleCalls === 1) {
+          yield { type: "text_delta", text: "Stable generated title" };
+          yield { type: "finish", reason: "stop" };
+          return;
+        }
+        regenerationStarted.resolve();
+        await releaseRegenerationFailure.promise;
+        throw new Error("Regeneration provider failed.");
+      }
+      yield { type: "text_delta", text: "Ordinary answer." };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver: model, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const firstLifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  firstLifecycle.enableAutomaticTitles();
+  let secondLifecycle: ReturnType<typeof createSessionLifecycle> | undefined;
+  let presentation: Awaited<ReturnType<typeof createPresentationSession>> | undefined;
+
+  try {
+    const created = await firstLifecycle.create({ targetIdentity });
+    await firstLifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Preserve the last completed title" },
+    });
+    await firstLifecycle.close();
+
+    secondLifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    presentation = await createPresentationSession({
+      lifecycle: secondLifecycle,
+      projectLabel: "workspace",
+      sessionId: created.sessionId,
+      stateRoot,
+      workspaceRoot,
+    });
+    const inProgress = Promise.withResolvers<void>();
+    const failed = Promise.withResolvers<void>();
+    const unsubscribe = presentation.subscribe(() => {
+      const naming = presentation?.getState().authoritative.active?.session.naming;
+      if (naming?.generation.status === "in_progress") {
+        inProgress.resolve();
+      }
+      if (naming?.generation.status === "failed") {
+        failed.resolve();
+      }
+    });
+
+    await expect(
+      presentation.dispatch({
+        type: "regenerate_session_title",
+        sessionId: created.sessionId,
+      }),
+    ).resolves.toMatchObject({ status: "admitted", resource: null });
+    await regenerationStarted.promise;
+    await inProgress.promise;
+    expect(presentation.getState().authoritative.active?.session.naming).toMatchObject({
+      generatedTitle: "Stable generated title",
+      displayLabel: "Stable generated title",
+      generation: { status: "in_progress" },
+    });
+
+    releaseRegenerationFailure.resolve();
+    await failed.promise;
+    expect(presentation.getState().authoritative.active?.session.naming).toMatchObject({
+      generatedTitle: "Stable generated title",
+      displayLabel: "Stable generated title",
+      generation: { status: "failed", reason: "model_request_failed" },
+    });
+    unsubscribe();
+  } finally {
+    releaseRegenerationFailure.resolve();
+    await presentation?.close();
+    await secondLifecycle?.close();
+    await firstLifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("PresentationSession gives a child an immutable branch fallback before its first turn", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-branch-name-"));
   const stateRoot = join(testRoot, "state");

--- a/packages/testkit/src/public-product-contract.test.ts
+++ b/packages/testkit/src/public-product-contract.test.ts
@@ -268,7 +268,7 @@ test("SessionLifecycle canonical history projections have package-internal owner
     modelMessagesFromCompleteRecords: ["session-history-replay.ts"],
     promptContextRecordFromRecords: ["session-history-folds.ts"],
     readValidatedLineagePrefix: ["session-lineage.ts"],
-    sessionDisplayLabelFromRecords: ["session-history-folds.ts"],
+    sessionNamingStateFromRecords: ["session-history-folds.ts"],
     sessionInheritsSourceBoundary: ["session-lineage.ts"],
     skillContextRecordFromRecords: ["session-history-folds.ts"],
     snapshotFromGenesis: ["session-history-folds.ts"],
@@ -301,6 +301,7 @@ test("SessionLifecycle canonical history projections have package-internal owner
     ModelResponseArtifactInspection: ["session-history-folds.ts"],
     SessionLineageRecordReader: ["session-lineage.ts"],
     SessionLineageTraversal: ["session-lineage.ts"],
+    SessionNamingHistoryState: ["session-history-folds.ts"],
     SessionContextSnapshot: ["session-snapshot-contracts.ts"],
     SessionContextUsageSnapshot: ["session-snapshot-contracts.ts"],
     SessionResumeResult: ["session-snapshot-contracts.ts"],
@@ -330,23 +331,27 @@ test("SessionLifecycle canonical history projections have package-internal owner
   );
   const forbiddenImports = extractedSources.flatMap(({ path, source }) =>
     moduleSpecifiers(source)
-      .filter((specifier) =>
-        [
-          "./agent-session.js",
-          "./extension-host.js",
-          "./index.js",
-          "./session-lifecycle.js",
-          "@adam-agent/agent",
-          "@adam-agent/presentation",
-          "node:child_process",
-          "node:fs",
-          "node:fs/promises",
-        ].includes(specifier),
+      .filter(
+        (specifier) =>
+          specifier.startsWith("./presentation-") ||
+          [
+            "./agent-session.js",
+            "./extension-host.js",
+            "./index.js",
+            "./session-lifecycle.js",
+            "@adam-agent/agent",
+            "@adam-agent/presentation",
+            "node:child_process",
+            "node:fs",
+            "node:fs/promises",
+          ].includes(specifier),
       )
       .map((specifier) => ({ path, specifier })),
   );
   const lifecycleSource = sources.find(({ path }) => path === "session-lifecycle.ts")?.source ?? "";
   const lineageSource = sources.find(({ path }) => path === "session-lineage.ts")?.source ?? "";
+  const presentationSource =
+    sources.find(({ path }) => path === "presentation-session.ts")?.source ?? "";
   const publicFacadeSource = sources.find(({ path }) => path === "index.ts")?.source ?? "";
   const testingFacadeSource =
     sources.find(({ path }) => path === "internal-testing.ts")?.source ?? "";
@@ -432,6 +437,29 @@ test("SessionLifecycle canonical history projections have package-internal owner
     })
     .toEqual({ storeSpecifierReferences: 1, storeRuntimeImport: false, storeTypeImport: true });
   expect.soft(directTestImports).toEqual([]);
+  expect
+    .soft({
+      historyImport: moduleSpecifiers(presentationSource).includes("./session-history-folds.js"),
+      namingStateConsumers: sources
+        .filter(
+          ({ path, source }) =>
+            path !== "session-history-folds.ts" &&
+            /\bsessionNamingStateFromRecords\b/u.test(source),
+        )
+        .map(({ path }) => path),
+      legacyDisplayLabelOwners: sources
+        .filter(({ source }) => /\bfunction\s+sessionDisplayLabelFromRecords\s*\(/u.test(source))
+        .map(({ path }) => path),
+      legacyPresentationNamingOwners: sources
+        .filter(({ source }) => /\bfunction\s+sessionNamingFromRecords\s*\(/u.test(source))
+        .map(({ path }) => path),
+    })
+    .toEqual({
+      historyImport: true,
+      namingStateConsumers: ["presentation-session.ts", "session-lifecycle.ts"],
+      legacyDisplayLabelOwners: [],
+      legacyPresentationNamingOwners: [],
+    });
   expect
     .soft({
       errorImport: lifecycleSource.includes('from "./session-lifecycle-error.js"'),


### PR DESCRIPTION
## Summary
- deepen the existing canonical history fold into one complete agent-internal naming state
- let SessionLifecycle consume only the shared display label while Presentation leaf-filters lineage records and exhaustively maps the domain union to browser-safe DTOs
- retire the duplicate label-only and Presentation naming folds without changing public interfaces, persistence, hydration, repair, or commands

## TDD evidence
- structural RED: new naming function/type owner absent, both retired folds still present, and Presentation not yet a history-fold consumer
- caller-visible reverse RED: clearing the previous completed title on regeneration start changed the public display to the fallback prompt
- focused GREEN: structural guard, new regeneration progress/failure tracer, and seven independent existing naming contracts
- complete Public Contract, SessionLifecycle, and PresentationSession files: 182/182
- final local non-sandbox Quality: 43 files passed, 2 skipped; 1080 tests passed, 10 skipped
- three final architecture, engineering, and test reviews: 0 Blocker/High/Medium findings

## Quality note
One preceding full run timed out only the unchanged Linux clipboard deadline test at its 30-second failure guard after the other 1079 tests passed. That exact test then passed independently with a 9 ms body, and the unchanged final tree passed two complete Quality runs without timeout, assertion, worker, or implementation changes.