### PR TITLE
B9.5-A4.4: isolate transcript projection

### DIFF
--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -8,7 +8,6 @@ import type {
   PresentationCommand,
   PresentationDisplayState,
   PresentationSession,
-  PresentationTransientState,
   RepositoryInstructionsDisplay,
   SessionNaming,
   SessionSummary,
@@ -45,6 +44,12 @@ import {
   projectToolDisplays,
   resolveActionableChangePreviewReference,
 } from "./presentation-tool-projection.js";
+import {
+  projectActiveReasoningSnapshot,
+  projectTranscript,
+  providerDisplayName,
+  reasoningDisplayId,
+} from "./presentation-transcript-projection.js";
 import { listProjectPaths } from "./project-path-catalog.js";
 import {
   type SessionNamingHistoryState,
@@ -231,8 +236,8 @@ export async function createPresentationSession(
     }
     let transcript: readonly TranscriptItem[] = projectTranscript(
       records,
-      projectedOperations,
-      changePreviewCache,
+      projectedOperations.map(({ display }) => display),
+      projectToolDisplays(records, changePreviewCache),
     );
     const historyPageSize = boundedHistoryPageSize(options[presentationHistoryPageSize]);
     let loadedTranscriptStart = Math.max(0, transcript.length - historyPageSize);
@@ -799,8 +804,8 @@ export async function createPresentationSession(
       }
       const activatedTranscript = projectTranscript(
         activatedRecords,
-        activatedOperations,
-        changePreviewCache,
+        activatedOperations.map(({ display }) => display),
+        projectToolDisplays(activatedRecords, changePreviewCache),
       );
       const activatedLoadedTranscriptStart = Math.max(
         0,
@@ -1176,8 +1181,8 @@ export async function createPresentationSession(
             }
             transcript = projectTranscript(
               refreshedRecords,
-              refreshedOperations,
-              changePreviewCache,
+              refreshedOperations.map(({ display }) => display),
+              projectToolDisplays(refreshedRecords, changePreviewCache),
             );
             loadedTranscriptStart = Math.min(
               loadedTranscriptStart,
@@ -2914,393 +2919,6 @@ async function readPresentationSessionRecords(
   );
 }
 
-function projectTranscript(
-  records: readonly SourcedSessionRecord[],
-  operations: readonly ProjectedOperation[],
-  changePreviewCache: ReadonlyMap<string, ToolPreviewDisplay | null>,
-): readonly TranscriptItem[] {
-  const toolDisplays = projectToolDisplays(records, changePreviewCache);
-  const attemptProviders = new Map<string, string>(
-    records.flatMap(({ entry, sessionId }) =>
-      entry.schemaVersion === 3 && entry.record.type === "provider_attempt_started"
-        ? [
-            [
-              `${sessionId}:${entry.record.runId}:${entry.record.turn}:${entry.record.attempt}`,
-              providerDisplayName(entry.record.targetIdentity.vendor),
-            ] as const,
-          ]
-        : [],
-    ),
-  );
-  const reasoningStarts = new Map(
-    records.flatMap(({ entry, sessionId }) =>
-      entry.schemaVersion === 3 &&
-      entry.record.type === "runtime_event" &&
-      entry.record.event.type === "model_reasoning_started"
-        ? [
-            [
-              `${sessionId}:${entry.record.runId}:${entry.record.event.id}`,
-              entry.record.event,
-            ] as const,
-          ]
-        : [],
-    ),
-  );
-  const terminalBoundaries = new Map(
-    records.flatMap(({ entry, sessionId }) => {
-      if (entry.schemaVersion !== 3) {
-        return [];
-      }
-      if (entry.record.type === "runtime_event" && entry.record.event.type === "session_settled") {
-        return [
-          [`${sessionId}:${entry.record.runId}`, { sessionId, sequence: entry.sequence }] as const,
-        ];
-      }
-      return entry.record.type === "run_settled"
-        ? [[`${sessionId}:${entry.record.runId}`, { sessionId, sequence: entry.sequence }] as const]
-        : [];
-    }),
-  );
-  const publishedResponses = new Set(
-    records.flatMap(({ entry, sessionId }) =>
-      entry.schemaVersion === 3 && entry.record.type === "model_response_published"
-        ? [`${sessionId}:${entry.record.responseSequence}`]
-        : [],
-    ),
-  );
-  const completedInlineRuns = new Set(
-    records.flatMap(({ entry, sessionId }) =>
-      entry.schemaVersion === 3 &&
-      entry.record.type === "runtime_event" &&
-      entry.record.event.type === "model_message_completed"
-        ? [`${sessionId}:${entry.record.runId}`]
-        : [],
-    ),
-  );
-  const items: TranscriptItem[] = [];
-  const terminalNoticeRuns = new Set<string>();
-  for (const { entry, sessionId } of records) {
-    if (entry.schemaVersion !== 3) {
-      continue;
-    }
-    if (entry.record.type === "logical_run_started") {
-      items.push({
-        type: "user_message",
-        id: `${sessionId}:${entry.sequence}`,
-        sequence: entry.sequence,
-        sourceSessionId: sessionId,
-        branchBoundary: null,
-        text: entry.record.userMessage,
-      });
-      continue;
-    }
-    if (entry.record.type === "runtime_event" && entry.record.event.type === "tool_requested") {
-      const tool = toolDisplays.get(`${sessionId}:${entry.record.event.callId}`);
-      if (tool !== undefined) {
-        items.push(tool);
-      }
-      continue;
-    }
-    if (entry.record.type === "context_compaction_committed") {
-      items.push({
-        type: "compaction_marker",
-        id: `${sessionId}:${entry.sequence}`,
-        sequence: entry.sequence,
-        sourceSessionId: sessionId,
-        branchBoundary: null,
-        windowNumber: entry.record.windowNumber,
-        sourceThrough: entry.record.sourceThrough,
-        retainedFrom: entry.record.retainedFrom,
-      });
-      continue;
-    }
-    if (
-      entry.record.type === "runtime_event" &&
-      entry.record.event.type === "model_reasoning_settled" &&
-      entry.record.event.status !== "completed"
-    ) {
-      const start = reasoningStarts.get(
-        `${sessionId}:${entry.record.runId}:${entry.record.event.id}`,
-      );
-      const attemptIdentity = /^(\d+):(\d+):/.exec(entry.record.event.id);
-      if (start !== undefined && attemptIdentity !== null) {
-        items.push({
-          type: "reasoning_block",
-          id: reasoningDisplayId(sessionId, entry.record.runId, entry.record.event.id),
-          sequence: entry.sequence,
-          sourceSessionId: sessionId,
-          branchBoundary: terminalBoundaries.get(`${sessionId}:${entry.record.runId}`) ?? null,
-          artifactType: start.artifactType,
-          disclosure: "owner_only",
-          provider:
-            attemptProviders.get(
-              `${sessionId}:${entry.record.runId}:${attemptIdentity[1]}:${attemptIdentity[2]}`,
-            ) ?? providerDisplayName(undefined),
-          status: entry.record.event.status,
-          text: null,
-          artifact: null,
-        });
-      }
-      continue;
-    }
-    if (
-      entry.record.type === "runtime_event" &&
-      entry.record.event.type === "session_interrupted"
-    ) {
-      items.push({
-        type: "session_notice",
-        id: `${sessionId}:${entry.sequence}`,
-        sequence: entry.sequence,
-        sourceSessionId: sessionId,
-        branchBoundary: terminalBoundaries.get(`${sessionId}:${entry.record.runId}`) ?? null,
-        status: "interrupted",
-        reason: entry.record.event.reason,
-      });
-      continue;
-    }
-    if (
-      entry.record.type === "provider_attempt_interrupted" &&
-      entry.record.reason === "process_restart"
-    ) {
-      items.push({
-        type: "session_notice",
-        id: `${sessionId}:${entry.sequence}`,
-        sequence: entry.sequence,
-        sourceSessionId: sessionId,
-        branchBoundary: null,
-        status: "interrupted",
-        reason: "process_restart",
-      });
-      continue;
-    }
-    if (
-      entry.record.type === "runtime_event" &&
-      entry.record.event.type === "session_settled" &&
-      (entry.record.event.result.status === "failed" ||
-        entry.record.event.result.status === "incomplete") &&
-      !terminalNoticeRuns.has(`${sessionId}:${entry.record.runId}`)
-    ) {
-      terminalNoticeRuns.add(`${sessionId}:${entry.record.runId}`);
-      const result = entry.record.event.result;
-      items.push(
-        result.status === "failed"
-          ? {
-              type: "session_notice",
-              id: `${sessionId}:${entry.sequence}`,
-              sequence: entry.sequence,
-              sourceSessionId: sessionId,
-              branchBoundary: { sessionId, sequence: entry.sequence },
-              status: "failed",
-              code: result.error.code,
-              message: safeRunFailureMessage(result.error.code),
-            }
-          : {
-              type: "session_notice",
-              id: `${sessionId}:${entry.sequence}`,
-              sequence: entry.sequence,
-              sourceSessionId: sessionId,
-              branchBoundary: { sessionId, sequence: entry.sequence },
-              status: "incomplete",
-              reason: result.reason,
-            },
-      );
-      continue;
-    }
-    if (
-      entry.record.type === "run_settled" &&
-      entry.record.status === "incomplete" &&
-      !terminalNoticeRuns.has(`${sessionId}:${entry.record.runId}`)
-    ) {
-      terminalNoticeRuns.add(`${sessionId}:${entry.record.runId}`);
-      items.push({
-        type: "session_notice",
-        id: `${sessionId}:${entry.sequence}`,
-        sequence: entry.sequence,
-        sourceSessionId: sessionId,
-        branchBoundary: { sessionId, sequence: entry.sequence },
-        status: "incomplete",
-        reason: entry.record.reason,
-      });
-      continue;
-    }
-    if (entry.record.type !== "model_response_completed") {
-      continue;
-    }
-    const artifactBacked =
-      entry.record.response.recordVersion === 2 &&
-      (entry.record.response.text.storage === "artifact" ||
-        entry.record.response.reasoning?.storage === "artifact");
-    if (
-      (artifactBacked && !publishedResponses.has(`${sessionId}:${entry.sequence}`)) ||
-      (!artifactBacked && !completedInlineRuns.has(`${sessionId}:${entry.record.runId}`))
-    ) {
-      continue;
-    }
-    const reasoningField = entry.record.response.reasoning;
-    if (reasoningField !== undefined) {
-      const reasoningText =
-        typeof reasoningField === "string"
-          ? reasoningField
-          : reasoningField.storage === "inline"
-            ? reasoningField.text
-            : null;
-      const reasoningArtifact =
-        typeof reasoningField !== "string" && reasoningField.storage === "artifact"
-          ? {
-              id: reasoningField.reference.id,
-              mediaType: reasoningField.reference.mediaType,
-              byteCount: reasoningField.reference.byteCount,
-              source: "model_response" as const,
-            }
-          : null;
-      if (reasoningArtifact !== null || (reasoningText !== null && reasoningText.length > 0)) {
-        items.push({
-          type: "reasoning_block",
-          id: reasoningDisplayId(
-            sessionId,
-            entry.record.runId,
-            `${entry.record.turn}:${entry.record.attempt}:provider-reasoning-0`,
-          ),
-          sequence: entry.sequence,
-          sourceSessionId: sessionId,
-          branchBoundary: terminalBoundaries.get(`${sessionId}:${entry.record.runId}`) ?? null,
-          artifactType: "provider_reasoning",
-          disclosure: "owner_only",
-          provider: providerDisplayName(entry.record.targetIdentity.vendor),
-          status: "completed",
-          text: reasoningText,
-          artifact: reasoningArtifact,
-        });
-      }
-    }
-    const text =
-      entry.record.response.recordVersion === 2
-        ? entry.record.response.text.storage === "inline"
-          ? entry.record.response.text.text
-          : null
-        : entry.record.response.text;
-    const artifact =
-      entry.record.response.recordVersion === 2 && entry.record.response.text.storage === "artifact"
-        ? {
-            id: entry.record.response.text.reference.id,
-            mediaType: entry.record.response.text.reference.mediaType,
-            byteCount: entry.record.response.text.reference.byteCount,
-            source: "model_response" as const,
-          }
-        : null;
-    if (artifact === null && (text === null || text.length === 0)) {
-      continue;
-    }
-    items.push({
-      type: "assistant_message",
-      id: `${sessionId}:${entry.sequence}`,
-      sequence: entry.sequence,
-      sourceSessionId: sessionId,
-      branchBoundary: terminalBoundaries.get(`${sessionId}:${entry.record.runId}`) ?? null,
-      text,
-      artifact,
-    });
-  }
-  const recordOrder = new Map(
-    records.map(
-      (record, index) => [`${record.sessionId}:${record.entry.sequence}`, index] as const,
-    ),
-  );
-  const itemOrder = new Map(items.map((item, index) => [item, index] as const));
-  const operationLinks: TranscriptItem[] = operations.map(({ display }) => ({
-    type: "operation_link",
-    id: `operation:${display.operationId}`,
-    operationId: display.operationId,
-    sequence: display.origin.sourceSequence,
-    sourceSessionId: display.origin.sessionId,
-    branchBoundary: {
-      sessionId: display.origin.sessionId,
-      sequence: display.origin.sourceSequence,
-    },
-  }));
-  return [...items, ...operationLinks].sort((left, right) => {
-    const leftRecord = recordOrder.get(`${left.sourceSessionId}:${left.sequence}`) ?? Infinity;
-    const rightRecord = recordOrder.get(`${right.sourceSessionId}:${right.sequence}`) ?? Infinity;
-    if (leftRecord !== rightRecord) {
-      return leftRecord - rightRecord;
-    }
-    if (left.type === "operation_link" && right.type === "operation_link") {
-      return left.operationId.localeCompare(right.operationId);
-    }
-    if (left.type === "operation_link") {
-      return 1;
-    }
-    if (right.type === "operation_link") {
-      return -1;
-    }
-    return (itemOrder.get(left) ?? 0) - (itemOrder.get(right) ?? 0);
-  });
-}
-
-function projectActiveReasoningSnapshot(input: {
-  readonly records: readonly SourcedSessionRecord[];
-  readonly sessionId: string;
-  readonly runId: string;
-  readonly expectedId: string;
-  readonly event: Extract<RuntimeEvent, { readonly type: "model_reasoning_updated" }>;
-  readonly afterSequence: number;
-  readonly provider: string;
-}): NonNullable<PresentationTransientState["reasoning"]> | undefined {
-  let start: Extract<RuntimeEvent, { readonly type: "model_reasoning_started" }> | undefined;
-  let startSequence = 0;
-  for (const { entry, sessionId } of input.records) {
-    if (
-      sessionId !== input.sessionId ||
-      entry.schemaVersion !== 3 ||
-      entry.record.type !== "runtime_event" ||
-      entry.record.runId !== input.runId
-    ) {
-      continue;
-    }
-    const event = entry.record.event;
-    if (
-      event.type === "model_reasoning_started" &&
-      reasoningDisplayId(sessionId, input.runId, event.id) === input.expectedId
-    ) {
-      start = event;
-      startSequence = entry.sequence;
-      continue;
-    }
-    if (
-      start !== undefined &&
-      entry.sequence > startSequence &&
-      event.type === "model_reasoning_settled" &&
-      event.id === start.id
-    ) {
-      return undefined;
-    }
-  }
-  if (start === undefined || start.id !== input.event.id) {
-    return undefined;
-  }
-  return {
-    id: input.expectedId,
-    afterSequence: input.afterSequence,
-    artifactType: start.artifactType,
-    disclosure: "owner_only",
-    provider: input.provider,
-    status: "active",
-    text: input.event.text,
-  };
-}
-
-function reasoningDisplayId(
-  sessionId: string | null,
-  runId: string | null,
-  runtimeReasoningId: string,
-): string {
-  return `${sessionId ?? "unknown-session"}:${runId ?? "unknown-run"}:${runtimeReasoningId}`;
-}
-
-function providerDisplayName(vendor: string | undefined): string {
-  return vendor === "deepseek" ? "DeepSeek" : (vendor ?? "Provider");
-}
-
 async function projectPendingInteractions(
   records: readonly SourcedSessionRecord[],
   options: Pick<CreatePresentationSessionOptions, "stateRoot" | "workspaceRoot">,
@@ -3417,22 +3035,6 @@ async function projectChangePreview(
   } catch {
     return null;
   }
-}
-
-function safeRunFailureMessage(code: string): string {
-  if (code === "tool_effect_indeterminate") {
-    return "A tool effect requires inspection before continuing.";
-  }
-  if (code === "session_persistence_failed") {
-    return "The session could not make its result durable.";
-  }
-  if (code.startsWith("context_") || code.startsWith("token_")) {
-    return "The run could not continue within its context limits.";
-  }
-  if (code === "skill_activation_failed") {
-    return "The requested Skill activation failed.";
-  }
-  return "The model run failed.";
 }
 
 function projectRepositoryInstructions(

--- a/packages/agent/src/presentation-transcript-projection.ts
+++ b/packages/agent/src/presentation-transcript-projection.ts
@@ -1,0 +1,415 @@
+import type {
+  OperationDisplay,
+  PresentationTransientState,
+  ToolCallDisplay,
+  TranscriptItem,
+} from "@adam-agent/presentation";
+import type { RuntimeEvent } from "./agent-session-contracts.js";
+import type { SessionRecord } from "./session-store.js";
+
+type PresentationTranscriptHistoryRecord = {
+  readonly sessionId: string;
+  readonly entry: SessionRecord;
+};
+
+export function projectTranscript(
+  records: readonly PresentationTranscriptHistoryRecord[],
+  operations: readonly OperationDisplay[],
+  toolDisplays: ReadonlyMap<string, ToolCallDisplay>,
+): readonly TranscriptItem[] {
+  const attemptProviders = new Map<string, string>(
+    records.flatMap(({ entry, sessionId }) =>
+      entry.schemaVersion === 3 && entry.record.type === "provider_attempt_started"
+        ? [
+            [
+              `${sessionId}:${entry.record.runId}:${entry.record.turn}:${entry.record.attempt}`,
+              providerDisplayName(entry.record.targetIdentity.vendor),
+            ] as const,
+          ]
+        : [],
+    ),
+  );
+  const reasoningStarts = new Map(
+    records.flatMap(({ entry, sessionId }) =>
+      entry.schemaVersion === 3 &&
+      entry.record.type === "runtime_event" &&
+      entry.record.event.type === "model_reasoning_started"
+        ? [
+            [
+              `${sessionId}:${entry.record.runId}:${entry.record.event.id}`,
+              entry.record.event,
+            ] as const,
+          ]
+        : [],
+    ),
+  );
+  const terminalBoundaries = new Map(
+    records.flatMap(({ entry, sessionId }) => {
+      if (entry.schemaVersion !== 3) {
+        return [];
+      }
+      if (entry.record.type === "runtime_event" && entry.record.event.type === "session_settled") {
+        return [
+          [`${sessionId}:${entry.record.runId}`, { sessionId, sequence: entry.sequence }] as const,
+        ];
+      }
+      return entry.record.type === "run_settled"
+        ? [[`${sessionId}:${entry.record.runId}`, { sessionId, sequence: entry.sequence }] as const]
+        : [];
+    }),
+  );
+  const publishedResponses = new Set(
+    records.flatMap(({ entry, sessionId }) =>
+      entry.schemaVersion === 3 && entry.record.type === "model_response_published"
+        ? [`${sessionId}:${entry.record.responseSequence}`]
+        : [],
+    ),
+  );
+  const completedInlineRuns = new Set(
+    records.flatMap(({ entry, sessionId }) =>
+      entry.schemaVersion === 3 &&
+      entry.record.type === "runtime_event" &&
+      entry.record.event.type === "model_message_completed"
+        ? [`${sessionId}:${entry.record.runId}`]
+        : [],
+    ),
+  );
+  const items: TranscriptItem[] = [];
+  const terminalNoticeRuns = new Set<string>();
+  for (const { entry, sessionId } of records) {
+    if (entry.schemaVersion !== 3) {
+      continue;
+    }
+    if (entry.record.type === "logical_run_started") {
+      items.push({
+        type: "user_message",
+        id: `${sessionId}:${entry.sequence}`,
+        sequence: entry.sequence,
+        sourceSessionId: sessionId,
+        branchBoundary: null,
+        text: entry.record.userMessage,
+      });
+      continue;
+    }
+    if (entry.record.type === "runtime_event" && entry.record.event.type === "tool_requested") {
+      const tool = toolDisplays.get(`${sessionId}:${entry.record.event.callId}`);
+      if (tool !== undefined) {
+        items.push(tool);
+      }
+      continue;
+    }
+    if (entry.record.type === "context_compaction_committed") {
+      items.push({
+        type: "compaction_marker",
+        id: `${sessionId}:${entry.sequence}`,
+        sequence: entry.sequence,
+        sourceSessionId: sessionId,
+        branchBoundary: null,
+        windowNumber: entry.record.windowNumber,
+        sourceThrough: entry.record.sourceThrough,
+        retainedFrom: entry.record.retainedFrom,
+      });
+      continue;
+    }
+    if (
+      entry.record.type === "runtime_event" &&
+      entry.record.event.type === "model_reasoning_settled" &&
+      entry.record.event.status !== "completed"
+    ) {
+      const start = reasoningStarts.get(
+        `${sessionId}:${entry.record.runId}:${entry.record.event.id}`,
+      );
+      const attemptIdentity = /^(\d+):(\d+):/.exec(entry.record.event.id);
+      if (start !== undefined && attemptIdentity !== null) {
+        items.push({
+          type: "reasoning_block",
+          id: reasoningDisplayId(sessionId, entry.record.runId, entry.record.event.id),
+          sequence: entry.sequence,
+          sourceSessionId: sessionId,
+          branchBoundary: terminalBoundaries.get(`${sessionId}:${entry.record.runId}`) ?? null,
+          artifactType: start.artifactType,
+          disclosure: "owner_only",
+          provider:
+            attemptProviders.get(
+              `${sessionId}:${entry.record.runId}:${attemptIdentity[1]}:${attemptIdentity[2]}`,
+            ) ?? providerDisplayName(undefined),
+          status: entry.record.event.status,
+          text: null,
+          artifact: null,
+        });
+      }
+      continue;
+    }
+    if (
+      entry.record.type === "runtime_event" &&
+      entry.record.event.type === "session_interrupted"
+    ) {
+      items.push({
+        type: "session_notice",
+        id: `${sessionId}:${entry.sequence}`,
+        sequence: entry.sequence,
+        sourceSessionId: sessionId,
+        branchBoundary: terminalBoundaries.get(`${sessionId}:${entry.record.runId}`) ?? null,
+        status: "interrupted",
+        reason: entry.record.event.reason,
+      });
+      continue;
+    }
+    if (
+      entry.record.type === "provider_attempt_interrupted" &&
+      entry.record.reason === "process_restart"
+    ) {
+      items.push({
+        type: "session_notice",
+        id: `${sessionId}:${entry.sequence}`,
+        sequence: entry.sequence,
+        sourceSessionId: sessionId,
+        branchBoundary: null,
+        status: "interrupted",
+        reason: "process_restart",
+      });
+      continue;
+    }
+    if (
+      entry.record.type === "runtime_event" &&
+      entry.record.event.type === "session_settled" &&
+      (entry.record.event.result.status === "failed" ||
+        entry.record.event.result.status === "incomplete") &&
+      !terminalNoticeRuns.has(`${sessionId}:${entry.record.runId}`)
+    ) {
+      terminalNoticeRuns.add(`${sessionId}:${entry.record.runId}`);
+      const result = entry.record.event.result;
+      items.push(
+        result.status === "failed"
+          ? {
+              type: "session_notice",
+              id: `${sessionId}:${entry.sequence}`,
+              sequence: entry.sequence,
+              sourceSessionId: sessionId,
+              branchBoundary: { sessionId, sequence: entry.sequence },
+              status: "failed",
+              code: result.error.code,
+              message: safeRunFailureMessage(result.error.code),
+            }
+          : {
+              type: "session_notice",
+              id: `${sessionId}:${entry.sequence}`,
+              sequence: entry.sequence,
+              sourceSessionId: sessionId,
+              branchBoundary: { sessionId, sequence: entry.sequence },
+              status: "incomplete",
+              reason: result.reason,
+            },
+      );
+      continue;
+    }
+    if (
+      entry.record.type === "run_settled" &&
+      entry.record.status === "incomplete" &&
+      !terminalNoticeRuns.has(`${sessionId}:${entry.record.runId}`)
+    ) {
+      terminalNoticeRuns.add(`${sessionId}:${entry.record.runId}`);
+      items.push({
+        type: "session_notice",
+        id: `${sessionId}:${entry.sequence}`,
+        sequence: entry.sequence,
+        sourceSessionId: sessionId,
+        branchBoundary: { sessionId, sequence: entry.sequence },
+        status: "incomplete",
+        reason: entry.record.reason,
+      });
+      continue;
+    }
+    if (entry.record.type !== "model_response_completed") {
+      continue;
+    }
+    const artifactBacked =
+      entry.record.response.recordVersion === 2 &&
+      (entry.record.response.text.storage === "artifact" ||
+        entry.record.response.reasoning?.storage === "artifact");
+    if (
+      (artifactBacked && !publishedResponses.has(`${sessionId}:${entry.sequence}`)) ||
+      (!artifactBacked && !completedInlineRuns.has(`${sessionId}:${entry.record.runId}`))
+    ) {
+      continue;
+    }
+    const reasoningField = entry.record.response.reasoning;
+    if (reasoningField !== undefined) {
+      const reasoningText =
+        typeof reasoningField === "string"
+          ? reasoningField
+          : reasoningField.storage === "inline"
+            ? reasoningField.text
+            : null;
+      const reasoningArtifact =
+        typeof reasoningField !== "string" && reasoningField.storage === "artifact"
+          ? {
+              id: reasoningField.reference.id,
+              mediaType: reasoningField.reference.mediaType,
+              byteCount: reasoningField.reference.byteCount,
+              source: "model_response" as const,
+            }
+          : null;
+      if (reasoningArtifact !== null || (reasoningText !== null && reasoningText.length > 0)) {
+        items.push({
+          type: "reasoning_block",
+          id: reasoningDisplayId(
+            sessionId,
+            entry.record.runId,
+            `${entry.record.turn}:${entry.record.attempt}:provider-reasoning-0`,
+          ),
+          sequence: entry.sequence,
+          sourceSessionId: sessionId,
+          branchBoundary: terminalBoundaries.get(`${sessionId}:${entry.record.runId}`) ?? null,
+          artifactType: "provider_reasoning",
+          disclosure: "owner_only",
+          provider: providerDisplayName(entry.record.targetIdentity.vendor),
+          status: "completed",
+          text: reasoningText,
+          artifact: reasoningArtifact,
+        });
+      }
+    }
+    const text =
+      entry.record.response.recordVersion === 2
+        ? entry.record.response.text.storage === "inline"
+          ? entry.record.response.text.text
+          : null
+        : entry.record.response.text;
+    const artifact =
+      entry.record.response.recordVersion === 2 && entry.record.response.text.storage === "artifact"
+        ? {
+            id: entry.record.response.text.reference.id,
+            mediaType: entry.record.response.text.reference.mediaType,
+            byteCount: entry.record.response.text.reference.byteCount,
+            source: "model_response" as const,
+          }
+        : null;
+    if (artifact === null && (text === null || text.length === 0)) {
+      continue;
+    }
+    items.push({
+      type: "assistant_message",
+      id: `${sessionId}:${entry.sequence}`,
+      sequence: entry.sequence,
+      sourceSessionId: sessionId,
+      branchBoundary: terminalBoundaries.get(`${sessionId}:${entry.record.runId}`) ?? null,
+      text,
+      artifact,
+    });
+  }
+  const recordOrder = new Map(
+    records.map(
+      (record, index) => [`${record.sessionId}:${record.entry.sequence}`, index] as const,
+    ),
+  );
+  const itemOrder = new Map(items.map((item, index) => [item, index] as const));
+  const operationLinks: TranscriptItem[] = operations.map((display) => ({
+    type: "operation_link",
+    id: `operation:${display.operationId}`,
+    operationId: display.operationId,
+    sequence: display.origin.sourceSequence,
+    sourceSessionId: display.origin.sessionId,
+    branchBoundary: {
+      sessionId: display.origin.sessionId,
+      sequence: display.origin.sourceSequence,
+    },
+  }));
+  return [...items, ...operationLinks].sort((left, right) => {
+    const leftRecord = recordOrder.get(`${left.sourceSessionId}:${left.sequence}`) ?? Infinity;
+    const rightRecord = recordOrder.get(`${right.sourceSessionId}:${right.sequence}`) ?? Infinity;
+    if (leftRecord !== rightRecord) {
+      return leftRecord - rightRecord;
+    }
+    if (left.type === "operation_link" && right.type === "operation_link") {
+      return left.operationId.localeCompare(right.operationId);
+    }
+    if (left.type === "operation_link") {
+      return 1;
+    }
+    if (right.type === "operation_link") {
+      return -1;
+    }
+    return (itemOrder.get(left) ?? 0) - (itemOrder.get(right) ?? 0);
+  });
+}
+
+export function projectActiveReasoningSnapshot(input: {
+  readonly records: readonly PresentationTranscriptHistoryRecord[];
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly expectedId: string;
+  readonly event: Extract<RuntimeEvent, { readonly type: "model_reasoning_updated" }>;
+  readonly afterSequence: number;
+  readonly provider: string;
+}): NonNullable<PresentationTransientState["reasoning"]> | undefined {
+  let start: Extract<RuntimeEvent, { readonly type: "model_reasoning_started" }> | undefined;
+  let startSequence = 0;
+  for (const { entry, sessionId } of input.records) {
+    if (
+      sessionId !== input.sessionId ||
+      entry.schemaVersion !== 3 ||
+      entry.record.type !== "runtime_event" ||
+      entry.record.runId !== input.runId
+    ) {
+      continue;
+    }
+    const event = entry.record.event;
+    if (
+      event.type === "model_reasoning_started" &&
+      reasoningDisplayId(sessionId, input.runId, event.id) === input.expectedId
+    ) {
+      start = event;
+      startSequence = entry.sequence;
+      continue;
+    }
+    if (
+      start !== undefined &&
+      entry.sequence > startSequence &&
+      event.type === "model_reasoning_settled" &&
+      event.id === start.id
+    ) {
+      return undefined;
+    }
+  }
+  if (start === undefined || start.id !== input.event.id) {
+    return undefined;
+  }
+  return {
+    id: input.expectedId,
+    afterSequence: input.afterSequence,
+    artifactType: start.artifactType,
+    disclosure: "owner_only",
+    provider: input.provider,
+    status: "active",
+    text: input.event.text,
+  };
+}
+
+export function reasoningDisplayId(
+  sessionId: string | null,
+  runId: string | null,
+  runtimeReasoningId: string,
+): string {
+  return `${sessionId ?? "unknown-session"}:${runId ?? "unknown-run"}:${runtimeReasoningId}`;
+}
+
+export function providerDisplayName(vendor: string | undefined): string {
+  return vendor === "deepseek" ? "DeepSeek" : (vendor ?? "Provider");
+}
+
+function safeRunFailureMessage(code: string): string {
+  if (code === "tool_effect_indeterminate") {
+    return "A tool effect requires inspection before continuing.";
+  }
+  if (code === "session_persistence_failed") {
+    return "The session could not make its result durable.";
+  }
+  if (code.startsWith("context_") || code.startsWith("token_")) {
+    return "The run could not continue within its context limits.";
+  }
+  if (code === "skill_activation_failed") {
+    return "The requested Skill activation failed.";
+  }
+  return "The model run failed.";
+}

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -9888,6 +9888,126 @@ test("PresentationSession preserves failed and output-limited run notices", asyn
   }
 });
 
+test("PresentationSession maps canonical failure codes to bounded safe run notices", async () => {
+  const scenarios = [
+    {
+      code: "tool_effect_indeterminate",
+      error: {
+        code: "tool_effect_indeterminate",
+        reason: "mcp_protocol_error",
+        message: "private indeterminate detail",
+      },
+      expectedMessage: "A tool effect requires inspection before continuing.",
+    },
+    {
+      code: "session_persistence_failed",
+      error: {
+        code: "session_persistence_failed",
+        message: "private persistence detail",
+      },
+      expectedMessage: "The session could not make its result durable.",
+    },
+    {
+      code: "context_window_unrecoverable",
+      error: {
+        code: "context_window_unrecoverable",
+        message: "private context detail",
+      },
+      expectedMessage: "The run could not continue within its context limits.",
+    },
+    {
+      code: "token_limit_exceeded",
+      error: {
+        code: "token_limit_exceeded",
+        message: "private token detail",
+      },
+      expectedMessage: "The run could not continue within its context limits.",
+    },
+    {
+      code: "skill_activation_failed",
+      error: {
+        code: "skill_activation_failed",
+        message: "private Skill detail",
+      },
+      expectedMessage: "The requested Skill activation failed.",
+    },
+    {
+      code: "model_protocol_invalid",
+      error: {
+        code: "model_protocol_invalid",
+        message: "private model detail",
+      },
+      expectedMessage: "The model run failed.",
+    },
+  ] as const;
+
+  for (const [index, scenario] of scenarios.entries()) {
+    const testRoot = await mkdtemp(
+      join(tmpdir(), `adam-agent-presentation-safe-${scenario.code}-`),
+    );
+    const stateRoot = join(testRoot, "state");
+    const workspaceRoot = join(testRoot, "workspace");
+    await mkdir(workspaceRoot);
+    const harness = createInMemorySessionLifecycleHarness();
+    const lifecycle = harness.createLifecycle({
+      modelTargets: settledModelTargets(),
+      stateRoot,
+      workspaceRoot,
+    });
+
+    try {
+      const created = await lifecycle.create({ targetIdentity });
+      const records = await harness.sessions.open(created.sessionId);
+      const genesis = (await records?.read())?.[0];
+      if (genesis === undefined) {
+        throw new Error("Expected the canonical session genesis.");
+      }
+      const projectedRecords: readonly SessionRecord[] = [
+        genesis,
+        {
+          schemaVersion: 3,
+          sequence: 2,
+          record: {
+            type: "runtime_event",
+            runId: `123e4567-e89b-42d3-a456-42661417400${index}`,
+            event: {
+              type: "session_settled",
+              result: { status: "failed", error: scenario.error },
+            },
+          },
+        },
+      ];
+      const presentation = await createPresentationSession({
+        lifecycle,
+        projectLabel: "workspace",
+        sessionId: created.sessionId,
+        stateRoot,
+        workspaceRoot,
+        [presentationSessionRecordReader]: async () => projectedRecords,
+      });
+      try {
+        const notice = presentation
+          .getState()
+          .authoritative.active?.transcript.items.find(
+            (item) => item.type === "session_notice" && item.status === "failed",
+          );
+        expect(notice).toMatchObject({
+          type: "session_notice",
+          status: "failed",
+          code: scenario.code,
+          message: scenario.expectedMessage,
+        });
+        expect(JSON.stringify(notice)).not.toContain(scenario.error.message);
+      } finally {
+        await presentation.close();
+      }
+    } finally {
+      await lifecycle.close();
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  }
+});
+
 test("PresentationSession preserves a bounded tool failure cause", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-tool-failure-"));
   const stateRoot = join(testRoot, "state");

--- a/packages/testkit/src/public-product-contract.test.ts
+++ b/packages/testkit/src/public-product-contract.test.ts
@@ -618,6 +618,107 @@ test("PresentationSession tool projection has one package-internal owner", async
   expect.soft(directTestImports).toEqual([]);
 });
 
+test("PresentationSession transcript projection has one package-internal owner", async () => {
+  const agentSourceRoot = join(productRoot, "packages", "agent", "src");
+  const sourceFiles = (await readdir(agentSourceRoot, { recursive: true }))
+    .filter((entry) => entry.endsWith(".ts"))
+    .sort();
+  const sources = await Promise.all(
+    sourceFiles.map(async (sourceFile) => ({
+      path: sourceFile,
+      source: await readFile(join(agentSourceRoot, sourceFile), "utf8"),
+    })),
+  );
+  const expectedOwners = {
+    projectActiveReasoningSnapshot: ["presentation-transcript-projection.ts"],
+    projectTranscript: ["presentation-transcript-projection.ts"],
+    providerDisplayName: ["presentation-transcript-projection.ts"],
+    reasoningDisplayId: ["presentation-transcript-projection.ts"],
+  } as const;
+  const actualOwners = Object.fromEntries(
+    Object.keys(expectedOwners).map((symbol) => [
+      symbol,
+      sources
+        .filter(({ source }) => new RegExp(`\\bfunction\\s+${symbol}\\s*\\(`, "u").test(source))
+        .map(({ path }) => path),
+    ]),
+  );
+  const projectionSource =
+    sources.find(({ path }) => path === "presentation-transcript-projection.ts")?.source ?? "";
+  const projectionConsumers = sources
+    .filter(({ source }) =>
+      moduleSpecifiers(source).includes("./presentation-transcript-projection.js"),
+    )
+    .map(({ path }) => path);
+  const projectionDependencies = [...moduleSpecifiers(projectionSource)].sort();
+  const projectionRuntimeImports = runtimeModuleSpecifiers(projectionSource);
+  const projectionTypeImports = typeOnlyImportSpecifiers(projectionSource).sort();
+  const publicFacadeSource = sources.find(({ path }) => path === "index.ts")?.source ?? "";
+  const testingFacadeSource =
+    sources.find(({ path }) => path === "internal-testing.ts")?.source ?? "";
+  const testSourceRoots = (
+    await Promise.all(
+      ["apps", "packages"].map(async (root) =>
+        (
+          await readdir(join(productRoot, root), { withFileTypes: true })
+        )
+          .filter((entry) => entry.isDirectory())
+          .map((entry) => join(productRoot, root, entry.name, "src")),
+      ),
+    )
+  ).flat();
+  const testSources = (
+    await Promise.all(
+      testSourceRoots.map(async (sourceRoot) => {
+        try {
+          return (await readdir(sourceRoot, { recursive: true }))
+            .filter((entry) => entry.endsWith(".test.ts"))
+            .map((entry) => join(sourceRoot, entry));
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            return [];
+          }
+          throw error;
+        }
+      }),
+    )
+  ).flat();
+  const directTestImports = (
+    await Promise.all(
+      testSources
+        .filter((testPath) => testPath !== fileURLToPath(import.meta.url))
+        .map(async (testPath) =>
+          moduleSpecifiers(await readFile(testPath, "utf8"))
+            .filter((specifier) => /presentation-transcript-projection\.js$/u.test(specifier))
+            .map((specifier) => ({
+              path: relative(productRoot, testPath),
+              specifier,
+            })),
+        ),
+    )
+  ).flat();
+
+  expect.soft(actualOwners).toEqual(expectedOwners);
+  expect.soft(projectionConsumers).toEqual(["presentation-session.ts"]);
+  expect.soft(projectionRuntimeImports).toEqual([]);
+  expect
+    .soft(projectionTypeImports)
+    .toEqual(["./agent-session-contracts.js", "./session-store.js", "@adam-agent/presentation"]);
+  expect
+    .soft(projectionDependencies)
+    .toEqual(["./agent-session-contracts.js", "./session-store.js", "@adam-agent/presentation"]);
+  const packageInternalSymbols = Object.keys(expectedOwners);
+  for (const facadeSource of [publicFacadeSource, testingFacadeSource]) {
+    expect
+      .soft(moduleSpecifiers(facadeSource))
+      .not.toContain("./presentation-transcript-projection.js");
+    expect
+      .soft(packageInternalSymbols.filter((symbol) => facadeSource.includes(symbol)))
+      .toEqual([]);
+  }
+  expect.soft(directTestImports).toEqual([]);
+});
+
 test("the runtime module detector covers every value-bearing module form", () => {
   expect(
     runtimeModuleSpecifiers(`


### PR DESCRIPTION
Summary
- move durable chronology, transcript, and reasoning projection into one package-private pure module
- keep hydration, cache, cursor, repair, dispatch, publication, and close ownership in PresentationSession
- add structural owner and dependency guards plus caller-visible safe failure notice coverage

Verification
- focused structural and PresentationSession suites: 124 passed
- full pnpm quality:check: 43 files passed, 2 skipped; 1084 tests passed, 10 opt-in skipped
- architecture, engineering, and test reviews: 0 findings