### PR TITLE
refactor(agent): isolate MCP profile identity

### DIFF
--- a/packages/agent/src/mcp-canonical-identity.ts
+++ b/packages/agent/src/mcp-canonical-identity.ts
@@ -1,0 +1,25 @@
+import { createHash } from "node:crypto";
+
+export type McpSha256Digest = `sha256:${string}`;
+
+export function canonicalMcpJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalMcpJson(entry)).join(",")}]`;
+  }
+  return `{${Object.entries(value)
+    .filter(([, entry]) => entry !== undefined)
+    .sort(([left], [right]) => compareCodeUnits(left, right))
+    .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalMcpJson(entry)}`)
+    .join(",")}}`;
+}
+
+export function digestCanonicalMcpJson(value: unknown): McpSha256Digest {
+  return `sha256:${createHash("sha256").update(canonicalMcpJson(value)).digest("hex")}`;
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/packages/agent/src/mcp-host.ts
+++ b/packages/agent/src/mcp-host.ts
@@ -34,10 +34,30 @@ import { AjvJsonSchemaValidator } from "@modelcontextprotocol/client/validators/
 import { valid as validSemver } from "semver";
 import { z } from "zod";
 import type { ArtifactStore } from "./artifact-store.js";
+import {
+  canonicalMcpJson,
+  digestCanonicalMcpJson,
+  type McpSha256Digest,
+} from "./mcp-canonical-identity.js";
 import { inspectMcpConfigurationDocument } from "./mcp-configuration-document.js";
+import {
+  createMcpToolProfileV1,
+  isMcpToolProfileV1Valid,
+  type McpSettledServerIdentity,
+  type McpToolProfileSnapshot,
+  type McpToolProfileV1,
+  mcpToolProfileSnapshot,
+} from "./mcp-profile-contracts.js";
 import type { JsonValue, ToolEffect, ToolRegistry, ToolResult } from "./tool-runtime.js";
 
-type Sha256Digest = `sha256:${string}`;
+export {
+  isMcpToolProfileV1Valid,
+  type McpToolProfileSnapshot,
+  type McpToolProfileV1,
+  mcpToolProfileSnapshot,
+} from "./mcp-profile-contracts.js";
+
+type Sha256Digest = McpSha256Digest;
 type McpJsonRecord = Readonly<Record<string, unknown>> & {
   readonly $anchor?: unknown;
   readonly $dynamicAnchor?: unknown;
@@ -71,8 +91,6 @@ type McpActivationErrorCode =
   | "mcp_shutdown_unconfirmed"
   | "mcp_start_failed"
   | "mcp_startup_timeout";
-
-const maximumMcpToolProfileDefinitionBytes = 64 * 1024;
 
 export type McpEffectiveBoundsV1 = {
   readonly version: 1;
@@ -216,61 +234,6 @@ export type McpToolDraft = {
   readonly definitionDigest: Sha256Digest;
 };
 
-export type McpToolProfileV1 = {
-  readonly version: 1;
-  readonly generationId: string;
-  readonly sdk: {
-    readonly package: "@modelcontextprotocol/client";
-    readonly version: "2.0.0";
-  };
-  readonly projectorVersion: 1;
-  readonly servers: McpLiveSessionSnapshot["settledServers"];
-  readonly tools: readonly {
-    readonly serverId: string;
-    readonly serverDefinitionDigest: Sha256Digest;
-    readonly originalName: string;
-    readonly qualifiedName: string;
-    readonly definitionDigest: Sha256Digest;
-    readonly modelDescription: string;
-    readonly rawSchema: {
-      readonly dialect: "unstamped" | "2020-12" | "2019-09" | "draft-07" | "draft-06";
-      readonly provenance: "tools/list";
-      readonly value: Readonly<Record<string, unknown>>;
-      readonly digest: Sha256Digest;
-    };
-    readonly modelProjection: {
-      readonly version: 1;
-      readonly schema: Readonly<Record<string, unknown>>;
-      readonly digest: Sha256Digest;
-    };
-    readonly effect: ToolEffect;
-    readonly replay: "never";
-    readonly cancellation: "abort_signal";
-    readonly outputPolicy: {
-      readonly version: 1;
-      readonly maximumInlineBytes: 65_536;
-      readonly maximumRawBytes: 8_388_608;
-      readonly supportedContent: readonly ["text", "structured_json"];
-    };
-  }[];
-  readonly digest: Sha256Digest;
-};
-
-export type McpToolProfileSnapshot = {
-  readonly version: 1;
-  readonly digest: Sha256Digest;
-  readonly projectorVersion: 1;
-  readonly tools: readonly {
-    readonly serverId: string;
-    readonly originalName: string;
-    readonly qualifiedName: string;
-    readonly definitionDigest: Sha256Digest;
-    readonly rawSchemaDigest: Sha256Digest;
-    readonly modelProjectionDigest: Sha256Digest;
-    readonly effect: ToolEffect;
-  }[];
-};
-
 export type McpActivationSnapshot = {
   readonly attempt: number;
   readonly generationId: string;
@@ -289,15 +252,7 @@ export type McpLiveSessionSnapshot = {
     readonly digest: Sha256Digest;
     readonly tools: readonly McpToolDraft[];
   };
-  readonly settledServers: readonly {
-    readonly serverId: string;
-    readonly definitionDigest: Sha256Digest;
-    readonly protocolVersion: string;
-    readonly serverName: string;
-    readonly serverVersion: string;
-    readonly capabilityDigest: Sha256Digest;
-    readonly launchIdentityDigest: Sha256Digest;
-  }[];
+  readonly settledServers: readonly McpSettledServerIdentity[];
   readonly profile?: McpToolProfileSnapshot;
 };
 
@@ -1234,29 +1189,15 @@ export function createMcpRuntimeHost(options: {
           supportedContent: ["text", "structured_json"] as const,
         },
       }));
-      const modelDefinitions = profileTools.map((tool) => ({
-        name: tool.qualifiedName,
-        description: tool.modelDescription,
-        inputSchema: tool.modelProjection.schema,
-      }));
-      if (
-        Buffer.byteLength(canonicalJson(modelDefinitions), "utf8") >
-        maximumMcpToolProfileDefinitionBytes
-      ) {
-        throw new McpHostError("mcp_catalog_invalid");
-      }
-      const profileWithoutDigest = {
-        version: 1,
+      const profile = createMcpToolProfileV1({
         generationId: input.generationId,
-        sdk: { package: "@modelcontextprotocol/client", version: "2.0.0" },
-        projectorVersion: 1,
         servers: generation.live.settledServers,
         tools: profileTools,
-      } as const;
-      return {
-        ...profileWithoutDigest,
-        digest: sha256(canonicalJson(profileWithoutDigest)),
-      };
+      });
+      if (profile === undefined) {
+        throw new McpHostError("mcp_catalog_invalid");
+      }
+      return profile;
     },
     async reactivateToolProfile(input) {
       const live = await activate(input);
@@ -1546,7 +1487,7 @@ async function startMcpGeneration(
       status: "ready",
     },
     readyServerIds: new Set(connections.map((connection) => connection.serverId)),
-    catalog: { status: "ready", digest: sha256(canonicalJson({ version: 1, tools })), tools },
+    catalog: { status: "ready", digest: digestCanonicalMcpJson({ version: 1, tools }), tools },
     settledServers: connections.map((connection) => connection.settlement),
   };
   generation.prepared = live;
