### PR TITLE
refactor(agent): extract presentation tool projection

### DIFF
--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -13,7 +13,6 @@ import type {
   SessionNaming,
   SessionSummary,
   SkillCatalogDisplay,
-  ToolCallDisplay,
   ToolPreviewDisplay,
   TranscriptItem,
 } from "@adam-agent/presentation";
@@ -38,6 +37,14 @@ import {
   projectLinkedOperation,
 } from "./presentation-operation-projection.js";
 import type { PresentationPreferences } from "./presentation-preferences.js";
+import {
+  type ChangePreviewProjectionRequest,
+  collectChangePreviewRequests,
+  projectChangePreviewPage,
+  projectPendingPermissionCandidates,
+  projectToolDisplays,
+  resolveActionableChangePreviewReference,
+} from "./presentation-tool-projection.js";
 import { listProjectPaths } from "./project-path-catalog.js";
 import {
   type SessionNamingHistoryState,
@@ -52,7 +59,6 @@ import {
   type SessionRuntimeNotification,
 } from "./session-lifecycle.js";
 import { readJsonlSessionRecords, type SessionRecord } from "./session-store.js";
-import type { JsonValue, PermissionSubject, ToolEffect } from "./tool-runtime.js";
 
 /** Tests only. Production hydration has no artificial publication barrier. */
 export const presentationHydrationBarrier = Symbol("adam-agent.presentation-hydration-barrier");
@@ -2913,7 +2919,7 @@ function projectTranscript(
   operations: readonly ProjectedOperation[],
   changePreviewCache: ReadonlyMap<string, ToolPreviewDisplay | null>,
 ): readonly TranscriptItem[] {
-  const toolDisplays = collectToolDisplays(records, changePreviewCache);
+  const toolDisplays = projectToolDisplays(records, changePreviewCache);
   const attemptProviders = new Map<string, string>(
     records.flatMap(({ entry, sessionId }) =>
       entry.schemaVersion === 3 && entry.record.type === "provider_attempt_started"
@@ -3295,243 +3301,20 @@ function providerDisplayName(vendor: string | undefined): string {
   return vendor === "deepseek" ? "DeepSeek" : (vendor ?? "Provider");
 }
 
-type MutableToolDisplay = {
-  sessionId: string;
-  callId: string;
-  sequence?: number;
-  name?: string;
-  source?: NonNullable<ToolCallDisplay["source"]>;
-  effect?: ToolEffect;
-  subject?: PermissionSubject;
-  status: ToolCallDisplay["status"];
-  output?: JsonValue;
-  failure?: { readonly code: string; readonly reason?: string; readonly message: string };
-  changePreviewRef?: NonNullable<ToolCallDisplay["changePreviewRef"]>;
-};
-
-function collectMutableToolDisplays(
-  records: readonly SourcedSessionRecord[],
-): ReadonlyMap<string, MutableToolDisplay> {
-  const tools = new Map<string, MutableToolDisplay>();
-  const toolFor = (sessionId: string, callId: string): MutableToolDisplay => {
-    const key = `${sessionId}:${callId}`;
-    const existing = tools.get(key);
-    if (existing !== undefined) {
-      return existing;
-    }
-    const created: MutableToolDisplay = { sessionId, callId, status: "requested" };
-    tools.set(key, created);
-    return created;
-  };
-
-  for (const { entry, sessionId } of records) {
-    if (entry.schemaVersion !== 3) {
-      continue;
-    }
-    if (entry.record.type === "model_response_completed") {
-      for (const intent of entry.record.response.toolIntents) {
-        const tool = toolFor(sessionId, intent.callId);
-        tool.name = intent.name;
-        tool.source = {
-          provenance: "provider_model_response",
-          sessionId,
-          responseSequence: entry.sequence,
-          argumentsDigest: intent.argumentsDigest,
-          definitionDigest: intent.definitionDigest ?? null,
-          replay: intent.replay,
-        };
-        if (intent.effect !== undefined) {
-          tool.effect = intent.effect;
-        }
-      }
-      continue;
-    }
-    if (entry.record.type !== "runtime_event") {
-      continue;
-    }
-    const event = entry.record.event;
-    if (event.type === "tool_requested") {
-      const tool = toolFor(sessionId, event.callId);
-      tool.sequence = entry.sequence;
-      tool.name = event.name;
-    } else if (event.type === "tool_permission_requested") {
-      const tool = toolFor(sessionId, event.callId);
-      tool.effect = event.effect;
-      tool.subject = event.subject;
-      tool.status = "permission_required";
-      if (event.changePreviewRef !== undefined) {
-        tool.changePreviewRef = presentationChangePreviewRef(event.changePreviewRef);
-      }
-    } else if (event.type === "tool_permission_decided") {
-      const tool = toolFor(sessionId, event.callId);
-      if (event.effect !== undefined) {
-        tool.effect = event.effect;
-      }
-      if (event.subject !== undefined) {
-        tool.subject = event.subject;
-      }
-      if (event.changePreviewRef !== undefined) {
-        tool.changePreviewRef = presentationChangePreviewRef(event.changePreviewRef);
-      }
-      tool.status = event.decision === "allow" ? "requested" : "denied";
-    } else if (event.type === "tool_started") {
-      const tool = toolFor(sessionId, event.callId);
-      tool.status = "running";
-    } else if (event.type === "tool_completed") {
-      const tool = toolFor(sessionId, event.callId);
-      tool.status = "completed";
-      tool.output = event.output;
-    } else if (event.type === "tool_failed") {
-      const tool = toolFor(sessionId, event.callId);
-      tool.status = event.error.code === "permission_denied" ? "denied" : "failed";
-      tool.failure = {
-        code: event.error.code,
-        ...(event.error.code === "tool_effect_indeterminate" ? { reason: event.error.reason } : {}),
-        message: boundedDisplayText(event.error.message),
-      };
-    }
-  }
-
-  return tools;
-}
-
-function collectToolDisplays(
-  records: readonly SourcedSessionRecord[],
-  changePreviewCache: ReadonlyMap<string, ToolPreviewDisplay | null>,
-): ReadonlyMap<string, ToolCallDisplay> {
-  const tools = collectMutableToolDisplays(records);
-  return new Map(
-    [...tools.entries()].flatMap(([key, tool]) => {
-      if (tool.sequence === undefined) {
-        return [];
-      }
-      const name = tool.name ?? "unknown";
-      const subject = safeToolSubject(tool.subject, tool.output);
-      return [
-        [
-          key,
-          {
-            type: "tool_call" as const,
-            id: `${tool.sessionId}:${tool.sequence}`,
-            sequence: tool.sequence,
-            sourceSessionId: tool.sessionId,
-            branchBoundary: null,
-            callId: tool.callId,
-            qualifiedName: name,
-            kind: toolKind(name),
-            effect: tool.effect ?? null,
-            label: toolLabel(name),
-            subject,
-            source: tool.source ?? null,
-            durationMs: null,
-            status: tool.status,
-            outcome: toolOutcome(tool),
-            resultSummary:
-              tool.failure === undefined
-                ? toolResultSummary(name, tool.output)
-                : `${tool.failure.code}: ${tool.failure.message}`,
-            artifacts: toolArtifacts(tool.output),
-            changePreviewRef: tool.changePreviewRef ?? null,
-            preview: toolPreview(
-              name,
-              tool.output,
-              subject,
-              tool.changePreviewRef,
-              changePreviewCache,
-            ),
-          },
-        ] as const,
-      ];
-    }),
-  );
-}
-
-function toolOutcome(tool: MutableToolDisplay): ToolCallDisplay["outcome"] {
-  if (tool.failure?.code === "tool_effect_indeterminate") {
-    return {
-      status: "indeterminate",
-      code: "tool_effect_indeterminate",
-      reason: tool.failure.reason ?? null,
-      message: tool.failure.message,
-    };
-  }
-  if (tool.failure !== undefined) {
-    return {
-      status: "failed",
-      code: tool.failure.code,
-      message: tool.failure.message,
-    };
-  }
-  if (tool.status === "completed") {
-    return { status: "completed" };
-  }
-  if (tool.status === "denied") {
-    return {
-      status: "denied",
-      code: "permission_denied",
-      message: "Permission was denied for this tool call.",
-    };
-  }
-  return null;
-}
-
 async function projectPendingInteractions(
   records: readonly SourcedSessionRecord[],
   options: Pick<CreatePresentationSessionOptions, "stateRoot" | "workspaceRoot">,
 ): Promise<readonly import("@adam-agent/presentation").PendingInteraction[]> {
-  const decided = new Set(
-    records.flatMap(({ entry, sessionId }) =>
-      entry.schemaVersion === 3 &&
-      entry.record.type === "runtime_event" &&
-      entry.record.event.type === "tool_permission_decided" &&
-      entry.record.event.requestId !== undefined
-        ? [`${sessionId}:${entry.record.event.requestId}`]
-        : [],
-    ),
-  );
-  const pending = records.flatMap(({ entry, sessionId }) => {
-    if (
-      entry.schemaVersion !== 3 ||
-      entry.record.type !== "runtime_event" ||
-      entry.record.event.type !== "tool_permission_requested" ||
-      decided.has(`${sessionId}:${entry.record.event.requestId}`)
-    ) {
-      return [];
-    }
-    const subject = safeToolSubject(entry.record.event.subject, undefined);
-    if (subject === null) {
-      return [];
-    }
-    const changePreviewRef =
-      entry.record.event.changePreviewRef === undefined
-        ? null
-        : presentationChangePreviewRef(entry.record.event.changePreviewRef);
-    return [
-      {
-        type: "permission" as const,
-        requestId: entry.record.event.requestId,
-        callId: entry.record.event.callId,
-        effect: entry.record.event.effect,
-        subject,
-        canAllow: entry.record.event.effect !== "write",
-        changePreviewRef,
-        sourceReference: entry.record.event.changePreviewRef,
-      },
-    ];
-  });
+  const activeSessionId =
+    records.findLast(
+      ({ entry }) => entry.schemaVersion === 3 && entry.record.type === "session_genesis",
+    )?.sessionId ?? "";
   return Promise.all(
-    pending.map(async ({ sourceReference: _sourceReference, ...interaction }) => ({
+    projectPendingPermissionCandidates(records).map(async (interaction) => ({
       ...interaction,
       canAllow:
         interaction.canAllow ||
-        (await isActionableChangePreview(
-          records,
-          records.findLast(
-            ({ entry }) => entry.schemaVersion === 3 && entry.record.type === "session_genesis",
-          )?.sessionId ?? "",
-          interaction.requestId,
-          options,
-        )),
+        (await isActionableChangePreview(records, activeSessionId, interaction.requestId, options)),
     })),
   );
 }
@@ -3545,71 +3328,8 @@ async function isActionableChangePreview(
   if (options.stateRoot === undefined) {
     return false;
   }
-  const requested = records.findLast(
-    ({ entry, sessionId }) =>
-      sessionId === activeSessionId &&
-      entry.schemaVersion === 3 &&
-      entry.record.type === "runtime_event" &&
-      entry.record.event.type === "tool_permission_requested" &&
-      entry.record.event.requestId === requestId,
-  );
-  if (
-    requested?.entry.schemaVersion !== 3 ||
-    requested.entry.record.type !== "runtime_event" ||
-    requested.entry.record.event.type !== "tool_permission_requested" ||
-    requested.entry.record.event.changePreviewRef === undefined ||
-    records.some(
-      ({ entry, sessionId }) =>
-        sessionId === activeSessionId &&
-        entry.schemaVersion === 3 &&
-        entry.record.type === "runtime_event" &&
-        entry.record.event.type === "tool_permission_decided" &&
-        entry.record.event.requestId === requestId,
-    )
-  ) {
-    return false;
-  }
-  const event = requested.entry.record.event;
-  const runId = requested.entry.record.runId;
-  const genesis = records.find(
-    ({ entry, sessionId }) =>
-      sessionId === activeSessionId &&
-      entry.schemaVersion === 3 &&
-      entry.record.type === "session_genesis",
-  );
-  const response = records.findLast(
-    ({ entry, sessionId }) =>
-      sessionId === activeSessionId &&
-      entry.schemaVersion === 3 &&
-      entry.record.type === "model_response_completed" &&
-      entry.record.runId === runId,
-  );
-  if (
-    genesis?.entry.schemaVersion !== 3 ||
-    genesis.entry.record.type !== "session_genesis" ||
-    response?.entry.schemaVersion !== 3 ||
-    response.entry.record.type !== "model_response_completed"
-  ) {
-    return false;
-  }
-  const callIndex = response.entry.record.response.toolCalls.findIndex(
-    (call) => call.id === event.callId && call.name === event.name,
-  );
-  const call = response.entry.record.response.toolCalls[callIndex];
-  const intent = response.entry.record.response.toolIntents[callIndex];
-  const reference = event.changePreviewRef;
-  if (
-    call === undefined ||
-    intent === undefined ||
-    reference === undefined ||
-    reference.source.projectId !== genesis.entry.record.projectId ||
-    reference.source.sessionId !== activeSessionId ||
-    reference.source.runId !== runId ||
-    reference.source.callId !== event.callId ||
-    reference.source.toolName !== event.name ||
-    reference.source.argumentsDigest !== intent.argumentsDigest ||
-    reference.source.provenance !== "prepared_tool_change"
-  ) {
+  const reference = resolveActionableChangePreviewReference(records, activeSessionId, requestId);
+  if (reference === null) {
     return false;
   }
   try {
@@ -3648,184 +3368,25 @@ async function isCurrentActionableChangePreview(
   }
 }
 
-function presentationChangePreviewRef(
-  reference: import("./artifact-store.js").ArtifactReference<
-    import("./artifact-store.js").ChangePreviewArtifactSource
-  >,
-): NonNullable<ToolCallDisplay["changePreviewRef"]> {
-  return {
-    id: reference.id,
-    mediaType: reference.mediaType,
-    byteCount: reference.byteCount,
-    source: "change_preview",
-  };
-}
-
-function toolKind(name: string): ToolCallDisplay["kind"] {
-  if (name === "read_file") {
-    return "read";
-  }
-  if (name === "run_shell") {
-    return "shell";
-  }
-  if (name === "write_file" || name === "edit_file") {
-    return "mutation";
-  }
-  return name.startsWith("mcp__") ? "mcp" : "unknown";
-}
-
-function toolLabel(name: string): string {
-  return name === "read_file"
-    ? "read"
-    : name === "run_shell"
-      ? "shell"
-      : name === "write_file"
-        ? "write"
-        : name === "edit_file"
-          ? "edit"
-          : name;
-}
-
-function safeToolSubject(
-  subject: PermissionSubject | undefined,
-  output: JsonValue | undefined,
-): ToolCallDisplay["subject"] {
-  if (subject?.type === "file" || subject?.type === "workspace_path") {
-    return { type: "path", value: subject.path };
-  }
-  if (subject?.type === "command") {
-    return { type: "command", value: subject.command };
-  }
-  const outputRecord = jsonRecord(output);
-  const outputPath = outputRecord?.path;
-  if (typeof outputPath === "string") {
-    return { type: "path", value: outputPath };
-  }
-  return subject === undefined ? null : { type: "generic", value: subject.type };
-}
-
-function toolResultSummary(name: string, output: JsonValue | undefined): string | null {
-  const outputRecord = jsonRecord(output);
-  if (name === "read_file" && typeof outputRecord?.content === "string") {
-    return `${Buffer.byteLength(outputRecord.content, "utf8")} bytes${
-      outputRecord.truncated === true ? " · output truncated" : ""
-    }`;
-  }
-  if (name === "run_shell") {
-    const termination = jsonRecord(outputRecord?.termination);
-    const stdout = jsonRecord(outputRecord?.stdout);
-    const stderr = jsonRecord(outputRecord?.stderr);
-    if (
-      termination?.type === "exited" &&
-      typeof termination.exitCode === "number" &&
-      typeof stdout?.totalBytes === "number" &&
-      typeof stderr?.totalBytes === "number"
-    ) {
-      const streamSummaries = [
-        ...(stdout.totalBytes > 0 || stderr.totalBytes === 0
-          ? [`${stdout.totalBytes} stdout bytes`]
-          : []),
-        ...(stderr.totalBytes > 0 ? [`${stderr.totalBytes} stderr bytes`] : []),
-      ];
-      const outputTruncated =
-        (typeof stdout.omittedBytes === "number" && stdout.omittedBytes > 0) ||
-        (typeof stderr.omittedBytes === "number" && stderr.omittedBytes > 0);
-      return `exit ${termination.exitCode} · ${streamSummaries.join(" · ")}${
-        outputTruncated ? " · output truncated" : ""
-      }`;
-    }
-  }
-  if (name.startsWith("mcp__")) {
-    const content = outputRecord?.content;
-    const outputTruncated =
-      (Array.isArray(content) && content.some((block) => jsonRecord(block)?.truncated === true)) ||
-      (typeof outputRecord?.omittedContentBlocks === "number" &&
-        outputRecord.omittedContentBlocks > 0);
-    return output === undefined ? null : `Completed${outputTruncated ? " · output truncated" : ""}`;
-  }
-  return output === undefined ? null : "Completed";
-}
-
-const toolTextPreviewMaximumBytes = 16 * 1024;
-const toolTextPreviewMaximumLines = 200;
-const toolShellStreamPreviewMaximumBytes = 8 * 1024;
-
 function hydrateChangePreviews(
   records: readonly SourcedSessionRecord[],
   options: PresentationSessionRecordOptions,
   changePreviewCache: Map<string, ToolPreviewDisplay | null>,
 ): Promise<void> | null {
-  const pending = [...collectMutableToolDisplays(records).values()].flatMap((tool) => {
-    const name = tool.name;
-    const reference = tool.changePreviewRef;
-    if (
-      (name !== "write_file" && name !== "edit_file") ||
-      reference === undefined ||
-      changePreviewCache.has(reference.id)
-    ) {
-      return [];
-    }
-    changePreviewCache.set(reference.id, null);
-    return [
-      projectChangePreview(name, reference, options).then((preview) => {
+  const pending = collectChangePreviewRequests(records, new Set(changePreviewCache.keys())).map(
+    ({ name, reference }) => {
+      changePreviewCache.set(reference.id, null);
+      return projectChangePreview(name, reference, options).then((preview) => {
         changePreviewCache.set(reference.id, preview);
-      }),
-    ];
-  });
+      });
+    },
+  );
   return pending.length === 0 ? null : Promise.all(pending).then(() => undefined);
-}
-
-function toolPreview(
-  name: string,
-  output: JsonValue | undefined,
-  subject: ToolCallDisplay["subject"],
-  changePreviewRef: ToolCallDisplay["changePreviewRef"] | undefined,
-  changePreviewCache: ReadonlyMap<string, ToolPreviewDisplay | null>,
-): ToolCallDisplay["preview"] {
-  const outputRecord = jsonRecord(output);
-  if (name === "read_file" && typeof outputRecord?.content === "string") {
-    const bounded = boundedTextLines(
-      outputRecord.content,
-      toolTextPreviewMaximumBytes,
-      toolTextPreviewMaximumLines,
-    );
-    return {
-      kind: "read_text",
-      language: subject?.type === "path" ? languageForPath(subject.value) : null,
-      lines: bounded.lines.map((text, index) => ({ number: index + 1, text })),
-      omittedBytes: bounded.omittedBytes,
-      sourceTruncated: outputRecord.truncated === true,
-    };
-  }
-  if (
-    (name === "write_file" || name === "edit_file") &&
-    changePreviewRef !== undefined &&
-    changePreviewRef !== null
-  ) {
-    return changePreviewCache.get(changePreviewRef.id) ?? null;
-  }
-  if (name === "run_shell") {
-    const termination = jsonRecord(outputRecord?.termination);
-    const stdout = jsonRecord(outputRecord?.stdout);
-    const stderr = jsonRecord(outputRecord?.stderr);
-    const projectedTermination = shellTerminationPreview(termination);
-    const projectedStdout = shellStreamPreview(stdout);
-    const projectedStderr = shellStreamPreview(stderr);
-    return projectedTermination === null || projectedStdout === null || projectedStderr === null
-      ? null
-      : {
-          kind: "shell_output",
-          termination: projectedTermination,
-          stdout: projectedStdout,
-          stderr: projectedStderr,
-        };
-  }
-  return null;
 }
 
 async function projectChangePreview(
   name: "write_file" | "edit_file",
-  reference: NonNullable<ToolCallDisplay["changePreviewRef"]>,
+  reference: ChangePreviewProjectionRequest["reference"],
   options: PresentationSessionRecordOptions,
 ): Promise<ToolPreviewDisplay | null> {
   if (
@@ -3847,193 +3408,15 @@ async function projectChangePreview(
       return null;
     }
     const decoded = decodeArtifactPage(page.bytes, page.eof);
-    const bounded = boundedTextLines(
-      decoded.text,
-      toolTextPreviewMaximumBytes,
-      toolTextPreviewMaximumLines,
-    );
-    const omittedBytes =
-      Math.max(0, reference.byteCount - decoded.byteCount) + bounded.omittedBytes;
-    const path = bounded.lines.find((line) => line.startsWith("+++ b/"))?.slice("+++ b/".length);
-    if (name === "write_file") {
-      const lines = bounded.lines
-        .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
-        .map((line, index) => ({ number: index + 1, text: line.slice(1) }));
-      return {
-        kind: "write_text",
-        language: path === undefined ? null : languageForPath(path),
-        lines,
-        omittedBytes,
-      };
-    }
-    return {
-      kind: "diff",
-      language: path === undefined ? null : languageForPath(path),
-      lines: bounded.lines.map((line) => {
-        const kind = diffLineKind(line);
-        return {
-          kind,
-          oldLineNumber: null,
-          newLineNumber: null,
-          text: kind === "addition" || kind === "deletion" ? line.slice(1) : line,
-        };
-      }),
-      omittedBytes,
-    };
+    return projectChangePreviewPage({
+      name,
+      referenceByteCount: reference.byteCount,
+      decodedText: decoded.text,
+      decodedByteCount: decoded.byteCount,
+    });
   } catch {
     return null;
   }
-}
-
-function diffLineKind(line: string): "meta" | "context" | "addition" | "deletion" {
-  if (line.startsWith("+++") || line.startsWith("---") || line.startsWith("@@")) {
-    return "meta";
-  }
-  if (line.startsWith("+")) {
-    return "addition";
-  }
-  if (line.startsWith("-")) {
-    return "deletion";
-  }
-  return "context";
-}
-
-function boundedTextLines(
-  text: string,
-  maximumBytes: number,
-  maximumLines: number,
-): { readonly lines: readonly string[]; readonly omittedBytes: number } {
-  const sourceBytes = Buffer.byteLength(text, "utf8");
-  const sourceLines = text.split("\n");
-  if (sourceLines.at(-1) === "") {
-    sourceLines.pop();
-  }
-  const lines: string[] = [];
-  let consumedBytes = 0;
-  for (const [index, line] of sourceLines.entries()) {
-    if (lines.length >= maximumLines || consumedBytes >= maximumBytes) {
-      break;
-    }
-    const lineBytes = Buffer.byteLength(line, "utf8");
-    const newlineBytes = index < sourceLines.length - 1 || text.endsWith("\n") ? 1 : 0;
-    if (consumedBytes + lineBytes + newlineBytes <= maximumBytes) {
-      lines.push(line);
-      consumedBytes += lineBytes + newlineBytes;
-      continue;
-    }
-    const remainingBytes = maximumBytes - consumedBytes;
-    const prefix = boundedUtf8Prefix(line, remainingBytes);
-    if (prefix.byteCount > 0 || lines.length === 0) {
-      lines.push(prefix.text);
-      consumedBytes += prefix.byteCount;
-    }
-    break;
-  }
-  return { lines, omittedBytes: Math.max(0, sourceBytes - consumedBytes) };
-}
-
-function boundedUtf8Prefix(
-  text: string,
-  maximumBytes: number,
-): { readonly text: string; readonly byteCount: number } {
-  const bytes = Buffer.from(text, "utf8");
-  if (bytes.byteLength <= maximumBytes) {
-    return { text, byteCount: bytes.byteLength };
-  }
-  let end = Math.max(0, maximumBytes);
-  while (end > 0 && (bytes[end] ?? 0) >= 0x80 && (bytes[end] ?? 0) < 0xc0) {
-    end -= 1;
-  }
-  return { text: bytes.subarray(0, end).toString("utf8"), byteCount: end };
-}
-
-function boundedUtf8Tail(
-  text: string,
-  maximumBytes: number,
-): { readonly text: string; readonly byteCount: number } {
-  const bytes = Buffer.from(text, "utf8");
-  if (bytes.byteLength <= maximumBytes) {
-    return { text, byteCount: bytes.byteLength };
-  }
-  let start = bytes.byteLength - maximumBytes;
-  while (start < bytes.byteLength && (bytes[start] ?? 0) >= 0x80 && (bytes[start] ?? 0) < 0xc0) {
-    start += 1;
-  }
-  return {
-    text: bytes.subarray(start).toString("utf8"),
-    byteCount: bytes.byteLength - start,
-  };
-}
-
-function shellStreamPreview(value: KnownJsonRecord | undefined): {
-  readonly text: string;
-  readonly totalBytes: number;
-  readonly omittedBytes: number;
-} | null {
-  if (
-    typeof value?.tail !== "string" ||
-    typeof value.totalBytes !== "number" ||
-    typeof value.omittedBytes !== "number"
-  ) {
-    return null;
-  }
-  const bounded = boundedUtf8Tail(value.tail, toolShellStreamPreviewMaximumBytes);
-  const retainedBytes = Buffer.byteLength(value.tail, "utf8");
-  return {
-    text: bounded.text,
-    totalBytes: value.totalBytes,
-    omittedBytes: value.omittedBytes + retainedBytes - bounded.byteCount,
-  };
-}
-
-function shellTerminationPreview(
-  value: KnownJsonRecord | undefined,
-): Extract<ToolCallDisplay["preview"], { readonly kind: "shell_output" }>["termination"] | null {
-  if (value?.type === "exited" && typeof value.exitCode === "number") {
-    return { type: "exited", exitCode: value.exitCode };
-  }
-  if (value?.type === "timed_out" || value?.type === "interrupted") {
-    return { type: value.type };
-  }
-  return value?.type === "signalled" && typeof value.signal === "string"
-    ? { type: "signalled", signal: value.signal }
-    : null;
-}
-
-function languageForPath(path: string): string | null {
-  const extension = /\.([^./]+)$/u.exec(path)?.[1]?.toLowerCase();
-  const languages: Readonly<Record<string, string>> = {
-    bash: "bash",
-    c: "c",
-    cc: "cpp",
-    cpp: "cpp",
-    css: "css",
-    go: "go",
-    h: "c",
-    hpp: "cpp",
-    html: "html",
-    java: "java",
-    js: "javascript",
-    json: "json",
-    jsx: "javascript",
-    kt: "kotlin",
-    kts: "kotlin",
-    md: "markdown",
-    py: "python",
-    rb: "ruby",
-    rs: "rust",
-    sh: "bash",
-    sql: "sql",
-    ts: "typescript",
-    tsx: "typescript",
-    yaml: "yaml",
-    yml: "yaml",
-  };
-  return extension === undefined ? "text" : (languages[extension] ?? "text");
-}
-
-function boundedDisplayText(value: string): string {
-  return [...value.replaceAll(/\s+/gu, " ").trim()].slice(0, 240).join("");
 }
 
 function safeRunFailureMessage(code: string): string {
@@ -4050,51 +3433,6 @@ function safeRunFailureMessage(code: string): string {
     return "The requested Skill activation failed.";
   }
   return "The model run failed.";
-}
-
-function toolArtifacts(
-  output: JsonValue | undefined,
-): readonly ToolCallDisplay["artifacts"][number][] {
-  const outputRecord = jsonRecord(output);
-  const candidates = [
-    jsonRecord(outputRecord?.artifact),
-    jsonRecord(jsonRecord(outputRecord?.stdout)?.artifact),
-    jsonRecord(jsonRecord(outputRecord?.stderr)?.artifact),
-  ];
-  return candidates.flatMap((candidate) => {
-    const id = candidate?.id;
-    const mediaType = candidate?.mediaType;
-    const byteCount = candidate?.byteCount;
-    return typeof id === "string" && typeof mediaType === "string" && typeof byteCount === "number"
-      ? [{ id, mediaType, byteCount, source: "tool_output" as const }]
-      : [];
-  });
-}
-
-type KnownJsonRecord = Readonly<Record<string, JsonValue>> & {
-  readonly path?: JsonValue;
-  readonly content?: JsonValue;
-  readonly termination?: JsonValue;
-  readonly stdout?: JsonValue;
-  readonly stderr?: JsonValue;
-  readonly artifact?: JsonValue;
-  readonly type?: JsonValue;
-  readonly exitCode?: JsonValue;
-  readonly signal?: JsonValue;
-  readonly tail?: JsonValue;
-  readonly totalBytes?: JsonValue;
-  readonly omittedBytes?: JsonValue;
-  readonly omittedContentBlocks?: JsonValue;
-  readonly truncated?: JsonValue;
-  readonly id?: JsonValue;
-  readonly mediaType?: JsonValue;
-  readonly byteCount?: JsonValue;
-};
-
-function jsonRecord(value: JsonValue | undefined): KnownJsonRecord | undefined {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as KnownJsonRecord)
-    : undefined;
 }
 
 function projectRepositoryInstructions(

--- a/packages/agent/src/presentation-tool-projection.ts
+++ b/packages/agent/src/presentation-tool-projection.ts
@@ -1,0 +1,719 @@
+import type {
+  PendingInteraction,
+  ToolCallDisplay,
+  ToolPreviewDisplay,
+} from "@adam-agent/presentation";
+import type { ArtifactReference, ChangePreviewArtifactSource } from "./artifact-store.js";
+import type { SessionRecord } from "./session-store.js";
+import type { JsonValue, PermissionSubject, ToolEffect } from "./tool-runtime.js";
+
+type PresentationToolHistoryRecord = {
+  readonly sessionId: string;
+  readonly entry: SessionRecord;
+};
+
+export type ChangePreviewProjectionRequest = {
+  readonly name: "write_file" | "edit_file";
+  readonly reference: NonNullable<ToolCallDisplay["changePreviewRef"]>;
+};
+
+type MutableToolDisplay = {
+  sessionId: string;
+  callId: string;
+  sequence?: number;
+  name?: string;
+  source?: NonNullable<ToolCallDisplay["source"]>;
+  effect?: ToolEffect;
+  subject?: PermissionSubject;
+  status: ToolCallDisplay["status"];
+  output?: JsonValue;
+  failure?: { readonly code: string; readonly reason?: string; readonly message: string };
+  changePreviewRef?: NonNullable<ToolCallDisplay["changePreviewRef"]>;
+};
+
+function collectMutableToolDisplays(
+  records: readonly PresentationToolHistoryRecord[],
+): ReadonlyMap<string, MutableToolDisplay> {
+  const tools = new Map<string, MutableToolDisplay>();
+  const toolFor = (sessionId: string, callId: string): MutableToolDisplay => {
+    const key = `${sessionId}:${callId}`;
+    const existing = tools.get(key);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const created: MutableToolDisplay = { sessionId, callId, status: "requested" };
+    tools.set(key, created);
+    return created;
+  };
+
+  for (const { entry, sessionId } of records) {
+    if (entry.schemaVersion !== 3) {
+      continue;
+    }
+    if (entry.record.type === "model_response_completed") {
+      for (const intent of entry.record.response.toolIntents) {
+        const tool = toolFor(sessionId, intent.callId);
+        tool.name = intent.name;
+        tool.source = {
+          provenance: "provider_model_response",
+          sessionId,
+          responseSequence: entry.sequence,
+          argumentsDigest: intent.argumentsDigest,
+          definitionDigest: intent.definitionDigest ?? null,
+          replay: intent.replay,
+        };
+        if (intent.effect !== undefined) {
+          tool.effect = intent.effect;
+        }
+      }
+      continue;
+    }
+    if (entry.record.type !== "runtime_event") {
+      continue;
+    }
+    const event = entry.record.event;
+    if (event.type === "tool_requested") {
+      const tool = toolFor(sessionId, event.callId);
+      tool.sequence = entry.sequence;
+      tool.name = event.name;
+    } else if (event.type === "tool_permission_requested") {
+      const tool = toolFor(sessionId, event.callId);
+      tool.effect = event.effect;
+      tool.subject = event.subject;
+      tool.status = "permission_required";
+      if (event.changePreviewRef !== undefined) {
+        tool.changePreviewRef = presentationChangePreviewRef(event.changePreviewRef);
+      }
+    } else if (event.type === "tool_permission_decided") {
+      const tool = toolFor(sessionId, event.callId);
+      if (event.effect !== undefined) {
+        tool.effect = event.effect;
+      }
+      if (event.subject !== undefined) {
+        tool.subject = event.subject;
+      }
+      if (event.changePreviewRef !== undefined) {
+        tool.changePreviewRef = presentationChangePreviewRef(event.changePreviewRef);
+      }
+      tool.status = event.decision === "allow" ? "requested" : "denied";
+    } else if (event.type === "tool_started") {
+      const tool = toolFor(sessionId, event.callId);
+      tool.status = "running";
+    } else if (event.type === "tool_completed") {
+      const tool = toolFor(sessionId, event.callId);
+      tool.status = "completed";
+      tool.output = event.output;
+    } else if (event.type === "tool_failed") {
+      const tool = toolFor(sessionId, event.callId);
+      tool.status = event.error.code === "permission_denied" ? "denied" : "failed";
+      tool.failure = {
+        code: event.error.code,
+        ...(event.error.code === "tool_effect_indeterminate" ? { reason: event.error.reason } : {}),
+        message: boundedDisplayText(event.error.message),
+      };
+    }
+  }
+
+  return tools;
+}
+
+export function projectToolDisplays(
+  records: readonly PresentationToolHistoryRecord[],
+  changePreviewCache: ReadonlyMap<string, ToolPreviewDisplay | null>,
+): ReadonlyMap<string, ToolCallDisplay> {
+  const tools = collectMutableToolDisplays(records);
+  return new Map(
+    [...tools.entries()].flatMap(([key, tool]) => {
+      if (tool.sequence === undefined) {
+        return [];
+      }
+      const name = tool.name ?? "unknown";
+      const subject = safeToolSubject(tool.subject, tool.output);
+      return [
+        [
+          key,
+          {
+            type: "tool_call" as const,
+            id: `${tool.sessionId}:${tool.sequence}`,
+            sequence: tool.sequence,
+            sourceSessionId: tool.sessionId,
+            branchBoundary: null,
+            callId: tool.callId,
+            qualifiedName: name,
+            kind: toolKind(name),
+            effect: tool.effect ?? null,
+            label: toolLabel(name),
+            subject,
+            source: tool.source ?? null,
+            durationMs: null,
+            status: tool.status,
+            outcome: toolOutcome(tool),
+            resultSummary:
+              tool.failure === undefined
+                ? toolResultSummary(name, tool.output)
+                : `${tool.failure.code}: ${tool.failure.message}`,
+            artifacts: toolArtifacts(tool.output),
+            changePreviewRef: tool.changePreviewRef ?? null,
+            preview: toolPreview(
+              name,
+              tool.output,
+              subject,
+              tool.changePreviewRef,
+              changePreviewCache,
+            ),
+          },
+        ] as const,
+      ];
+    }),
+  );
+}
+
+export function projectPendingPermissionCandidates(
+  records: readonly PresentationToolHistoryRecord[],
+): readonly Extract<PendingInteraction, { readonly type: "permission" }>[] {
+  const decided = new Set(
+    records.flatMap(({ entry, sessionId }) =>
+      entry.schemaVersion === 3 &&
+      entry.record.type === "runtime_event" &&
+      entry.record.event.type === "tool_permission_decided" &&
+      entry.record.event.requestId !== undefined
+        ? [`${sessionId}:${entry.record.event.requestId}`]
+        : [],
+    ),
+  );
+  return records.flatMap(({ entry, sessionId }) => {
+    if (
+      entry.schemaVersion !== 3 ||
+      entry.record.type !== "runtime_event" ||
+      entry.record.event.type !== "tool_permission_requested" ||
+      decided.has(`${sessionId}:${entry.record.event.requestId}`)
+    ) {
+      return [];
+    }
+    const subject = safeToolSubject(entry.record.event.subject, undefined);
+    if (subject === null) {
+      return [];
+    }
+    const changePreviewRef =
+      entry.record.event.changePreviewRef === undefined
+        ? null
+        : presentationChangePreviewRef(entry.record.event.changePreviewRef);
+    return [
+      {
+        type: "permission" as const,
+        requestId: entry.record.event.requestId,
+        callId: entry.record.event.callId,
+        effect: entry.record.event.effect,
+        subject,
+        canAllow: entry.record.event.effect !== "write",
+        changePreviewRef,
+      },
+    ];
+  });
+}
+
+export function collectChangePreviewRequests(
+  records: readonly PresentationToolHistoryRecord[],
+  knownPreviewIds: ReadonlySet<string>,
+): readonly ChangePreviewProjectionRequest[] {
+  const seen = new Set(knownPreviewIds);
+  return [...collectMutableToolDisplays(records).values()].flatMap((tool) => {
+    const name = tool.name;
+    const reference = tool.changePreviewRef;
+    if (
+      (name !== "write_file" && name !== "edit_file") ||
+      reference === undefined ||
+      seen.has(reference.id)
+    ) {
+      return [];
+    }
+    seen.add(reference.id);
+    return [{ name, reference }];
+  });
+}
+
+export function resolveActionableChangePreviewReference(
+  records: readonly PresentationToolHistoryRecord[],
+  activeSessionId: string,
+  requestId: string,
+): ArtifactReference<ChangePreviewArtifactSource> | null {
+  const requested = records.findLast(
+    ({ entry, sessionId }) =>
+      sessionId === activeSessionId &&
+      entry.schemaVersion === 3 &&
+      entry.record.type === "runtime_event" &&
+      entry.record.event.type === "tool_permission_requested" &&
+      entry.record.event.requestId === requestId,
+  );
+  if (
+    requested?.entry.schemaVersion !== 3 ||
+    requested.entry.record.type !== "runtime_event" ||
+    requested.entry.record.event.type !== "tool_permission_requested" ||
+    requested.entry.record.event.changePreviewRef === undefined ||
+    records.some(
+      ({ entry, sessionId }) =>
+        sessionId === activeSessionId &&
+        entry.schemaVersion === 3 &&
+        entry.record.type === "runtime_event" &&
+        entry.record.event.type === "tool_permission_decided" &&
+        entry.record.event.requestId === requestId,
+    )
+  ) {
+    return null;
+  }
+  const event = requested.entry.record.event;
+  const runId = requested.entry.record.runId;
+  const genesis = records.find(
+    ({ entry, sessionId }) =>
+      sessionId === activeSessionId &&
+      entry.schemaVersion === 3 &&
+      entry.record.type === "session_genesis",
+  );
+  const response = records.findLast(
+    ({ entry, sessionId }) =>
+      sessionId === activeSessionId &&
+      entry.schemaVersion === 3 &&
+      entry.record.type === "model_response_completed" &&
+      entry.record.runId === runId,
+  );
+  if (
+    genesis?.entry.schemaVersion !== 3 ||
+    genesis.entry.record.type !== "session_genesis" ||
+    response?.entry.schemaVersion !== 3 ||
+    response.entry.record.type !== "model_response_completed"
+  ) {
+    return null;
+  }
+  const callIndex = response.entry.record.response.toolCalls.findIndex(
+    (call) => call.id === event.callId && call.name === event.name,
+  );
+  const call = response.entry.record.response.toolCalls[callIndex];
+  const intent = response.entry.record.response.toolIntents[callIndex];
+  const reference = event.changePreviewRef;
+  return reference !== undefined &&
+    call !== undefined &&
+    intent !== undefined &&
+    reference.source.projectId === genesis.entry.record.projectId &&
+    reference.source.sessionId === activeSessionId &&
+    reference.source.runId === runId &&
+    reference.source.callId === event.callId &&
+    reference.source.toolName === event.name &&
+    reference.source.argumentsDigest === intent.argumentsDigest &&
+    reference.source.provenance === "prepared_tool_change"
+    ? reference
+    : null;
+}
+
+export function projectChangePreviewPage(input: {
+  readonly name: "write_file" | "edit_file";
+  readonly referenceByteCount: number;
+  readonly decodedText: string;
+  readonly decodedByteCount: number;
+}): ToolPreviewDisplay {
+  const bounded = boundedTextLines(
+    input.decodedText,
+    toolTextPreviewMaximumBytes,
+    toolTextPreviewMaximumLines,
+  );
+  const omittedBytes =
+    Math.max(0, input.referenceByteCount - input.decodedByteCount) + bounded.omittedBytes;
+  const path = bounded.lines.find((line) => line.startsWith("+++ b/"))?.slice("+++ b/".length);
+  if (input.name === "write_file") {
+    const lines = bounded.lines
+      .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+      .map((line, index) => ({ number: index + 1, text: line.slice(1) }));
+    return {
+      kind: "write_text",
+      language: path === undefined ? null : languageForPath(path),
+      lines,
+      omittedBytes,
+    };
+  }
+  return {
+    kind: "diff",
+    language: path === undefined ? null : languageForPath(path),
+    lines: bounded.lines.map((line) => {
+      const kind = diffLineKind(line);
+      return {
+        kind,
+        oldLineNumber: null,
+        newLineNumber: null,
+        text: kind === "addition" || kind === "deletion" ? line.slice(1) : line,
+      };
+    }),
+    omittedBytes,
+  };
+}
+
+function presentationChangePreviewRef(
+  reference: ArtifactReference<ChangePreviewArtifactSource>,
+): NonNullable<ToolCallDisplay["changePreviewRef"]> {
+  return {
+    id: reference.id,
+    mediaType: reference.mediaType,
+    byteCount: reference.byteCount,
+    source: "change_preview",
+  };
+}
+
+function toolKind(name: string): ToolCallDisplay["kind"] {
+  if (name === "read_file") {
+    return "read";
+  }
+  if (name === "run_shell") {
+    return "shell";
+  }
+  if (name === "write_file" || name === "edit_file") {
+    return "mutation";
+  }
+  return name.startsWith("mcp__") ? "mcp" : "unknown";
+}
+
+function toolLabel(name: string): string {
+  return name === "read_file"
+    ? "read"
+    : name === "run_shell"
+      ? "shell"
+      : name === "write_file"
+        ? "write"
+        : name === "edit_file"
+          ? "edit"
+          : name;
+}
+
+function safeToolSubject(
+  subject: PermissionSubject | undefined,
+  output: JsonValue | undefined,
+): ToolCallDisplay["subject"] {
+  if (subject?.type === "file" || subject?.type === "workspace_path") {
+    return { type: "path", value: subject.path };
+  }
+  if (subject?.type === "command") {
+    return { type: "command", value: subject.command };
+  }
+  const outputRecord = jsonRecord(output);
+  const outputPath = outputRecord?.path;
+  if (typeof outputPath === "string") {
+    return { type: "path", value: outputPath };
+  }
+  return subject === undefined ? null : { type: "generic", value: subject.type };
+}
+
+function toolResultSummary(name: string, output: JsonValue | undefined): string | null {
+  const outputRecord = jsonRecord(output);
+  if (name === "read_file" && typeof outputRecord?.content === "string") {
+    return `${Buffer.byteLength(outputRecord.content, "utf8")} bytes${
+      outputRecord.truncated === true ? " · output truncated" : ""
+    }`;
+  }
+  if (name === "run_shell") {
+    const termination = jsonRecord(outputRecord?.termination);
+    const stdout = jsonRecord(outputRecord?.stdout);
+    const stderr = jsonRecord(outputRecord?.stderr);
+    if (
+      termination?.type === "exited" &&
+      typeof termination.exitCode === "number" &&
+      typeof stdout?.totalBytes === "number" &&
+      typeof stderr?.totalBytes === "number"
+    ) {
+      const streamSummaries = [
+        ...(stdout.totalBytes > 0 || stderr.totalBytes === 0
+          ? [`${stdout.totalBytes} stdout bytes`]
+          : []),
+        ...(stderr.totalBytes > 0 ? [`${stderr.totalBytes} stderr bytes`] : []),
+      ];
+      const outputTruncated =
+        (typeof stdout.omittedBytes === "number" && stdout.omittedBytes > 0) ||
+        (typeof stderr.omittedBytes === "number" && stderr.omittedBytes > 0);
+      return `exit ${termination.exitCode} · ${streamSummaries.join(" · ")}${
+        outputTruncated ? " · output truncated" : ""
+      }`;
+    }
+  }
+  if (name.startsWith("mcp__")) {
+    const content = outputRecord?.content;
+    const outputTruncated =
+      (Array.isArray(content) && content.some((block) => jsonRecord(block)?.truncated === true)) ||
+      (typeof outputRecord?.omittedContentBlocks === "number" &&
+        outputRecord.omittedContentBlocks > 0);
+    return output === undefined ? null : `Completed${outputTruncated ? " · output truncated" : ""}`;
+  }
+  return output === undefined ? null : "Completed";
+}
+
+const toolTextPreviewMaximumBytes = 16 * 1024;
+const toolTextPreviewMaximumLines = 200;
+const toolShellStreamPreviewMaximumBytes = 8 * 1024;
+
+function toolPreview(
+  name: string,
+  output: JsonValue | undefined,
+  subject: ToolCallDisplay["subject"],
+  changePreviewRef: ToolCallDisplay["changePreviewRef"] | undefined,
+  changePreviewCache: ReadonlyMap<string, ToolPreviewDisplay | null>,
+): ToolCallDisplay["preview"] {
+  const outputRecord = jsonRecord(output);
+  if (name === "read_file" && typeof outputRecord?.content === "string") {
+    const bounded = boundedTextLines(
+      outputRecord.content,
+      toolTextPreviewMaximumBytes,
+      toolTextPreviewMaximumLines,
+    );
+    return {
+      kind: "read_text",
+      language: subject?.type === "path" ? languageForPath(subject.value) : null,
+      lines: bounded.lines.map((text, index) => ({ number: index + 1, text })),
+      omittedBytes: bounded.omittedBytes,
+      sourceTruncated: outputRecord.truncated === true,
+    };
+  }
+  if (
+    (name === "write_file" || name === "edit_file") &&
+    changePreviewRef !== undefined &&
+    changePreviewRef !== null
+  ) {
+    return changePreviewCache.get(changePreviewRef.id) ?? null;
+  }
+  if (name === "run_shell") {
+    const termination = jsonRecord(outputRecord?.termination);
+    const stdout = jsonRecord(outputRecord?.stdout);
+    const stderr = jsonRecord(outputRecord?.stderr);
+    const projectedTermination = shellTerminationPreview(termination);
+    const projectedStdout = shellStreamPreview(stdout);
+    const projectedStderr = shellStreamPreview(stderr);
+    return projectedTermination === null || projectedStdout === null || projectedStderr === null
+      ? null
+      : {
+          kind: "shell_output",
+          termination: projectedTermination,
+          stdout: projectedStdout,
+          stderr: projectedStderr,
+        };
+  }
+  return null;
+}
+
+function toolOutcome(tool: MutableToolDisplay): ToolCallDisplay["outcome"] {
+  if (tool.failure?.code === "tool_effect_indeterminate") {
+    return {
+      status: "indeterminate",
+      code: "tool_effect_indeterminate",
+      reason: tool.failure.reason ?? null,
+      message: tool.failure.message,
+    };
+  }
+  if (tool.failure !== undefined) {
+    return {
+      status: "failed",
+      code: tool.failure.code,
+      message: tool.failure.message,
+    };
+  }
+  if (tool.status === "completed") {
+    return { status: "completed" };
+  }
+  if (tool.status === "denied") {
+    return {
+      status: "denied",
+      code: "permission_denied",
+      message: "Permission was denied for this tool call.",
+    };
+  }
+  return null;
+}
+
+function diffLineKind(line: string): "meta" | "context" | "addition" | "deletion" {
+  if (line.startsWith("+++") || line.startsWith("---") || line.startsWith("@@")) {
+    return "meta";
+  }
+  if (line.startsWith("+")) {
+    return "addition";
+  }
+  if (line.startsWith("-")) {
+    return "deletion";
+  }
+  return "context";
+}
+
+function boundedTextLines(
+  text: string,
+  maximumBytes: number,
+  maximumLines: number,
+): { readonly lines: readonly string[]; readonly omittedBytes: number } {
+  const sourceBytes = Buffer.byteLength(text, "utf8");
+  const sourceLines = text.split("\n");
+  if (sourceLines.at(-1) === "") {
+    sourceLines.pop();
+  }
+  const lines: string[] = [];
+  let consumedBytes = 0;
+  for (const [index, line] of sourceLines.entries()) {
+    if (lines.length >= maximumLines || consumedBytes >= maximumBytes) {
+      break;
+    }
+    const lineBytes = Buffer.byteLength(line, "utf8");
+    const newlineBytes = index < sourceLines.length - 1 || text.endsWith("\n") ? 1 : 0;
+    if (consumedBytes + lineBytes + newlineBytes <= maximumBytes) {
+      lines.push(line);
+      consumedBytes += lineBytes + newlineBytes;
+      continue;
+    }
+    const remainingBytes = maximumBytes - consumedBytes;
+    const prefix = boundedUtf8Prefix(line, remainingBytes);
+    if (prefix.byteCount > 0 || lines.length === 0) {
+      lines.push(prefix.text);
+      consumedBytes += prefix.byteCount;
+    }
+    break;
+  }
+  return { lines, omittedBytes: Math.max(0, sourceBytes - consumedBytes) };
+}
+
+function boundedUtf8Prefix(
+  text: string,
+  maximumBytes: number,
+): { readonly text: string; readonly byteCount: number } {
+  const bytes = Buffer.from(text, "utf8");
+  if (bytes.byteLength <= maximumBytes) {
+    return { text, byteCount: bytes.byteLength };
+  }
+  let end = Math.max(0, maximumBytes);
+  while (end > 0 && (bytes[end] ?? 0) >= 0x80 && (bytes[end] ?? 0) < 0xc0) {
+    end -= 1;
+  }
+  return { text: bytes.subarray(0, end).toString("utf8"), byteCount: end };
+}
+
+function boundedUtf8Tail(
+  text: string,
+  maximumBytes: number,
+): { readonly text: string; readonly byteCount: number } {
+  const bytes = Buffer.from(text, "utf8");
+  if (bytes.byteLength <= maximumBytes) {
+    return { text, byteCount: bytes.byteLength };
+  }
+  let start = bytes.byteLength - maximumBytes;
+  while (start < bytes.byteLength && (bytes[start] ?? 0) >= 0x80 && (bytes[start] ?? 0) < 0xc0) {
+    start += 1;
+  }
+  return {
+    text: bytes.subarray(start).toString("utf8"),
+    byteCount: bytes.byteLength - start,
+  };
+}
+
+function shellStreamPreview(value: KnownJsonRecord | undefined): {
+  readonly text: string;
+  readonly totalBytes: number;
+  readonly omittedBytes: number;
+} | null {
+  if (
+    typeof value?.tail !== "string" ||
+    typeof value.totalBytes !== "number" ||
+    typeof value.omittedBytes !== "number"
+  ) {
+    return null;
+  }
+  const bounded = boundedUtf8Tail(value.tail, toolShellStreamPreviewMaximumBytes);
+  const retainedBytes = Buffer.byteLength(value.tail, "utf8");
+  return {
+    text: bounded.text,
+    totalBytes: value.totalBytes,
+    omittedBytes: value.omittedBytes + retainedBytes - bounded.byteCount,
+  };
+}
+
+function shellTerminationPreview(
+  value: KnownJsonRecord | undefined,
+): Extract<ToolCallDisplay["preview"], { readonly kind: "shell_output" }>["termination"] | null {
+  if (value?.type === "exited" && typeof value.exitCode === "number") {
+    return { type: "exited", exitCode: value.exitCode };
+  }
+  if (value?.type === "timed_out" || value?.type === "interrupted") {
+    return { type: value.type };
+  }
+  return value?.type === "signalled" && typeof value.signal === "string"
+    ? { type: "signalled", signal: value.signal }
+    : null;
+}
+
+function languageForPath(path: string): string | null {
+  const extension = /\.([^./]+)$/u.exec(path)?.[1]?.toLowerCase();
+  const languages: Readonly<Record<string, string>> = {
+    bash: "bash",
+    c: "c",
+    cc: "cpp",
+    cpp: "cpp",
+    css: "css",
+    go: "go",
+    h: "c",
+    hpp: "cpp",
+    html: "html",
+    java: "java",
+    js: "javascript",
+    json: "json",
+    jsx: "javascript",
+    kt: "kotlin",
+    kts: "kotlin",
+    md: "markdown",
+    py: "python",
+    rb: "ruby",
+    rs: "rust",
+    sh: "bash",
+    sql: "sql",
+    ts: "typescript",
+    tsx: "typescript",
+    yaml: "yaml",
+    yml: "yaml",
+  };
+  return extension === undefined ? "text" : (languages[extension] ?? "text");
+}
+
+function boundedDisplayText(value: string): string {
+  return [...value.replaceAll(/\s+/gu, " ").trim()].slice(0, 240).join("");
+}
+
+function toolArtifacts(
+  output: JsonValue | undefined,
+): readonly ToolCallDisplay["artifacts"][number][] {
+  const outputRecord = jsonRecord(output);
+  const candidates = [
+    jsonRecord(outputRecord?.artifact),
+    jsonRecord(jsonRecord(outputRecord?.stdout)?.artifact),
+    jsonRecord(jsonRecord(outputRecord?.stderr)?.artifact),
+  ];
+  return candidates.flatMap((candidate) => {
+    const id = candidate?.id;
+    const mediaType = candidate?.mediaType;
+    const byteCount = candidate?.byteCount;
+    return typeof id === "string" && typeof mediaType === "string" && typeof byteCount === "number"
+      ? [{ id, mediaType, byteCount, source: "tool_output" as const }]
+      : [];
+  });
+}
+
+type KnownJsonRecord = Readonly<Record<string, JsonValue>> & {
+  readonly path?: JsonValue;
+  readonly content?: JsonValue;
+  readonly termination?: JsonValue;
+  readonly stdout?: JsonValue;
+  readonly stderr?: JsonValue;
+  readonly artifact?: JsonValue;
+  readonly type?: JsonValue;
+  readonly exitCode?: JsonValue;
+  readonly signal?: JsonValue;
+  readonly tail?: JsonValue;
+  readonly totalBytes?: JsonValue;
+  readonly omittedBytes?: JsonValue;
+  readonly omittedContentBlocks?: JsonValue;
+  readonly truncated?: JsonValue;
+  readonly id?: JsonValue;
+  readonly mediaType?: JsonValue;
+  readonly byteCount?: JsonValue;
+};
+
+function jsonRecord(value: JsonValue | undefined): KnownJsonRecord | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as KnownJsonRecord)
+    : undefined;
+}

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -7888,9 +7888,25 @@ test("PresentationSession projects one live pending permission with its inline t
       throw new Error("Expected an active session.");
     }
     const pendingVisible = Promise.withResolvers<void>();
+    const deniedVisible = Promise.withResolvers<void>();
+    let deniedProjection:
+      | { readonly pendingInteractionCount: number; readonly tool: unknown }
+      | undefined;
     const unsubscribePresentation = presentation.subscribe(() => {
-      if (presentation.getState().authoritative.active?.pendingInteractions.length === 1) {
+      const active = presentation.getState().authoritative.active;
+      if (active?.pendingInteractions.length === 1) {
         pendingVisible.resolve();
+      }
+      const deniedTool = active?.transcript.items.find(
+        (item) =>
+          item.type === "tool_call" && item.callId === "pending-read" && item.status === "denied",
+      );
+      if (active?.pendingInteractions.length === 0 && deniedTool !== undefined) {
+        deniedProjection = {
+          pendingInteractionCount: active.pendingInteractions.length,
+          tool: deniedTool,
+        };
+        deniedVisible.resolve();
       }
     });
     const continuation = lifecycle.continue({
@@ -7900,6 +7916,8 @@ test("PresentationSession projects one live pending permission with its inline t
     });
     await permissionRequested.promise;
     let failureGuard: ReturnType<typeof setTimeout> | undefined;
+    let deniedFailureGuard: ReturnType<typeof setTimeout> | undefined;
+    let permissionSettled = false;
     try {
       await Promise.race([
         pendingVisible.promise,
@@ -7929,11 +7947,43 @@ test("PresentationSession projects one live pending permission with its inline t
           changePreviewRef: null,
         },
       ]);
+      if (requestId === undefined) {
+        throw new Error("Expected the pending permission request identity.");
+      }
+      await expect(
+        presentation.dispatch({ type: "decide_permission", requestId, decision: "deny" }),
+      ).resolves.toMatchObject({ status: "admitted", resource: null });
+      permissionSettled = true;
+      await Promise.race([
+        deniedVisible.promise,
+        new Promise<never>((_resolve, reject) => {
+          deniedFailureGuard = setTimeout(
+            () => reject(new Error("The denied Presentation state was never published.")),
+            5_000,
+          );
+        }),
+      ]);
+      expect(deniedProjection).toMatchObject({
+        pendingInteractionCount: 0,
+        tool: {
+          type: "tool_call",
+          callId: "pending-read",
+          status: "denied",
+          outcome: {
+            status: "failed",
+            code: "permission_denied",
+            message: "Permission denied for tool: read_file",
+          },
+        },
+      });
     } finally {
       if (failureGuard !== undefined) {
         clearTimeout(failureGuard);
       }
-      if (requestId !== undefined) {
+      if (deniedFailureGuard !== undefined) {
+        clearTimeout(deniedFailureGuard);
+      }
+      if (!permissionSettled && requestId !== undefined) {
         lifecycle.decidePermission({ requestId, decision: "deny" });
       }
       await continuation;

--- a/packages/testkit/src/public-product-contract.test.ts
+++ b/packages/testkit/src/public-product-contract.test.ts
@@ -491,6 +491,153 @@ test("SessionLifecycle canonical history projections have package-internal owner
   }
 });
 
+test("PresentationSession tool projection has one package-internal owner", async () => {
+  const agentSourceRoot = join(productRoot, "packages", "agent", "src");
+  const sourceFiles = (await readdir(agentSourceRoot, { recursive: true }))
+    .filter((entry) => entry.endsWith(".ts"))
+    .sort();
+  const sources = await Promise.all(
+    sourceFiles.map(async (sourceFile) => ({
+      path: sourceFile,
+      source: await readFile(join(agentSourceRoot, sourceFile), "utf8"),
+    })),
+  );
+  const expectedOwners = {
+    collectChangePreviewRequests: ["presentation-tool-projection.ts"],
+    projectChangePreviewPage: ["presentation-tool-projection.ts"],
+    projectPendingPermissionCandidates: ["presentation-tool-projection.ts"],
+    projectToolDisplays: ["presentation-tool-projection.ts"],
+    resolveActionableChangePreviewReference: ["presentation-tool-projection.ts"],
+  } as const;
+  const actualOwners = Object.fromEntries(
+    Object.keys(expectedOwners).map((symbol) => [
+      symbol,
+      sources
+        .filter(({ source }) => new RegExp(`\\bfunction\\s+${symbol}\\s*\\(`, "u").test(source))
+        .map(({ path }) => path),
+    ]),
+  );
+  const expectedTypeOwners = {
+    ChangePreviewProjectionRequest: ["presentation-tool-projection.ts"],
+  } as const;
+  const actualTypeOwners = Object.fromEntries(
+    Object.keys(expectedTypeOwners).map((symbol) => [
+      symbol,
+      sources
+        .filter(({ source }) => new RegExp(`\\bexport\\s+type\\s+${symbol}\\b`, "u").test(source))
+        .map(({ path }) => path),
+    ]),
+  );
+  const projectionSource =
+    sources.find(({ path }) => path === "presentation-tool-projection.ts")?.source ?? "";
+  const projectionConsumers = sources
+    .filter(({ source }) => moduleSpecifiers(source).includes("./presentation-tool-projection.js"))
+    .map(({ path }) => path);
+  const projectionDependencies = [...moduleSpecifiers(projectionSource)].sort();
+  const projectionRuntimeImports = runtimeModuleSpecifiers(projectionSource);
+  const projectionTypeImports = typeOnlyImportSpecifiers(projectionSource).sort();
+  const publicFacadeSource = sources.find(({ path }) => path === "index.ts")?.source ?? "";
+  const testingFacadeSource =
+    sources.find(({ path }) => path === "internal-testing.ts")?.source ?? "";
+  const testSourceRoots = (
+    await Promise.all(
+      ["apps", "packages"].map(async (root) =>
+        (
+          await readdir(join(productRoot, root), { withFileTypes: true })
+        )
+          .filter((entry) => entry.isDirectory())
+          .map((entry) => join(productRoot, root, entry.name, "src")),
+      ),
+    )
+  ).flat();
+  const testSources = (
+    await Promise.all(
+      testSourceRoots.map(async (sourceRoot) => {
+        try {
+          return (await readdir(sourceRoot, { recursive: true }))
+            .filter((entry) => entry.endsWith(".test.ts"))
+            .map((entry) => join(sourceRoot, entry));
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            return [];
+          }
+          throw error;
+        }
+      }),
+    )
+  ).flat();
+  const directTestImports = (
+    await Promise.all(
+      testSources
+        .filter((testPath) => testPath !== fileURLToPath(import.meta.url))
+        .map(async (testPath) =>
+          moduleSpecifiers(await readFile(testPath, "utf8"))
+            .filter((specifier) => /presentation-tool-projection\.js$/u.test(specifier))
+            .map((specifier) => ({
+              path: relative(productRoot, testPath),
+              specifier,
+            })),
+        ),
+    )
+  ).flat();
+
+  expect.soft(actualOwners).toEqual(expectedOwners);
+  expect.soft(actualTypeOwners).toEqual(expectedTypeOwners);
+  expect.soft(projectionConsumers).toEqual(["presentation-session.ts"]);
+  expect.soft(projectionRuntimeImports).toEqual([]);
+  expect
+    .soft(projectionTypeImports)
+    .toEqual([
+      "./artifact-store.js",
+      "./session-store.js",
+      "./tool-runtime.js",
+      "@adam-agent/presentation",
+    ]);
+  expect
+    .soft(projectionDependencies)
+    .toEqual([
+      "./artifact-store.js",
+      "./session-store.js",
+      "./tool-runtime.js",
+      "@adam-agent/presentation",
+    ]);
+  const packageInternalSymbols = [
+    "ChangePreviewProjectionRequest",
+    "collectChangePreviewRequests",
+    "projectChangePreviewPage",
+    "projectPendingPermissionCandidates",
+    "projectToolDisplays",
+    "resolveActionableChangePreviewReference",
+  ];
+  for (const facadeSource of [publicFacadeSource, testingFacadeSource]) {
+    expect.soft(moduleSpecifiers(facadeSource)).not.toContain("./presentation-tool-projection.js");
+    expect
+      .soft(packageInternalSymbols.filter((symbol) => facadeSource.includes(symbol)))
+      .toEqual([]);
+  }
+  expect.soft(directTestImports).toEqual([]);
+});
+
+test("the runtime module detector covers every value-bearing module form", () => {
+  expect(
+    runtimeModuleSpecifiers(`
+      import { staticValue } from "static-module";
+      import "side-effect-module";
+      const dynamicValue = import("dynamic-module");
+      export { runtimeValue } from "runtime-reexport-module";
+      export * from "star-reexport-module";
+      import type { StaticType } from "type-module";
+      export type { ReexportedType } from "type-reexport-module";
+    `),
+  ).toEqual([
+    "static-module",
+    "side-effect-module",
+    "dynamic-module",
+    "runtime-reexport-module",
+    "star-reexport-module",
+  ]);
+});
+
 test("PresentationSession linked-operation projection has one package-internal owner", async () => {
   const agentSourceRoot = join(productRoot, "packages", "agent", "src");
   const sourceFiles = (await readdir(agentSourceRoot, { recursive: true }))
@@ -633,5 +780,23 @@ function moduleSpecifiers(source: string): readonly string[] {
   ];
   return patterns.flatMap((pattern) =>
     [...source.matchAll(pattern)].map((match) => match[1] ?? ""),
+  );
+}
+
+function runtimeModuleSpecifiers(source: string): readonly string[] {
+  const patterns = [
+    /\bimport\s+(?!type\b)[^;]*?\sfrom\s*["']([^"']+)["']/gu,
+    /\bimport\s*["']([^"']+)["']/gu,
+    /\bimport\s*\(\s*["']([^"']+)["']\s*\)/gu,
+    /\bexport\s+(?!type\b)(?:\*(?:\s+as\s+\S+)?|\{[^}]*\})\s+from\s+["']([^"']+)["']/gu,
+  ];
+  return patterns.flatMap((pattern) =>
+    [...source.matchAll(pattern)].map((match) => match[1] ?? ""),
+  );
+}
+
+function typeOnlyImportSpecifiers(source: string): string[] {
+  return [...source.matchAll(/\bimport\s+type\s+[^;]*?\sfrom\s*["']([^"']+)["']/gu)].map(
+    (match) => match[1] ?? "",
   );
 }


### PR DESCRIPTION
## Summary
- extract durable tool history, pending permission candidates, actionable change references, and bounded tool/change previews into one package-private Presentation projection module
- retain artifact I/O, mutable preview cache, hydration sequencing, Lifecycle freshness checks, publish/repair/cursor, and dispatch authority in the PresentationSession controller
- keep every dependency type-only and preserve the existing public package, Interface, persistence, browser build, and caller behavior

## TDD evidence
- structural RED: the five projection operations and cross-module request type had no unique owner, the controller still owned every fold, and the dependency/facade boundaries were absent
- caller-visible reverse RED: suppressing the durable permission decision prevented the public denied Presentation state from publishing
- focused GREEN: two structural contracts and nine shell, permission, write/edit preview, missing-artifact, bounded-failure, indeterminate-outcome, duplicate-decision, and gap-repair tracers passed independently
- complete Public Contract plus PresentationSession files: 122/122
- final local non-sandbox Quality: 43 files passed, 2 skipped; 1082 tests passed, 10 skipped
- final architecture, engineering, and test/contract reviews: 0 High/Medium/Low findings

## Quality note
Pre-publication full-suite runs exposed an unrelated real owner-death lock-release race. That defect was not folded into this structural PR: it was diagnosed, published separately in PR #69, merged and exact-main verified, and this branch was then rebased onto that verified main before all final evidence above was rerun.