### PR TITLE
B9.5-A5.1: isolate MCP configuration documents

### DIFF
--- a/packages/agent/src/mcp-configuration-document.ts
+++ b/packages/agent/src/mcp-configuration-document.ts
@@ -1,0 +1,200 @@
+import { isUtf8 } from "node:buffer";
+import { createHash } from "node:crypto";
+
+type McpConfigurationRecord = Readonly<Record<string, unknown>> & {
+  readonly mcpServers?: unknown;
+};
+
+export type McpConfigurationDocument = {
+  readonly sourceDigest: `sha256:${string}`;
+  readonly servers: readonly {
+    readonly serverId: string;
+    readonly configuration: Readonly<Record<string, unknown>>;
+  }[];
+};
+
+const knownMcpServerConfigurationFields = new Set([
+  "type",
+  "command",
+  "args",
+  "cwd",
+  "env",
+  "url",
+  "headers",
+  "oauth",
+  "socket",
+  "resources",
+  "prompts",
+  "lifecycle",
+  "credentials",
+]);
+
+export function inspectMcpConfigurationDocument(
+  bytes: Buffer,
+): McpConfigurationDocument | undefined {
+  if (!isUtf8(bytes)) {
+    throw new TypeError("The MCP configuration is not valid UTF-8.");
+  }
+  const parsed = parseJsonWithoutDuplicateKeys(bytes.toString("utf8"));
+  if (!isMcpConfigurationRecord(parsed) || Object.keys(parsed).length !== 1) {
+    return undefined;
+  }
+  const mcpServers = parsed.mcpServers;
+  if (!isMcpServerConfigurations(mcpServers)) {
+    return undefined;
+  }
+  return {
+    sourceDigest: `sha256:${createHash("sha256").update(bytes).digest("hex")}`,
+    servers: Object.entries(mcpServers)
+      .map(([serverId, configuration]) => ({ serverId, configuration }))
+      .sort(({ serverId: left }, { serverId: right }) =>
+        left < right ? -1 : left > right ? 1 : 0,
+      ),
+  };
+}
+
+function parseJsonWithoutDuplicateKeys(source: string): unknown {
+  let index = 0;
+  const skipWhitespace = () => {
+    while (/\s/u.test(source[index] ?? "")) {
+      index += 1;
+    }
+  };
+  const fail = (): never => {
+    throw new SyntaxError("Invalid or duplicate-key JSON.");
+  };
+  const parseString = (): string => {
+    if (source[index] !== '"') {
+      return fail();
+    }
+    const start = index;
+    index += 1;
+    while (index < source.length) {
+      const character = source[index];
+      if (character === "\\") {
+        index += 2;
+        continue;
+      }
+      index += 1;
+      if (character === '"') {
+        return JSON.parse(source.slice(start, index)) as string;
+      }
+    }
+    return fail();
+  };
+  const parseValue = (depth: number): unknown => {
+    if (depth > 128) {
+      return fail();
+    }
+    skipWhitespace();
+    const character = source[index];
+    if (character === '"') {
+      return parseString();
+    }
+    if (character === "{") {
+      index += 1;
+      skipWhitespace();
+      const entries: [string, unknown][] = [];
+      const keys = new Set<string>();
+      if (source[index] === "}") {
+        index += 1;
+        return Object.fromEntries(entries);
+      }
+      for (;;) {
+        skipWhitespace();
+        const key = parseString();
+        if (keys.has(key)) {
+          return fail();
+        }
+        keys.add(key);
+        skipWhitespace();
+        if (source[index] !== ":") {
+          return fail();
+        }
+        index += 1;
+        entries.push([key, parseValue(depth + 1)]);
+        skipWhitespace();
+        if (source[index] === "}") {
+          index += 1;
+          return Object.fromEntries(entries);
+        }
+        if (source[index] !== ",") {
+          return fail();
+        }
+        index += 1;
+      }
+    }
+    if (character === "[") {
+      index += 1;
+      skipWhitespace();
+      const values: unknown[] = [];
+      if (source[index] === "]") {
+        index += 1;
+        return values;
+      }
+      for (;;) {
+        values.push(parseValue(depth + 1));
+        skipWhitespace();
+        if (source[index] === "]") {
+          index += 1;
+          return values;
+        }
+        if (source[index] !== ",") {
+          return fail();
+        }
+        index += 1;
+      }
+    }
+    for (const [literal, value] of [
+      ["true", true],
+      ["false", false],
+      ["null", null],
+    ] as const) {
+      if (source.startsWith(literal, index)) {
+        index += literal.length;
+        return value;
+      }
+    }
+    const start = index;
+    while (/[0-9eE+.-]/u.test(source[index] ?? "")) {
+      index += 1;
+    }
+    if (index === start) {
+      return fail();
+    }
+    const number = JSON.parse(source.slice(start, index)) as unknown;
+    if (typeof number !== "number" || !Number.isFinite(number)) {
+      return fail();
+    }
+    return number;
+  };
+  const value = parseValue(0);
+  skipWhitespace();
+  if (index !== source.length) {
+    return fail();
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isMcpConfigurationRecord(value: unknown): value is McpConfigurationRecord {
+  return isRecord(value);
+}
+
+function isMcpServerConfigurations(
+  value: unknown,
+): value is Readonly<Record<string, Readonly<Record<string, unknown>>>> {
+  return (
+    isRecord(value) &&
+    Object.keys(value).length <= 8 &&
+    Object.entries(value).every(
+      ([serverId, configuration]) =>
+        /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/u.test(serverId) &&
+        isRecord(configuration) &&
+        Object.keys(configuration).every((key) => knownMcpServerConfigurationFields.has(key)),
+    )
+  );
+}

--- a/packages/agent/src/mcp-host.ts
+++ b/packages/agent/src/mcp-host.ts
@@ -34,6 +34,7 @@ import { AjvJsonSchemaValidator } from "@modelcontextprotocol/client/validators/
 import { valid as validSemver } from "semver";
 import { z } from "zod";
 import type { ArtifactStore } from "./artifact-store.js";
+import { inspectMcpConfigurationDocument } from "./mcp-configuration-document.js";
 import type { JsonValue, ToolEffect, ToolRegistry, ToolResult } from "./tool-runtime.js";
 
 type Sha256Digest = `sha256:${string}`;
@@ -368,33 +369,19 @@ export async function inspectMcpConfiguration(
     throw new McpConfigurationError({ cause: error });
   }
 
-  let parsed: unknown;
+  let document: ReturnType<typeof inspectMcpConfigurationDocument>;
   try {
-    if (!isUtf8(bytes)) {
-      throw new TypeError("The MCP configuration is not valid UTF-8.");
-    }
-    parsed = parseJsonWithoutDuplicateKeys(bytes.toString("utf8"));
+    document = inspectMcpConfigurationDocument(bytes);
   } catch (error) {
     throw new McpConfigurationError({ cause: error });
   }
-  if (
-    !isRecord(parsed) ||
-    Object.keys(parsed).length !== 1 ||
-    !isRecord(parsed.mcpServers) ||
-    Object.keys(parsed.mcpServers).length > 8 ||
-    Object.entries(parsed.mcpServers).some(
-      ([serverId, value]) =>
-        !/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/u.test(serverId) ||
-        !isRecord(value) ||
-        Object.keys(value).some((key) => !knownMcpServerConfigurationFields.has(key)),
-    )
-  ) {
+  if (document === undefined) {
     throw new McpConfigurationError();
   }
 
   const source = {
     path: ".mcp.json",
-    digest: `sha256:${createHash("sha256").update(bytes).digest("hex")}`,
+    digest: document.sourceDigest,
   } as const;
   if (confirmedSourceDigest === undefined) {
     return {
@@ -414,11 +401,13 @@ export async function inspectMcpConfiguration(
   let inspections: readonly McpServerConfigurationInspection[];
   try {
     inspections = await Promise.all(
-      Object.entries(parsed.mcpServers)
-        .sort(([left], [right]) => compareCodeUnits(left, right))
-        .map(([serverId, value]) =>
-          inspectMcpServerConfiguration({ canonicalWorkspaceRoot, serverId, value }),
-        ),
+      document.servers.map(({ serverId, configuration }) =>
+        inspectMcpServerConfiguration({
+          canonicalWorkspaceRoot,
+          serverId,
+          value: configuration,
+        }),
+      ),
     );
   } catch (error) {
     throw error instanceof McpConfigurationError
@@ -490,129 +479,6 @@ export async function inspectMcpConfiguration(
   };
 }
 
-function parseJsonWithoutDuplicateKeys(source: string): unknown {
-  let index = 0;
-  const skipWhitespace = () => {
-    while (/\s/u.test(source[index] ?? "")) {
-      index += 1;
-    }
-  };
-  const fail = (): never => {
-    throw new SyntaxError("Invalid or duplicate-key JSON.");
-  };
-  const parseString = (): string => {
-    if (source[index] !== '"') {
-      return fail();
-    }
-    const start = index;
-    index += 1;
-    while (index < source.length) {
-      const character = source[index];
-      if (character === "\\") {
-        index += 2;
-        continue;
-      }
-      index += 1;
-      if (character === '"') {
-        return JSON.parse(source.slice(start, index)) as string;
-      }
-    }
-    return fail();
-  };
-  const parseValue = (depth: number): unknown => {
-    if (depth > 128) {
-      return fail();
-    }
-    skipWhitespace();
-    const character = source[index];
-    if (character === '"') {
-      return parseString();
-    }
-    if (character === "{") {
-      index += 1;
-      skipWhitespace();
-      const entries: [string, unknown][] = [];
-      const keys = new Set<string>();
-      if (source[index] === "}") {
-        index += 1;
-        return Object.fromEntries(entries);
-      }
-      for (;;) {
-        skipWhitespace();
-        const key = parseString();
-        if (keys.has(key)) {
-          return fail();
-        }
-        keys.add(key);
-        skipWhitespace();
-        if (source[index] !== ":") {
-          return fail();
-        }
-        index += 1;
-        entries.push([key, parseValue(depth + 1)]);
-        skipWhitespace();
-        if (source[index] === "}") {
-          index += 1;
-          return Object.fromEntries(entries);
-        }
-        if (source[index] !== ",") {
-          return fail();
-        }
-        index += 1;
-      }
-    }
-    if (character === "[") {
-      index += 1;
-      skipWhitespace();
-      const values: unknown[] = [];
-      if (source[index] === "]") {
-        index += 1;
-        return values;
-      }
-      for (;;) {
-        values.push(parseValue(depth + 1));
-        skipWhitespace();
-        if (source[index] === "]") {
-          index += 1;
-          return values;
-        }
-        if (source[index] !== ",") {
-          return fail();
-        }
-        index += 1;
-      }
-    }
-    for (const [literal, value] of [
-      ["true", true],
-      ["false", false],
-      ["null", null],
-    ] as const) {
-      if (source.startsWith(literal, index)) {
-        index += literal.length;
-        return value;
-      }
-    }
-    const start = index;
-    while (/[0-9eE+.-]/u.test(source[index] ?? "")) {
-      index += 1;
-    }
-    if (index === start) {
-      return fail();
-    }
-    const number = JSON.parse(source.slice(start, index)) as unknown;
-    if (typeof number !== "number" || !Number.isFinite(number)) {
-      return fail();
-    }
-    return number;
-  };
-  const value = parseValue(0);
-  skipWhitespace();
-  if (index !== source.length) {
-    return fail();
-  }
-  return value;
-}
-
 type McpServerConfigurationInspection = {
   readonly server?: McpServerPreview;
   readonly diagnostic?: {
@@ -620,22 +486,6 @@ type McpServerConfigurationInspection = {
     readonly serverId: string;
   };
 };
-
-const knownMcpServerConfigurationFields = new Set([
-  "type",
-  "command",
-  "args",
-  "cwd",
-  "env",
-  "url",
-  "headers",
-  "oauth",
-  "socket",
-  "resources",
-  "prompts",
-  "lifecycle",
-  "credentials",
-]);
 
 const unsupportedMcpServerConfigurationFields = new Set([
   "url",

--- a/packages/testkit/src/public-product-contract.test.ts
+++ b/packages/testkit/src/public-product-contract.test.ts
@@ -491,6 +491,116 @@ test("SessionLifecycle canonical history projections have package-internal owner
   }
 });
 
+test("MCP configuration documents have one package-internal owner", async () => {
+  const agentSourceRoot = join(productRoot, "packages", "agent", "src");
+  const sourceFiles = (await readdir(agentSourceRoot, { recursive: true }))
+    .filter((entry) => entry.endsWith(".ts"))
+    .sort();
+  const sources = await Promise.all(
+    sourceFiles.map(async (sourceFile) => ({
+      path: sourceFile,
+      source: await readFile(join(agentSourceRoot, sourceFile), "utf8"),
+    })),
+  );
+  const expectedOwners = {
+    inspectMcpConfigurationDocument: ["mcp-configuration-document.ts"],
+  } as const;
+  const actualOwners = Object.fromEntries(
+    Object.keys(expectedOwners).map((symbol) => [
+      symbol,
+      sources
+        .filter(({ source }) =>
+          new RegExp(`\\bexport\\s+function\\s+${symbol}\\s*\\(`, "u").test(source),
+        )
+        .map(({ path }) => path),
+    ]),
+  );
+  const expectedTypeOwners = {
+    McpConfigurationDocument: ["mcp-configuration-document.ts"],
+  } as const;
+  const actualTypeOwners = Object.fromEntries(
+    Object.keys(expectedTypeOwners).map((symbol) => [
+      symbol,
+      sources
+        .filter(({ source }) => new RegExp(`\\bexport\\s+type\\s+${symbol}\\b`, "u").test(source))
+        .map(({ path }) => path),
+    ]),
+  );
+  const documentSource =
+    sources.find(({ path }) => path === "mcp-configuration-document.ts")?.source ?? "";
+  const mcpHostSource = sources.find(({ path }) => path === "mcp-host.ts")?.source ?? "";
+  const documentConsumers = sources
+    .filter(({ source }) => moduleSpecifiers(source).includes("./mcp-configuration-document.js"))
+    .map(({ path }) => path);
+  const publicFacadeSource = sources.find(({ path }) => path === "index.ts")?.source ?? "";
+  const testingFacadeSource =
+    sources.find(({ path }) => path === "internal-testing.ts")?.source ?? "";
+  const testSourceRoots = (
+    await Promise.all(
+      ["apps", "packages"].map(async (root) =>
+        (
+          await readdir(join(productRoot, root), { withFileTypes: true })
+        )
+          .filter((entry) => entry.isDirectory())
+          .map((entry) => join(productRoot, root, entry.name, "src")),
+      ),
+    )
+  ).flat();
+  const testSources = (
+    await Promise.all(
+      testSourceRoots.map(async (sourceRoot) => {
+        try {
+          return (await readdir(sourceRoot, { recursive: true }))
+            .filter((entry) => entry.endsWith(".test.ts"))
+            .map((entry) => join(sourceRoot, entry));
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            return [];
+          }
+          throw error;
+        }
+      }),
+    )
+  ).flat();
+  const directTestImports = (
+    await Promise.all(
+      testSources
+        .filter((testPath) => testPath !== fileURLToPath(import.meta.url))
+        .map(async (testPath) =>
+          moduleSpecifiers(await readFile(testPath, "utf8"))
+            .filter((specifier) => /mcp-configuration-document\.js$/u.test(specifier))
+            .map((specifier) => ({
+              path: relative(productRoot, testPath),
+              specifier,
+            })),
+        ),
+    )
+  ).flat();
+
+  expect.soft(actualOwners).toEqual(expectedOwners);
+  expect.soft(actualTypeOwners).toEqual(expectedTypeOwners);
+  expect.soft(documentConsumers).toEqual(["mcp-host.ts"]);
+  expect
+    .soft(
+      runtimeModuleSpecifiers(mcpHostSource).filter(
+        (specifier) => specifier === "./mcp-configuration-document.js",
+      ),
+    )
+    .toEqual(["./mcp-configuration-document.js"]);
+  expect.soft(mcpHostSource.match(/\binspectMcpConfigurationDocument\s*\(/gu)).toHaveLength(1);
+  expect.soft(runtimeModuleSpecifiers(documentSource)).toEqual(["node:buffer", "node:crypto"]);
+  expect.soft(typeOnlyImportSpecifiers(documentSource)).toEqual([]);
+  expect.soft([...moduleSpecifiers(documentSource)].sort()).toEqual(["node:buffer", "node:crypto"]);
+  const packageInternalSymbols = ["inspectMcpConfigurationDocument", "McpConfigurationDocument"];
+  for (const facadeSource of [publicFacadeSource, testingFacadeSource]) {
+    expect.soft(moduleSpecifiers(facadeSource)).not.toContain("./mcp-configuration-document.js");
+    expect
+      .soft(packageInternalSymbols.filter((symbol) => facadeSource.includes(symbol)))
+      .toEqual([]);
+  }
+  expect.soft(directTestImports).toEqual([]);
+});
+
 test("PresentationSession tool projection has one package-internal owner", async () => {
   const agentSourceRoot = join(productRoot, "packages", "agent", "src");
   const sourceFiles = (await readdir(agentSourceRoot, { recursive: true }))

--- a/packages/testkit/src/trusted-mcp-host.test.ts
+++ b/packages/testkit/src/trusted-mcp-host.test.ts
@@ -1826,6 +1826,55 @@ test("SessionLifecycle reports a remote MCP entry as inert without exposing endp
   }
 });
 
+test("SessionLifecycle orders MCP diagnostics by server ID without exposing endpoint data", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-mcp-diagnostic-order-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const endpoints = [
+    "https://zeta-secret.example.invalid/mcp",
+    "https://alpha-secret.example.invalid/mcp",
+    "https://capital-secret.example.invalid/mcp",
+  ] as const;
+  const configurationSource =
+    '{"mcpServers":{"zeta":{"type":"http","url":"https://zeta-secret.example.invalid/mcp"},"alpha":{"type":"http","url":"https://alpha-secret.example.invalid/mcp"},"Alpha":{"type":"http","url":"https://capital-secret.example.invalid/mcp"}}}';
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, ".mcp.json"), configurationSource);
+
+  try {
+    const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+      stateRoot,
+      workspaceRoot,
+    });
+    const created = await lifecycle.create({ targetIdentity });
+    if (created.mcp === undefined) {
+      throw new Error("The fixture requires an MCP configuration snapshot.");
+    }
+    const confirmed = await lifecycle.configureMcp({
+      type: "confirm_workspace",
+      sessionId: created.sessionId,
+      sourceDigest: created.mcp.source.digest,
+    });
+    const snapshot = confirmed.snapshot.mcp;
+    const serialized = JSON.stringify(snapshot);
+
+    expect(snapshot?.servers).toEqual([]);
+    expect(snapshot?.source.digest).toBe(
+      "sha256:7731e1a173155dde64a639f8da6f7b7edb9c322ee7c84c936d6216e6041564fe",
+    );
+    expect(snapshot?.diagnostics).toEqual(
+      ["Alpha", "alpha", "zeta"].map((serverId) => ({
+        code: "mcp_transport_unsupported",
+        serverId,
+      })),
+    );
+    for (const endpoint of endpoints) {
+      expect(serialized).not.toContain(endpoint);
+    }
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("SessionLifecycle keeps exact server approval separate from process launch", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-mcp-server-approval-"));
   const stateRoot = join(testRoot, "state");


### PR DESCRIPTION
Summary
- move raw MCP configuration admission, duplicate-key parsing, raw-byte digesting, and server ordering into one package-private module
- keep bounded file I/O, McpConfigurationError identity, workspace confirmation, server resolution, runtime state, and close ownership in the MCP Host
- add structural ownership guards plus caller-visible ordering, digest, and endpoint-redaction coverage

Verification
- focused structural and Lifecycle tracers passed independently
- removing server ordering made the caller-visible tracer deterministically RED; restoring it returned GREEN
- full pnpm quality:check: 43 files passed, 2 skipped; 1086 tests passed, 10 opt-in skipped
- three independent final reviews: 0 unresolved findings