@@ -1608,14 +1549,14 @@ async function resolveMcpServerLaunch(
 ): Promise<ResolvedStdioLaunch> {
   if (server.command.kind === "executable") {
     const identity = await inspectMcpExecutableIdentity(server.command.path);
-    if (canonicalJson(identity) !== canonicalJson(server.command.identity)) {
+    if (canonicalMcpJson(identity) !== canonicalMcpJson(server.command.identity)) {
       throw new TypeError("The approved MCP executable identity changed before launch.");
     }
     return {
       path: server.command.path,
       arguments: server.arguments,
       cwd: server.cwd,
-      identityDigest: sha256(canonicalJson({ version: 1, path: server.command.path, identity })),
+      identityDigest: digestCanonicalMcpJson({ version: 1, path: server.command.path, identity }),
     };
   }
   const cacheKey = `${server.command.packageName}@${server.command.version}`;
@@ -1793,20 +1734,18 @@ async function bootstrapExactMcpPackage(
       mcpEffectiveBoundsV1.maximumExecutableBytes,
       effectiveSignal,
     );
-    const identityDigest = sha256(
-      canonicalJson({
-        version: 1,
-        packageName: command.packageName,
-        packageVersion: command.version,
-        integrity: lockedPackage.integrity,
-        dependencyTreeDigest: sha256(canonicalJson({ version: 1, packages: dependencyTree })),
-        binPolicy: command.binPolicy,
-        binRelativePath,
-        binDigest,
-        npmVersion: "11.6.2",
-        lifecycleScripts: "disabled",
-      }),
-    );
+    const identityDigest = digestCanonicalMcpJson({
+      version: 1,
+      packageName: command.packageName,
+      packageVersion: command.version,
+      integrity: lockedPackage.integrity,
+      dependencyTreeDigest: digestCanonicalMcpJson({ version: 1, packages: dependencyTree }),
+      binPolicy: command.binPolicy,
+      binRelativePath,
+      binDigest,
+      npmVersion: "11.6.2",
+      lifecycleScripts: "disabled",
+    });
     await rm(target, { recursive: true, force: true });
     await rename(staging, target);
     const packageRoot = join(target, packageRelativePath);
@@ -2024,7 +1963,7 @@ function createMcpToolAdapter(input: {
       if (!validation.valid || !isRecord(argumentsValue)) {
         return invalidMcpToolInput();
       }
-      const argumentsDigest = sha256(canonicalJson(argumentsValue));
+      const argumentsDigest = digestCanonicalMcpJson(argumentsValue);
       return {
         status: "ready" as const,
         permissionSubject: {
@@ -2183,7 +2122,7 @@ async function executeMcpTool(input: {
         : { structuredContent: result.structuredContent }),
       isError: result.isError === true,
     };
-    const outputBytes = Buffer.from(canonicalJson(output), "utf8");
+    const outputBytes = Buffer.from(canonicalMcpJson(output), "utf8");
     if (outputBytes.byteLength > 8 * 1024 * 1024) {
       return {
         status: "failed",
@@ -2385,7 +2324,7 @@ async function activateServer(
         protocolVersion,
         serverName,
         serverVersion: negotiatedServerVersion,
-        capabilityDigest: sha256(canonicalJson(capabilities)),
+        capabilityDigest: digestCanonicalMcpJson(capabilities),
         launchIdentityDigest: activeTransport.launchIdentityDigest,
       },
     };
@@ -2439,14 +2378,14 @@ async function discoverMcpTools(
         dialect: schemaDialect(inputSchema),
         provenance: "tools/list" as const,
         value: inputSchema,
-        digest: sha256(canonicalJson(inputSchema)),
+        digest: digestCanonicalMcpJson(inputSchema),
       };
       const projected = projectMcpInputSchemaV1(inputSchema);
       assertMcpSchemaAdmissible(projected.schema);
       const modelProjection = {
         version: 1 as const,
         schema: projected.schema,
-        digest: sha256(canonicalJson({ version: 1, schema: projected.schema })),
+        digest: digestCanonicalMcpJson({ version: 1, schema: projected.schema }),
       };
       const qualifiedName = qualifiedToolName(server, tool.name);
       const serverDescription = normalizeMcpServerDescription(tool.description ?? "");
@@ -2456,20 +2395,18 @@ async function discoverMcpTools(
         serverDescription,
         projected.compatibilityHint,
       );
-      const definitionDigest = sha256(
-        canonicalJson({
-          version: 1,
-          serverId: server.serverId,
-          serverDefinitionDigest: server.definitionDigest,
-          originalName: tool.name,
-          qualifiedName,
-          description: serverDescription,
-          rawSchemaDigest: rawSchema.digest,
-          modelProjectionDigest: modelProjection.digest,
-          outputSchemaDigest:
-            tool.outputSchema === undefined ? null : sha256(canonicalJson(tool.outputSchema)),
-        }),
-      );
+      const definitionDigest = digestCanonicalMcpJson({
+        version: 1,
+        serverId: server.serverId,
+        serverDefinitionDigest: server.definitionDigest,
+        originalName: tool.name,
+        qualifiedName,
+        description: serverDescription,
+        rawSchemaDigest: rawSchema.digest,
+        modelProjectionDigest: modelProjection.digest,
+        outputSchemaDigest:
+          tool.outputSchema === undefined ? null : digestCanonicalMcpJson(tool.outputSchema),
+      });
       return [
         {
           draft: {
@@ -2760,7 +2697,8 @@ function projectMcpRootChoice(
       }
       const candidates = branchPropertySets.map((candidate) => candidate[name]);
       properties[name] = candidates.every(
-        (candidate) => candidate !== undefined && canonicalJson(candidate) === canonicalJson(value),
+        (candidate) =>
+          candidate !== undefined && canonicalMcpJson(candidate) === canonicalMcpJson(value),
       )
         ? value
         : {};
@@ -2839,7 +2777,7 @@ async function listAllTools(
       },
     );
     for (const tool of page.tools) {
-      const definitionBytes = Buffer.byteLength(canonicalJson(tool), "utf8");
+      const definitionBytes = Buffer.byteLength(canonicalMcpJson(tool), "utf8");
       aggregateDefinitionBytes += definitionBytes;
       if (seenNames.has(tool.name)) {
         throw new McpHostError("mcp_catalog_invalid", { serverId });
@@ -3365,7 +3303,7 @@ async function createExecutableServerPreview(input: {
         requestedEnvironmentNames,
         startupEffects: ["execute", "network"],
         limits: mcpEffectiveBoundsV1,
-        definitionDigest: sha256(canonicalJson(definition)),
+        definitionDigest: digestCanonicalMcpJson(definition),
       },
     };
   }
@@ -3412,7 +3350,7 @@ async function createExecutableServerPreview(input: {
       requestedEnvironmentNames,
       startupEffects: ["execute"],
       limits: mcpEffectiveBoundsV1,
-      definitionDigest: sha256(canonicalJson(definition)),
+      definitionDigest: digestCanonicalMcpJson(definition),
     },
   };
 }
@@ -3579,20 +3517,6 @@ function sameMcpExecutableStat(left: BigIntStats, right: BigIntStats): boolean {
   );
 }
 
-function canonicalJson(value: unknown): string {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value);
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
-  }
-  return `{${Object.entries(value)
-    .filter(([, entry]) => entry !== undefined)
-    .sort(([left], [right]) => compareCodeUnits(left, right))
-    .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`)
-    .join(",")}}`;
-}
-
 function compareCodeUnits(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
 }
@@ -3670,53 +3594,6 @@ function schemaDialect(
     return "draft-06";
   }
   throw new TypeError("MCP schema dialect is unsupported.");
-}
-
-export function mcpToolProfileSnapshot(profile: McpToolProfileV1): McpToolProfileSnapshot {
-  return {
-    version: 1,
-    digest: profile.digest,
-    projectorVersion: profile.projectorVersion,
-    tools: profile.tools.map((tool) => ({
-      serverId: tool.serverId,
-      originalName: tool.originalName,
-      qualifiedName: tool.qualifiedName,
-      definitionDigest: tool.definitionDigest,
-      rawSchemaDigest: tool.rawSchema.digest,
-      modelProjectionDigest: tool.modelProjection.digest,
-      effect: tool.effect,
-    })),
-  };
-}
-
-export function isMcpToolProfileV1Valid(profile: McpToolProfileV1): boolean {
-  const { digest, ...withoutDigest } = profile;
-  return (
-    profile.version === 1 &&
-    profile.sdk.package === "@modelcontextprotocol/client" &&
-    profile.sdk.version === "2.0.0" &&
-    profile.projectorVersion === 1 &&
-    profile.tools.length >= 1 &&
-    profile.tools.length <= 20 &&
-    new Set(profile.tools.map((tool) => tool.qualifiedName)).size === profile.tools.length &&
-    profile.tools.every(
-      (tool) =>
-        profile.servers.some(
-          (server) =>
-            server.serverId === tool.serverId &&
-            server.definitionDigest === tool.serverDefinitionDigest,
-        ) &&
-        tool.rawSchema.digest === sha256(canonicalJson(tool.rawSchema.value)) &&
-        tool.modelProjection.digest ===
-          sha256(canonicalJson({ version: 1, schema: tool.modelProjection.schema })) &&
-        tool.modelDescription.length <= 2 * 1024,
-    ) &&
-    digest === sha256(canonicalJson(withoutDigest))
-  );
-}
-
-function sha256(value: string): Sha256Digest {
-  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
 }
 
 function asError(error: unknown): Error {

--- a/packages/agent/src/mcp-profile-contracts.ts
+++ b/packages/agent/src/mcp-profile-contracts.ts
@@ -1,0 +1,146 @@
+import {
+  canonicalMcpJson,
+  digestCanonicalMcpJson,
+  type McpSha256Digest,
+} from "./mcp-canonical-identity.js";
+import type { ToolEffect } from "./tool-runtime.js";
+
+const maximumMcpToolProfileDefinitionBytes = 64 * 1024;
+
+export type McpSettledServerIdentity = {
+  readonly serverId: string;
+  readonly definitionDigest: McpSha256Digest;
+  readonly protocolVersion: string;
+  readonly serverName: string;
+  readonly serverVersion: string;
+  readonly capabilityDigest: McpSha256Digest;
+  readonly launchIdentityDigest: McpSha256Digest;
+};
+
+export type McpToolProfileV1 = {
+  readonly version: 1;
+  readonly generationId: string;
+  readonly sdk: {
+    readonly package: "@modelcontextprotocol/client";
+    readonly version: "2.0.0";
+  };
+  readonly projectorVersion: 1;
+  readonly servers: readonly McpSettledServerIdentity[];
+  readonly tools: readonly {
+    readonly serverId: string;
+    readonly serverDefinitionDigest: McpSha256Digest;
+    readonly originalName: string;
+    readonly qualifiedName: string;
+    readonly definitionDigest: McpSha256Digest;
+    readonly modelDescription: string;
+    readonly rawSchema: {
+      readonly dialect: "unstamped" | "2020-12" | "2019-09" | "draft-07" | "draft-06";
+      readonly provenance: "tools/list";
+      readonly value: Readonly<Record<string, unknown>>;
+      readonly digest: McpSha256Digest;
+    };
+    readonly modelProjection: {
+      readonly version: 1;
+      readonly schema: Readonly<Record<string, unknown>>;
+      readonly digest: McpSha256Digest;
+    };
+    readonly effect: ToolEffect;
+    readonly replay: "never";
+    readonly cancellation: "abort_signal";
+    readonly outputPolicy: {
+      readonly version: 1;
+      readonly maximumInlineBytes: 65_536;
+      readonly maximumRawBytes: 8_388_608;
+      readonly supportedContent: readonly ["text", "structured_json"];
+    };
+  }[];
+  readonly digest: McpSha256Digest;
+};
+
+export type McpToolProfileSnapshot = {
+  readonly version: 1;
+  readonly digest: McpSha256Digest;
+  readonly projectorVersion: 1;
+  readonly tools: readonly {
+    readonly serverId: string;
+    readonly originalName: string;
+    readonly qualifiedName: string;
+    readonly definitionDigest: McpSha256Digest;
+    readonly rawSchemaDigest: McpSha256Digest;
+    readonly modelProjectionDigest: McpSha256Digest;
+    readonly effect: ToolEffect;
+  }[];
+};
+
+export function createMcpToolProfileV1(input: {
+  readonly generationId: string;
+  readonly servers: readonly McpSettledServerIdentity[];
+  readonly tools: McpToolProfileV1["tools"];
+}): McpToolProfileV1 | undefined {
+  const modelDefinitions = input.tools.map((tool) => ({
+    name: tool.qualifiedName,
+    description: tool.modelDescription,
+    inputSchema: tool.modelProjection.schema,
+  }));
+  if (
+    Buffer.byteLength(canonicalMcpJson(modelDefinitions), "utf8") >
+    maximumMcpToolProfileDefinitionBytes
+  ) {
+    return undefined;
+  }
+  const profileWithoutDigest = {
+    version: 1,
+    generationId: input.generationId,
+    sdk: { package: "@modelcontextprotocol/client", version: "2.0.0" },
+    projectorVersion: 1,
+    servers: input.servers,
+    tools: input.tools,
+  } as const;
+  return {
+    ...profileWithoutDigest,
+    digest: digestCanonicalMcpJson(profileWithoutDigest),
+  };
+}
+
+export function mcpToolProfileSnapshot(profile: McpToolProfileV1): McpToolProfileSnapshot {
+  return {
+    version: 1,
+    digest: profile.digest,
+    projectorVersion: profile.projectorVersion,
+    tools: profile.tools.map((tool) => ({
+      serverId: tool.serverId,
+      originalName: tool.originalName,
+      qualifiedName: tool.qualifiedName,
+      definitionDigest: tool.definitionDigest,
+      rawSchemaDigest: tool.rawSchema.digest,
+      modelProjectionDigest: tool.modelProjection.digest,
+      effect: tool.effect,
+    })),
+  };
+}
+
+export function isMcpToolProfileV1Valid(profile: McpToolProfileV1): boolean {
+  const { digest, ...withoutDigest } = profile;
+  return (
+    profile.version === 1 &&
+    profile.sdk.package === "@modelcontextprotocol/client" &&
+    profile.sdk.version === "2.0.0" &&
+    profile.projectorVersion === 1 &&
+    profile.tools.length >= 1 &&
+    profile.tools.length <= 20 &&
+    new Set(profile.tools.map((tool) => tool.qualifiedName)).size === profile.tools.length &&
+    profile.tools.every(
+      (tool) =>
+        profile.servers.some(
+          (server) =>
+            server.serverId === tool.serverId &&
+            server.definitionDigest === tool.serverDefinitionDigest,
+        ) &&
+        tool.rawSchema.digest === digestCanonicalMcpJson(tool.rawSchema.value) &&
+        tool.modelProjection.digest ===
+          digestCanonicalMcpJson({ version: 1, schema: tool.modelProjection.schema }) &&
+        tool.modelDescription.length <= 2 * 1024,
+    ) &&
+    digest === digestCanonicalMcpJson(withoutDigest)
+  );
+}

--- a/packages/agent/src/prompt-assembly.ts
+++ b/packages/agent/src/prompt-assembly.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { z } from "zod";
 import type { ModelMessage } from "./agent-session-contracts.js";
 import type { ContextProfile } from "./context-profile.js";
-import type { McpToolProfileV1 } from "./mcp-host.js";
+import type { McpToolProfileV1 } from "./mcp-profile-contracts.js";
 import type { SkillContextRecordV1 } from "./skills.js";
 import type { ModelToolDefinition, ToolRegistry } from "./tool-runtime.js";
 

--- a/packages/agent/src/session-history-validation.ts
+++ b/packages/agent/src/session-history-validation.ts
@@ -11,7 +11,7 @@ import {
   digestContextRecordPrefix,
   reduceContextEvidence,
 } from "./durable-context.js";
-import { isMcpToolProfileV1Valid } from "./mcp-host.js";
+import { isMcpToolProfileV1Valid } from "./mcp-profile-contracts.js";
 import { sameModelTargetIdentity } from "./model-targets.js";
 import {
   commitMcpToolProfileV3,

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -43,7 +43,6 @@ import {
   type McpIdleScheduler,
   type McpRequestScheduler,
   type McpSessionSnapshot,
-  type McpToolProfileV1,
   type McpTransportFactory,
   mcpBeforeToolDispatchBarrier,
   mcpBootstrapScheduler,
@@ -56,6 +55,7 @@ import {
   mcpRequestScheduler,
   mcpTransportFactory,
 } from "./mcp-host.js";
+import type { McpToolProfileV1 } from "./mcp-profile-contracts.js";
 import {
   type ModelTargetIdentity,
   type ModelTargets,

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -10,7 +10,7 @@ import type { ArtifactReference, ModelResponseArtifactSource } from "./artifact-
 import type { ContextProfile } from "./context-profile.js";
 import type { ContextCallUsage, ContextEvidenceV1, ContextSummaryV1 } from "./durable-context.js";
 import { maximumInlineModelResponseFieldBytes } from "./durable-model-response-policy.js";
-import type { McpToolProfileV1 } from "./mcp-host.js";
+import type { McpToolProfileV1 } from "./mcp-profile-contracts.js";
 import { modelDriverErrorCategories } from "./model-driver-error.js";
 import type { ModelTargetIdentity } from "./model-targets.js";
 import {

--- a/packages/testkit/src/public-product-contract.test.ts
+++ b/packages/testkit/src/public-product-contract.test.ts
@@ -601,6 +601,181 @@ test("MCP configuration documents have one package-internal owner", async () => 
   expect.soft(directTestImports).toEqual([]);
 });
 
+test("MCP canonical identity and durable Tool Profile contracts have package-internal owners", async () => {
+  const agentSourceRoot = join(productRoot, "packages", "agent", "src");
+  const sourceFiles = (await readdir(agentSourceRoot, { recursive: true }))
+    .filter((entry) => entry.endsWith(".ts"))
+    .sort();
+  const sources = await Promise.all(
+    sourceFiles.map(async (sourceFile) => ({
+      path: sourceFile,
+      source: await readFile(join(agentSourceRoot, sourceFile), "utf8"),
+    })),
+  );
+  const expectedOwners = {
+    canonicalMcpJson: ["mcp-canonical-identity.ts"],
+    createMcpToolProfileV1: ["mcp-profile-contracts.ts"],
+    digestCanonicalMcpJson: ["mcp-canonical-identity.ts"],
+    isMcpToolProfileV1Valid: ["mcp-profile-contracts.ts"],
+    mcpToolProfileSnapshot: ["mcp-profile-contracts.ts"],
+  } as const;
+  const actualOwners = Object.fromEntries(
+    Object.keys(expectedOwners).map((symbol) => [
+      symbol,
+      sources
+        .filter(({ source }) =>
+          new RegExp(`\\bexport\\s+function\\s+${symbol}\\s*\\(`, "u").test(source),
+        )
+        .map(({ path }) => path),
+    ]),
+  );
+  const expectedTypeOwners = {
+    McpSha256Digest: ["mcp-canonical-identity.ts"],
+    McpSettledServerIdentity: ["mcp-profile-contracts.ts"],
+    McpToolProfileSnapshot: ["mcp-profile-contracts.ts"],
+    McpToolProfileV1: ["mcp-profile-contracts.ts"],
+  } as const;
+  const actualTypeOwners = Object.fromEntries(
+    Object.keys(expectedTypeOwners).map((symbol) => [
+      symbol,
+      sources
+        .filter(({ source }) => new RegExp(`\\bexport\\s+type\\s+${symbol}\\b`, "u").test(source))
+        .map(({ path }) => path),
+    ]),
+  );
+  const canonicalSource =
+    sources.find(({ path }) => path === "mcp-canonical-identity.ts")?.source ?? "";
+  const profileSource =
+    sources.find(({ path }) => path === "mcp-profile-contracts.ts")?.source ?? "";
+  const hostSource = sources.find(({ path }) => path === "mcp-host.ts")?.source ?? "";
+  const historyValidationSource =
+    sources.find(({ path }) => path === "session-history-validation.ts")?.source ?? "";
+  const canonicalConsumers = sources
+    .filter(({ source }) => runtimeModuleSpecifiers(source).includes("./mcp-canonical-identity.js"))
+    .map(({ path }) => path);
+  const profileConsumers = sources
+    .filter(({ source }) => moduleSpecifiers(source).includes("./mcp-profile-contracts.js"))
+    .map(({ path }) => path);
+  const profileRuntimeConsumers = sources
+    .filter(({ source }) => runtimeModuleSpecifiers(source).includes("./mcp-profile-contracts.js"))
+    .map(({ path }) => path);
+  const profileCompatibilityExports = [
+    ...hostSource.matchAll(/export\s*\{([^}]*)\}\s*from\s+"\.\/mcp-profile-contracts\.js"/gu),
+  ]
+    .flatMap((match) =>
+      (match[1] ?? "")
+        .split(",")
+        .map((entry) => entry.trim().replace(/\s+/gu, " "))
+        .filter((entry) => entry.length > 0),
+    )
+    .sort();
+  const publicFacadeSource = sources.find(({ path }) => path === "index.ts")?.source ?? "";
+  const testingFacadeSource =
+    sources.find(({ path }) => path === "internal-testing.ts")?.source ?? "";
+  const testSourceRoots = (
+    await Promise.all(
+      ["apps", "packages"].map(async (root) =>
+        (
+          await readdir(join(productRoot, root), { withFileTypes: true })
+        )
+          .filter((entry) => entry.isDirectory())
+          .map((entry) => join(productRoot, root, entry.name, "src")),
+      ),
+    )
+  ).flat();
+  const testSources = (
+    await Promise.all(
+      testSourceRoots.map(async (sourceRoot) => {
+        try {
+          return (await readdir(sourceRoot, { recursive: true }))
+            .filter((entry) => entry.endsWith(".test.ts"))
+            .map((entry) => join(sourceRoot, entry));
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            return [];
+          }
+          throw error;
+        }
+      }),
+    )
+  ).flat();
+  const directTestImports = (
+    await Promise.all(
+      testSources
+        .filter((testPath) => testPath !== fileURLToPath(import.meta.url))
+        .map(async (testPath) =>
+          moduleSpecifiers(await readFile(testPath, "utf8"))
+            .filter((specifier) =>
+              /mcp-(?:canonical-identity|profile-contracts)\.js$/u.test(specifier),
+            )
+            .map((specifier) => ({
+              path: relative(productRoot, testPath),
+              specifier,
+            })),
+        ),
+    )
+  ).flat();
+
+  expect.soft(actualOwners).toEqual(expectedOwners);
+  expect.soft(actualTypeOwners).toEqual(expectedTypeOwners);
+  expect.soft(canonicalConsumers).toEqual(["mcp-host.ts", "mcp-profile-contracts.ts"]);
+  expect
+    .soft(profileConsumers)
+    .toEqual([
+      "mcp-host.ts",
+      "prompt-assembly.ts",
+      "session-history-validation.ts",
+      "session-lifecycle.ts",
+      "session-store.ts",
+    ]);
+  expect.soft(profileRuntimeConsumers).toEqual(["mcp-host.ts", "session-history-validation.ts"]);
+  expect.soft(moduleSpecifiers(canonicalSource)).toEqual(["node:crypto"]);
+  expect.soft(runtimeModuleSpecifiers(canonicalSource)).toEqual(["node:crypto"]);
+  expect.soft(typeOnlyImportSpecifiers(canonicalSource)).toEqual([]);
+  expect
+    .soft([...moduleSpecifiers(profileSource)].sort())
+    .toEqual(["./mcp-canonical-identity.js", "./tool-runtime.js"]);
+  expect.soft(runtimeModuleSpecifiers(profileSource)).toEqual(["./mcp-canonical-identity.js"]);
+  expect.soft(typeOnlyImportSpecifiers(profileSource)).toEqual(["./tool-runtime.js"]);
+  expect.soft(moduleSpecifiers(historyValidationSource)).not.toContain("./mcp-host.js");
+  expect.soft(hostSource.match(/\bcreateMcpToolProfileV1\s*\(/gu)).toHaveLength(1);
+  const legacyHostProfileOwnerFragments = [
+    "maximumMcpToolProfileDefinitionBytes",
+    "profileWithoutDigest",
+    "canonicalMcpJson(modelDefinitions)",
+  ];
+  expect
+    .soft(legacyHostProfileOwnerFragments.filter((fragment) => hostSource.includes(fragment)))
+    .toEqual([]);
+  expect
+    .soft(profileCompatibilityExports)
+    .toEqual([
+      "isMcpToolProfileV1Valid",
+      "mcpToolProfileSnapshot",
+      "type McpToolProfileSnapshot",
+      "type McpToolProfileV1",
+    ]);
+  const packagePrivateSymbols = [
+    "McpSettledServerIdentity",
+    "McpSha256Digest",
+    "McpToolProfileSnapshot",
+    "McpToolProfileV1",
+    "canonicalMcpJson",
+    "createMcpToolProfileV1",
+    "digestCanonicalMcpJson",
+    "isMcpToolProfileV1Valid",
+    "mcpToolProfileSnapshot",
+  ];
+  for (const facadeSource of [publicFacadeSource, testingFacadeSource]) {
+    expect.soft(moduleSpecifiers(facadeSource)).not.toContain("./mcp-canonical-identity.js");
+    expect.soft(moduleSpecifiers(facadeSource)).not.toContain("./mcp-profile-contracts.js");
+    expect
+      .soft(packagePrivateSymbols.filter((symbol) => facadeSource.includes(symbol)))
+      .toEqual([]);
+  }
+  expect.soft(directTestImports).toEqual([]);
+});
+
 test("PresentationSession tool projection has one package-internal owner", async () => {
   const agentSourceRoot = join(productRoot, "packages", "agent", "src");
   const sourceFiles = (await readdir(agentSourceRoot, { recursive: true }))

--- a/packages/testkit/src/trusted-mcp-host.test.ts
+++ b/packages/testkit/src/trusted-mcp-host.test.ts
@@ -26,8 +26,10 @@ import {
   type ModelTargetIdentity,
   type ModelTargets,
   type RuntimeEvent,
+  type ToolEffect,
 } from "@adam-agent/agent";
 import {
+  createInMemorySessionStoreDirectory,
   type McpIdleScheduler,
   mcpActivationSettlementBarrier,
   mcpBeforeToolDispatchBarrier,
@@ -41,6 +43,8 @@ import {
   mcpPackageRegistryUrl,
   mcpRequestScheduler,
   mcpTransportFactory,
+  type SessionRecord,
+  sessionStoreDirectory,
 } from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
 
@@ -269,6 +273,7 @@ function createManualMcpIdleScheduler(): {
 
 async function commitFixtureEchoTool(
   lifecycle: ReturnType<typeof createSessionLifecycle>,
+  effect: ToolEffect = "read",
 ): Promise<{
   readonly sessionId: string;
   readonly qualifiedName: string;
@@ -315,7 +320,7 @@ async function commitFixtureEchoTool(
       {
         qualifiedName: echo.qualifiedName,
         definitionDigest: echo.definitionDigest,
-        effect: "read",
+        effect,
       },
     ],
   });
@@ -4404,6 +4409,108 @@ test("SessionLifecycle commits one discovery-bound MCP Tool Profile before makin
   }
 });
 
+test("SessionLifecycle rejects a persisted MCP Tool Profile whose canonical schema digest is invalid", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-mcp-profile-canonical-tamper-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeScriptedMcpConfiguration(testRoot, workspaceRoot);
+
+  const {
+    harness,
+    lifecycle: initial,
+    peer: initialPeer,
+  } = createScriptedMcpLifecycle(
+    { stateRoot, workspaceRoot },
+    { fixture: ordinaryScriptedMcpServer() },
+  );
+  let corrupted: ReturnType<typeof createSessionLifecycle> | undefined;
+  try {
+    const committed = await commitFixtureEchoTool(initial);
+    const initialStore = await harness.sessions.open(committed.sessionId);
+    if (initialStore === undefined) {
+      throw new Error("The fixture requires the committed in-memory session store.");
+    }
+    const committedRecords = await initialStore.read();
+    const initialTransportClosed = initialPeer.nextClose("fixture");
+    expect(await initial.close()).toEqual({ status: "closed" });
+    await initialTransportClosed;
+
+    const corruptedDirectory = createInMemorySessionStoreDirectory<SessionRecord>();
+    const corruptedStore = await corruptedDirectory.create(committed.sessionId);
+    let corruptedProfileRecords = 0;
+    for (const entry of committedRecords) {
+      const corruptedEntry: SessionRecord =
+        entry.schemaVersion === 3 && entry.record.type === "mcp_tool_profile_committed"
+          ? {
+              ...entry,
+              record: {
+                ...entry.record,
+                profile: {
+                  ...entry.record.profile,
+                  tools: entry.record.profile.tools.map((tool, index) =>
+                    index === 0
+                      ? {
+                          ...tool,
+                          rawSchema: {
+                            ...tool.rawSchema,
+                            value: { ...tool.rawSchema.value, fixtureTamper: true },
+                          },
+                        }
+                      : tool,
+                  ),
+                },
+              },
+            }
+          : entry;
+      if (corruptedEntry !== entry) {
+        corruptedProfileRecords += 1;
+      }
+      await corruptedStore.append(corruptedEntry);
+    }
+    expect(corruptedProfileRecords).toBe(1);
+
+    let modelResolveCount = 0;
+    const modelTargets: ModelTargets = {
+      async resolve() {
+        modelResolveCount += 1;
+        throw new Error("The model must not resolve an invalid durable MCP Tool Profile.");
+      },
+      async snapshot() {
+        return {
+          targets: [
+            {
+              identity: targetIdentity,
+              readiness: { status: "available", credentialSource: "test" },
+              contextProfile,
+            },
+          ],
+        };
+      },
+    };
+    const corruptedPeer = createScriptedMcpTransportFactory({
+      fixture: ordinaryScriptedMcpServer(),
+    });
+    corrupted = createSessionLifecycle({
+      [mcpTransportFactory]: corruptedPeer,
+      [sessionStoreDirectory]: corruptedDirectory,
+      modelTargets,
+      stateRoot,
+      workspaceRoot,
+    });
+
+    await expect(corrupted.inspect({ sessionId: committed.sessionId })).rejects.toMatchObject({
+      code: "session_invalid",
+    });
+    expect(modelResolveCount).toBe(0);
+    expect(corruptedPeer.requests("fixture")).toEqual([]);
+  } finally {
+    await initial.close();
+    await corrupted?.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("SessionLifecycle commits MCP after a base-only run and exposes it only to the next run", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-mcp-after-base-run-"));
   const stateRoot = join(testRoot, "state");
@@ -5469,6 +5576,139 @@ test("SessionLifecycle rejects a child activation outside its inherited MCP appr
     });
   } finally {
     await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle binds MCP permission arguments to a canonical code-unit digest", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-mcp-canonical-arguments-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeScriptedMcpConfiguration(testRoot, workspaceRoot);
+
+  let qualifiedName: string | undefined;
+  let modelRequestCount = 0;
+  const driver = new FakeModelDriver(() => {
+    modelRequestCount += 1;
+    if (modelRequestCount === 1) {
+      return [
+        { type: "tool_call_start", id: "mcp-canonical", name: qualifiedName as string },
+        {
+          type: "tool_call_delta",
+          id: "mcp-canonical",
+          json: '{"zeta":{"Zulu":2,"alpha":1},"value":"hello","Alpha":true}',
+        },
+        { type: "tool_call_end", id: "mcp-canonical" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    return [
+      { type: "text_delta", text: "Denied canonical MCP call settled." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "test" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const { lifecycle, peer } = createScriptedMcpLifecycle(
+    {
+      modelTargets,
+      permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["execute"] }),
+      stateRoot,
+      workspaceRoot,
+    },
+    {
+      fixture: {
+        toolPages: [
+          {
+            tools: [
+              {
+                ...scriptedStringTool("echo", {
+                  type: "object",
+                  properties: {
+                    zeta: {
+                      type: "object",
+                      properties: { Zulu: { type: "number" }, alpha: { type: "number" } },
+                      required: ["Zulu", "alpha"],
+                      additionalProperties: false,
+                    },
+                    value: { type: "string" },
+                    Alpha: { type: "boolean" },
+                  },
+                  required: ["zeta", "value", "Alpha"],
+                  additionalProperties: false,
+                }),
+                description: "Echo a value.",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  );
+  let resolvePermissionRequest:
+    | ((event: Extract<RuntimeEvent, { readonly type: "tool_permission_requested" }>) => void)
+    | undefined;
+  const permissionRequested = new Promise<
+    Extract<RuntimeEvent, { readonly type: "tool_permission_requested" }>
+  >((resolve) => {
+    resolvePermissionRequest = resolve;
+  });
+  lifecycle.subscribe((event) => {
+    if (event.type === "tool_permission_requested" && event.callId === "mcp-canonical") {
+      resolvePermissionRequest?.(event);
+    }
+  });
+  let transportClosed: Promise<void> | undefined;
+
+  try {
+    const committed = await commitFixtureEchoTool(lifecycle, "execute");
+    qualifiedName = committed.qualifiedName;
+    transportClosed = peer.nextClose("fixture");
+    const pendingContinue = lifecycle.continue({
+      sessionId: committed.sessionId,
+      input: { text: "Characterize canonical MCP arguments" },
+      limits: { maxTurns: 2 },
+    });
+    const permissionRequest = await permissionRequested;
+
+    expect(permissionRequest.subject).toMatchObject({
+      type: "mcp_tool",
+      argumentsDigest: "sha256:4cc12dac3291c3482baf1146911db47606ff92ea3c1576c7bec2197b190e5380",
+    });
+    expect(peer.requests("fixture").filter((request) => request.method === "tools/call")).toEqual(
+      [],
+    );
+    expect(
+      lifecycle.decidePermission({ requestId: permissionRequest.requestId, decision: "deny" }),
+    ).toEqual({ status: "accepted" });
+    await expect(pendingContinue).resolves.toMatchObject({
+      result: { status: "completed", answer: "Denied canonical MCP call settled." },
+    });
+    expect(modelRequestCount).toBe(2);
+    expect(peer.requests("fixture").filter((request) => request.method === "tools/call")).toEqual(
+      [],
+    );
+  } finally {
+    const closed = await lifecycle.close();
+    if (transportClosed !== undefined) {
+      await transportClosed;
+    }
+    expect(closed).toEqual({ status: "closed" });
     await rm(testRoot, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- add package-private owners for MCP canonical JSON/SHA-256 identity and durable Tool Profile construction/validation
- preserve the Host compatibility bindings while moving direct Lifecycle, Store, Prompt, and history-validation consumers to the Profile owner
- keep MCP generation, admission, selection, revalidation, stale publication, dispatch, process, and close coordination in `mcp-host.ts`
- reduce `mcp-host.ts` from 3,736 to 3,613 lines without changing public exports or durable schemas

## TDD evidence
- structural owner/consumer/dependency guard was RED before extraction and GREEN after
- a fixed nested reverse-key permission digest tracer detects canonical ordering mutations
- a corrupted persisted Profile tracer detects validator-always-true mutations before model or transport work
- exact-name caller tracers pass independently; no sleeps, polling, timeout changes, Adam-owned mocks, or private-module tests

## Verification
- `pnpm quality:check`: 43 files passed, 2 skipped; 1,089 tests passed, 10 skipped
- full MCP Host plus public-contract matrix, Prompt/Store matrix, browser typecheck, Biome, Markdown, and TypeScript pass
- three independent architecture, engineering, and test-contract reviews: zero unresolved findings