### PR TITLE
B9.5: repair MCP watcher causality

### DIFF
--- a/packages/testkit/src/trusted-mcp-host.test.ts
+++ b/packages/testkit/src/trusted-mcp-host.test.ts
@@ -185,11 +185,10 @@ function scriptedReferenceDepthSchema(referenceCount: number): Readonly<Record<s
 function observeFileCreation(path: string): Promise<void> {
   return new Promise((resolve, reject) => {
     let settled = false;
-    const watcher = watch(dirname(path), (_event, filename) => {
-      if (filename === basename(path)) {
-        finish();
-      }
-    });
+    const observeTarget = () => {
+      void stat(path).then(finish, () => undefined);
+    };
+    const watcher = watch(dirname(path), observeTarget);
     const guard = setTimeout(() => {
       settled = true;
       watcher.close();
@@ -204,7 +203,7 @@ function observeFileCreation(path: string): Promise<void> {
       watcher.close();
       resolve();
     };
-    void stat(path).then(finish, () => undefined);
+    observeTarget();
   });
 }
 


### PR DESCRIPTION
Summary
- treat each MCP fixture directory event only as a wake-up and re-stat the exact durable marker
- retain watcher-before-trigger installation, initial exact-target observation, idempotent settlement, and the existing failure-only timeout
- keep the repair test-only with no product, Adapter, timeout, or OS-contract change

Verification
- four affected real OS caller tracers passed independently
- full pnpm quality:check: 43 files passed, 2 skipped; 1086 tests passed, 10 opt-in skipped
- three independent final reviews: 0 findings