### PR TITLE
refactor(agent): isolate MCP schema admission

### DIFF
--- a/packages/agent/src/mcp-host.ts
+++ b/packages/agent/src/mcp-host.ts
@@ -48,6 +48,7 @@ import {
   type McpToolProfileV1,
   mcpToolProfileSnapshot,
 } from "./mcp-profile-contracts.js";
+import { admitMcpSchema, type McpSchemaAdmission } from "./mcp-schema-admission.js";
 import type { JsonValue, ToolEffect, ToolRegistry, ToolResult } from "./tool-runtime.js";
 
 export {
@@ -2361,9 +2362,9 @@ async function discoverMcpTools(
   return catalog.tools.flatMap((tool): McpDiscoveredTool[] => {
     const inputSchema = tool.inputSchema as McpJsonRecord;
     try {
-      assertMcpSchemaAdmissible(inputSchema);
+      const inputAdmission = admitMcpSchema(inputSchema);
       if (tool.outputSchema !== undefined) {
-        assertMcpSchemaAdmissible(tool.outputSchema as McpJsonRecord);
+        admitMcpSchema(tool.outputSchema as McpJsonRecord);
       }
       const validateInput = validatorProvider.getValidator<unknown>(
         structuredClone(tool.inputSchema) as JsonSchemaType,
@@ -2375,13 +2376,13 @@ async function discoverMcpTools(
               structuredClone(tool.outputSchema) as JsonSchemaType,
             );
       const rawSchema = {
-        dialect: schemaDialect(inputSchema),
+        dialect: inputAdmission.dialect,
         provenance: "tools/list" as const,
-        value: inputSchema,
-        digest: digestCanonicalMcpJson(inputSchema),
+        value: inputAdmission.schema,
+        digest: digestCanonicalMcpJson(inputAdmission.schema),
       };
-      const projected = projectMcpInputSchemaV1(inputSchema);
-      assertMcpSchemaAdmissible(projected.schema);
+      const projected = projectMcpInputSchemaV1(inputAdmission);
+      admitMcpSchema(projected.schema);
       const modelProjection = {
         version: 1 as const,
         schema: projected.schema,
@@ -2437,167 +2438,11 @@ async function discoverMcpTools(
   });
 }
 
-const mcpSchemaLimits = {
-  maximumBranches: 64,
-  maximumBranchesPerCombinator: 16,
-  maximumDefinitions: 64,
-  maximumDepth: 32,
-  maximumNodes: 1_024,
-  maximumProperties: 256,
-  maximumReferenceBytes: 512,
-  maximumReferenceDepth: 16,
-  maximumReferences: 128,
-  maximumReferenceSegments: 32,
-} as const;
-
-function assertMcpSchemaAdmissible(root: McpJsonRecord): void {
-  let branchCount = 0;
-  let definitionCount = 0;
-  let nodeCount = 0;
-  let propertyCount = 0;
-  let referenceCount = 0;
-  const activeObjects = new Set<McpJsonRecord>();
-
-  schemaDialect(root);
-
-  const visit = (value: unknown, depth: number): void => {
-    nodeCount += 1;
-    if (nodeCount > mcpSchemaLimits.maximumNodes || depth > mcpSchemaLimits.maximumDepth) {
-      throw new TypeError("MCP schema traversal limit exceeded.");
-    }
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        visit(item, depth + 1);
-      }
-      return;
-    }
-    if (!isRecord(value)) {
-      return;
-    }
-    if (activeObjects.has(value)) {
-      throw new TypeError("MCP schema reference cycle detected.");
-    }
-    activeObjects.add(value);
-    try {
-      const properties = value.properties;
-      if (isRecord(properties)) {
-        propertyCount += Object.keys(properties).length;
-        if (propertyCount > mcpSchemaLimits.maximumProperties) {
-          throw new TypeError("MCP schema property limit exceeded.");
-        }
-      }
-      for (const keyword of ["allOf", "anyOf", "oneOf"] as const) {
-        const branches = value[keyword];
-        if (Array.isArray(branches)) {
-          branchCount += branches.length;
-          if (
-            branches.length > mcpSchemaLimits.maximumBranchesPerCombinator ||
-            branchCount > mcpSchemaLimits.maximumBranches
-          ) {
-            throw new TypeError("MCP schema branch limit exceeded.");
-          }
-        }
-      }
-      for (const keyword of ["$defs", "definitions"] as const) {
-        const definitions = value[keyword];
-        if (isRecord(definitions)) {
-          definitionCount += Object.keys(definitions).length;
-          if (definitionCount > mcpSchemaLimits.maximumDefinitions) {
-            throw new TypeError("MCP schema definition limit exceeded.");
-          }
-        }
-      }
-      if (
-        value.$dynamicRef !== undefined ||
-        value.$recursiveRef !== undefined ||
-        value.$id !== undefined ||
-        value.$anchor !== undefined ||
-        value.$dynamicAnchor !== undefined
-      ) {
-        throw new TypeError("MCP schema dynamic or alternate reference scopes are unsupported.");
-      }
-      const reference = value.$ref;
-      if (reference !== undefined) {
-        referenceCount += 1;
-        if (
-          typeof reference !== "string" ||
-          Buffer.byteLength(reference, "utf8") > mcpSchemaLimits.maximumReferenceBytes ||
-          reference.slice(2).split("/").length > mcpSchemaLimits.maximumReferenceSegments ||
-          referenceCount > mcpSchemaLimits.maximumReferences ||
-          (!reference.startsWith("#/$defs/") && !reference.startsWith("#/definitions/"))
-        ) {
-          throw new TypeError("MCP schema reference is not a supported bounded local reference.");
-        }
-        resolveLocalSchemaReference(root, reference);
-      }
-      for (const [key, child] of Object.entries(value)) {
-        if (key !== "$ref") {
-          visit(child, depth + 1);
-        }
-      }
-    } finally {
-      activeObjects.delete(value);
-    }
-  };
-
-  visit(root, 0);
-  validateMcpReferenceGraph(root, root, 0, new Set([root]));
-}
-
-function validateMcpReferenceGraph(
-  root: McpJsonRecord,
-  value: unknown,
-  referenceDepth: number,
-  activeTargets: Set<McpJsonRecord>,
-): void {
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      validateMcpReferenceGraph(root, item, referenceDepth, activeTargets);
-    }
-    return;
-  }
-  if (!isRecord(value)) {
-    return;
-  }
-  const reference = value.$ref;
-  if (typeof reference === "string") {
-    if (referenceDepth >= mcpSchemaLimits.maximumReferenceDepth) {
-      throw new TypeError("MCP schema reference depth limit exceeded.");
-    }
-    const target = resolveLocalSchemaReference(root, reference);
-    if (!isRecord(target) || activeTargets.has(target)) {
-      throw new TypeError("MCP schema reference cycle detected.");
-    }
-    activeTargets.add(target);
-    try {
-      validateMcpReferenceGraph(root, target, referenceDepth + 1, activeTargets);
-    } finally {
-      activeTargets.delete(target);
-    }
-  }
-  for (const [key, child] of Object.entries(value)) {
-    if (key !== "$ref") {
-      validateMcpReferenceGraph(root, child, referenceDepth, activeTargets);
-    }
-  }
-}
-
-function resolveLocalSchemaReference(root: McpJsonRecord, reference: string): unknown {
-  let current: unknown = root;
-  for (const encodedSegment of reference.slice(2).split("/")) {
-    const segment = encodedSegment.replace(/~1/gu, "/").replace(/~0/gu, "~");
-    if (!isRecord(current) || !Object.hasOwn(current, segment)) {
-      throw new TypeError("MCP schema local reference does not resolve.");
-    }
-    current = current[segment];
-  }
-  return current;
-}
-
-function projectMcpInputSchemaV1(schema: McpJsonRecord): {
+function projectMcpInputSchemaV1(admission: McpSchemaAdmission): {
   readonly schema: Readonly<Record<string, unknown>>;
   readonly compatibilityHint?: string;
 } {
+  const schema = admission.schema as McpJsonRecord;
   const allOf = schema.allOf;
   const rootChoice = (["anyOf", "oneOf"] as const).find(
     (keyword) => Array.isArray(schema[keyword]) && schema[keyword].length > 0,
@@ -2606,7 +2451,7 @@ function projectMcpInputSchemaV1(schema: McpJsonRecord): {
     throw new TypeError("MCP root schema cannot combine allOf with anyOf or oneOf.");
   }
   if (rootChoice !== undefined) {
-    return projectMcpRootChoice(schema, rootChoice);
+    return projectMcpRootChoice(admission, rootChoice);
   }
   if (!Array.isArray(allOf) || allOf.length === 0) {
     return { schema };
@@ -2618,7 +2463,7 @@ function projectMcpInputSchemaV1(schema: McpJsonRecord): {
     : [];
   const seenRequired = new Set(required);
   for (const unresolvedBranch of allOf) {
-    const branch = resolveMcpProjectionBranch(schema, unresolvedBranch);
+    const branch = admission.resolveProjectionBranch(unresolvedBranch);
     if (!isRecord(branch) || (branch.type !== undefined && branch.type !== "object")) {
       throw new TypeError("MCP root allOf branches must be object schemas.");
     }
@@ -2655,9 +2500,10 @@ function projectMcpInputSchemaV1(schema: McpJsonRecord): {
 }
 
 function projectMcpRootChoice(
-  schema: McpJsonRecord,
+  admission: McpSchemaAdmission,
   keyword: "anyOf" | "oneOf",
 ): { readonly schema: Readonly<Record<string, unknown>>; readonly compatibilityHint: string } {
+  const schema = admission.schema as McpJsonRecord;
   const branches = schema[keyword];
   if (!Array.isArray(branches) || branches.length === 0) {
     throw new TypeError("MCP root choice requires branches.");
@@ -2672,7 +2518,7 @@ function projectMcpRootChoice(
   const branchRequirements: string[][] = [];
   const branchPropertySets: Readonly<Record<string, unknown>>[] = [];
   for (const unresolvedBranch of branches) {
-    const branch = resolveMcpProjectionBranch(schema, unresolvedBranch);
+    const branch = admission.resolveProjectionBranch(unresolvedBranch);
     if (!isRecord(branch) || (branch.type !== undefined && branch.type !== "object")) {
       throw new TypeError("MCP root choice branches must be object schemas.");
     }
@@ -2725,29 +2571,6 @@ function projectMcpRootChoice(
     },
     compatibilityHint,
   };
-}
-
-function resolveMcpProjectionBranch(root: McpJsonRecord, branch: unknown): McpJsonRecord {
-  let current = branch;
-  const seen = new Set<McpJsonRecord>();
-  for (let depth = 0; depth <= mcpSchemaLimits.maximumReferenceDepth; depth += 1) {
-    if (!isRecord(current)) {
-      throw new TypeError("MCP root combinator branches must be object schemas.");
-    }
-    const reference = current.$ref;
-    if (reference === undefined) {
-      return current;
-    }
-    if (typeof reference !== "string" || Object.keys(current).some((key) => key !== "$ref")) {
-      throw new TypeError("MCP projected references cannot have sibling keywords.");
-    }
-    if (depth === mcpSchemaLimits.maximumReferenceDepth || seen.has(current)) {
-      throw new TypeError("MCP projected reference depth or cycle limit exceeded.");
-    }
-    seen.add(current);
-    current = resolveLocalSchemaReference(root, reference);
-  }
-  throw new TypeError("MCP projected reference depth limit exceeded.");
 }
 
 async function listAllTools(
@@ -3556,44 +3379,6 @@ function isJsonValue(value: unknown): value is JsonValue {
     }
   }
   return true;
-}
-
-function schemaDialect(
-  schema: McpJsonRecord,
-): McpToolProfileV1["tools"][number]["rawSchema"]["dialect"] {
-  const declared = schema.$schema;
-  if (declared === undefined) {
-    return "unstamped";
-  }
-  if (typeof declared !== "string") {
-    throw new TypeError("MCP schema dialect declaration must be a string.");
-  }
-  const normalized = declared.replace(/#$/u, "");
-  if (
-    normalized === "https://json-schema.org/draft/2020-12/schema" ||
-    normalized === "http://json-schema.org/draft/2020-12/schema"
-  ) {
-    return "2020-12";
-  }
-  if (
-    normalized === "https://json-schema.org/draft/2019-09/schema" ||
-    normalized === "http://json-schema.org/draft/2019-09/schema"
-  ) {
-    return "2019-09";
-  }
-  if (
-    normalized === "http://json-schema.org/draft-07/schema" ||
-    normalized === "https://json-schema.org/draft-07/schema"
-  ) {
-    return "draft-07";
-  }
-  if (
-    normalized === "http://json-schema.org/draft-06/schema" ||
-    normalized === "https://json-schema.org/draft-06/schema"
-  ) {
-    return "draft-06";
-  }
-  throw new TypeError("MCP schema dialect is unsupported.");
 }
 
 function asError(error: unknown): Error {

--- a/packages/agent/src/mcp-schema-admission.ts
+++ b/packages/agent/src/mcp-schema-admission.ts
@@ -1,0 +1,252 @@
+import type { McpToolProfileV1 } from "./mcp-profile-contracts.js";
+
+type McpJsonRecord = Readonly<Record<string, unknown>> & {
+  readonly $anchor?: unknown;
+  readonly $dynamicAnchor?: unknown;
+  readonly $dynamicRef?: unknown;
+  readonly $id?: unknown;
+  readonly $recursiveRef?: unknown;
+  readonly $ref?: unknown;
+  readonly $schema?: unknown;
+  readonly properties?: unknown;
+};
+
+export type McpSchemaAdmission = {
+  readonly schema: Readonly<Record<string, unknown>>;
+  readonly dialect: McpToolProfileV1["tools"][number]["rawSchema"]["dialect"];
+  readonly resolveProjectionBranch: (branch: unknown) => Readonly<Record<string, unknown>>;
+};
+
+const mcpSchemaLimits = {
+  maximumBranches: 64,
+  maximumBranchesPerCombinator: 16,
+  maximumDefinitions: 64,
+  maximumDepth: 32,
+  maximumNodes: 1_024,
+  maximumProperties: 256,
+  maximumReferenceBytes: 512,
+  maximumReferenceDepth: 16,
+  maximumReferences: 128,
+  maximumReferenceSegments: 32,
+} as const;
+
+export function admitMcpSchema(schema: Readonly<Record<string, unknown>>): McpSchemaAdmission {
+  const root = schema as McpJsonRecord;
+  const dialect = schemaDialect(root);
+  assertMcpSchemaAdmissible(root);
+  return {
+    schema: root,
+    dialect,
+    resolveProjectionBranch: (branch) => resolveMcpProjectionBranch(root, branch),
+  };
+}
+
+function assertMcpSchemaAdmissible(root: McpJsonRecord): void {
+  let branchCount = 0;
+  let definitionCount = 0;
+  let nodeCount = 0;
+  let propertyCount = 0;
+  let referenceCount = 0;
+  const activeObjects = new Set<McpJsonRecord>();
+
+  const visit = (value: unknown, depth: number): void => {
+    nodeCount += 1;
+    if (nodeCount > mcpSchemaLimits.maximumNodes || depth > mcpSchemaLimits.maximumDepth) {
+      throw new TypeError("MCP schema traversal limit exceeded.");
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        visit(item, depth + 1);
+      }
+      return;
+    }
+    if (!isRecord(value)) {
+      return;
+    }
+    if (activeObjects.has(value)) {
+      throw new TypeError("MCP schema reference cycle detected.");
+    }
+    activeObjects.add(value);
+    try {
+      const properties = value.properties;
+      if (isRecord(properties)) {
+        propertyCount += Object.keys(properties).length;
+        if (propertyCount > mcpSchemaLimits.maximumProperties) {
+          throw new TypeError("MCP schema property limit exceeded.");
+        }
+      }
+      for (const keyword of ["allOf", "anyOf", "oneOf"] as const) {
+        const branches = value[keyword];
+        if (Array.isArray(branches)) {
+          branchCount += branches.length;
+          if (
+            branches.length > mcpSchemaLimits.maximumBranchesPerCombinator ||
+            branchCount > mcpSchemaLimits.maximumBranches
+          ) {
+            throw new TypeError("MCP schema branch limit exceeded.");
+          }
+        }
+      }
+      for (const keyword of ["$defs", "definitions"] as const) {
+        const definitions = value[keyword];
+        if (isRecord(definitions)) {
+          definitionCount += Object.keys(definitions).length;
+          if (definitionCount > mcpSchemaLimits.maximumDefinitions) {
+            throw new TypeError("MCP schema definition limit exceeded.");
+          }
+        }
+      }
+      if (
+        value.$dynamicRef !== undefined ||
+        value.$recursiveRef !== undefined ||
+        value.$id !== undefined ||
+        value.$anchor !== undefined ||
+        value.$dynamicAnchor !== undefined
+      ) {
+        throw new TypeError("MCP schema dynamic or alternate reference scopes are unsupported.");
+      }
+      const reference = value.$ref;
+      if (reference !== undefined) {
+        referenceCount += 1;
+        if (
+          typeof reference !== "string" ||
+          Buffer.byteLength(reference, "utf8") > mcpSchemaLimits.maximumReferenceBytes ||
+          reference.slice(2).split("/").length > mcpSchemaLimits.maximumReferenceSegments ||
+          referenceCount > mcpSchemaLimits.maximumReferences ||
+          (!reference.startsWith("#/$defs/") && !reference.startsWith("#/definitions/"))
+        ) {
+          throw new TypeError("MCP schema reference is not a supported bounded local reference.");
+        }
+        resolveLocalSchemaReference(root, reference);
+      }
+      for (const [key, child] of Object.entries(value)) {
+        if (key !== "$ref") {
+          visit(child, depth + 1);
+        }
+      }
+    } finally {
+      activeObjects.delete(value);
+    }
+  };
+
+  visit(root, 0);
+  validateMcpReferenceGraph(root, root, 0, new Set([root]));
+}
+
+function validateMcpReferenceGraph(
+  root: McpJsonRecord,
+  value: unknown,
+  referenceDepth: number,
+  activeTargets: Set<McpJsonRecord>,
+): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      validateMcpReferenceGraph(root, item, referenceDepth, activeTargets);
+    }
+    return;
+  }
+  if (!isRecord(value)) {
+    return;
+  }
+  const reference = value.$ref;
+  if (typeof reference === "string") {
+    if (referenceDepth >= mcpSchemaLimits.maximumReferenceDepth) {
+      throw new TypeError("MCP schema reference depth limit exceeded.");
+    }
+    const target = resolveLocalSchemaReference(root, reference);
+    if (!isRecord(target) || activeTargets.has(target)) {
+      throw new TypeError("MCP schema reference cycle detected.");
+    }
+    activeTargets.add(target);
+    try {
+      validateMcpReferenceGraph(root, target, referenceDepth + 1, activeTargets);
+    } finally {
+      activeTargets.delete(target);
+    }
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (key !== "$ref") {
+      validateMcpReferenceGraph(root, child, referenceDepth, activeTargets);
+    }
+  }
+}
+
+function resolveLocalSchemaReference(root: McpJsonRecord, reference: string): unknown {
+  let current: unknown = root;
+  for (const encodedSegment of reference.slice(2).split("/")) {
+    const segment = encodedSegment.replace(/~1/gu, "/").replace(/~0/gu, "~");
+    if (!isRecord(current) || !Object.hasOwn(current, segment)) {
+      throw new TypeError("MCP schema local reference does not resolve.");
+    }
+    current = current[segment];
+  }
+  return current;
+}
+
+function resolveMcpProjectionBranch(
+  root: McpJsonRecord,
+  branch: unknown,
+): Readonly<Record<string, unknown>> {
+  let current = branch;
+  const seen = new Set<McpJsonRecord>();
+  for (let depth = 0; depth <= mcpSchemaLimits.maximumReferenceDepth; depth += 1) {
+    if (!isRecord(current)) {
+      throw new TypeError("MCP root combinator branches must be object schemas.");
+    }
+    const reference = current.$ref;
+    if (reference === undefined) {
+      return current;
+    }
+    if (typeof reference !== "string" || Object.keys(current).some((key) => key !== "$ref")) {
+      throw new TypeError("MCP projected references cannot have sibling keywords.");
+    }
+    if (depth === mcpSchemaLimits.maximumReferenceDepth || seen.has(current)) {
+      throw new TypeError("MCP projected reference depth or cycle limit exceeded.");
+    }
+    seen.add(current);
+    current = resolveLocalSchemaReference(root, reference);
+  }
+  throw new TypeError("MCP projected reference depth limit exceeded.");
+}
+
+function schemaDialect(
+  schema: McpJsonRecord,
+): McpToolProfileV1["tools"][number]["rawSchema"]["dialect"] {
+  const declared = schema.$schema;
+  if (declared === undefined) {
+    return "unstamped";
+  }
+  if (typeof declared !== "string") {
+    throw new TypeError("MCP schema dialect declaration must be a string.");
+  }
+  const normalized = declared.replace(/#$/u, "");
+  if (
+    normalized === "https://json-schema.org/draft/2020-12/schema" ||
+    normalized === "http://json-schema.org/draft/2020-12/schema"
+  ) {
+    return "2020-12";
+  }
+  if (
+    normalized === "https://json-schema.org/draft/2019-09/schema" ||
+    normalized === "http://json-schema.org/draft/2019-09/schema"
+  ) {
+    return "2019-09";
+  }
+  if (
+    normalized === "http://json-schema.org/draft-07/schema" ||
+    normalized === "https://json-schema.org/draft-07/schema"
+  ) {
+    return "draft-07";
+  }
+  if (
+    normalized === "http://json-schema.org/draft-06/schema" ||
+    normalized === "https://json-schema.org/draft-06/schema"
+  ) {
+    return "draft-06";
+  }
+  throw new TypeError("MCP schema dialect is unsupported.");
+}
+
+function isRecord(value: unknown): value is McpJsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/testkit/src/public-product-contract.test.ts
+++ b/packages/testkit/src/public-product-contract.test.ts
@@ -723,6 +723,7 @@ test("MCP canonical identity and durable Tool Profile contracts have package-int
     .soft(profileConsumers)
     .toEqual([
       "mcp-host.ts",
+      "mcp-schema-admission.ts",
       "prompt-assembly.ts",
       "session-history-validation.ts",
       "session-lifecycle.ts",
@@ -771,6 +772,163 @@ test("MCP canonical identity and durable Tool Profile contracts have package-int
     expect.soft(moduleSpecifiers(facadeSource)).not.toContain("./mcp-profile-contracts.js");
     expect
       .soft(packagePrivateSymbols.filter((symbol) => facadeSource.includes(symbol)))
+      .toEqual([]);
+  }
+  expect.soft(directTestImports).toEqual([]);
+});
+
+test("MCP schema admission has one package-internal owner", async () => {
+  const agentSourceRoot = join(productRoot, "packages", "agent", "src");
+  const sourceFiles = (await readdir(agentSourceRoot, { recursive: true }))
+    .filter((entry) => entry.endsWith(".ts"))
+    .sort();
+  const sources = await Promise.all(
+    sourceFiles.map(async (sourceFile) => ({
+      path: sourceFile,
+      source: await readFile(join(agentSourceRoot, sourceFile), "utf8"),
+    })),
+  );
+  const expectedOwners = { admitMcpSchema: ["mcp-schema-admission.ts"] } as const;
+  const actualOwners = Object.fromEntries(
+    Object.keys(expectedOwners).map((symbol) => [
+      symbol,
+      sources
+        .filter(({ source }) =>
+          new RegExp(`\\bexport\\s+function\\s+${symbol}\\s*\\(`, "u").test(source),
+        )
+        .map(({ path }) => path),
+    ]),
+  );
+  const expectedTypeOwners = { McpSchemaAdmission: ["mcp-schema-admission.ts"] } as const;
+  const actualTypeOwners = Object.fromEntries(
+    Object.keys(expectedTypeOwners).map((symbol) => [
+      symbol,
+      sources
+        .filter(({ source }) => new RegExp(`\\bexport\\s+type\\s+${symbol}\\b`, "u").test(source))
+        .map(({ path }) => path),
+    ]),
+  );
+  const schemaSource = sources.find(({ path }) => path === "mcp-schema-admission.ts")?.source ?? "";
+  const hostSource = sources.find(({ path }) => path === "mcp-host.ts")?.source ?? "";
+  const expectedProjectorOwners = {
+    projectMcpInputSchemaV1: ["mcp-host.ts"],
+    projectMcpRootChoice: ["mcp-host.ts"],
+  } as const;
+  const actualProjectorOwners = Object.fromEntries(
+    Object.keys(expectedProjectorOwners).map((symbol) => [
+      symbol,
+      sources
+        .filter(({ source }) => new RegExp(`\\bfunction\\s+${symbol}\\s*\\(`, "u").test(source))
+        .map(({ path }) => path),
+    ]),
+  );
+  const schemaConsumers = sources
+    .filter(({ source }) => moduleSpecifiers(source).includes("./mcp-schema-admission.js"))
+    .map(({ path }) => path);
+  const schemaRuntimeConsumers = sources
+    .filter(({ source }) => runtimeModuleSpecifiers(source).includes("./mcp-schema-admission.js"))
+    .map(({ path }) => path);
+  const publicFacadeSource = sources.find(({ path }) => path === "index.ts")?.source ?? "";
+  const testingFacadeSource =
+    sources.find(({ path }) => path === "internal-testing.ts")?.source ?? "";
+  const testSourceRoots = (
+    await Promise.all(
+      ["apps", "packages"].map(async (root) =>
+        (
+          await readdir(join(productRoot, root), { withFileTypes: true })
+        )
+          .filter((entry) => entry.isDirectory())
+          .map((entry) => join(productRoot, root, entry.name, "src")),
+      ),
+    )
+  ).flat();
+  const testSources = (
+    await Promise.all(
+      testSourceRoots.map(async (sourceRoot) => {
+        try {
+          return (await readdir(sourceRoot, { recursive: true }))
+            .filter((entry) => entry.endsWith(".test.ts"))
+            .map((entry) => join(sourceRoot, entry));
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            return [];
+          }
+          throw error;
+        }
+      }),
+    )
+  ).flat();
+  const directTestImports = (
+    await Promise.all(
+      testSources
+        .filter((testPath) => testPath !== fileURLToPath(import.meta.url))
+        .map(async (testPath) =>
+          moduleSpecifiers(await readFile(testPath, "utf8"))
+            .filter((specifier) => /mcp-schema-admission\.js$/u.test(specifier))
+            .map((specifier) => ({ path: relative(productRoot, testPath), specifier })),
+        ),
+    )
+  ).flat();
+
+  expect.soft(actualOwners).toEqual(expectedOwners);
+  expect.soft(actualTypeOwners).toEqual(expectedTypeOwners);
+  expect.soft(actualProjectorOwners).toEqual(expectedProjectorOwners);
+  expect.soft(schemaSource.match(/\bexport\s+/gu) ?? []).toHaveLength(2);
+  expect
+    .soft(
+      [
+        ...schemaSource.matchAll(/\bexport\s+(?:async\s+)?(?:function|const|class|enum)\s+(\w+)/gu),
+      ].map((match) => match[1]),
+    )
+    .toEqual(["admitMcpSchema"]);
+  expect
+    .soft(
+      [...schemaSource.matchAll(/\bexport\s+(?:type|interface)\s+(\w+)/gu)].map(
+        (match) => match[1],
+      ),
+    )
+    .toEqual(["McpSchemaAdmission"]);
+  expect.soft(schemaConsumers).toEqual(["mcp-host.ts"]);
+  expect.soft(schemaRuntimeConsumers).toEqual(["mcp-host.ts"]);
+  expect.soft(moduleSpecifiers(schemaSource)).toEqual(["./mcp-profile-contracts.js"]);
+  expect.soft(runtimeModuleSpecifiers(schemaSource)).toEqual([]);
+  expect.soft(typeOnlyImportSpecifiers(schemaSource)).toEqual(["./mcp-profile-contracts.js"]);
+  expect
+    .soft(
+      runtimeModuleSpecifiers(hostSource).filter(
+        (specifier) => specifier === "./mcp-schema-admission.js",
+      ),
+    )
+    .toEqual(["./mcp-schema-admission.js"]);
+  expect.soft(hostSource.match(/\badmitMcpSchema\s*\(/gu) ?? []).toHaveLength(3);
+  const legacyHostAdmissionOwnerFragments = [
+    "const mcpSchemaLimits",
+    "function assertMcpSchemaAdmissible",
+    "function validateMcpReferenceGraph",
+    "function resolveLocalSchemaReference",
+    "function resolveMcpProjectionBranch",
+    "function schemaDialect",
+  ];
+  expect
+    .soft(legacyHostAdmissionOwnerFragments.filter((fragment) => hostSource.includes(fragment)))
+    .toEqual([]);
+  const forbiddenSchemaOwnerFragments = [
+    "compatibilityHint",
+    "digestCanonicalMcpJson",
+    "truncateUtf8",
+    "@modelcontextprotocol/sdk",
+    "Ajv",
+    "McpHostError",
+    "McpTransportFactory",
+  ];
+  expect
+    .soft(forbiddenSchemaOwnerFragments.filter((fragment) => schemaSource.includes(fragment)))
+    .toEqual([]);
+  const packageInternalSymbols = ["admitMcpSchema", "McpSchemaAdmission"];
+  for (const facadeSource of [publicFacadeSource, testingFacadeSource]) {
+    expect.soft(moduleSpecifiers(facadeSource)).not.toContain("./mcp-schema-admission.js");
+    expect
+      .soft(packageInternalSymbols.filter((symbol) => facadeSource.includes(symbol)))
       .toEqual([]);
   }
   expect.soft(directTestImports).toEqual([]);

--- a/packages/testkit/src/trusted-mcp-host.test.ts
+++ b/packages/testkit/src/trusted-mcp-host.test.ts
@@ -3581,6 +3581,149 @@ test("SessionLifecycle projects root allOf local references without narrowing th
   }
 });
 
+test("SessionLifecycle preserves a supported MCP schema dialect and exact raw and projected identities", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-mcp-schema-dialect-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeScriptedMcpConfiguration(testRoot, workspaceRoot);
+  const inputSchema = {
+    $schema: "https://json-schema.org/draft/2020-12/schema#",
+    type: "object",
+    $defs: {
+      left: {
+        type: "object",
+        properties: { left: { type: "string" } },
+        required: ["left"],
+      },
+      right: {
+        type: "object",
+        properties: { right: { type: "integer" } },
+        required: ["right"],
+      },
+    },
+    allOf: [{ $ref: "#/$defs/left" }, { $ref: "#/$defs/right" }],
+    additionalProperties: false,
+  } as const;
+  const projectedSchema = {
+    $schema: "https://json-schema.org/draft/2020-12/schema#",
+    type: "object",
+    $defs: inputSchema.$defs,
+    properties: { left: { type: "string" }, right: { type: "integer" } },
+    required: ["left", "right"],
+    additionalProperties: false,
+  } as const;
+  const { harness, lifecycle, peer } = createScriptedMcpLifecycle(
+    { stateRoot, workspaceRoot },
+    {
+      fixture: {
+        toolPages: [{ tools: [scriptedStringTool("echo", inputSchema)] }],
+      },
+    },
+  );
+  let transportClosed: Promise<void> | undefined;
+  try {
+    const committed = await commitFixtureEchoTool(lifecycle);
+    transportClosed = peer.nextClose("fixture");
+    const sessionStore = await harness.sessions.open(committed.sessionId);
+    if (sessionStore === undefined) {
+      throw new Error("The fixture requires the committed in-memory session store.");
+    }
+    const profileRecord = (await sessionStore.read()).find(
+      (entry) => entry.schemaVersion === 3 && entry.record.type === "mcp_tool_profile_committed",
+    );
+    if (
+      profileRecord?.schemaVersion !== 3 ||
+      profileRecord.record.type !== "mcp_tool_profile_committed"
+    ) {
+      throw new Error("The fixture requires one durable MCP Tool Profile.");
+    }
+
+    expect(profileRecord.record.profile.tools[0]).toMatchObject({
+      rawSchema: {
+        dialect: "2020-12",
+        provenance: "tools/list",
+        value: inputSchema,
+        digest: "sha256:ae389fa3a818b9384383ae04c10692569da95ce96ee4bb7910754479ca05d44e",
+      },
+      modelProjection: {
+        version: 1,
+        schema: projectedSchema,
+        digest: "sha256:b9ba51bb6b450a6a92b892fd821aa70dc16708dc9450c32695fb439add2c79a3",
+      },
+    });
+  } finally {
+    expect(await lifecycle.close()).toEqual({ status: "closed" });
+    if (transportClosed !== undefined) {
+      await transportClosed;
+    }
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle quarantines an unsupported MCP schema dialect without hiding a healthy sibling", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-mcp-schema-dialect-quarantine-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeScriptedMcpConfiguration(testRoot, workspaceRoot);
+
+  const { lifecycle } = createScriptedMcpLifecycle(
+    { stateRoot, workspaceRoot },
+    {
+      fixture: {
+        toolPages: [
+          {
+            tools: [
+              scriptedStringTool("unsupported_dialect", {
+                $schema: "https://json-schema.org/draft/2020-13/schema",
+                type: "object",
+                properties: { value: { type: "string" } },
+              }),
+              scriptedStringTool("healthy_unstamped"),
+            ],
+          },
+        ],
+      },
+    },
+  );
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    if (created.mcp === undefined) {
+      throw new Error("The fixture requires an MCP configuration snapshot.");
+    }
+    const confirmed = await lifecycle.configureMcp({
+      type: "confirm_workspace",
+      sessionId: created.sessionId,
+      sourceDigest: created.mcp.source.digest,
+    });
+    const preview = confirmed.snapshot.mcp?.servers[0];
+    if (preview === undefined) {
+      throw new Error("The fixture requires one MCP server preview.");
+    }
+    await lifecycle.configureMcp({
+      type: "approve_server",
+      sessionId: created.sessionId,
+      serverId: preview.serverId,
+      definitionDigest: preview.definitionDigest,
+    });
+    const activated = await lifecycle.configureMcp({
+      type: "activate_servers",
+      sessionId: created.sessionId,
+      servers: [{ serverId: preview.serverId, definitionDigest: preview.definitionDigest }],
+    });
+
+    expect(activated.snapshot.mcp).toMatchObject({
+      status: "tool_selection_required",
+      catalog: { tools: [{ serverId: "fixture", originalName: "healthy_unstamped" }] },
+      diagnostics: [],
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("SessionLifecycle quarantines a recursive MCP schema without hiding its healthy sibling", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-mcp-recursive-schema-"));
   const stateRoot = join(testRoot, "state");


### PR DESCRIPTION
## Summary

- isolate bounded dialect and local-reference schema admission in one package-private deep module
- keep projection, AJV, digests, catalog, generation, dispatch, and process ownership in the MCP Host
- lock the module DAG, export set, sole consumer, and projector ownership with structural guards

## Verification

- focused MCP Host and public-contract suite: 110/110
- schema caller matrix: 7/7
- complete pnpm quality:check: 1092 passed, 10 opt-in skipped
- two behavior reverse mutations and two structural reverse mutations produced exact RED
- three independent reviews: zero unresolved findings