### PR TITLE
B10-A2: add persistent workspace trust

### DIFF
--- a/apps/cli/src/main.os.test.ts
+++ b/apps/cli/src/main.os.test.ts
@@ -77,6 +77,7 @@ describe("one-shot CLI deterministic coding process", () => {
     const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-fake-skill-context-"));
     const workspaceRoot = join(testRoot, "workspace");
     const stateRoot = join(testRoot, "state");
+    const configRoot = join(testRoot, "config");
     const userHome = join(testRoot, "home");
     const skillRoot = join(userHome, ".agents", "skills", "visible-skill");
     const demoPath = join(workspaceRoot, "demo.txt");
@@ -90,10 +91,17 @@ describe("one-shot CLI deterministic coding process", () => {
     );
 
     try {
+      const trusted = await runCliArguments({
+        args: ["--trust-workspace"],
+        cwd: workspaceRoot,
+        environment: { HOME: userHome, XDG_CONFIG_HOME: configRoot },
+        stateRoot,
+      });
+      expect(trusted).toMatchObject({ exitCode: 0, signal: null, stderr: "" });
       const result = await runCliArguments({
         args: ["Update the demo file and verify it"],
         cwd: workspaceRoot,
-        environment: { HOME: userHome },
+        environment: { HOME: userHome, XDG_CONFIG_HOME: configRoot },
         stateRoot,
         stdin: "y\ny\n",
       });

--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -6,6 +6,7 @@ import {
   open,
   readdir,
   readFile,
+  realpath,
   rm,
   stat,
   watch,
@@ -18,10 +19,15 @@ import { fileURLToPath } from "node:url";
 import {
   createCodingToolRegistry,
   createSessionLifecycle,
+  createWorkspaceTrust,
   type ModelTargetIdentity,
   type ModelToolDefinition,
 } from "@adam-agent/agent";
-import { openJsonlSessionStore, type SessionRecord } from "@adam-agent/agent/internal-testing";
+import {
+  createTrustedWorkspaceTrustForTesting,
+  openJsonlSessionStore,
+  type SessionRecord,
+} from "@adam-agent/agent/internal-testing";
 import { describe, expect, test } from "vitest";
 
 const cliPath = fileURLToPath(new URL("../dist/main.js", import.meta.url));
@@ -488,13 +494,193 @@ describe("one-shot CLI", () => {
 
     try {
       const result = await runCliArguments({
-        args: ["Use the process owner's home fallback."],
+        args: ["--workspace-trust-status"],
         cwd: workspaceRoot,
         environment: { HOME: undefined, XDG_CONFIG_HOME: undefined },
         stateRoot,
       });
 
       expect(result).toMatchObject({ exitCode: 0, signal: null, stderr: "" });
+      expect(JSON.parse(result.stdout)).toMatchObject({ status: "untrusted", diagnostic: null });
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("workspace trust administration persists grant and revoke without session work", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-workspace-trust-"));
+    const workspaceRoot = join(testRoot, "workspace");
+    const configRoot = join(testRoot, "config");
+    const stateRoot = join(testRoot, "state");
+    await mkdir(workspaceRoot);
+    const projectId = `sha256:${createHash("sha256").update(workspaceRoot).digest("hex")}`;
+    const environment = { XDG_CONFIG_HOME: configRoot };
+
+    try {
+      const statusBefore = await runCliArguments({
+        args: ["--workspace-trust-status"],
+        cwd: workspaceRoot,
+        environment,
+        stateRoot,
+      });
+      const granted = await runCliArguments({
+        args: ["--trust-workspace"],
+        cwd: workspaceRoot,
+        environment,
+        stateRoot,
+      });
+      const statusAfter = await runCliArguments({
+        args: ["--workspace-trust-status"],
+        cwd: workspaceRoot,
+        environment,
+        stateRoot,
+      });
+      const revoked = await runCliArguments({
+        args: ["--revoke-workspace-trust"],
+        cwd: workspaceRoot,
+        environment,
+        stateRoot,
+      });
+
+      expect([statusBefore, granted, statusAfter, revoked]).toEqual([
+        {
+          exitCode: 0,
+          signal: null,
+          stderr: "",
+          stdout: `${JSON.stringify({ projectId, projectLabel: "workspace", status: "untrusted", diagnostic: null })}\n`,
+        },
+        {
+          exitCode: 0,
+          signal: null,
+          stderr: "",
+          stdout: `${JSON.stringify({ projectId, projectLabel: "workspace", status: "trusted", diagnostic: null })}\n`,
+        },
+        {
+          exitCode: 0,
+          signal: null,
+          stderr: "",
+          stdout: `${JSON.stringify({ projectId, projectLabel: "workspace", status: "trusted", diagnostic: null })}\n`,
+        },
+        {
+          exitCode: 0,
+          signal: null,
+          stderr: "",
+          stdout: `${JSON.stringify({ projectId, projectLabel: "workspace", status: "untrusted", diagnostic: null })}\n`,
+        },
+      ]);
+      await expect(
+        readFile(join(configRoot, "adam-agent", "workspace-trust.json"), "utf8"),
+      ).resolves.toBe(`${JSON.stringify({ schemaVersion: 1, trustedProjectIds: [] })}\n`);
+      expect(await readdir(stateRoot, { recursive: true })).not.toEqual(
+        expect.arrayContaining([expect.stringMatching(/sessions|\.jsonl$/u)]),
+      );
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("workspace trust administration cannot revoke beneath an active MCP runtime lease", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-workspace-trust-owner-"));
+    const workspaceRoot = join(testRoot, "workspace");
+    const configRoot = join(testRoot, "config");
+    const stateRoot = join(testRoot, "state");
+    await mkdir(workspaceRoot);
+    const trust = createWorkspaceTrust({
+      environment: { XDG_CONFIG_HOME: configRoot },
+      workspaceRoot,
+    });
+    const initial = await trust.load();
+    if (initial.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    await trust.setTrusted({ projectId: initial.projectId, trusted: true });
+    const lease = await trust.acquireMcpLease();
+
+    try {
+      const result = await runCliArguments({
+        args: ["--revoke-workspace-trust"],
+        cwd: workspaceRoot,
+        environment: { XDG_CONFIG_HOME: configRoot },
+        stateRoot,
+      });
+
+      expect(result).toMatchObject({ exitCode: 1, signal: null, stdout: "" });
+      expect(result.stderr).toContain("Another Adam MCP runtime owns this canonical project.");
+      await expect(
+        readFile(join(configRoot, "adam-agent", "workspace-trust.json"), "utf8"),
+      ).resolves.toBe(
+        `${JSON.stringify({ schemaVersion: 1, trustedProjectIds: [initial.projectId] })}\n`,
+      );
+    } finally {
+      await lease.release();
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("read-only workspace inspection remains available beside an active MCP lease", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-workspace-trust-readonly-"));
+    const workspaceRoot = join(testRoot, "workspace");
+    const configRoot = join(testRoot, "config");
+    await mkdir(workspaceRoot);
+    const environment = { XDG_CONFIG_HOME: configRoot };
+    const firstTrust = createWorkspaceTrust({ environment, workspaceRoot });
+    const first = createSessionLifecycle({
+      workspaceRoot,
+      workspaceTrust: firstTrust,
+    });
+    const second = createSessionLifecycle({
+      workspaceRoot,
+      workspaceTrust: createWorkspaceTrust({ environment, workspaceRoot }),
+    });
+
+    try {
+      const firstSnapshot = await first.inspectWorkspaceTrust();
+      if (firstSnapshot.projectId === null) {
+        throw new Error("The fixture requires one canonical project identity.");
+      }
+      await firstTrust.setTrusted({ projectId: firstSnapshot.projectId, trusted: true });
+      const lease = await firstTrust.acquireMcpLease();
+      try {
+        await expect(second.inspectWorkspaceTrust()).resolves.toEqual({
+          ...firstSnapshot,
+          status: "trusted",
+        });
+      } finally {
+        await lease.release();
+      }
+    } finally {
+      await first.close();
+      await second.close();
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("an ordinary untrusted prompt fails before project context, MCP, model, or session work", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-cli-untrusted-prompt-"));
+    const workspaceRoot = join(testRoot, "workspace");
+    const stateRoot = join(testRoot, "state");
+    await mkdir(workspaceRoot);
+    await writeFile(join(workspaceRoot, "AGENTS.md"), "MUST_NOT_LOAD\n", "utf8");
+    await writeFile(join(workspaceRoot, ".mcp.json"), "not json\n", "utf8");
+
+    try {
+      const result = await runCliArguments({
+        args: ["Do not dispatch this prompt."],
+        cwd: workspaceRoot,
+        stateRoot,
+        trustWorkspace: false,
+      });
+
+      expect(result).toEqual({
+        exitCode: 1,
+        signal: null,
+        stdout: "",
+        stderr:
+          "This workspace is not trusted. Run adam-agent --trust-workspace in this project, then retry.\n",
+      });
+      expect(await readdir(stateRoot, { recursive: true })).not.toEqual(
+        expect.arrayContaining([expect.stringMatching(/sessions|\.jsonl$/u)]),
+      );
     } finally {
       await rm(testRoot, { recursive: true, force: true });
     }
@@ -1117,9 +1303,12 @@ describe("session lifecycle CLI", () => {
 
     try {
       const tools = createCodingToolRegistry({ stateRoot, workspaceRoot });
-      const created = await createSessionLifecycle({ stateRoot, tools, workspaceRoot }).create({
-        targetIdentity: fakeTargetIdentity,
-      });
+      const created = await createSessionLifecycle({
+        stateRoot,
+        tools,
+        workspaceRoot,
+        workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
+      }).create({ targetIdentity: fakeTargetIdentity });
       const readTool = tools.resolve("read_file");
       if (readTool === undefined) {
         throw new Error("Expected the read_file tool.");
@@ -1277,9 +1466,12 @@ describe("session lifecycle CLI", () => {
 
     try {
       const tools = createCodingToolRegistry({ stateRoot, workspaceRoot });
-      const created = await createSessionLifecycle({ stateRoot, tools, workspaceRoot }).create({
-        targetIdentity: fakeTargetIdentity,
-      });
+      const created = await createSessionLifecycle({
+        stateRoot,
+        tools,
+        workspaceRoot,
+        workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
+      }).create({ targetIdentity: fakeTargetIdentity });
       const runId = "123e4567-e89b-42d3-a456-426614175000";
       const store = await openJsonlSessionStore<SessionRecord>({
         stateRoot,
@@ -1496,16 +1688,26 @@ async function runCliArguments(options: {
   readonly cwd: string;
   readonly environment?: Readonly<Record<string, string | undefined>>;
   readonly stateRoot: string;
+  readonly trustWorkspace?: boolean;
 }): Promise<{
   readonly stdout: string;
   readonly stderr: string;
   readonly exitCode: number | null;
   readonly signal: NodeJS.Signals | null;
 }> {
+  const environment = cliEnvironment(options.stateRoot, options.environment ?? {});
+  const workspaceTrustAdministration =
+    options.args.length === 1 &&
+    ["--workspace-trust-status", "--trust-workspace", "--revoke-workspace-trust"].includes(
+      options.args[0] ?? "",
+    );
+  if (options.trustWorkspace !== false && !workspaceTrustAdministration) {
+    await trustWorkspaceForCliTest(options.cwd, environment);
+  }
   return new Promise((resolvePromise, rejectPromise) => {
     const child = spawn(process.execPath, [cliPath, ...options.args], {
       cwd: options.cwd,
-      env: cliEnvironment(options.stateRoot, options.environment ?? {}),
+      env: environment,
       stdio: ["ignore", "pipe", "pipe"],
     });
     let stdout = "";
@@ -1537,9 +1739,11 @@ async function interruptCliDuringShell(options: {
 }> {
   await writeFile(options.stdinPath, "y\n", "utf8");
   const input = await open(options.stdinPath, "r");
+  const environment = cliEnvironment(options.stateRoot);
+  await trustWorkspaceForCliTest(options.cwd, environment);
   const child = spawn(process.execPath, [cliPath, "Run the long repository verification command"], {
     cwd: options.cwd,
-    env: cliEnvironment(options.stateRoot),
+    env: environment,
     stdio: [input.fd, "pipe", "pipe"],
   });
   await input.close();
@@ -1581,10 +1785,12 @@ async function interruptCliAtPermission(options: {
   readonly exitCode: number | null;
   readonly signal: NodeJS.Signals | null;
 }> {
+  const environment = cliEnvironment(options.stateRoot);
+  await trustWorkspaceForCliTest(options.cwd, environment);
   return new Promise((resolvePromise, rejectPromise) => {
     const child = spawn(process.execPath, [cliPath, "Run the repository verification command"], {
       cwd: options.cwd,
-      env: cliEnvironment(options.stateRoot),
+      env: environment,
       stdio: ["pipe", "pipe", "pipe"],
     });
     let stdout = "";
@@ -1634,6 +1840,15 @@ async function runCli(options: {
   readonly exitCode: number | null;
   readonly signal: NodeJS.Signals | null;
 }> {
+  const environment = cliEnvironment(
+    options.stateRoot,
+    {
+      ADAM_AGENT_CLI_TEST_STDIN: options.stdin,
+      ...options.env,
+    },
+    options.omitDefaultTarget !== true,
+  );
+  await trustWorkspaceForCliTest(options.cwd, environment);
   return new Promise((resolvePromise, rejectPromise) => {
     const child = spawn(
       "/bin/sh",
@@ -1647,14 +1862,7 @@ async function runCli(options: {
       ],
       {
         cwd: options.cwd,
-        env: cliEnvironment(
-          options.stateRoot,
-          {
-            ADAM_AGENT_CLI_TEST_STDIN: options.stdin,
-            ...options.env,
-          },
-          options.omitDefaultTarget !== true,
-        ),
+        env: environment,
         stdio: ["ignore", "pipe", "pipe"],
       },
     );
@@ -1692,6 +1900,7 @@ function cliEnvironment(
   }
   return {
     ...environment,
+    XDG_CONFIG_HOME: join(dirname(stateRoot), "config"),
     ADAM_AGENT_STATE_ROOT: stateRoot,
     ...(includeDefaultTarget &&
     ADAM_AGENT_TARGET === undefined &&
@@ -1701,6 +1910,29 @@ function cliEnvironment(
       : {}),
     ...additional,
   };
+}
+
+async function trustWorkspaceForCliTest(
+  workspaceRoot: string,
+  environment: NodeJS.ProcessEnv,
+): Promise<void> {
+  // biome-ignore lint/complexity/useLiteralKeys: TypeScript requires indexed ProcessEnv access.
+  const configuredRoot = environment["XDG_CONFIG_HOME"];
+  // biome-ignore lint/complexity/useLiteralKeys: TypeScript requires indexed ProcessEnv access.
+  const home = environment["HOME"];
+  const configurationRoot =
+    configuredRoot === undefined || configuredRoot.length === 0
+      ? join(home === undefined || home.length === 0 ? tmpdir() : home, ".config")
+      : configuredRoot;
+  const directory = join(configurationRoot, "adam-agent");
+  const canonicalRoot = await realpath(workspaceRoot);
+  const projectId = `sha256:${createHash("sha256").update(canonicalRoot).digest("hex")}`;
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  await writeFile(
+    join(directory, "workspace-trust.json"),
+    `${JSON.stringify({ schemaVersion: 1, trustedProjectIds: [projectId] })}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
 }
 
 async function waitForFile(path: string): Promise<void> {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -16,6 +16,7 @@ import {
   createPermissionPolicy,
   createPresentationPreferences,
   createSessionLifecycle,
+  createWorkspaceTrust,
   ExtensionConfigurationError,
   ExtensionHostError,
   type JsonValue,
@@ -45,7 +46,11 @@ const userConfigurationEnvironment: NodeJS.ProcessEnv = {
     ? ownerConfigurationRoot
     : resolve(ownerConfigurationRoot),
 };
-if (command.type !== "help" && command.type !== "recover_operation") {
+if (
+  command.type !== "help" &&
+  command.type !== "recover_operation" &&
+  command.type !== "workspace_trust"
+) {
   loadProjectEnvironment();
 }
 const workspaceRoot = process.cwd();
@@ -388,6 +393,10 @@ function writeText(fileDescriptor: number, text: string): void {
 
 type CliCommand =
   | { readonly type: "help" }
+  | {
+      readonly type: "workspace_trust";
+      readonly action: "status" | "grant" | "revoke";
+    }
   | { readonly type: "prompt"; readonly prompt: string; readonly skills?: readonly string[] }
   | { readonly type: "recover_operation"; readonly operationId: string }
   | { readonly type: "resume"; readonly sessionId: string; readonly continue: boolean }
@@ -402,6 +411,52 @@ async function runCliCommand(activeCommand: CliCommand): Promise<void> {
   try {
     if (activeCommand.type === "help") {
       writeText(1, `${cliUsage()}\n`);
+      return;
+    }
+    if (activeCommand.type === "workspace_trust") {
+      const workspaceTrust = createWorkspaceTrust({
+        environment: userConfigurationEnvironment,
+        workspaceRoot,
+      });
+      const current = await workspaceTrust.load();
+      if (activeCommand.action === "status") {
+        writeText(1, `${JSON.stringify(current)}\n`);
+        return;
+      }
+      if (current.projectId === null || current.diagnostic !== null) {
+        writeText(
+          2,
+          `${current.diagnostic?.message ?? "The canonical workspace identity is unavailable."}\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+      const lifecycle = createSessionLifecycle({
+        stateRoot,
+        workspaceRoot,
+        workspaceTrust,
+      });
+      let commandSucceeded = false;
+      try {
+        const result = await lifecycle.configureWorkspaceTrust({
+          type: activeCommand.action === "grant" ? "grant" : "revoke",
+          projectId: current.projectId,
+        });
+        writeText(1, `${JSON.stringify(result.snapshot)}\n`);
+        commandSucceeded = true;
+      } catch (error) {
+        writeText(
+          2,
+          `${error instanceof Error ? error.message : "The workspace trust configuration could not be saved."}\n`,
+        );
+        process.exitCode = 1;
+      } finally {
+        const closed = await lifecycle.close();
+        if (closed.status !== "closed" && commandSucceeded) {
+          writeText(2, "The workspace trust administration runtime did not close safely.\n");
+          process.exitCode = 1;
+        }
+      }
       return;
     }
     if (activeCommand.type === "recover_operation") {
@@ -490,6 +545,10 @@ async function createRunLifecycle(modelTargets: ModelTargets): Promise<SessionLi
   return createSessionLifecycle({
     modelTargets,
     preferences: createPresentationPreferences({ environment: userConfigurationEnvironment }),
+    workspaceTrust: createWorkspaceTrust({
+      environment: userConfigurationEnvironment,
+      workspaceRoot,
+    }),
     stateRoot,
     workspaceRoot,
     tools: createCodingToolRegistry({ workspaceRoot, stateRoot, artifactStore }),
@@ -619,6 +678,17 @@ function parseCliCommand(arguments_: readonly string[]): CliCommand {
     }
     return { type: "recover_operation", operationId };
   }
+  if (arguments_.length === 1) {
+    if (arguments_[0] === "--workspace-trust-status") {
+      return { type: "workspace_trust", action: "status" };
+    }
+    if (arguments_[0] === "--trust-workspace") {
+      return { type: "workspace_trust", action: "grant" };
+    }
+    if (arguments_[0] === "--revoke-workspace-trust") {
+      return { type: "workspace_trust", action: "revoke" };
+    }
+  }
   if (arguments_[0] === "--resume") {
     const sessionId = arguments_[1];
     const tail = arguments_.slice(2);
@@ -700,6 +770,7 @@ function cliUsage(): string {
     "       adam-agent --resume <session-id> [--continue]",
     "       adam-agent --branch <parent-session-id> --at <event-position> [--target <target-id>]",
     "       adam-agent --recover-operation <operation-id>",
+    "       adam-agent --workspace-trust-status | --trust-workspace | --revoke-workspace-trust",
     "       adam-agent --help | -h",
     "",
     "From a source checkout:",

--- a/apps/tui/src/command-registry.ts
+++ b/apps/tui/src/command-registry.ts
@@ -28,6 +28,7 @@ export type AdamCommandDefinition = {
     | "skills"
     | "target"
     | "thinking"
+    | "trust"
     | "tree";
   readonly name: string;
   readonly summary: string;
@@ -213,6 +214,14 @@ const builtInCommands: readonly AdamCommandDefinition[] = [
     name: "config",
     summary: "Inspect and tighten owner-local model limits for new sessions.",
     usage: "/config [context|output|compaction <tokens|default>]",
+  },
+  {
+    aliases: [],
+    availability: "idle",
+    id: "trust",
+    name: "trust",
+    summary: "Inspect, grant, or revoke owner-local trust for this exact project.",
+    usage: "/trust [status|grant|revoke]",
   },
   {
     aliases: [],

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -10,7 +10,9 @@ import {
   createJsonlOperationStore,
   createModelTargets,
   createSessionLifecycle,
+  createWorkspaceTrust,
 } from "@adam-agent/agent";
+import { createTrustedWorkspaceTrustForTesting } from "@adam-agent/agent/internal-testing";
 import { afterEach, expect, test } from "vitest";
 import {
   removeTuiFixtureRoot as rm,
@@ -26,6 +28,7 @@ const productionPath = fileURLToPath(new URL("../dist/main.js", import.meta.url)
 const productionFixturePath = fileURLToPath(
   new URL("../dist/production-main.fixture.js", import.meta.url),
 );
+const cliPath = fileURLToPath(new URL("../../cli/dist/main.js", import.meta.url));
 const productRoot = fileURLToPath(new URL("../../..", import.meta.url));
 const execFile = promisify(execFileCallback);
 const mcpFixturePath = fileURLToPath(
@@ -400,7 +403,12 @@ test("the production TUI composes the Linux clipboard adapter for copy commands"
     if (targetIdentity === undefined) {
       throw new Error("The production clipboard fixture requires the DeepSeek Flash target.");
     }
-    const seedLifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const seedLifecycle = createSessionLifecycle({
+      modelTargets,
+      stateRoot,
+      workspaceRoot,
+      workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
+    });
     const created = await seedLifecycle.create({ targetIdentity });
     await seedLifecycle.continue({
       sessionId: created.sessionId,
@@ -594,7 +602,12 @@ test("the production TUI reviews real Git changes through the exact public Eve a
   if (targetIdentity === undefined) {
     throw new Error("The registry Eve fixture requires the DeepSeek Flash target.");
   }
-  const seedLifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const seedLifecycle = createSessionLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+    workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
+  });
   const created = await seedLifecycle.create({ targetIdentity });
   await seedLifecycle.close();
   const program = {
@@ -681,7 +694,12 @@ test("a missing configured package disables admission while preserving generic h
   if (targetIdentity === undefined) {
     throw new Error("The missing-extension fixture requires the DeepSeek Flash target.");
   }
-  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const lifecycle = createSessionLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+    workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
+  });
   const created = await lifecycle.create({ targetIdentity });
   await lifecycle.close();
   const operationStore = await createJsonlOperationStore({ stateRoot, workspaceRoot });
@@ -788,7 +806,12 @@ test("the production TUI rehydrates and explicitly recovers one operation after 
   if (targetIdentity === undefined) {
     throw new Error("The operation restart fixture requires the DeepSeek Flash target.");
   }
-  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const lifecycle = createSessionLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+    workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
+  });
   const created = await lifecycle.create({ targetIdentity });
   await lifecycle.close();
   const program = {
@@ -906,6 +929,7 @@ test("the production TUI resumes and explicitly reactivates one committed MCP pr
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-mcp-reactivation-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
+  const configRoot = join(testRoot, "config");
   const spawnMarker = join(testRoot, "mcp-spawned");
   const closeMarker = join(testRoot, "mcp-closed");
   await mkdir(workspaceRoot);
@@ -925,10 +949,22 @@ test("the production TUI resumes and explicitly reactivates one committed MCP pr
     arguments: ["--state-root", stateRoot],
     cwd: workspaceRoot,
     entrypoint: productionPath,
-    environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
+    environment: {
+      DEEPSEEK_API_KEY: "deterministic-non-network-fixture",
+      XDG_CONFIG_HOME: configRoot,
+    },
   } as const;
 
   try {
+    const workspaceTrust = createWorkspaceTrust({
+      environment: { XDG_CONFIG_HOME: configRoot },
+      workspaceRoot,
+    });
+    const trustStatus = await workspaceTrust.load();
+    if (trustStatus.projectId === null) {
+      throw new Error("The MCP reactivation fixture requires one canonical project identity.");
+    }
+    await workspaceTrust.setTrusted({ projectId: trustStatus.projectId, trusted: true });
     const modelTargets = createModelTargets({
       environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
       fetch: async () =>
@@ -944,7 +980,12 @@ test("the production TUI resumes and explicitly reactivates one committed MCP pr
     if (targetIdentity === undefined) {
       throw new Error("The MCP reactivation fixture requires the DeepSeek Flash target.");
     }
-    const seedLifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    const seedLifecycle = createSessionLifecycle({
+      modelTargets,
+      stateRoot,
+      workspaceRoot,
+      workspaceTrust,
+    });
     const created = await seedLifecycle.create({ targetIdentity });
     await seedLifecycle.continue({
       sessionId: created.sessionId,
@@ -1013,8 +1054,33 @@ test("the production TUI resumes and explicitly reactivates one committed MCP pr
     beforeStep = resumed.output().length;
     resumed.write("\r");
     await resumed.waitForCompleteFrameAfter("MCP authority · profile committed", beforeStep);
+    const activeMcpPid = Number(await readFile(spawnMarker, "utf8"));
+    expect(() => process.kill(activeMcpPid, 0)).not.toThrow();
+    let revokeFailure: unknown;
+    try {
+      await execFile(process.execPath, [cliPath, "--revoke-workspace-trust"], {
+        cwd: workspaceRoot,
+        env: {
+          ...process.env,
+          ADAM_AGENT_STATE_ROOT: join(testRoot, "independent-cli-state"),
+          XDG_CONFIG_HOME: configRoot,
+        },
+      });
+    } catch (error) {
+      revokeFailure = error;
+    }
+    expect(revokeFailure).toMatchObject({
+      code: 1,
+      stderr: expect.stringContaining("Another Adam MCP runtime owns this canonical project."),
+    });
+    await expect(workspaceTrust.load()).resolves.toMatchObject({ status: "trusted" });
+    expect(() => process.kill(activeMcpPid, 0)).not.toThrow();
+    const closesBeforeRuntimeExit = await readFile(closeMarker, "utf8");
     resumed.write("\u0011");
     await expect(resumed.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    await expect(
+      waitForFileContents(closeMarker, `${closesBeforeRuntimeExit}closed\n`),
+    ).resolves.toBe(`${closesBeforeRuntimeExit}closed\n`);
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -925,6 +925,112 @@ test("the production TUI applies one exact draft policy command", async () => {
   }
 });
 
+test("the production TUI reports and grants exact owner-local workspace trust", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-draft-workspace-trust-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const configRoot = join(testRoot, "config");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      launch: {
+        configRoot,
+        startupTargetId: "deepseek-v4-flash.direct",
+        workspaceTrust: "owner-local",
+      },
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    const beforeStatus = fixture.output().length;
+    fixture.write("/trust status\r");
+    await fixture.waitForAfter("Workspace trust: untrusted", beforeStatus);
+    const beforeGrant = fixture.output().length;
+    fixture.write("/trust grant\r");
+    await fixture.waitForAfter("Workspace trust granted.", beforeGrant);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+
+    const document = JSON.parse(
+      await readFile(join(configRoot, "adam-agent", "workspace-trust.json"), "utf8"),
+    ) as { readonly schemaVersion: number; readonly trustedProjectIds: readonly string[] };
+    expect(document).toEqual({
+      schemaVersion: 1,
+      trustedProjectIds: [expect.stringMatching(/^sha256:[0-9a-f]{64}$/u)],
+    });
+    expect(await readFilesRecursively(stateRoot)).not.toContain('"type":"session_genesis"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI gives copy-pastable guidance for an untrusted draft prompt", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-untrusted-prompt-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const configRoot = join(testRoot, "config");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      launch: {
+        configRoot,
+        startupTargetId: "deepseek-v4-flash.direct",
+        workspaceTrust: "owner-local",
+      },
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    const beforePrompt = fixture.output().length;
+    fixture.write("Do not dispatch this prompt.\r");
+    await fixture.waitForAfter("adam-agent --trust-workspace", beforePrompt);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(await readFilesRecursively(stateRoot)).not.toContain('"type":"session_genesis"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the workspace trust page defaults to cancel without writing authority", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-workspace-trust-cancel-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const configRoot = join(testRoot, "config");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      launch: {
+        configRoot,
+        startupTargetId: "deepseek-v4-flash.direct",
+        workspaceTrust: "owner-local",
+      },
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    const beforePage = fixture.output().length;
+    fixture.write("/trust\r");
+    await fixture.waitForCompleteFrameAfter("Workspace trust", beforePage);
+    const beforeCancel = fixture.output().length;
+    fixture.write("\r");
+    await fixture.waitForAfter("Workspace trust unchanged.", beforeCancel);
+    const beforeStatus = fixture.output().length;
+    fixture.write("/trust status\r");
+    await fixture.waitForAfter("Workspace trust: untrusted", beforeStatus);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    await expect(
+      access(join(configRoot, "adam-agent", "workspace-trust.json")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("the production TUI clears draft Skill selections when the exact target changes", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-draft-target-skills-"));
   const workspaceRoot = join(testRoot, "workspace");

--- a/apps/tui/src/main.ts
+++ b/apps/tui/src/main.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
 import { homedir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, isAbsolute, join, resolve } from "node:path";
 
 import {
   createModelTargets,
   createPermissionPolicy,
   createPresentationPreferences,
+  createWorkspaceTrust,
   selectModelTargetId,
 } from "@adam-agent/agent";
 import {
@@ -24,11 +25,28 @@ try {
     process.stdout.write(`${usage()}\n`);
   } else {
     const workspaceRoot = process.cwd();
+    const { XDG_CONFIG_HOME: inheritedUserConfigurationRoot } = process.env;
+    const ownerConfigurationRoot =
+      inheritedUserConfigurationRoot === undefined || inheritedUserConfigurationRoot.length === 0
+        ? join(homedir(), ".config")
+        : inheritedUserConfigurationRoot;
+    const userConfigurationEnvironment: NodeJS.ProcessEnv = {
+      XDG_CONFIG_HOME: isAbsolute(ownerConfigurationRoot)
+        ? ownerConfigurationRoot
+        : resolve(ownerConfigurationRoot),
+    };
+    loadProjectEnvironment();
     const { ADAM_AGENT_STATE_ROOT: configuredStateRoot } = process.env;
     const stateRoot =
       command.stateRoot ?? configuredStateRoot ?? join(homedir(), ".local", "state", "adam-agent");
     const modelTargets = createModelTargets({ environment: process.env });
-    const preferences = createPresentationPreferences({ environment: process.env });
+    const preferences = createPresentationPreferences({
+      environment: userConfigurationEnvironment,
+    });
+    const workspaceTrust = createWorkspaceTrust({
+      environment: userConfigurationEnvironment,
+      workspaceRoot,
+    });
     const clipboard = createLinuxClipboardAdapter();
     const permissions = createPermissionPolicy({
       allowedEffects: ["read"],
@@ -36,7 +54,7 @@ try {
     });
     const extensionPermissions = createPermissionPolicy({ allowedEffects: ["execute"] });
     const runtime = await createProductionProjectRuntime({
-      environment: process.env,
+      environment: userConfigurationEnvironment,
       extensionPermissions,
       modelTargets,
       permissions,
@@ -47,6 +65,7 @@ try {
         .flatMap((entry) => [entry.name, ...entry.aliases]),
       stateRoot,
       workspaceRoot,
+      workspaceTrust,
     });
     const commandRegistry = createAdamCommandRegistryFromContributions(runtime.contributions);
     const startupNotice = runtime.extensionAvailability.configurationUnavailable
@@ -157,6 +176,17 @@ function parseCommand(arguments_: readonly string[]): TuiCommand {
       : { stateRoot: values.get("--state-root") as string }),
     ...(values.get("--target") === undefined ? {} : { targetId: values.get("--target") as string }),
   };
+}
+
+function loadProjectEnvironment(): void {
+  try {
+    process.loadEnvFile(join(process.cwd(), ".env"));
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return;
+    }
+    throw new TuiConfigurationError("Adam Agent could not load the project .env file.");
+  }
 }
 
 function usage(): string {

--- a/apps/tui/src/project-runtime.test.ts
+++ b/apps/tui/src/project-runtime.test.ts
@@ -6,6 +6,7 @@ import {
   createModelTargets,
   createPermissionPolicy,
   createPresentationPreferences,
+  createWorkspaceTrust,
 } from "@adam-agent/agent";
 import { expect, test } from "vitest";
 import { createProductionProjectRuntime } from "./project-runtime.js";
@@ -35,6 +36,7 @@ test("the project runtime owns only one Presentation across a concurrent close",
       reservedCommandNames: [],
       stateRoot,
       workspaceRoot,
+      workspaceTrust: createWorkspaceTrust({ environment, workspaceRoot }),
     });
 
     const presentation = runtime.createPresentation({ openProject: true });

--- a/apps/tui/src/project-runtime.ts
+++ b/apps/tui/src/project-runtime.ts
@@ -14,6 +14,7 @@ import {
   type PermissionPolicy,
   type PresentationPreferences,
   type SessionSnapshot,
+  type WorkspaceTrustController,
 } from "@adam-agent/agent";
 import type { PresentationSession } from "@adam-agent/presentation";
 import { requireConfirmedLifecycleClose } from "./lifecycle-close.js";
@@ -28,6 +29,7 @@ export type ProductionProjectRuntimeOptions = {
   readonly reservedCommandNames: readonly string[];
   readonly stateRoot: string;
   readonly workspaceRoot: string;
+  readonly workspaceTrust: WorkspaceTrustController;
 };
 
 export type ProductionProjectRuntime = {
@@ -103,6 +105,7 @@ export async function createProductionProjectRuntime(
     preferences: options.preferences,
     stateRoot: options.stateRoot,
     workspaceRoot: options.workspaceRoot,
+    workspaceTrust: options.workspaceTrust,
   });
   let presentationPromise: Promise<PresentationSession> | undefined;
   let closePromise: Promise<void> | undefined;

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -13,12 +13,14 @@ import {
   createPresentationPreferences,
   createPresentationSession,
   createSessionLifecycle,
+  createWorkspaceTrust,
   type ModelDriver,
   ModelDriverError,
   type ModelTargetIdentity,
   type ModelTargets,
 } from "@adam-agent/agent";
 import {
+  createTrustedWorkspaceTrustForTesting,
   mcpCloseConfirmation,
   type PresentationArtifactReadBarrier,
   preparedDirectDeepSeekV2ContextProfile,
@@ -133,6 +135,7 @@ export type TuiFixtureOptions = {
     readonly configRoot?: string;
     readonly seedTargetIds?: readonly string[];
     readonly startupTargetId?: string;
+    readonly workspaceTrust?: "owner-local";
   };
   readonly presentationCloseMarker?: string;
   readonly scenario?: FixtureScenario;
@@ -194,6 +197,18 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
           : ["read"],
       askedEffects: ["write"],
     }),
+    workspaceTrust:
+      options.launch?.workspaceTrust === "owner-local"
+        ? createWorkspaceTrust({
+            environment: {
+              ...process.env,
+              ...(options.launch.configRoot === undefined
+                ? {}
+                : { XDG_CONFIG_HOME: options.launch.configRoot }),
+            },
+            workspaceRoot: options.workspaceRoot,
+          })
+        : createTrustedWorkspaceTrustForTesting(options.workspaceRoot),
     stateRoot: options.stateRoot,
     workspaceRoot: options.workspaceRoot,
   });

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -69,6 +69,7 @@ import { TargetPicker } from "./target-picker.js";
 import { createAdamTuiTheme } from "./theme.js";
 import { ThinkingPicker } from "./thinking-picker.js";
 import { ToolPreview } from "./tool-preview.js";
+import { WorkspaceTrustPage } from "./workspace-trust-page.js";
 
 export type { ClipboardAdapter, DeadlineScheduler } from "./exit-policy.js";
 
@@ -231,6 +232,12 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         readonly hide: () => void;
       }
     | undefined;
+  let workspaceTrustPage:
+    | {
+        readonly close: () => void;
+        readonly hide: () => void;
+      }
+    | undefined;
   let skillPalette:
     | {
         readonly close: () => void;
@@ -276,6 +283,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     sessionInspector,
     chronologyPicker,
     resourceReloadPicker,
+    workspaceTrustPage,
     configurationPage,
     sessionPicker,
     targetPicker,
@@ -296,6 +304,8 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     chronologyPicker = undefined;
     resourceReloadPicker?.hide();
     resourceReloadPicker = undefined;
+    workspaceTrustPage?.hide();
+    workspaceTrustPage = undefined;
     configurationPage?.hide();
     configurationPage = undefined;
     artifactNavigator?.hide();
@@ -1543,6 +1553,92 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     }
     applyConfigurationMutation(mutation.field, mutation.value);
   };
+  const applyWorkspaceTrustMutation = (trusted: boolean, onAdmitted?: () => void): void => {
+    const project = options.presentation.getState().authoritative.project;
+    clearExitWindow();
+    editor.disableSubmit = true;
+    void options.presentation
+      .dispatch({
+        type: "set_workspace_trust",
+        projectId: project.id,
+        trusted,
+      })
+      .then((receipt) => {
+        if (receipt.status === "admitted") {
+          editor.setText("");
+          statusMessage = trusted ? "Workspace trust granted." : "Workspace trust revoked.";
+          onAdmitted?.();
+        } else {
+          statusMessage = receipt.message;
+        }
+      })
+      .catch(() => {
+        statusMessage = "The owner-local workspace trust configuration could not be saved.";
+      })
+      .finally(() => {
+        editor.disableSubmit = false;
+        renderState();
+      });
+  };
+  const showWorkspaceTrustPage = (): void => {
+    const project = options.presentation.getState().authoritative.project;
+    editor.setText("");
+    editor.disableSubmit = false;
+    workspaceTrustPage?.hide();
+    let handle: { hide(): void } | undefined;
+    const close = () => {
+      handle?.hide();
+      workspaceTrustPage = undefined;
+      statusMessage = "Workspace trust unchanged.";
+      tui.setFocus(editor);
+      renderState();
+    };
+    const page = new WorkspaceTrustPage({
+      diagnostic: project.workspaceTrust.diagnostic,
+      onChange(trusted) {
+        applyWorkspaceTrustMutation(trusted, () => {
+          handle?.hide();
+          workspaceTrustPage = undefined;
+          tui.setFocus(editor);
+        });
+      },
+      onClose: close,
+      projectId: project.id,
+      projectLabel: project.label,
+      status: project.workspaceTrust.status,
+      theme,
+    });
+    handle = showOverlay(page, {
+      width: "90%",
+      minWidth: 36,
+      maxHeight: "80%",
+      margin: 1,
+    });
+    workspaceTrustPage = { close, hide: () => handle?.hide() };
+    statusMessage = null;
+    tui.requestRender();
+  };
+  const handleWorkspaceTrustCommand = (argumentsText: string): void => {
+    const project = options.presentation.getState().authoritative.project;
+    if (argumentsText.length === 0) {
+      showWorkspaceTrustPage();
+      return;
+    }
+    if (argumentsText === "status") {
+      editor.setText("");
+      editor.disableSubmit = false;
+      statusMessage = `Workspace trust: ${project.workspaceTrust.status} · ${safeTerminalText(project.label)} · ${safeTerminalText(project.id)}`;
+      renderState();
+      return;
+    }
+    if (argumentsText !== "grant" && argumentsText !== "revoke") {
+      statusMessage = "Usage: /trust [status|grant|revoke]";
+      editor.disableSubmit = false;
+      renderState();
+      return;
+    }
+    applyWorkspaceTrustMutation(argumentsText === "grant");
+  };
   editor.onSubmit = (text) => {
     const state = options.presentation.getState();
     const active = state.authoritative.active;
@@ -1560,6 +1656,10 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       }
       if (parsedDraft.kind === "known" && parsedDraft.command.id === "config") {
         handleConfigurationCommand(parsedDraft.argumentsText);
+        return;
+      }
+      if (parsedDraft.kind === "known" && parsedDraft.command.id === "trust") {
+        handleWorkspaceTrustCommand(parsedDraft.argumentsText);
         return;
       }
       if (
@@ -1750,6 +1850,10 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     }
     if (parsedCommand.kind === "known" && parsedCommand.command.id === "config") {
       handleConfigurationCommand(parsedCommand.argumentsText);
+      return;
+    }
+    if (parsedCommand.kind === "known" && parsedCommand.command.id === "trust") {
+      handleWorkspaceTrustCommand(parsedCommand.argumentsText);
       return;
     }
     if (

--- a/apps/tui/src/tui-fixture.test-support.ts
+++ b/apps/tui/src/tui-fixture.test-support.ts
@@ -35,6 +35,7 @@ export type StartTuiFixtureOptions = {
     readonly configRoot?: string;
     readonly seedTargetIds?: readonly string[];
     readonly startupTargetId?: string;
+    readonly workspaceTrust?: "owner-local";
   };
   readonly noColor?: boolean;
   readonly program?: {

--- a/apps/tui/src/workspace-trust-page.test.ts
+++ b/apps/tui/src/workspace-trust-page.test.ts
@@ -1,0 +1,23 @@
+import { expect, test, vi } from "vitest";
+
+import { createAdamTuiTheme } from "./theme.js";
+import { WorkspaceTrustPage } from "./workspace-trust-page.js";
+
+test("workspace trust confirmation defaults Enter to cancel", () => {
+  const onClose = vi.fn();
+  const onChange = vi.fn();
+  const page = new WorkspaceTrustPage({
+    diagnostic: null,
+    onChange,
+    onClose,
+    projectId: `sha256:${"a".repeat(64)}`,
+    projectLabel: "fixture",
+    status: "untrusted",
+    theme: createAdamTuiTheme(true),
+  });
+
+  page.handleInput("\r");
+
+  expect(onClose).toHaveBeenCalledOnce();
+  expect(onChange).not.toHaveBeenCalled();
+});

--- a/apps/tui/src/workspace-trust-page.ts
+++ b/apps/tui/src/workspace-trust-page.ts
@@ -1,0 +1,88 @@
+import type { Component, SelectItem } from "@earendil-works/pi-tui";
+
+import { safeTerminalText } from "./safe-terminal-text.js";
+import { SearchableSelectList } from "./searchable-select-list.js";
+import type { AdamTuiTheme } from "./theme.js";
+
+export class WorkspaceTrustPage implements Component {
+  readonly #diagnostic: string | null;
+  readonly #list: SearchableSelectList;
+  readonly #projectId: string;
+  readonly #projectLabel: string;
+  readonly #status: "trusted" | "unavailable" | "untrusted";
+  readonly #theme: AdamTuiTheme;
+
+  constructor(options: {
+    readonly diagnostic: { readonly code: string; readonly message: string } | null;
+    readonly onChange: (trusted: boolean) => void;
+    readonly onClose: () => void;
+    readonly projectId: string;
+    readonly projectLabel: string;
+    readonly status: "trusted" | "unavailable" | "untrusted";
+    readonly theme: AdamTuiTheme;
+  }) {
+    this.#diagnostic =
+      options.diagnostic === null ? null : safeTerminalText(options.diagnostic.message);
+    this.#projectId = safeTerminalText(options.projectId);
+    this.#projectLabel = safeTerminalText(options.projectLabel);
+    this.#status = options.status;
+    this.#theme = options.theme;
+    const action = options.status === "trusted" ? "revoke" : "grant";
+    const items: SelectItem[] = [
+      {
+        value: "cancel",
+        label: "Cancel",
+        description: "Keep the current owner-local trust decision unchanged",
+      },
+      ...(options.status === "unavailable"
+        ? []
+        : [
+            {
+              value: action,
+              label: action === "grant" ? "Trust this exact project" : "Revoke project trust",
+              description:
+                action === "grant"
+                  ? "Permit new mutable project context to be considered"
+                  : "Block later project reload and MCP use after causal shutdown",
+            },
+          ]),
+    ];
+    this.#list = new SearchableSelectList({
+      items: items.map((item) => ({
+        item,
+        searchText: `${item.label ?? ""} ${item.description ?? ""} ${item.value}`,
+      })),
+      maxVisible: 2,
+      onCancel: options.onClose,
+      onSelect(item) {
+        if (item.value === "cancel") {
+          options.onClose();
+        } else {
+          options.onChange(item.value === "grant");
+        }
+      },
+      theme: options.theme.editor.selectList,
+    });
+  }
+
+  handleInput(data: string): void {
+    this.#list.handleInput(data);
+  }
+
+  invalidate(): void {
+    this.#list.invalidate();
+  }
+
+  render(width: number): string[] {
+    return [
+      this.#theme.toolTitle("Workspace trust"),
+      this.#theme.muted(`${this.#projectLabel} · ${this.#status}`),
+      this.#theme.muted(this.#projectId),
+      "",
+      ...this.#list.render(width),
+      ...(this.#diagnostic === null ? [] : ["", this.#theme.muted(this.#diagnostic)]),
+      "",
+      this.#theme.muted("Enter confirm selected · Esc cancel · Ctrl+Q exit"),
+    ];
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "markdown:check": "markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#dist\" \"#coverage\"",
     "markdown:fix": "markdownlint-cli2 --fix \"**/*.md\" \"#node_modules\" \"#dist\" \"#coverage\"",
     "browser:check": "tsc -p packages/presentation/tsconfig.browser.json --pretty false",
-    "tui": "tsc -b --pretty false && node --env-file-if-exists=.env apps/tui/dist/main.js",
+    "tui": "tsc -b --pretty false && node apps/tui/dist/main.js",
     "quality:check": "pnpm code:check && pnpm markdown:check && pnpm typecheck && pnpm browser:check && pnpm test",
     "quality:fix": "pnpm code:fix && pnpm markdown:fix",
     "test": "tsc -b && vitest run",

--- a/packages/agent/src/agent-session.ts
+++ b/packages/agent/src/agent-session.ts
@@ -1582,6 +1582,12 @@ export class AgentSession {
         if (candidate === undefined || this.#repositoryWorkspaceRoot === undefined) {
           return skillActivationFailure("Explicit Agent Skill content is unavailable.");
         }
+        if (
+          candidate.locator.source === "project" &&
+          (await this.#durableContext?.authorizeProjectContextLoad?.()) === false
+        ) {
+          return skillActivationFailure("Explicit Agent Skill content is unavailable.");
+        }
         const manifest =
           this.#durableContext?.preparedExplicitSkillManifests?.get(selection.requestId) ??
           (await buildSkillResourceManifestV1({
@@ -2086,6 +2092,12 @@ export class AgentSession {
       if (candidate === undefined || this.#repositoryWorkspaceRoot === undefined) {
         throw new SkillsError("skill_catalog_unavailable");
       }
+      if (
+        candidate.locator.source === "project" &&
+        (await this.#durableContext?.authorizeProjectContextLoad?.()) === false
+      ) {
+        throw new SkillsError("skill_catalog_unavailable");
+      }
       const manifest = await buildSkillResourceManifestV1({
         candidate,
         workspaceRoot: this.#repositoryWorkspaceRoot,
@@ -2255,6 +2267,18 @@ export class AgentSession {
         "The requested Agent Skill resource is unavailable in this session.",
       );
     }
+    const candidate = context.registry.candidates.find(
+      (entry) => entry.qualifiedId === input.qualifiedId,
+    );
+    if (
+      candidate?.locator.source === "project" &&
+      (await this.#durableContext?.authorizeProjectContextLoad?.()) === false
+    ) {
+      return skillResourceFailure(
+        "skill_resource_unavailable",
+        "The requested Agent Skill resource is unavailable in this session.",
+      );
+    }
     let page: Awaited<ReturnType<typeof readSkillResourcePageV1>>;
     try {
       page = await readSkillResourcePageV1({
@@ -2371,6 +2395,9 @@ export class AgentSession {
     const unionScopes = [...activeScopes, ...requestedScopes];
     let repository: PromptContextRecordV1["repository"];
     try {
+      if ((await this.#durableContext?.authorizeProjectContextLoad?.()) === false) {
+        throw new Error("Workspace trust does not authorize new project context.");
+      }
       repository = await loadRepositoryInstructions({
         workspaceRoot,
         activeScopes: unionScopes,
@@ -2491,6 +2518,9 @@ export class AgentSession {
     let repository: PromptContextRecordV1["repository"];
     let nextSkillContext: SkillContextRecordV1;
     try {
+      if ((await this.#durableContext?.authorizeProjectContextLoad?.()) === false) {
+        throw new Error("Workspace trust does not authorize new project context.");
+      }
       repository = await loadRepositoryInstructions({
         workspaceRoot,
         activeScopes: repositoryScopes,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -98,12 +98,17 @@ export {
 } from "./operation-store.js";
 export {
   createPresentationPreferences,
+  createWorkspaceTrust,
   type PresentationPreferences,
   type PresentationPreferencesDiagnostic,
   type PresentationPreferencesSnapshot,
   type UserModelPolicyField,
   type UserModelPolicyResolver,
   type UserModelPolicySnapshot,
+  type WorkspaceTrustController,
+  type WorkspaceTrustDiagnostic,
+  type WorkspaceTrustMcpLease,
+  type WorkspaceTrustSnapshot,
 } from "./presentation-preferences.js";
 export {
   type CreatePresentationSessionOptions,
@@ -132,6 +137,8 @@ export {
   type SessionRuntimeNotification,
   type SessionRuntimeNotificationListener,
   type SessionSnapshot,
+  type WorkspaceTrustCommand,
+  type WorkspaceTrustConfigurationResult,
 } from "./session-lifecycle.js";
 export {
   type CanonicalRuntimeEvent,

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -48,9 +48,16 @@ export type {
   ProjectLifecycleOwner,
   ProjectLifecycleOwnerLease,
 } from "./project-lifecycle-owner.js";
-export { ProjectLifecycleOwnerError } from "./project-lifecycle-owner.js";
+export {
+  createProjectLifecycleOwner,
+  ProjectLifecycleOwnerError,
+} from "./project-lifecycle-owner.js";
 export { assemblePromptMessagesV1, digestPromptRequestV1 } from "./prompt-assembly.js";
-export { createPresentationPreferencesWithStorageForTesting } from "./secure-user-configuration.js";
+export {
+  createPresentationPreferencesWithStorageForTesting,
+  createTrustedWorkspaceTrustForTesting,
+  createWorkspaceTrustWithStorageForTesting,
+} from "./secure-user-configuration.js";
 export {
   sessionDurableContext,
   sessionDurableOutputLimits,
@@ -73,6 +80,8 @@ export {
   sessionRuntimeNotificationTransform,
   sessionStoreDirectory,
   sessionTitleDeadlineScheduler,
+  type WorkspaceMcpLeaseTransitionBarrier,
+  workspaceMcpLeaseTransitionBarrier,
 } from "./session-lifecycle.js";
 export {
   createInMemorySessionStoreDirectory,

--- a/packages/agent/src/mcp-host.ts
+++ b/packages/agent/src/mcp-host.ts
@@ -584,6 +584,22 @@ export type McpRuntimeHost = {
       readonly servers: McpLiveSessionSnapshot["settledServers"];
     }[];
   }>;
+  closeWorkspaceSessions(): Promise<{
+    readonly status: "closed" | "mcp_shutdown_unconfirmed";
+    readonly closedSessions: readonly {
+      readonly sessionId: string;
+      readonly generationId: string;
+      readonly attempt: number;
+      readonly servers: McpLiveSessionSnapshot["settledServers"];
+    }[];
+    readonly unconfirmedSessions: readonly {
+      readonly sessionId: string;
+      readonly generationId: string;
+      readonly attempt: number;
+      readonly catalogDigest?: Sha256Digest;
+      readonly servers: McpLiveSessionSnapshot["settledServers"];
+    }[];
+  }>;
   closeSession(input: { readonly sessionId: string; readonly generationId: string }): Promise<{
     readonly status: "closed" | "mcp_shutdown_unconfirmed";
     readonly attempt: number;
@@ -636,6 +652,7 @@ export type McpRuntimeHost = {
     readonly servers: readonly McpServerPreview[];
     readonly profile: McpToolProfileV1;
   }): Promise<McpLiveSessionSnapshot>;
+  hasWorkspaceSessions(): boolean;
   snapshot(sessionId: string): McpLiveSessionSnapshot | undefined;
   toolRegistry(
     sessionId: string,
@@ -796,6 +813,82 @@ export function createMcpRuntimeHost(options: {
       throw error;
     }
   };
+  const closeOwnedGenerations = async (cause: string) => {
+    const owned = [...generations.values()];
+    for (const generation of owned) {
+      generation.cancelled = true;
+      generation.closing = true;
+      cancelledGenerations.add(generation.generationId);
+      generation.abortController.abort(new Error(cause));
+    }
+    const generationOutcomes = await Promise.all(
+      owned.map(async (generation) => {
+        const settledServers =
+          generation.live?.settledServers ?? generation.prepared?.settledServers ?? [];
+        const closeOutcomes = await Promise.allSettled(generation.slots.map(closeMcpServerSlot));
+        await generation.activation?.catch(() => undefined);
+        const confirmed = closeOutcomes.every((outcome) => outcome.status === "fulfilled");
+        return {
+          confirmed,
+          ...(confirmed && settledServers.length > 0
+            ? {
+                closedSession: {
+                  sessionId: generation.sessionId,
+                  generationId: generation.generationId,
+                  attempt: generation.attempt,
+                  servers: settledServers,
+                },
+              }
+            : {}),
+        };
+      }),
+    );
+    for (const [index, generation] of owned.entries()) {
+      if (
+        generationOutcomes[index]?.confirmed === true &&
+        generations.get(generation.sessionId) === generation
+      ) {
+        generations.delete(generation.sessionId);
+      }
+    }
+    const caches = [...packageCaches.entries()];
+    const cacheOutcomes = await Promise.allSettled(
+      caches.map(([, cache]) => removeMcpPackageCache(cache)),
+    );
+    for (const [index, [sessionId]] of caches.entries()) {
+      if (cacheOutcomes[index]?.status === "fulfilled") {
+        packageCaches.delete(sessionId);
+      }
+    }
+    const status =
+      generationOutcomes.every((outcome) => outcome.confirmed) &&
+      cacheOutcomes.every((outcome) => outcome.status === "fulfilled")
+        ? ("closed" as const)
+        : ("mcp_shutdown_unconfirmed" as const);
+    return {
+      status,
+      closedSessions: generationOutcomes.flatMap((outcome) =>
+        outcome.closedSession === undefined ? [] : [outcome.closedSession],
+      ),
+      unconfirmedSessions: generationOutcomes.flatMap((outcome, index) => {
+        const generation = owned[index];
+        if (outcome.confirmed || generation === undefined) {
+          return [];
+        }
+        const catalogDigest =
+          generation.live?.catalog.digest ?? generation.prepared?.catalog.digest;
+        return [
+          {
+            sessionId: generation.sessionId,
+            generationId: generation.generationId,
+            attempt: generation.attempt,
+            ...(catalogDigest === undefined ? {} : { catalogDigest }),
+            servers: generation.live?.settledServers ?? generation.prepared?.settledServers ?? [],
+          },
+        ];
+      }),
+    };
+  };
   return {
     activate,
     commitActivation(input) {
@@ -864,80 +957,11 @@ export function createMcpRuntimeHost(options: {
         return closePromise;
       }
       accepting = false;
-      const owned = [...generations.values()];
-      for (const generation of owned) {
-        generation.cancelled = true;
-        generation.closing = true;
-        cancelledGenerations.add(generation.generationId);
-        generation.abortController.abort(new Error("MCP runtime host is closing."));
-      }
-      closePromise = (async () => {
-        const generationOutcomes = await Promise.all(
-          owned.map(async (generation) => {
-            const settledServers =
-              generation.live?.settledServers ?? generation.prepared?.settledServers ?? [];
-            const closeOutcomes = await Promise.allSettled(
-              generation.slots.map(closeMcpServerSlot),
-            );
-            await generation.activation?.catch(() => undefined);
-            const confirmed = closeOutcomes.every((outcome) => outcome.status === "fulfilled");
-            return {
-              confirmed,
-              ...(confirmed && settledServers.length > 0
-                ? {
-                    closedSession: {
-                      sessionId: generation.sessionId,
-                      generationId: generation.generationId,
-                      attempt: generation.attempt,
-                      servers: settledServers,
-                    },
-                  }
-                : {}),
-            };
-          }),
-        );
-        for (const [index, generation] of owned.entries()) {
-          if (
-            generationOutcomes[index]?.confirmed === true &&
-            generations.get(generation.sessionId) === generation
-          ) {
-            generations.delete(generation.sessionId);
-          }
-        }
-        const cacheOutcomes = await Promise.allSettled(
-          [...packageCaches.values()].map(removeMcpPackageCache),
-        );
-        const status =
-          generationOutcomes.every((outcome) => outcome.confirmed) &&
-          cacheOutcomes.every((outcome) => outcome.status === "fulfilled")
-            ? ("closed" as const)
-            : ("mcp_shutdown_unconfirmed" as const);
-        return {
-          status,
-          closedSessions: generationOutcomes.flatMap((outcome) =>
-            outcome.closedSession === undefined ? [] : [outcome.closedSession],
-          ),
-          unconfirmedSessions: generationOutcomes.flatMap((outcome, index) => {
-            const generation = owned[index];
-            if (outcome.confirmed || generation === undefined) {
-              return [];
-            }
-            const catalogDigest =
-              generation.live?.catalog.digest ?? generation.prepared?.catalog.digest;
-            return [
-              {
-                sessionId: generation.sessionId,
-                generationId: generation.generationId,
-                attempt: generation.attempt,
-                ...(catalogDigest === undefined ? {} : { catalogDigest }),
-                servers:
-                  generation.live?.settledServers ?? generation.prepared?.settledServers ?? [],
-              },
-            ];
-          }),
-        };
-      })();
+      closePromise = closeOwnedGenerations("MCP runtime host is closing.");
       return closePromise;
+    },
+    async closeWorkspaceSessions() {
+      return closeOwnedGenerations("Workspace trust was revoked.");
     },
     async closeSession(input) {
       const generation = generations.get(input.sessionId);
@@ -1232,6 +1256,9 @@ export function createMcpRuntimeHost(options: {
       }
       generation.prepared = { ...live, profile: mcpToolProfileSnapshot(input.profile) };
       return generation.prepared;
+    },
+    hasWorkspaceSessions() {
+      return generations.size > 0;
     },
     snapshot(sessionId) {
       const generation = generations.get(sessionId);

--- a/packages/agent/src/presentation-preferences.ts
+++ b/packages/agent/src/presentation-preferences.ts
@@ -1,9 +1,14 @@
 export {
   createPresentationPreferences,
+  createWorkspaceTrust,
   type PresentationPreferences,
   type PresentationPreferencesDiagnostic,
   type PresentationPreferencesSnapshot,
   type UserModelPolicyField,
   type UserModelPolicyResolver,
   type UserModelPolicySnapshot,
+  type WorkspaceTrustController,
+  type WorkspaceTrustDiagnostic,
+  type WorkspaceTrustMcpLease,
+  type WorkspaceTrustSnapshot,
 } from "./secure-user-configuration.js";

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -366,6 +366,7 @@ export async function createPresentationSession(
       knownTargets.set(options.targetIdentity.targetId, options.targetIdentity);
     }
     const catalogPage = await options.lifecycle.listProjectSessions({ limit: catalogPageSize });
+    const workspaceTrustSnapshot = await options.lifecycle.inspectWorkspaceTrust();
     const projectPaths = await listProjectPaths(options.workspaceRoot);
     const catalogItems = (
       await Promise.all(
@@ -414,7 +415,14 @@ export async function createPresentationSession(
             sessionThroughSequence: activeSessionThroughSequence,
             operationThrough: operationCursorSnapshot(),
           },
-      project: { id: catalogPage.projectId, label: options.projectLabel },
+      project: {
+        id: workspaceTrustSnapshot.projectId ?? catalogPage.projectId,
+        label: workspaceTrustSnapshot.projectLabel,
+        workspaceTrust: {
+          status: workspaceTrustSnapshot.status,
+          diagnostic: workspaceTrustSnapshot.diagnostic,
+        },
+      },
       targets: {
         items: (modelTargetSnapshot?.targets ?? []).map((target) => {
           const context = configuredTargetContexts.get(target.identity.targetId);
@@ -1494,6 +1502,49 @@ export async function createPresentationSession(
           code: "presentation_closed",
           message: "The presentation session is closed.",
         };
+      }
+      if (command.type === "set_workspace_trust") {
+        const conflict = configurationMutationConflict();
+        if (conflict !== null) {
+          return conflict;
+        }
+        if (command.projectId !== state.authoritative.project.id) {
+          return {
+            status: "rejected",
+            code: "stale_interaction",
+            message: "The workspace trust command targets a stale project identity.",
+          };
+        }
+        try {
+          const result = await options.lifecycle.configureWorkspaceTrust({
+            type: command.trusted ? "grant" : "revoke",
+            projectId: command.projectId,
+          });
+          state = {
+            revision: state.revision + 1,
+            authoritative: {
+              ...state.authoritative,
+              project: {
+                id: result.snapshot.projectId ?? state.authoritative.project.id,
+                label: result.snapshot.projectLabel,
+                workspaceTrust: {
+                  status: result.snapshot.status,
+                  diagnostic: result.snapshot.diagnostic,
+                },
+              },
+            },
+            draft: state.draft,
+            transient: state.transient,
+          };
+          publishStateChange();
+          return { status: "admitted", commandId: randomUUID(), resource: null };
+        } catch {
+          return {
+            status: "rejected",
+            code: "persistence_failed",
+            message: "The workspace trust configuration could not be saved.",
+          };
+        }
       }
       if (command.type === "set_default_target") {
         const conflict = configurationMutationConflict();
@@ -3307,6 +3358,14 @@ function draftAdmissionRejection(
       status: "rejected",
       code: "authority_rejected",
       message: "One selected Agent Skill requires confirmation before draft admission.",
+    };
+  }
+  if (code === "session_workspace_untrusted") {
+    return {
+      status: "rejected",
+      code: "authority_rejected",
+      message:
+        "This workspace is not trusted. Run adam-agent --trust-workspace in this project, then retry.",
     };
   }
   if (code === "session_persistence_failed") {

--- a/packages/agent/src/repository-instructions.ts
+++ b/packages/agent/src/repository-instructions.ts
@@ -25,8 +25,17 @@ export class RepositoryInstructionsError extends Error {
 }
 
 export async function loadInitialRepositoryInstructions(input: {
+  readonly includeProjectSources?: boolean;
   readonly workspaceRoot: string;
 }): Promise<PromptContextRecordV1["repository"]> {
+  if (input.includeProjectSources === false) {
+    return createRepositoryInstructionRevisionV1({
+      revision: 1,
+      activeScopes: ["."],
+      sources: [],
+      diagnostics: [],
+    });
+  }
   return loadRepositoryInstructions({
     workspaceRoot: input.workspaceRoot,
     activeScopes: ["."],

--- a/packages/agent/src/secure-user-configuration.ts
+++ b/packages/agent/src/secure-user-configuration.ts
@@ -1,8 +1,9 @@
-import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
 import { constants } from "node:fs";
-import { type FileHandle, mkdir, open, rename, unlink } from "node:fs/promises";
+import { type FileHandle, mkdir, open, realpath, rename, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import {
   createUserModelPolicyResolver,
   type UserModelPolicyField,
@@ -17,6 +18,8 @@ export type {
 } from "./user-model-policy.js";
 
 const maximumConfigurationBytes = 8 * 1024;
+const maximumWorkspaceTrustBytes = 128 * 1024;
+const maximumTrustedProjectIds = 1_024;
 
 export type PresentationPreferencesDiagnostic = {
   readonly code: "target_configuration_invalid" | "target_configuration_unsafe";
@@ -45,9 +48,50 @@ type UserConfigurationRead =
   | { readonly status: "missing" }
   | { readonly status: "unsafe" };
 
-type UserConfigurationStorage = {
+export type UserConfigurationStorage = {
   read(): Promise<UserConfigurationRead>;
   write(text: string): Promise<void>;
+};
+
+type OwnerConfigurationStorage = UserConfigurationStorage & {
+  runExclusive?<T>(operation: () => Promise<T>): Promise<T>;
+};
+
+export type WorkspaceTrustMcpLease = {
+  release(): Promise<void>;
+};
+
+export class WorkspaceTrustMcpLeaseError extends Error {
+  readonly code = "project_in_use";
+
+  constructor() {
+    super("Another Adam MCP runtime owns this canonical project.");
+    this.name = "WorkspaceTrustMcpLeaseError";
+  }
+}
+
+export type WorkspaceTrustDiagnostic = {
+  readonly code:
+    | "workspace_trust_invalid"
+    | "workspace_trust_unsafe"
+    | "workspace_trust_unavailable";
+  readonly message: string;
+};
+
+export type WorkspaceTrustSnapshot = {
+  readonly projectId: `sha256:${string}` | null;
+  readonly projectLabel: string;
+  readonly status: "trusted" | "untrusted" | "unavailable";
+  readonly diagnostic: WorkspaceTrustDiagnostic | null;
+};
+
+export type WorkspaceTrustController = {
+  acquireMcpLease(): Promise<WorkspaceTrustMcpLease>;
+  load(): Promise<WorkspaceTrustSnapshot>;
+  setTrusted(input: {
+    readonly projectId: string;
+    readonly trusted: boolean;
+  }): Promise<WorkspaceTrustSnapshot>;
 };
 
 export function createPresentationPreferences(options: {
@@ -61,8 +105,43 @@ export function createPresentationPreferences(options: {
   const directoryPath = join(root, "adam-agent");
   const configurationPath = join(directoryPath, "config.json");
   return createPresentationPreferencesFromStorage(
-    createUserConfigurationFileStorage({ configurationPath, directoryPath }),
+    createOwnerConfigurationFileStorage({
+      configurationPath,
+      directoryPath,
+      maximumBytes: maximumConfigurationBytes,
+      temporaryPrefix: ".config",
+    }),
   );
+}
+
+export function createWorkspaceTrust(options: {
+  readonly environment: NodeJS.ProcessEnv;
+  readonly workspaceRoot: string;
+}): WorkspaceTrustController {
+  const { XDG_CONFIG_HOME: configuredRoot } = options.environment;
+  const root =
+    configuredRoot === undefined || configuredRoot.length === 0
+      ? join(homedir(), ".config")
+      : configuredRoot;
+  const directoryPath = join(root, "adam-agent");
+  return createWorkspaceTrustFromStorage({
+    workspaceRoot: options.workspaceRoot,
+    storage: createOwnerConfigurationFileStorage({
+      configurationPath: join(directoryPath, "workspace-trust.json"),
+      directoryPath,
+      maximumBytes: maximumWorkspaceTrustBytes,
+      mutationLockName: ".workspace-trust.lock",
+      temporaryPrefix: ".workspace-trust",
+    }),
+    async acquireMcpLock() {
+      const identity = await resolveCanonicalWorkspaceIdentity(options.workspaceRoot);
+      return acquireOwnerConfigurationLock(
+        directoryPath,
+        `.workspace-mcp-${identity.projectId.slice("sha256:".length)}.lock`,
+        true,
+      );
+    },
+  });
 }
 
 /** Tests only through the internal-testing entry; production uses the owner-only file Adapter. */
@@ -70,6 +149,175 @@ export function createPresentationPreferencesWithStorageForTesting(
   storage: UserConfigurationStorage,
 ): PresentationPreferences {
   return createPresentationPreferencesFromStorage(storage);
+}
+
+/** Tests only through the internal-testing entry; production uses the owner-only file Adapter. */
+export function createWorkspaceTrustWithStorageForTesting(options: {
+  readonly workspaceRoot: string;
+  readonly storage: UserConfigurationStorage;
+}): WorkspaceTrustController {
+  return createWorkspaceTrustFromStorage(options);
+}
+
+/** Keeps established behavior tests focused on their original contract. */
+export function createTrustedWorkspaceTrustForTesting(
+  workspaceRoot: string,
+): WorkspaceTrustController {
+  let text: string | null = null;
+  return createWorkspaceTrustFromStorage({
+    workspaceRoot,
+    storage: {
+      async read() {
+        if (text === null) {
+          const identity = await resolveCanonicalWorkspaceIdentity(workspaceRoot);
+          text = serializeWorkspaceTrust([identity.projectId]);
+        }
+        return { status: "available", text };
+      },
+      async write(nextText) {
+        text = nextText;
+      },
+    },
+  });
+}
+
+function createWorkspaceTrustFromStorage(options: {
+  readonly workspaceRoot: string;
+  readonly storage: OwnerConfigurationStorage;
+  readonly acquireMcpLock?: () => Promise<WorkspaceTrustMcpLease>;
+}): WorkspaceTrustController {
+  let activeMcpLease: WorkspaceTrustMcpLease | undefined;
+  let mcpLeaseAcquisition: Promise<WorkspaceTrustMcpLease> | undefined;
+  const resolveIdentity = () => resolveCanonicalWorkspaceIdentity(options.workspaceRoot);
+  const unavailable = (): WorkspaceTrustSnapshot => ({
+    projectId: null,
+    projectLabel: basename(options.workspaceRoot) || "project",
+    status: "unavailable",
+    diagnostic: {
+      code: "workspace_trust_unavailable",
+      message: "The canonical workspace identity is unavailable.",
+    },
+  });
+  const loadDocument = async (): Promise<
+    | { readonly status: "valid"; readonly trustedProjectIds: readonly `sha256:${string}`[] }
+    | { readonly status: "missing" }
+    | { readonly status: "invalid" }
+    | { readonly status: "unsafe" }
+  > => {
+    const stored = await options.storage.read().catch(() => ({ status: "unsafe" as const }));
+    if (stored.status !== "available") {
+      return { status: stored.status };
+    }
+    return parseWorkspaceTrust(stored.text);
+  };
+  const load = async (): Promise<WorkspaceTrustSnapshot> => {
+    const identity = await resolveIdentity().catch(() => undefined);
+    if (identity === undefined) {
+      return unavailable();
+    }
+    const document = await loadDocument();
+    if (document.status === "missing") {
+      return { ...identity, status: "untrusted", diagnostic: null };
+    }
+    if (document.status === "invalid") {
+      return {
+        ...identity,
+        status: "untrusted",
+        diagnostic: {
+          code: "workspace_trust_invalid",
+          message: "The saved workspace trust configuration is invalid.",
+        },
+      };
+    }
+    if (document.status === "unsafe") {
+      return {
+        ...identity,
+        status: "untrusted",
+        diagnostic: {
+          code: "workspace_trust_unsafe",
+          message: "The saved workspace trust configuration is not an owner-only ordinary file.",
+        },
+      };
+    }
+    return {
+      ...identity,
+      status: document.trustedProjectIds.includes(identity.projectId) ? "trusted" : "untrusted",
+      diagnostic: null,
+    };
+  };
+  return {
+    async acquireMcpLease() {
+      if (activeMcpLease !== undefined || mcpLeaseAcquisition !== undefined) {
+        throw new TypeError("This workspace trust controller already owns the MCP trust lease.");
+      }
+      mcpLeaseAcquisition = options.acquireMcpLock?.() ?? Promise.resolve({ async release() {} });
+      let owned: WorkspaceTrustMcpLease;
+      try {
+        owned = await mcpLeaseAcquisition;
+        activeMcpLease = owned;
+      } finally {
+        mcpLeaseAcquisition = undefined;
+      }
+      let releasePromise: Promise<void> | undefined;
+      return {
+        release() {
+          releasePromise ??= owned.release().then(() => {
+            if (activeMcpLease === owned) {
+              activeMcpLease = undefined;
+            }
+          });
+          return releasePromise;
+        },
+      };
+    },
+    load,
+    async setTrusted(input) {
+      const mutate = async () => {
+        const identity = await resolveIdentity().catch(() => undefined);
+        if (identity === undefined || input.projectId !== identity.projectId) {
+          throw new TypeError("The workspace trust command targets a stale project identity.");
+        }
+        const document = await loadDocument();
+        if (document.status === "invalid" || document.status === "unsafe") {
+          throw new TypeError("The saved workspace trust configuration requires manual repair.");
+        }
+        const trustedProjectIds = new Set(
+          document.status === "valid" ? document.trustedProjectIds : [],
+        );
+        if (input.trusted) {
+          trustedProjectIds.add(identity.projectId);
+        } else {
+          trustedProjectIds.delete(identity.projectId);
+        }
+        const sorted = [...trustedProjectIds].sort();
+        if (sorted.length > maximumTrustedProjectIds) {
+          throw new TypeError("The workspace trust configuration is full.");
+        }
+        await options.storage.write(serializeWorkspaceTrust(sorted));
+        return {
+          ...identity,
+          status: input.trusted ? ("trusted" as const) : ("untrusted" as const),
+          diagnostic: null,
+        };
+      };
+      const mutateDocument = () =>
+        options.storage.runExclusive === undefined
+          ? mutate()
+          : options.storage.runExclusive(mutate);
+      if (activeMcpLease !== undefined) {
+        throw new WorkspaceTrustMcpLeaseError();
+      }
+      if (options.acquireMcpLock === undefined) {
+        return mutateDocument();
+      }
+      const temporaryMcpLease = await options.acquireMcpLock();
+      try {
+        return await mutateDocument();
+      } finally {
+        await temporaryMcpLease.release();
+      }
+    },
+  };
 }
 
 function createPresentationPreferencesFromStorage(
@@ -160,11 +408,30 @@ function createPresentationPreferencesFromStorage(
   };
 }
 
-function createUserConfigurationFileStorage(options: {
+function createOwnerConfigurationFileStorage(options: {
   readonly configurationPath: string;
   readonly directoryPath: string;
-}): UserConfigurationStorage {
+  readonly maximumBytes: number;
+  readonly mutationLockName?: string;
+  readonly temporaryPrefix: string;
+}): OwnerConfigurationStorage {
   return {
+    ...(options.mutationLockName === undefined
+      ? {}
+      : {
+          async runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+            const lease = await acquireOwnerConfigurationLock(
+              options.directoryPath,
+              options.mutationLockName as string,
+              false,
+            );
+            try {
+              return await operation();
+            } finally {
+              await lease.release();
+            }
+          },
+        }),
     async read() {
       const directory = await openOwnerDirectory(options.directoryPath).catch(() => undefined);
       if (directory === undefined) {
@@ -187,7 +454,7 @@ function createUserConfigurationFileStorage(options: {
             !stats.isFile() ||
             !Number.isSafeInteger(stats.size) ||
             stats.size <= 0 ||
-            stats.size > maximumConfigurationBytes ||
+            stats.size > options.maximumBytes ||
             stats.uid !== currentEffectiveUserId() ||
             (stats.mode & 0o077) !== 0
           ) {
@@ -208,7 +475,7 @@ function createUserConfigurationFileStorage(options: {
       if (directory === null) {
         throw new TypeError("The user configuration directory is unavailable.");
       }
-      const temporaryPath = join(directoryPath, `.config-${randomUUID()}.tmp`);
+      const temporaryPath = join(directoryPath, `${options.temporaryPrefix}-${randomUUID()}.tmp`);
       let temporary: FileHandle | undefined;
       try {
         const existing = await openOwnerFile(configurationPath).catch(() => undefined);
@@ -255,6 +522,60 @@ function createUserConfigurationFileStorage(options: {
   };
 }
 
+function parseWorkspaceTrust(
+  text: string,
+):
+  | { readonly status: "valid"; readonly trustedProjectIds: readonly `sha256:${string}`[] }
+  | { readonly status: "invalid" } {
+  if (text.length === 0 || Buffer.byteLength(text, "utf8") > maximumWorkspaceTrustBytes) {
+    return { status: "invalid" };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { status: "invalid" };
+  }
+  if (hasDuplicateJsonObjectKey(text) || !isPlainRecord(parsed)) {
+    return { status: "invalid" };
+  }
+  const { schemaVersion, trustedProjectIds } = parsed;
+  if (
+    schemaVersion !== 1 ||
+    Object.keys(parsed).length !== 2 ||
+    !Array.isArray(trustedProjectIds) ||
+    trustedProjectIds.length > maximumTrustedProjectIds ||
+    trustedProjectIds.some(
+      (projectId) => typeof projectId !== "string" || !/^sha256:[0-9a-f]{64}$/u.test(projectId),
+    ) ||
+    new Set(trustedProjectIds).size !== trustedProjectIds.length ||
+    trustedProjectIds.some(
+      (projectId, index) => index > 0 && trustedProjectIds[index - 1] >= projectId,
+    )
+  ) {
+    return { status: "invalid" };
+  }
+  return {
+    status: "valid",
+    trustedProjectIds: trustedProjectIds as readonly `sha256:${string}`[],
+  };
+}
+
+function serializeWorkspaceTrust(trustedProjectIds: readonly `sha256:${string}`[]): string {
+  return `${JSON.stringify({ schemaVersion: 1, trustedProjectIds })}\n`;
+}
+
+export async function resolveCanonicalWorkspaceIdentity(workspaceRoot: string): Promise<{
+  readonly projectId: `sha256:${string}`;
+  readonly projectLabel: string;
+}> {
+  const canonicalRoot = await realpath(workspaceRoot);
+  return {
+    projectId: `sha256:${createHash("sha256").update(canonicalRoot).digest("hex")}`,
+    projectLabel: basename(canonicalRoot) || "project",
+  };
+}
+
 async function openOwnerDirectory(path: string): Promise<FileHandle | null> {
   let directory: FileHandle;
   try {
@@ -283,6 +604,110 @@ async function openOwnerFile(path: string): Promise<FileHandle | null> {
   } catch (error) {
     return isNodeError(error) && error.code === "ENOENT" ? null : Promise.reject(error);
   }
+}
+
+async function acquireOwnerConfigurationLock(
+  directoryPath: string,
+  lockName: string,
+  nonblocking: boolean,
+): Promise<WorkspaceTrustMcpLease> {
+  await mkdir(directoryPath, { recursive: true, mode: 0o700 });
+  const directory = await openOwnerDirectory(directoryPath);
+  if (directory === null) {
+    throw new TypeError("The owner configuration directory is unavailable.");
+  }
+  let lease: WorkspaceTrustMcpLease | undefined;
+  let acquisitionError: unknown;
+  try {
+    const lock = await open(
+      join(directoryPath, lockName),
+      constants.O_RDWR | constants.O_CREAT | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+      0o600,
+    );
+    lease = createConfigurationLockLease(lock);
+    const stats = await lock.stat();
+    if (!stats.isFile() || stats.uid !== currentEffectiveUserId() || (stats.mode & 0o077) !== 0) {
+      throw new TypeError("The owner configuration lock is unsafe.");
+    }
+    const child = spawn("flock", ["--exclusive", ...(nonblocking ? ["--nonblock"] : []), "3"], {
+      stdio: ["ignore", "ignore", "pipe", lock.fd],
+    });
+    await waitForConfigurationLock(child, nonblocking);
+  } catch (error) {
+    acquisitionError = error;
+  }
+  let directoryCloseError: unknown;
+  try {
+    await directory.close();
+  } catch (error) {
+    directoryCloseError = error;
+  }
+  if (acquisitionError === undefined && directoryCloseError === undefined && lease !== undefined) {
+    return lease;
+  }
+  let lockCloseError: unknown;
+  try {
+    await lease?.release();
+  } catch (error) {
+    lockCloseError = error;
+  }
+  const errors = [acquisitionError, directoryCloseError, lockCloseError].filter(
+    (error) => error !== undefined,
+  );
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  throw new AggregateError(errors, "The owner configuration lock could not be acquired safely.");
+}
+
+function createConfigurationLockLease(lock: FileHandle): WorkspaceTrustMcpLease {
+  let closePromise: Promise<void> | undefined;
+  return {
+    release() {
+      closePromise ??= lock.close();
+      return closePromise;
+    },
+  };
+}
+
+async function waitForConfigurationLock(
+  child: ReturnType<typeof spawn>,
+  nonblocking: boolean,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    let stderr = "";
+    let settled = false;
+    let spawnError: TypeError | undefined;
+    const finish = (error?: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (error === undefined) {
+        resolve();
+      } else {
+        reject(error);
+      }
+    };
+    child.stderr?.setEncoding("utf8");
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", () => {
+      spawnError = new TypeError("The owner configuration lock is unavailable.");
+    });
+    child.once("close", (code) => {
+      if (spawnError !== undefined) {
+        finish(spawnError);
+      } else if (code === 0) {
+        finish();
+      } else if (nonblocking && code === 1 && stderr.length === 0) {
+        finish(new WorkspaceTrustMcpLeaseError());
+      } else {
+        finish(new TypeError("The owner configuration lock is unavailable."));
+      }
+    });
+  });
 }
 
 function parseConfiguration(text: string): LoadedPresentationPreferences {

--- a/packages/agent/src/session-durable-context.ts
+++ b/packages/agent/src/session-durable-context.ts
@@ -42,6 +42,7 @@ export type AgentSessionDurableContext = {
     | undefined;
   readonly referencedModelResponseArtifactBytes?: number;
   readonly repositoryWorkspaceRoot?: string;
+  readonly authorizeProjectContextLoad?: (() => Promise<boolean>) | undefined;
   readonly skillResourceLineageBytes?: number;
   readonly skillResourceRunBytes?: number;
   readonly sessionId?: string;

--- a/packages/agent/src/session-lifecycle-error.ts
+++ b/packages/agent/src/session-lifecycle-error.ts
@@ -5,6 +5,7 @@ export class SessionLifecycleError extends Error {
     | "session_model_target_incompatible"
     | "session_model_target_unavailable"
     | "session_user_configuration_invalid"
+    | "session_workspace_untrusted"
     | "session_thinking_policy_unsupported"
     | "session_persistence_failed"
     | "session_skill_confirmation_required"
@@ -73,6 +74,8 @@ function sessionLifecycleErrorMessage(code: SessionLifecycleError["code"]): stri
       return "The requested exact model target is not ready in this runtime.";
     case "session_user_configuration_invalid":
       return "The user model configuration does not produce a supported context profile.";
+    case "session_workspace_untrusted":
+      return "This workspace is not trusted. Run adam-agent --trust-workspace in this project, then retry.";
     case "session_thinking_policy_unsupported":
       return "The requested thinking level is unavailable for this exact model target.";
     case "session_persistence_failed":

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -1,5 +1,4 @@
 import { createHash, randomUUID } from "node:crypto";
-import { realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { isDeepStrictEqual } from "node:util";
@@ -84,6 +83,14 @@ import {
   loadRepositoryInstructions,
   RepositoryInstructionsError,
 } from "./repository-instructions.js";
+import {
+  createWorkspaceTrust,
+  resolveCanonicalWorkspaceIdentity,
+  type WorkspaceTrustController,
+  type WorkspaceTrustMcpLease,
+  WorkspaceTrustMcpLeaseError,
+  type WorkspaceTrustSnapshot,
+} from "./secure-user-configuration.js";
 import {
   type AgentSessionDurableContext,
   type AgentSessionDurableOutputLimits,
@@ -250,6 +257,16 @@ export type SessionRuntimeNotificationTransform = {
   project(notification: SessionRuntimeNotification): readonly SessionRuntimeNotification[];
 };
 
+/** Tests only. Production MCP lease transitions have no observation barrier. */
+export const workspaceMcpLeaseTransitionBarrier = Symbol(
+  "adam-agent.workspace-mcp-lease-transition-barrier",
+);
+
+export type WorkspaceMcpLeaseTransitionBarrier = {
+  activationLeaseReady?(): Promise<void> | void;
+  waitingForRelease(): Promise<void> | void;
+};
+
 export type SessionLifecycleOptions = {
   readonly extensionHost?: ExtensionHost;
   readonly modelTargets?: ModelTargets;
@@ -258,6 +275,7 @@ export type SessionLifecycleOptions = {
   readonly workspaceRoot: string;
   readonly stateRoot?: string;
   readonly tools?: ToolRegistry;
+  readonly workspaceTrust?: WorkspaceTrustController;
   readonly [mcpBootstrapScheduler]?: McpBootstrapScheduler;
   readonly [mcpBeforeToolDispatchBarrier]?: McpBeforeToolDispatchBarrier;
   readonly [mcpDiscoveryScheduler]?: McpDiscoveryScheduler;
@@ -277,6 +295,7 @@ export type SessionLifecycleOptions = {
   readonly [sessionProjectLifecycleOwner]?: ProjectLifecycleOwner;
   readonly [sessionStoreDirectory]?: SessionStoreDirectory<SessionRecord>;
   readonly [sessionRuntimeNotificationTransform]?: SessionRuntimeNotificationTransform;
+  readonly [workspaceMcpLeaseTransitionBarrier]?: WorkspaceMcpLeaseTransitionBarrier;
 };
 
 export type SessionContinueResult = {
@@ -404,6 +423,16 @@ export type McpConfigurationResult = {
   readonly snapshot: CurrentSessionSnapshot;
 };
 
+export type WorkspaceTrustCommand = {
+  readonly type: "grant" | "revoke";
+  readonly projectId: string;
+};
+
+export type WorkspaceTrustConfigurationResult = {
+  readonly status: "updated";
+  readonly snapshot: WorkspaceTrustSnapshot;
+};
+
 export type McpCloseResult = {
   readonly status: "closed" | "mcp_shutdown_unconfirmed";
 };
@@ -462,11 +491,15 @@ export interface SessionLifecycle {
     readonly thinkingSelection?: ThinkingPolicySelectionV1;
   }): Promise<SessionContinueResult>;
   configureMcp(command: McpConfigurationCommand): Promise<McpConfigurationResult>;
+  configureWorkspaceTrust(
+    command: WorkspaceTrustCommand,
+  ): Promise<WorkspaceTrustConfigurationResult>;
   create(input: { readonly targetIdentity: ModelTargetIdentity }): Promise<CurrentSessionSnapshot>;
   decidePermission(command: PermissionDecisionCommand): PermissionDecisionCommandResult;
   enableAutomaticTitles(): void;
   ensureAutomaticTitle(input: { readonly sessionId: string }): Promise<SessionNamingResult>;
   inspect(input: { readonly sessionId: string }): Promise<SessionSnapshot>;
+  inspectWorkspaceTrust(): Promise<WorkspaceTrustSnapshot>;
   inspectContextUsage(input: {
     readonly sessionId: string;
   }): Promise<SessionContextUsageSnapshot | null>;
@@ -602,6 +635,12 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     });
   const options: SessionLifecycleOptions = {
     ...providedOptions,
+    workspaceTrust:
+      providedOptions.workspaceTrust ??
+      createWorkspaceTrust({
+        environment: process.env,
+        workspaceRoot: providedOptions.workspaceRoot,
+      }),
     [sessionStoreDirectory]: storeDirectory,
     tools:
       providedOptions.tools ??
@@ -630,6 +669,77 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
   let lifecycleClosing = false;
   let automaticTitlesEnabled = options[sessionAutomaticTitlesEnabled] ?? true;
   let lifecycleClosePromise: Promise<McpCloseResult> | undefined;
+  let workspaceMcpLeasePromise: Promise<WorkspaceTrustMcpLease> | undefined;
+  let workspaceMcpLeaseReleasePromise: Promise<void> | undefined;
+  let workspaceMcpLeaseFenced = false;
+  let workspaceMcpActivationClaims = 0;
+  const ensureWorkspaceMcpLease = async (): Promise<void> => {
+    if (options.workspaceTrust === undefined) {
+      return;
+    }
+    for (;;) {
+      if (workspaceMcpLeaseFenced) {
+        throw new SessionLifecycleError("project_owner_unavailable");
+      }
+      const release = workspaceMcpLeaseReleasePromise;
+      if (release !== undefined) {
+        await options[workspaceMcpLeaseTransitionBarrier]?.waitingForRelease();
+        await release;
+        continue;
+      }
+      const acquisition = workspaceMcpLeasePromise ?? options.workspaceTrust.acquireMcpLease();
+      workspaceMcpLeasePromise = acquisition;
+      try {
+        await acquisition;
+      } catch (error) {
+        if (workspaceMcpLeasePromise === acquisition) {
+          workspaceMcpLeasePromise = undefined;
+        }
+        if (error instanceof WorkspaceTrustMcpLeaseError) {
+          throw new SessionLifecycleError("project_in_use");
+        }
+        throw error;
+      }
+      if (
+        workspaceMcpLeasePromise === acquisition &&
+        workspaceMcpLeaseReleasePromise === undefined
+      ) {
+        return;
+      }
+    }
+  };
+  const releaseWorkspaceMcpLease = async (): Promise<void> => {
+    if (workspaceMcpLeaseFenced) {
+      throw new SessionLifecycleError("project_owner_unavailable");
+    }
+    if (workspaceMcpLeaseReleasePromise !== undefined) {
+      return workspaceMcpLeaseReleasePromise;
+    }
+    const acquisition = workspaceMcpLeasePromise;
+    if (acquisition === undefined) {
+      return;
+    }
+    const release = (async () => {
+      const lease = await acquisition;
+      try {
+        await lease.release();
+      } catch {
+        workspaceMcpLeaseFenced = true;
+        throw new SessionLifecycleError("project_owner_unavailable");
+      }
+      if (workspaceMcpLeasePromise === acquisition) {
+        workspaceMcpLeasePromise = undefined;
+      }
+    })();
+    workspaceMcpLeaseReleasePromise = release;
+    try {
+      await release;
+    } finally {
+      if (workspaceMcpLeaseReleasePromise === release) {
+        workspaceMcpLeaseReleasePromise = undefined;
+      }
+    }
+  };
   const pendingMcpCatalogDurability = new Map<string, Promise<void>>();
   const preparedAdmissionTargets = new Map<
     string,
@@ -690,6 +800,23 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       ? {}
       : { transportFactory: options[mcpTransportFactory] }),
   });
+  const releaseWorkspaceMcpLeaseIfIdle = async (): Promise<void> => {
+    if (workspaceMcpActivationClaims === 0 && !mcpHost.hasWorkspaceSessions()) {
+      await releaseWorkspaceMcpLease();
+    }
+  };
+  const activateWithWorkspaceMcpLease = async <T>(activation: () => Promise<T>): Promise<T> => {
+    workspaceMcpActivationClaims += 1;
+    try {
+      await ensureWorkspaceMcpLease();
+      await options[workspaceMcpLeaseTransitionBarrier]?.activationLeaseReady?.();
+      await requireTrustedWorkspace();
+      return await activation();
+    } finally {
+      workspaceMcpActivationClaims -= 1;
+      await releaseWorkspaceMcpLeaseIfIdle();
+    }
+  };
   const closePreparedMcpActivation = async (input: {
     readonly sessionId: string;
     readonly generationId: string;
@@ -697,6 +824,9 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
   }): Promise<McpHostError> => {
     try {
       const closed = await mcpHost.closePreparedActivation(input);
+      if (closed.status === "closed") {
+        await releaseWorkspaceMcpLeaseIfIdle();
+      }
       return new McpHostError(
         closed.status === "closed" ? "mcp_start_failed" : "mcp_shutdown_unconfirmed",
         { cause: input.cause, closedServers: closed.servers },
@@ -1214,6 +1344,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         }
         return;
       }
+      await releaseWorkspaceMcpLeaseIfIdle();
       for (const [index, server] of closed.servers.entries()) {
         await store.append({
           schemaVersion: 3,
@@ -1314,22 +1445,24 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         mcpCatalogStateFromLineage(lineage, first, records),
       ]);
     let mcp: McpSessionSnapshot | undefined;
-    try {
-      mcp = await inspectMcpConfiguration(
-        options.workspaceRoot,
-        mcpWorkspaceConfirmation?.sourceDigest,
-        mcpServerApprovals,
-        mcpHost.snapshot(input.sessionId),
-        mcpActivationFailureFromRecords(records),
-        mcpCommittedProfile,
-        mcpCatalogState,
-        mcpActivationFromRecords(records),
-      );
-    } catch (error) {
-      if (error instanceof McpConfigurationError) {
-        throw new SessionLifecycleError("mcp_config_invalid");
+    if ((await inspectWorkspaceTrust()).status === "trusted") {
+      try {
+        mcp = await inspectMcpConfiguration(
+          options.workspaceRoot,
+          mcpWorkspaceConfirmation?.sourceDigest,
+          mcpServerApprovals,
+          mcpHost.snapshot(input.sessionId),
+          mcpActivationFailureFromRecords(records),
+          mcpCommittedProfile,
+          mcpCatalogState,
+          mcpActivationFromRecords(records),
+        );
+      } catch (error) {
+        if (error instanceof McpConfigurationError) {
+          throw new SessionLifecycleError("mcp_config_invalid");
+        }
+        throw error;
       }
-      throw error;
     }
     return {
       ...snapshot,
@@ -1569,6 +1702,19 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     }
   };
 
+  const inspectWorkspaceTrust = async (): Promise<WorkspaceTrustSnapshot> => {
+    if (options.workspaceTrust !== undefined) {
+      return options.workspaceTrust.load();
+    }
+    const identity = await resolveCanonicalWorkspaceIdentity(options.workspaceRoot);
+    return { ...identity, status: "trusted", diagnostic: null };
+  };
+  const requireTrustedWorkspace = async (): Promise<void> => {
+    if ((await inspectWorkspaceTrust()).status !== "trusted") {
+      throw new SessionLifecycleError("session_workspace_untrusted");
+    }
+  };
+
   const prepareSessionCreation = async (input: {
     readonly targetIdentity: ModelTargetIdentity;
     readonly runId?: string;
@@ -1583,18 +1729,23 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     readonly selectedSkills?: readonly string[];
   }> => {
     input.signal?.throwIfAborted();
+    const workspaceTrust = await inspectWorkspaceTrust();
+    const projectInputsTrusted = workspaceTrust.status === "trusted";
     let mcp: McpSessionSnapshot | undefined;
-    try {
-      mcp = await inspectMcpConfiguration(options.workspaceRoot);
-    } catch (error) {
-      if (error instanceof McpConfigurationError) {
-        throw new SessionLifecycleError("mcp_config_invalid");
+    if (projectInputsTrusted) {
+      try {
+        mcp = await inspectMcpConfiguration(options.workspaceRoot);
+      } catch (error) {
+        if (error instanceof McpConfigurationError) {
+          throw new SessionLifecycleError("mcp_config_invalid");
+        }
+        throw error;
       }
-      throw error;
     }
     const sessionId = randomUUID();
     const projectId = await canonicalProjectId(options.workspaceRoot);
     const repository = await loadInitialRepositoryInstructions({
+      includeProjectSources: projectInputsTrusted,
       workspaceRoot: options.workspaceRoot,
     });
     const skillBudgetContext =
@@ -1614,6 +1765,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       userHome: homedir(),
       workspaceRoot: options.workspaceRoot,
       extensionSources,
+      includeProjectSources: projectInputsTrusted,
     });
     const selectedSkills: string[] = [];
     const skillManifests = new Map<string, SkillResourceManifestV1>();
@@ -1718,6 +1870,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         throw new SessionLifecycleError("session_invalid");
       }
       const created = await withOwner(async () => {
+        await requireTrustedWorkspace();
         const officialResolved = await options.modelTargets?.resolve({
           targetId: input.targetIdentity.targetId,
           targetIdentity: input.targetIdentity,
@@ -2102,6 +2255,9 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         mcpIdleTimers.clear();
         await Promise.allSettled(mcpIdleOperations.values());
         const hostResult = await mcpHost.close();
+        if (hostResult.status === "closed") {
+          await releaseWorkspaceMcpLeaseIfIdle();
+        }
         await Promise.allSettled(activeMcpConfigurationOperations.values());
         await drainOwnerOperations();
         await drainTitleOperations();
@@ -2196,11 +2352,12 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       return lifecycleClosePromise;
     },
     async create(input) {
-      return withOwner(async () =>
-        persistPreparedSession(
+      return withOwner(async () => {
+        await requireTrustedWorkspace();
+        return persistPreparedSession(
           await prepareSessionCreation({ targetIdentity: input.targetIdentity }),
-        ),
-      );
+        );
+      });
     },
     async continue(input) {
       if (input.runId !== undefined && !z.uuid().safeParse(input.runId).success) {
@@ -2209,6 +2366,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       disarmMcpIdle(input.sessionId);
       await waitForMcpIdleOperation(input.sessionId);
       const continued = await withOwner(async () => {
+        const workspaceTrusted = (await inspectWorkspaceTrust()).status === "trusted";
         const artifactCache = createArtifactMaterializationCache();
         const resumed = await resumeSession({ sessionId: input.sessionId }, artifactCache);
         if (resumed.status === "rejected") {
@@ -2297,7 +2455,10 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             persistedPromptContext,
           );
           committedMcpProfile = profile;
-          if (mcpHost.snapshot(input.sessionId)?.profile?.digest !== profile.digest) {
+          if (
+            workspaceTrusted &&
+            mcpHost.snapshot(input.sessionId)?.profile?.digest !== profile.digest
+          ) {
             const mcp = resumed.snapshot.mcp;
             const selectedServers = profile.servers.map((profileServer) => {
               const server = mcp?.servers.find(
@@ -2341,13 +2502,15 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             let activationPrepared = false;
             let readySettlementDurable = false;
             try {
-              const live = await mcpHost.reactivateToolProfile({
-                sessionId: input.sessionId,
-                generationId,
-                attempt,
-                servers: selectedServers,
-                profile,
-              });
+              const live = await activateWithWorkspaceMcpLease(() =>
+                mcpHost.reactivateToolProfile({
+                  sessionId: input.sessionId,
+                  generationId,
+                  attempt,
+                  servers: selectedServers,
+                  profile,
+                }),
+              );
               activationPrepared = true;
               await options[mcpActivationSettlementBarrier]?.beforeReadySettlement({
                 sessionId: input.sessionId,
@@ -2583,7 +2746,11 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
                 }),
             ...(activePromptContext === undefined
               ? {}
-              : { repositoryWorkspaceRoot: options.workspaceRoot }),
+              : {
+                  repositoryWorkspaceRoot: options.workspaceRoot,
+                  authorizeProjectContextLoad: async () =>
+                    (await inspectWorkspaceTrust()).status === "trusted",
+                }),
             sessionId: resumed.snapshot.sessionId,
             ...(options[sessionLogicalRunStartedBarrier] === undefined &&
             preparedAdmission?.onAdmitted === undefined
@@ -2652,11 +2819,15 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
                   activePromptContext?.recordVersion === 3 && activePromptContext.mcp !== undefined
                     ? combineToolRegistries(
                         options.tools,
-                        mcpHost.toolRegistry(
-                          input.sessionId,
-                          requireMcpCommittedProfile(committedMcpProfile, activePromptContext),
-                          artifactStore,
-                        ),
+                        workspaceTrusted
+                          ? mcpHost.toolRegistry(
+                              input.sessionId,
+                              requireMcpCommittedProfile(committedMcpProfile, activePromptContext),
+                              artifactStore,
+                            )
+                          : mcpProfileDefinitionRegistry(
+                              requireMcpCommittedProfile(committedMcpProfile, activePromptContext),
+                            ),
                       )
                     : options.tools,
               }),
@@ -2739,10 +2910,50 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       );
       return titleSnapshot === undefined ? continued : { ...continued, snapshot: titleSnapshot };
     },
+    async configureWorkspaceTrust(command) {
+      if (activeSession !== undefined || options.workspaceTrust === undefined) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      if (command.type === "revoke") {
+        for (const timer of mcpIdleTimers.values()) {
+          timer.cancel();
+        }
+        mcpIdleTimers.clear();
+        await Promise.allSettled(mcpIdleOperations.values());
+        await Promise.allSettled(pendingMcpCatalogDurability.values());
+        await Promise.allSettled(activeMcpConfigurationOperations.values());
+      }
+      return withOwner(async () => {
+        const current = await inspectWorkspaceTrust();
+        if (
+          current.projectId === null ||
+          current.projectId !== command.projectId ||
+          current.diagnostic !== null
+        ) {
+          throw new SessionLifecycleError("session_invalid");
+        }
+        if (command.type === "revoke") {
+          const closed = await mcpHost.closeWorkspaceSessions();
+          if (closed.status !== "closed") {
+            throw new SessionLifecycleError("mcp_shutdown_unconfirmed");
+          }
+          await releaseWorkspaceMcpLeaseIfIdle();
+        }
+        const snapshot = await options.workspaceTrust?.setTrusted({
+          projectId: command.projectId,
+          trusted: command.type === "grant",
+        });
+        if (snapshot === undefined) {
+          throw new SessionLifecycleError("session_invalid");
+        }
+        return { status: "updated", snapshot };
+      });
+    },
     async configureMcp(command) {
       if (activeSession !== undefined) {
         throw new SessionLifecycleError("session_invalid");
       }
+      await requireTrustedWorkspace();
       await pendingMcpCatalogDurability.get(command.sessionId);
       if (command.type === "cancel_configuration") {
         const before = await inspectSession({ sessionId: command.sessionId });
@@ -2765,7 +2976,9 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         if (closed.status !== "closed") {
           throw new SessionLifecycleError("mcp_shutdown_unconfirmed");
         }
+        await releaseWorkspaceMcpLeaseIfIdle();
         return withOwner(async () => {
+          await requireTrustedWorkspace();
           const inspected = await inspectSession({ sessionId: command.sessionId });
           if (inspected.schemaVersion !== 3) {
             throw new SessionLifecycleError("session_invalid");
@@ -2801,6 +3014,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       }
       let ownerOperation!: Promise<McpConfigurationResult>;
       ownerOperation = withOwner(async () => {
+        await requireTrustedWorkspace();
         await flushPendingMcpCatalogChanges(command.sessionId);
         const inspected = await inspectSession({ sessionId: command.sessionId });
         if (
@@ -2936,21 +3150,22 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           let activationPrepared = false;
           let readySettlementDurable = false;
           try {
-            const live =
+            const live = await activateWithWorkspaceMcpLease(() =>
               reactivationProfile === undefined
-                ? await mcpHost.activate({
+                ? mcpHost.activate({
                     sessionId: command.sessionId,
                     generationId,
                     attempt,
                     servers: selectedServers,
                   })
-                : await mcpHost.reactivateToolProfile({
+                : mcpHost.reactivateToolProfile({
                     sessionId: command.sessionId,
                     generationId,
                     attempt,
                     servers: selectedServers,
                     profile: reactivationProfile,
-                  });
+                  }),
+            );
             activationPrepared = true;
             await options[mcpActivationSettlementBarrier]?.beforeReadySettlement({
               sessionId: command.sessionId,
@@ -3117,12 +3332,14 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           let activationPrepared = false;
           let readySettlementDurable = false;
           try {
-            const live = await mcpHost.activate({
-              sessionId: command.sessionId,
-              generationId,
-              attempt,
-              servers: selectedServers,
-            });
+            const live = await activateWithWorkspaceMcpLease(() =>
+              mcpHost.activate({
+                sessionId: command.sessionId,
+                generationId,
+                attempt,
+                servers: selectedServers,
+              }),
+            );
             activationPrepared = true;
             await options[mcpActivationSettlementBarrier]?.beforeReadySettlement({
               sessionId: command.sessionId,
@@ -3383,6 +3600,9 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       await prepareSessionInspection(input.sessionId);
       return inspectSession(input);
     },
+    async inspectWorkspaceTrust() {
+      return inspectWorkspaceTrust();
+    },
     async inspectContextUsage(input) {
       await prepareSessionInspection(input.sessionId);
       return inspectSessionContextUsage(input);
@@ -3444,6 +3664,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     },
     async previewNewSession(input) {
       return withOwner(async () => {
+        const projectInputsTrusted = (await inspectWorkspaceTrust()).status === "trusted";
         if (options.modelTargets === undefined) {
           throw new SessionLifecycleError("session_model_target_unavailable");
         }
@@ -3482,6 +3703,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           userHome: homedir(),
           workspaceRoot: options.workspaceRoot,
           extensionSources,
+          includeProjectSources: projectInputsTrusted,
         });
         return {
           targetIdentity: input.targetIdentity,
@@ -3495,6 +3717,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         throw new SessionLifecycleError("session_invalid");
       }
       return withOwner(async () => {
+        await requireTrustedWorkspace();
         const inspected = await inspectSession({ sessionId: input.sessionId });
         if (
           inspected.schemaVersion !== 3 ||
@@ -3579,6 +3802,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         throw new SessionLifecycleError("session_invalid");
       }
       return withOwner(async () => {
+        await requireTrustedWorkspace();
         const inspected = await inspectSession({ sessionId: input.sessionId });
         if (inspected.schemaVersion !== 3) {
           throw new SessionLifecycleError("session_invalid");
@@ -5509,8 +5733,7 @@ async function skillResourceBytesFromLineage(
 }
 
 async function canonicalProjectId(workspaceRoot: string): Promise<string> {
-  const canonicalRoot = await realpath(workspaceRoot);
-  return `sha256:${createHash("sha256").update(canonicalRoot).digest("hex")}`;
+  return (await resolveCanonicalWorkspaceIdentity(workspaceRoot)).projectId;
 }
 
 async function resolveSkillBudgetContext(

--- a/packages/agent/src/skills.ts
+++ b/packages/agent/src/skills.ts
@@ -423,6 +423,7 @@ export async function createInitialSkillContextV1(input: {
   readonly userHome: string;
   readonly workspaceRoot: string;
   readonly extensionSources?: readonly ExtensionSkillSourceV1[];
+  readonly includeProjectSources?: boolean;
 }): Promise<SkillContextRecordV1> {
   const canonicalProject = await realpath(input.workspaceRoot);
   const canonicalHome = await realpath(input.userHome);
@@ -436,12 +437,14 @@ export async function createInitialSkillContextV1(input: {
     diagnostics,
     catalogRevision: 1,
   };
-  await discoverSource({
-    ...shared,
-    authorityRoot: canonicalProject,
-    lexicalRoot: join(canonicalProject, ".agents", "skills"),
-    locator: { source: "project", scope: "." },
-  });
+  if (input.includeProjectSources !== false) {
+    await discoverSource({
+      ...shared,
+      authorityRoot: canonicalProject,
+      lexicalRoot: join(canonicalProject, ".agents", "skills"),
+      locator: { source: "project", scope: "." },
+    });
+  }
   await discoverSource({
     ...shared,
     authorityRoot: canonicalHome,

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -1,6 +1,10 @@
 export type ProjectDisplay = {
   readonly id: string;
   readonly label: string;
+  readonly workspaceTrust: {
+    readonly status: "trusted" | "untrusted" | "unavailable";
+    readonly diagnostic: { readonly code: string; readonly message: string } | null;
+  };
 };
 
 export type ThinkingCapabilityDisplay = {
@@ -753,6 +757,11 @@ export type PresentationCommand =
         | "maximumOutputTokens"
         | "automaticCompactionWindowTokens";
       readonly value: number | null;
+    }
+  | {
+      readonly type: "set_workspace_trust";
+      readonly projectId: string;
+      readonly trusted: boolean;
     }
   | {
       readonly type: "load_older_transcript";

--- a/packages/presentation/src/presentation.test.ts
+++ b/packages/presentation/src/presentation.test.ts
@@ -13,7 +13,11 @@ const emptySnapshot: AuthoritativePresentationSnapshot = {
     sessionThroughSequence: 0,
     operationThrough: [],
   },
-  project: { id: "project-1", label: "adam-agent" },
+  project: {
+    id: "project-1",
+    label: "adam-agent",
+    workspaceTrust: { status: "trusted", diagnostic: null },
+  },
   targets: { items: [], defaultTargetId: null, diagnostic: null },
   sessions: {
     items: [

--- a/packages/testkit/src/context-compaction-process.test.ts
+++ b/packages/testkit/src/context-compaction-process.test.ts
@@ -11,6 +11,7 @@ import {
   type ModelTargetIdentity,
 } from "@adam-agent/agent";
 import {
+  createTrustedWorkspaceTrustForTesting,
   openJsonlSessionStore,
   type SessionContextCompactionCommittedRecord,
   type SessionContextCompactionInterruptedRecord,
@@ -548,6 +549,7 @@ async function createProcessHarness(prefix: string): Promise<{
   const created = await createSessionLifecycle({
     stateRoot,
     workspaceRoot,
+    workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
     tools: createReadToolRegistry({ workspaceRoot }),
   }).create({ targetIdentity });
   return {
@@ -584,6 +586,7 @@ async function createSkillProcessHarness(): Promise<{
   const created = await createSessionLifecycle({
     stateRoot,
     workspaceRoot,
+    workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
     tools: createCodingToolRegistry({ stateRoot, workspaceRoot }),
   }).create({ targetIdentity });
   return {

--- a/packages/testkit/src/context-compaction.fixture.ts
+++ b/packages/testkit/src/context-compaction.fixture.ts
@@ -9,7 +9,10 @@ import {
   type ModelTargetIdentity,
   type ModelTargets,
 } from "@adam-agent/agent";
-import { sessionAutomaticTitlesEnabled } from "@adam-agent/agent/internal-testing";
+import {
+  createTrustedWorkspaceTrustForTesting,
+  sessionAutomaticTitlesEnabled,
+} from "@adam-agent/agent/internal-testing";
 
 const workspaceRoot = requiredEnvironment("ADAM_AGENT_FIXTURE_WORKSPACE_ROOT");
 const stateRoot = requiredEnvironment("ADAM_AGENT_FIXTURE_STATE_ROOT");
@@ -217,6 +220,7 @@ const lifecycle = createSessionLifecycle({
   modelTargets,
   stateRoot,
   workspaceRoot,
+  workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
   tools: mode.startsWith("skill-")
     ? createCodingToolRegistry({ stateRoot, workspaceRoot })
     : createReadToolRegistry({ workspaceRoot }),

--- a/packages/testkit/src/index.ts
+++ b/packages/testkit/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from "@adam-agent/agent";
 import {
   createInMemorySessionStoreDirectory,
+  createTrustedWorkspaceTrustForTesting,
   type McpClientTransport,
   type McpTransportFactory,
   type ProjectLifecycleOwner,
@@ -63,6 +64,7 @@ export type ScriptedMcpServer = {
 };
 
 export type ScriptedMcpTransportFactory = McpTransportFactory & {
+  activeCount(serverId: string): number;
   disconnect(serverId: string): void;
   nextClose(serverId: string): Promise<void>;
   notifyToolsChanged(serverId: string): void;
@@ -205,6 +207,9 @@ export function createScriptedMcpTransportFactory(
       };
       return transport;
     },
+    activeCount(serverId) {
+      return active.get(serverId)?.size ?? 0;
+    },
     disconnect(serverId) {
       for (const transport of [...(active.get(serverId) ?? [])]) {
         transport.disconnect();
@@ -309,7 +314,12 @@ function scriptedMcpCall(params: unknown): {
 export function createSessionLifecycleForTesting(
   options: SessionLifecycleOptions,
 ): SessionLifecycle {
-  return createSessionLifecycle({ ...options, [sessionAutomaticTitlesEnabled]: false });
+  return createSessionLifecycle({
+    ...options,
+    workspaceTrust:
+      options.workspaceTrust ?? createTrustedWorkspaceTrustForTesting(options.workspaceRoot),
+    [sessionAutomaticTitlesEnabled]: false,
+  });
 }
 
 export function createInMemorySessionLifecycleHarness(): {
@@ -330,6 +340,8 @@ export function createInMemorySessionLifecycleHarness(): {
       }
       return createSessionLifecycle({
         ...options,
+        workspaceTrust:
+          options.workspaceTrust ?? createTrustedWorkspaceTrustForTesting(options.workspaceRoot),
         [sessionAutomaticTitlesEnabled]: false,
         [sessionProjectLifecycleOwner]: owner,
         [sessionStoreDirectory]: directory,

--- a/packages/testkit/src/presentation-session.os.test.ts
+++ b/packages/testkit/src/presentation-session.os.test.ts
@@ -5,11 +5,12 @@ import { join } from "node:path";
 import {
   type ContextProfile,
   createPresentationSession,
-  createSessionLifecycle,
+  createSessionLifecycle as createRawSessionLifecycle,
   type ModelTargetIdentity,
   type ModelTargets,
 } from "@adam-agent/agent";
 import {
+  createTrustedWorkspaceTrustForTesting,
   openJsonlSessionStore,
   type SessionRecord,
   sessionLogicalRunStartedBarrier,
@@ -35,6 +36,16 @@ const contextProfile: ContextProfile = {
   retainedTargetTokens: 20_000,
   estimatorVersion: 1,
 };
+
+function createSessionLifecycle(
+  options: Parameters<typeof createRawSessionLifecycle>[0],
+): ReturnType<typeof createRawSessionLifecycle> {
+  return createRawSessionLifecycle({
+    ...options,
+    workspaceTrust:
+      options.workspaceTrust ?? createTrustedWorkspaceTrustForTesting(options.workspaceRoot),
+  });
+}
 
 test("PresentationSession publishes admission only after the durable logical-input record", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-draft-durable-input-"));

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -24,8 +24,8 @@ import {
   createPermissionPolicy,
   createPresentationPreferences,
   createPresentationSession as createProductPresentationSession,
+  createSessionLifecycle as createRawSessionLifecycle,
   createReadToolRegistry,
-  createSessionLifecycle,
   type ModelDriver,
   ModelDriverError,
   type ModelTargetIdentity,
@@ -38,6 +38,7 @@ import {
 import {
   assemblePromptMessagesV1,
   createInMemorySessionStoreDirectory,
+  createTrustedWorkspaceTrustForTesting,
   digestPromptRequestV1,
   mcpCatalogStaleDurableBarrier,
   mcpTransportFactory,
@@ -84,6 +85,16 @@ const contextProfile: ContextProfile = {
   retainedTargetTokens: 20_000,
   estimatorVersion: 1,
 };
+
+function createSessionLifecycle(
+  options: Parameters<typeof createRawSessionLifecycle>[0],
+): ReturnType<typeof createRawSessionLifecycle> {
+  return createRawSessionLifecycle({
+    ...options,
+    workspaceTrust:
+      options.workspaceTrust ?? createTrustedWorkspaceTrustForTesting(options.workspaceRoot),
+  });
+}
 
 async function createPresentationSession(
   options: Parameters<typeof createProductPresentationSession>[0],
@@ -786,7 +797,11 @@ test("PresentationSession opens an empty project catalog without creating a sess
           sessionThroughSequence: 0,
           operationThrough: [],
         },
-        project: { id: state.authoritative.project.id, label: "workspace" },
+        project: {
+          id: state.authoritative.project.id,
+          label: "workspace",
+          workspaceTrust: { status: "trusted", diagnostic: null },
+        },
         targets: { items: [], defaultTargetId: null, diagnostic: null },
         sessions: { items: [], nextCursor: null },
         active: null,
@@ -2300,7 +2315,11 @@ test("PresentationSession opens an exact target as a process-local draft", async
           sessionThroughSequence: 0,
           operationThrough: [],
         },
-        project: { id: state.authoritative.project.id, label: "workspace" },
+        project: {
+          id: state.authoritative.project.id,
+          label: "workspace",
+          workspaceTrust: { status: "trusted", diagnostic: null },
+        },
         targets: {
           items: [expect.objectContaining({ targetId: targetIdentity.targetId })],
           defaultTargetId: null,

--- a/packages/testkit/src/session-lifecycle-test-topology.test.ts
+++ b/packages/testkit/src/session-lifecycle-test-topology.test.ts
@@ -67,7 +67,7 @@ test("SessionLifecycle behavior and OS contracts keep separate environment owner
     .toEqual(["createSessionLifecycle"]);
   expect
     .soft(runtimeImportedBindings(supportSource, "@adam-agent/agent/internal-testing"))
-    .toEqual(["sessionAutomaticTitlesEnabled"]);
+    .toEqual(["createTrustedWorkspaceTrustForTesting", "sessionAutomaticTitlesEnabled"]);
   expect
     .soft(topLevelValueDeclarations(supportSource))
     .toEqual([

--- a/packages/testkit/src/session-lifecycle.test-support.ts
+++ b/packages/testkit/src/session-lifecycle.test-support.ts
@@ -2,7 +2,10 @@ import {
   createSessionLifecycle as createRawSessionLifecycle,
   type ModelTargetIdentity,
 } from "@adam-agent/agent";
-import { sessionAutomaticTitlesEnabled } from "@adam-agent/agent/internal-testing";
+import {
+  createTrustedWorkspaceTrustForTesting,
+  sessionAutomaticTitlesEnabled,
+} from "@adam-agent/agent/internal-testing";
 
 export const sessionLifecycleTargetIdentity: ModelTargetIdentity = {
   targetId: "deepseek-v4-flash.direct",
@@ -30,5 +33,10 @@ data: [DONE]
 export function createSessionLifecycleForTests(
   options: Parameters<typeof createRawSessionLifecycle>[0],
 ): ReturnType<typeof createRawSessionLifecycle> {
-  return createRawSessionLifecycle({ ...options, [sessionAutomaticTitlesEnabled]: false });
+  return createRawSessionLifecycle({
+    ...options,
+    workspaceTrust:
+      options.workspaceTrust ?? createTrustedWorkspaceTrustForTesting(options.workspaceRoot),
+    [sessionAutomaticTitlesEnabled]: false,
+  });
 }

--- a/packages/testkit/src/trusted-mcp-host-test-topology.test.ts
+++ b/packages/testkit/src/trusted-mcp-host-test-topology.test.ts
@@ -108,7 +108,7 @@ test("MCP deterministic and operating-system contracts keep separate harness own
 
   const behaviorNames = declaredTestNames(behaviorSource);
   const operatingSystemNames = declaredTestNames(operatingSystemSource);
-  expect.soft(behaviorNames).toHaveLength(76);
+  expect.soft(behaviorNames).toHaveLength(79);
   expect.soft(operatingSystemNames).toHaveLength(19);
   expect.soft(operatingSystemNames).toEqual([...operatingSystemTestNames].sort());
   expect.soft(operatingSystemTestNames.filter((name) => behaviorNames.includes(name))).toEqual([]);

--- a/packages/testkit/src/trusted-mcp-host.test.ts
+++ b/packages/testkit/src/trusted-mcp-host.test.ts
@@ -21,6 +21,7 @@ import {
   type ModelRequest,
   type ModelTargets,
   type RuntimeEvent,
+  type WorkspaceTrustController,
 } from "@adam-agent/agent";
 import {
   createInMemorySessionStoreDirectory,
@@ -33,8 +34,11 @@ import {
   mcpIdleScheduler,
   mcpRequestScheduler,
   mcpTransportFactory,
+  type ProjectLifecycleOwner,
   type SessionRecord,
+  sessionProjectLifecycleOwner,
   sessionStoreDirectory,
+  workspaceMcpLeaseTransitionBarrier,
 } from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
 
@@ -88,6 +92,67 @@ function createScriptedMcpLifecycle(
     lifecycle: harness.createLifecycle({ ...options, [mcpTransportFactory]: peer }),
     peer,
   };
+}
+
+function createQueuedProjectLifecycleOwner(
+  onAcquire: () => void = () => {},
+): ProjectLifecycleOwner {
+  let tail = Promise.resolve();
+  const acquire: ProjectLifecycleOwner["acquire"] = async () => {
+    onAcquire();
+    const predecessor = tail;
+    const available = Promise.withResolvers<void>();
+    tail = predecessor.then(() => available.promise);
+    await predecessor;
+    let released = false;
+    return {
+      async release() {
+        if (!released) {
+          released = true;
+          available.resolve();
+        }
+      },
+    };
+  };
+  return {
+    acquire,
+    async run(operation) {
+      const lease = await acquire();
+      try {
+        return await operation();
+      } finally {
+        await lease.release();
+      }
+    },
+  };
+}
+
+async function prepareScriptedMcpSession(
+  lifecycle: ReturnType<typeof createSessionLifecycle>,
+): Promise<{
+  readonly sessionId: string;
+  readonly server: { readonly serverId: string; readonly definitionDigest: `sha256:${string}` };
+}> {
+  const created = await lifecycle.create({ targetIdentity });
+  if (created.mcp === undefined) {
+    throw new Error("The fixture requires an MCP configuration snapshot.");
+  }
+  const confirmed = await lifecycle.configureMcp({
+    type: "confirm_workspace",
+    sessionId: created.sessionId,
+    sourceDigest: created.mcp.source.digest,
+  });
+  const preview = confirmed.snapshot.mcp?.servers[0];
+  if (preview === undefined) {
+    throw new Error("The fixture requires one MCP server preview.");
+  }
+  await lifecycle.configureMcp({
+    type: "approve_server",
+    sessionId: created.sessionId,
+    serverId: preview.serverId,
+    definitionDigest: preview.definitionDigest,
+  });
+  return { sessionId: created.sessionId, server: preview };
 }
 
 function scriptedStringTool(
@@ -1460,10 +1525,34 @@ test("SessionLifecycle surfaces unconfirmed activation shutdown without offering
   await mkdir(workspaceRoot);
   await writeScriptedMcpConfiguration(testRoot, workspaceRoot);
   let confirmationAttempts = 0;
+  let leaseReleaseCount = 0;
+  const canonicalRoot = await realpath(workspaceRoot);
+  const trustedSnapshot = {
+    projectId: `sha256:${createHash("sha256").update(canonicalRoot).digest("hex")}` as const,
+    projectLabel: basename(canonicalRoot),
+    status: "trusted" as const,
+    diagnostic: null,
+  };
+  const workspaceTrust: WorkspaceTrustController = {
+    async acquireMcpLease() {
+      return {
+        async release() {
+          leaseReleaseCount += 1;
+        },
+      };
+    },
+    async load() {
+      return trustedSnapshot;
+    },
+    async setTrusted() {
+      return trustedSnapshot;
+    },
+  };
   const { lifecycle, peer } = createScriptedMcpLifecycle(
     {
       stateRoot,
       workspaceRoot,
+      workspaceTrust,
       [mcpCloseConfirmation]: {
         async confirm() {
           confirmationAttempts += 1;
@@ -1536,9 +1625,370 @@ test("SessionLifecycle surfaces unconfirmed activation shutdown without offering
     ).rejects.toMatchObject({ code: "session_invalid" });
     await expect(lifecycle.close()).resolves.toEqual({ status: "mcp_shutdown_unconfirmed" });
     expect(confirmationAttempts).toBe(1);
+    expect(leaseReleaseCount).toBe(0);
   } finally {
     await lifecycle.close();
     await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle waits for a releasing MCP lease before concurrent activation", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-mcp-lease-transition-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeScriptedMcpConfiguration(testRoot, workspaceRoot);
+  const canonicalRoot = await realpath(workspaceRoot);
+  const trustedSnapshot = {
+    projectId: `sha256:${createHash("sha256").update(canonicalRoot).digest("hex")}` as const,
+    projectLabel: basename(canonicalRoot),
+    status: "trusted" as const,
+    diagnostic: null,
+  };
+  const firstReleaseStarted = Promise.withResolvers<void>();
+  const allowFirstRelease = Promise.withResolvers<void>();
+  const secondActivationWaiting = Promise.withResolvers<void>();
+  let leaseAcquisitionCount = 0;
+  const workspaceTrust: WorkspaceTrustController = {
+    async acquireMcpLease() {
+      leaseAcquisitionCount += 1;
+      const acquisition = leaseAcquisitionCount;
+      return {
+        async release() {
+          if (acquisition === 1) {
+            firstReleaseStarted.resolve();
+            await allowFirstRelease.promise;
+          }
+        },
+      };
+    },
+    async load() {
+      return trustedSnapshot;
+    },
+    async setTrusted() {
+      return trustedSnapshot;
+    },
+  };
+  const peer = createScriptedMcpTransportFactory({ fixture: ordinaryScriptedMcpServer() });
+  const lifecycle = createSessionLifecycle({
+    stateRoot,
+    workspaceRoot,
+    workspaceTrust,
+    [mcpTransportFactory]: peer,
+    [sessionProjectLifecycleOwner]: createQueuedProjectLifecycleOwner(),
+    [workspaceMcpLeaseTransitionBarrier]: {
+      waitingForRelease() {
+        secondActivationWaiting.resolve();
+      },
+    },
+  });
+  let cancellingFirst: Promise<unknown> | undefined;
+  let activatingSecond: Promise<unknown> | undefined;
+  try {
+    const first = await prepareScriptedMcpSession(lifecycle);
+    const second = await prepareScriptedMcpSession(lifecycle);
+    const activatedFirst = await lifecycle.configureMcp({
+      type: "activate_servers",
+      sessionId: first.sessionId,
+      servers: [
+        { serverId: first.server.serverId, definitionDigest: first.server.definitionDigest },
+      ],
+    });
+    const firstMcp = activatedFirst.snapshot.mcp;
+    const firstGeneration =
+      firstMcp?.workspaceConfirmed === true ? firstMcp.activation?.generationId : undefined;
+    if (firstGeneration === undefined) {
+      throw new Error("The fixture requires one active MCP generation.");
+    }
+
+    cancellingFirst = lifecycle.configureMcp({
+      type: "cancel_configuration",
+      sessionId: first.sessionId,
+      generationId: firstGeneration,
+    });
+    await withFailureGuard(
+      firstReleaseStarted.promise,
+      5_000,
+      "The first MCP lease release did not start.",
+    );
+    activatingSecond = lifecycle.configureMcp({
+      type: "activate_servers",
+      sessionId: second.sessionId,
+      servers: [
+        { serverId: second.server.serverId, definitionDigest: second.server.definitionDigest },
+      ],
+    });
+
+    await expect(
+      withFailureGuard(
+        Promise.race([
+          secondActivationWaiting.promise.then(() => "waiting" as const),
+          activatingSecond.then(() => "activated" as const),
+        ]),
+        5_000,
+        "The concurrent MCP activation neither waited for release nor activated.",
+      ),
+    ).resolves.toBe("waiting");
+    expect(leaseAcquisitionCount).toBe(1);
+    allowFirstRelease.resolve();
+    await withFailureGuard(
+      Promise.all([cancellingFirst, activatingSecond]),
+      5_000,
+      "The concurrent MCP release and activation did not settle after release resumed.",
+    );
+    expect(leaseAcquisitionCount).toBe(2);
+  } finally {
+    allowFirstRelease.resolve();
+    try {
+      await withFailureGuard(
+        Promise.allSettled([cancellingFirst, activatingSecond].filter(Boolean)),
+        5_000,
+        "The concurrent MCP lease operations did not settle during cleanup.",
+      );
+    } finally {
+      try {
+        await withFailureGuard(
+          lifecycle.close(),
+          5_000,
+          "SessionLifecycle did not close after the concurrent MCP lease transition.",
+        );
+      } finally {
+        await rm(testRoot, { recursive: true, force: true });
+      }
+    }
+  }
+});
+
+test("SessionLifecycle retains its MCP lease while an activation claim precedes generation start", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-mcp-lease-activation-claim-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeScriptedMcpConfiguration(testRoot, workspaceRoot);
+  const canonicalRoot = await realpath(workspaceRoot);
+  const trustedSnapshot = {
+    projectId: `sha256:${createHash("sha256").update(canonicalRoot).digest("hex")}` as const,
+    projectLabel: basename(canonicalRoot),
+    status: "trusted" as const,
+    diagnostic: null,
+  };
+  const secondActivationLeaseReady = Promise.withResolvers<void>();
+  const allowSecondActivation = Promise.withResolvers<void>();
+  const cancellationReachedOwner = Promise.withResolvers<void>();
+  let holdNextActivation = false;
+  let observeNextOwnerAcquire = false;
+  let leaseAcquisitionCount = 0;
+  let leaseReleaseCount = 0;
+  const workspaceTrust: WorkspaceTrustController = {
+    async acquireMcpLease() {
+      leaseAcquisitionCount += 1;
+      return {
+        async release() {
+          leaseReleaseCount += 1;
+        },
+      };
+    },
+    async load() {
+      return trustedSnapshot;
+    },
+    async setTrusted() {
+      return trustedSnapshot;
+    },
+  };
+  const peer = createScriptedMcpTransportFactory({ fixture: ordinaryScriptedMcpServer() });
+  const lifecycle = createSessionLifecycle({
+    stateRoot,
+    workspaceRoot,
+    workspaceTrust,
+    [mcpTransportFactory]: peer,
+    [sessionProjectLifecycleOwner]: createQueuedProjectLifecycleOwner(() => {
+      if (observeNextOwnerAcquire) {
+        observeNextOwnerAcquire = false;
+        cancellationReachedOwner.resolve();
+      }
+    }),
+    [workspaceMcpLeaseTransitionBarrier]: {
+      async activationLeaseReady() {
+        if (holdNextActivation) {
+          holdNextActivation = false;
+          secondActivationLeaseReady.resolve();
+          await allowSecondActivation.promise;
+        }
+      },
+      waitingForRelease() {},
+    },
+  });
+  let activatingSecond: Promise<unknown> | undefined;
+  let cancellingFirst: Promise<unknown> | undefined;
+  try {
+    const first = await prepareScriptedMcpSession(lifecycle);
+    const second = await prepareScriptedMcpSession(lifecycle);
+    const activatedFirst = await lifecycle.configureMcp({
+      type: "activate_servers",
+      sessionId: first.sessionId,
+      servers: [
+        { serverId: first.server.serverId, definitionDigest: first.server.definitionDigest },
+      ],
+    });
+    const firstMcp = activatedFirst.snapshot.mcp;
+    const firstGeneration =
+      firstMcp?.workspaceConfirmed === true ? firstMcp.activation?.generationId : undefined;
+    if (firstGeneration === undefined) {
+      throw new Error("The fixture requires one active MCP generation.");
+    }
+
+    holdNextActivation = true;
+    activatingSecond = lifecycle.configureMcp({
+      type: "activate_servers",
+      sessionId: second.sessionId,
+      servers: [
+        { serverId: second.server.serverId, definitionDigest: second.server.definitionDigest },
+      ],
+    });
+    await withFailureGuard(
+      secondActivationLeaseReady.promise,
+      5_000,
+      "The second MCP activation did not acquire its pre-generation lease claim.",
+    );
+    const firstTransportClosed = peer.nextClose("fixture");
+    observeNextOwnerAcquire = true;
+    cancellingFirst = lifecycle.configureMcp({
+      type: "cancel_configuration",
+      sessionId: first.sessionId,
+      generationId: firstGeneration,
+    });
+    await withFailureGuard(
+      firstTransportClosed,
+      5_000,
+      "The first MCP generation did not close while the second activation held its claim.",
+    );
+    await withFailureGuard(
+      cancellationReachedOwner.promise,
+      5_000,
+      "MCP cancellation did not finish its lease-release decision.",
+    );
+    expect(leaseAcquisitionCount).toBe(1);
+    expect(leaseReleaseCount).toBe(0);
+
+    allowSecondActivation.resolve();
+    await withFailureGuard(
+      Promise.all([activatingSecond, cancellingFirst]),
+      5_000,
+      "The activation-claim MCP operations did not settle after activation resumed.",
+    );
+    expect(peer.activeCount("fixture")).toBe(1);
+    expect(leaseAcquisitionCount).toBe(1);
+    expect(leaseReleaseCount).toBe(0);
+  } finally {
+    allowSecondActivation.resolve();
+    try {
+      await withFailureGuard(
+        Promise.allSettled([activatingSecond, cancellingFirst].filter(Boolean)),
+        5_000,
+        "The activation-claim MCP operations did not settle during cleanup.",
+      );
+    } finally {
+      try {
+        await withFailureGuard(
+          lifecycle.close(),
+          5_000,
+          "SessionLifecycle did not close after the MCP activation-claim race.",
+        );
+      } finally {
+        await rm(testRoot, { recursive: true, force: true });
+      }
+    }
+  }
+});
+
+test("SessionLifecycle fences later MCP activation when lease release fails", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-mcp-lease-release-failure-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeScriptedMcpConfiguration(testRoot, workspaceRoot);
+  const canonicalRoot = await realpath(workspaceRoot);
+  const trustedSnapshot = {
+    projectId: `sha256:${createHash("sha256").update(canonicalRoot).digest("hex")}` as const,
+    projectLabel: basename(canonicalRoot),
+    status: "trusted" as const,
+    diagnostic: null,
+  };
+  let leaseAcquisitionCount = 0;
+  let leaseReleaseCount = 0;
+  const workspaceTrust: WorkspaceTrustController = {
+    async acquireMcpLease() {
+      leaseAcquisitionCount += 1;
+      return {
+        async release() {
+          leaseReleaseCount += 1;
+          throw new Error("Injected MCP lease release failure.");
+        },
+      };
+    },
+    async load() {
+      return trustedSnapshot;
+    },
+    async setTrusted() {
+      return trustedSnapshot;
+    },
+  };
+  const peer = createScriptedMcpTransportFactory({ fixture: ordinaryScriptedMcpServer() });
+  const lifecycle = createSessionLifecycle({
+    stateRoot,
+    workspaceRoot,
+    workspaceTrust,
+    [mcpTransportFactory]: peer,
+    [sessionProjectLifecycleOwner]: createQueuedProjectLifecycleOwner(),
+  });
+  try {
+    const first = await prepareScriptedMcpSession(lifecycle);
+    const second = await prepareScriptedMcpSession(lifecycle);
+    const activatedFirst = await lifecycle.configureMcp({
+      type: "activate_servers",
+      sessionId: first.sessionId,
+      servers: [
+        { serverId: first.server.serverId, definitionDigest: first.server.definitionDigest },
+      ],
+    });
+    const firstMcp = activatedFirst.snapshot.mcp;
+    const firstGeneration =
+      firstMcp?.workspaceConfirmed === true ? firstMcp.activation?.generationId : undefined;
+    if (firstGeneration === undefined) {
+      throw new Error("The fixture requires one active MCP generation.");
+    }
+
+    await expect(
+      lifecycle.configureMcp({
+        type: "cancel_configuration",
+        sessionId: first.sessionId,
+        generationId: firstGeneration,
+      }),
+    ).rejects.toBeDefined();
+    const requestCountAfterReleaseFailure = peer.requests("fixture").length;
+    await expect(
+      lifecycle.configureMcp({
+        type: "activate_servers",
+        sessionId: second.sessionId,
+        servers: [
+          { serverId: second.server.serverId, definitionDigest: second.server.definitionDigest },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "mcp_start_failed" });
+    expect(peer.requests("fixture")).toHaveLength(requestCountAfterReleaseFailure);
+    expect(peer.activeCount("fixture")).toBe(0);
+    expect(leaseAcquisitionCount).toBe(1);
+    expect(leaseReleaseCount).toBe(1);
+  } finally {
+    try {
+      await withFailureGuard(
+        lifecycle.close(),
+        5_000,
+        "SessionLifecycle did not settle after the injected MCP lease release failure.",
+      ).catch(() => undefined);
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
   }
 });
 

--- a/packages/testkit/src/user-configuration.os.test.ts
+++ b/packages/testkit/src/user-configuration.os.test.ts
@@ -13,7 +13,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { createPresentationPreferences } from "@adam-agent/agent";
+import { createPresentationPreferences, createWorkspaceTrust } from "@adam-agent/agent";
 import { expect, test } from "vitest";
 
 const emptyPolicy = {
@@ -238,6 +238,270 @@ test("user configuration rejects a document larger than the 8 KiB bound", async 
   }
 });
 
+test("workspace trust survives Adapter restart with owner-only durable modes", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-durability-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const configurationRoot = join(testRoot, "config");
+  const configurationDirectory = join(configurationRoot, "adam-agent");
+  const trustPath = join(configurationDirectory, "workspace-trust.json");
+  const environment = { XDG_CONFIG_HOME: configurationRoot };
+  await mkdir(workspaceRoot);
+
+  try {
+    const trust = createWorkspaceTrust({ environment, workspaceRoot });
+    const initial = await trust.load();
+    if (initial.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    await trust.setTrusted({ projectId: initial.projectId, trusted: true });
+
+    const restarted = createWorkspaceTrust({ environment, workspaceRoot });
+    await expect(restarted.load()).resolves.toMatchObject({
+      projectId: initial.projectId,
+      status: "trusted",
+      diagnostic: null,
+    });
+    expect({
+      directoryMode: (await stat(configurationDirectory)).mode & 0o777,
+      fileMode: (await stat(trustPath)).mode & 0o777,
+      bytes: await readFile(trustPath, "utf8"),
+    }).toEqual({
+      directoryMode: 0o700,
+      fileMode: 0o600,
+      bytes: `${JSON.stringify({ schemaVersion: 1, trustedProjectIds: [initial.projectId] })}\n`,
+    });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("workspace trust survives an actual process restart", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-process-restart-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const configurationRoot = join(testRoot, "config");
+  const resultPath = join(testRoot, "restart-result.json");
+  await mkdir(workspaceRoot);
+
+  try {
+    await expect(
+      runWorkspaceTrustProcess("write", configurationRoot, workspaceRoot),
+    ).resolves.toMatchObject({
+      code: 0,
+      signal: null,
+      stderr: "",
+    });
+    await expect(
+      runWorkspaceTrustProcess("read", configurationRoot, workspaceRoot, resultPath),
+    ).resolves.toEqual({ code: 0, signal: null, stderr: "", stdout: "" });
+    expect(JSON.parse(await readFile(resultPath, "utf8"))).toMatchObject({
+      projectLabel: "workspace",
+      status: "trusted",
+      diagnostic: null,
+    });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("concurrent project processes preserve both additions to the global trust document", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-concurrent-"));
+  const configurationRoot = join(testRoot, "config");
+  const firstWorkspace = join(testRoot, "first");
+  const secondWorkspace = join(testRoot, "second");
+  await mkdir(firstWorkspace);
+  await mkdir(secondWorkspace);
+  const environment = { XDG_CONFIG_HOME: configurationRoot };
+  let first: ReturnType<typeof startConcurrentWorkspaceTrustGrant> | undefined;
+  let second: ReturnType<typeof startConcurrentWorkspaceTrustGrant> | undefined;
+
+  try {
+    const firstIdentity = await createWorkspaceTrust({
+      environment,
+      workspaceRoot: firstWorkspace,
+    }).load();
+    const secondIdentity = await createWorkspaceTrust({
+      environment,
+      workspaceRoot: secondWorkspace,
+    }).load();
+    if (firstIdentity.projectId === null || secondIdentity.projectId === null) {
+      throw new Error("The fixture requires two canonical project identities.");
+    }
+    first = startConcurrentWorkspaceTrustGrant(configurationRoot, firstWorkspace);
+    second = startConcurrentWorkspaceTrustGrant(configurationRoot, secondWorkspace);
+    await Promise.all([first.ready, second.ready]);
+
+    const results = await Promise.all([first.run(), second.run()]);
+
+    expect(results).toEqual([
+      { code: 0, signal: null, stderr: "", stdout: "" },
+      { code: 0, signal: null, stderr: "", stdout: "" },
+    ]);
+    expect(
+      JSON.parse(
+        await readFile(join(configurationRoot, "adam-agent", "workspace-trust.json"), "utf8"),
+      ),
+    ).toEqual({
+      schemaVersion: 1,
+      trustedProjectIds: [firstIdentity.projectId, secondIdentity.projectId].sort(),
+    });
+  } finally {
+    await Promise.allSettled([first?.close(), second?.close()]);
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test.each([
+  { name: "group-readable file", directoryMode: 0o700, fileMode: 0o640 },
+  { name: "searchable directory", directoryMode: 0o710, fileMode: 0o600 },
+])("workspace trust rejects an unsafe $name", async ({ directoryMode, fileMode }) => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-mode-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const configurationRoot = join(testRoot, "config");
+  const configurationDirectory = join(configurationRoot, "adam-agent");
+  await mkdir(workspaceRoot);
+  await mkdir(configurationDirectory, { recursive: true, mode: 0o700 });
+  await writeFile(
+    join(configurationDirectory, "workspace-trust.json"),
+    `${JSON.stringify({ schemaVersion: 1, trustedProjectIds: [] })}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+  await chmod(configurationDirectory, directoryMode);
+  await chmod(join(configurationDirectory, "workspace-trust.json"), fileMode);
+
+  try {
+    await expect(
+      createWorkspaceTrust({
+        environment: { XDG_CONFIG_HOME: configurationRoot },
+        workspaceRoot,
+      }).load(),
+    ).resolves.toMatchObject({
+      status: "untrusted",
+      diagnostic: { code: "workspace_trust_unsafe" },
+    });
+  } finally {
+    await chmod(configurationDirectory, 0o700).catch(() => undefined);
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("workspace trust rejects a symlinked document without reading its target", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-symlink-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const configurationRoot = join(testRoot, "config");
+  const configurationDirectory = join(configurationRoot, "adam-agent");
+  const outsidePath = join(testRoot, "outside.json");
+  await mkdir(workspaceRoot);
+  await mkdir(configurationDirectory, { recursive: true, mode: 0o700 });
+  await writeFile(outsidePath, `${JSON.stringify({ schemaVersion: 1, trustedProjectIds: [] })}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  await symlink(outsidePath, join(configurationDirectory, "workspace-trust.json"));
+
+  try {
+    const trust = createWorkspaceTrust({
+      environment: { XDG_CONFIG_HOME: configurationRoot },
+      workspaceRoot,
+    });
+    await expect(trust.load()).resolves.toMatchObject({
+      status: "untrusted",
+      diagnostic: { code: "workspace_trust_unsafe" },
+    });
+    const identity = await trust.load();
+    if (identity.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    await expect(
+      trust.setTrusted({ projectId: identity.projectId, trusted: true }),
+    ).rejects.toThrow();
+    expect(
+      (await lstat(join(configurationDirectory, "workspace-trust.json"))).isSymbolicLink(),
+    ).toBe(true);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test.each(["fifo", "directory"])(
+  "workspace trust rejects a non-ordinary %s without blocking",
+  async (name) => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-nonordinary-"));
+    const workspaceRoot = join(testRoot, "workspace");
+    const configurationRoot = join(testRoot, "config");
+    const configurationDirectory = join(configurationRoot, "adam-agent");
+    const trustPath = join(configurationDirectory, "workspace-trust.json");
+    await mkdir(workspaceRoot);
+    await mkdir(configurationDirectory, { recursive: true, mode: 0o700 });
+    if (name === "fifo") {
+      execFileSync("mkfifo", [trustPath]);
+    } else {
+      await mkdir(trustPath, { mode: 0o700 });
+    }
+
+    try {
+      await expect(
+        createWorkspaceTrust({
+          environment: { XDG_CONFIG_HOME: configurationRoot },
+          workspaceRoot,
+        }).load(),
+      ).resolves.toMatchObject({
+        status: "untrusted",
+        diagnostic: { code: "workspace_trust_unsafe" },
+      });
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test("a failed workspace trust replacement preserves every owner-local document", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-write-failure-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const configurationRoot = join(testRoot, "config");
+  const configurationDirectory = join(configurationRoot, "adam-agent");
+  const trustPath = join(configurationDirectory, "workspace-trust.json");
+  const configPath = join(configurationDirectory, "config.json");
+  const extensionsPath = join(configurationDirectory, "extensions.json");
+  const config = `${JSON.stringify({ schemaVersion: 1, defaultTargetId: "fake.local" })}\n`;
+  const extensions = '{"schemaVersion":1,"extensions":[]}\n';
+  await mkdir(workspaceRoot);
+  const trust = createWorkspaceTrust({
+    environment: { XDG_CONFIG_HOME: configurationRoot },
+    workspaceRoot,
+  });
+
+  try {
+    const initial = await trust.load();
+    if (initial.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    await trust.setTrusted({ projectId: initial.projectId, trusted: true });
+    const originalTrust = await readFile(trustPath, "utf8");
+    await writeFile(configPath, config, { encoding: "utf8", mode: 0o600 });
+    await writeFile(extensionsPath, extensions, { encoding: "utf8", mode: 0o600 });
+    await chmod(configurationDirectory, 0o500);
+    await expect(
+      trust.setTrusted({ projectId: initial.projectId, trusted: false }),
+    ).rejects.toThrow();
+    await chmod(configurationDirectory, 0o700);
+
+    expect({
+      trust: await readFile(trustPath, "utf8"),
+      config: await readFile(configPath, "utf8"),
+      extensions: await readFile(extensionsPath, "utf8"),
+      snapshot: await trust.load(),
+    }).toEqual({
+      trust: originalTrust,
+      config,
+      extensions,
+      snapshot: expect.objectContaining({ status: "trusted", diagnostic: null }),
+    });
+  } finally {
+    await chmod(configurationDirectory, 0o700).catch(() => undefined);
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 function runPreferenceProcess(
   operation: "read" | "write",
   configurationRoot: string,
@@ -266,6 +530,63 @@ function runPreferenceProcess(
     },
     stdio: ["ignore", "pipe", "pipe"],
   });
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  let processError: Error | undefined;
+  return new Promise((resolve, reject) => {
+    child.once("error", (error) => {
+      processError = error;
+    });
+    child.once("close", (code, signal) => {
+      if (processError === undefined) {
+        resolve({ code, signal, stderr, stdout });
+      } else {
+        reject(processError);
+      }
+    });
+  });
+}
+
+function runWorkspaceTrustProcess(
+  operation: "read" | "write",
+  configurationRoot: string,
+  workspaceRoot: string,
+  resultPath?: string,
+): Promise<{
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly stderr: string;
+  readonly stdout: string;
+}> {
+  const script = `
+    import { writeFile } from "node:fs/promises";
+    import { createWorkspaceTrust } from ${JSON.stringify(agentEntryUrl)};
+    const trust = createWorkspaceTrust({ environment: process.env, workspaceRoot: process.env.ADAM_AGENT_WORKSPACE_ROOT });
+    const snapshot = await trust.load();
+    if (${JSON.stringify(operation)} === "write") {
+      if (snapshot.projectId === null) throw new Error("missing project identity");
+      await trust.setTrusted({ projectId: snapshot.projectId, trusted: true });
+    } else {
+      await writeFile(process.env.ADAM_AGENT_CONFIGURATION_RESULT, JSON.stringify(snapshot), "utf8");
+    }
+  `;
+  const child = spawn(process.execPath, ["--input-type=module", "--eval", script], {
+    env: {
+      ...process.env,
+      ...(resultPath === undefined ? {} : { ADAM_AGENT_CONFIGURATION_RESULT: resultPath }),
+      ADAM_AGENT_WORKSPACE_ROOT: workspaceRoot,
+      XDG_CONFIG_HOME: configurationRoot,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
   child.stdout.setEncoding("utf8");
   child.stderr.setEncoding("utf8");
   let stdout = "";
@@ -276,8 +597,140 @@ function runPreferenceProcess(
   child.stderr.on("data", (chunk: string) => {
     stderr += chunk;
   });
+  let processError: Error | undefined;
   return new Promise((resolve, reject) => {
-    child.once("error", reject);
-    child.once("close", (code, signal) => resolve({ code, signal, stderr, stdout }));
+    child.once("error", (error) => {
+      processError = error;
+    });
+    child.once("close", (code, signal) => {
+      if (processError === undefined) {
+        resolve({ code, signal, stderr, stdout });
+      } else {
+        reject(processError);
+      }
+    });
   });
+}
+
+function startConcurrentWorkspaceTrustGrant(
+  configurationRoot: string,
+  workspaceRoot: string,
+): {
+  readonly ready: Promise<void>;
+  run(): Promise<{
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+    readonly stderr: string;
+    readonly stdout: string;
+  }>;
+  close(): Promise<void>;
+} {
+  const script = `
+    import { createWorkspaceTrust } from ${JSON.stringify(agentEntryUrl)};
+    const trust = createWorkspaceTrust({ environment: process.env, workspaceRoot: process.env.ADAM_AGENT_WORKSPACE_ROOT });
+    process.send("ready");
+    await new Promise((resolve) => process.once("message", resolve));
+    const snapshot = await trust.load();
+    if (snapshot.projectId === null) throw new Error("missing project identity");
+    await trust.setTrusted({ projectId: snapshot.projectId, trusted: true });
+    process.disconnect();
+  `;
+  const child = spawn(process.execPath, ["--input-type=module", "--eval", script], {
+    env: {
+      ...process.env,
+      ADAM_AGENT_WORKSPACE_ROOT: workspaceRoot,
+      XDG_CONFIG_HOME: configurationRoot,
+    },
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  let processError: Error | undefined;
+  let readyObserved = false;
+  let resolveReady: (() => void) | undefined;
+  let rejectReady: ((error: Error) => void) | undefined;
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+  child.once("message", (message) => {
+    if (message === "ready") {
+      readyObserved = true;
+      resolveReady?.();
+    } else {
+      processError = new Error("The workspace trust writer sent an invalid ready message.");
+      child.kill("SIGTERM");
+    }
+  });
+  const closed = new Promise<{
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+    readonly stderr: string;
+    readonly stdout: string;
+  }>((resolve) => {
+    child.once("error", (error) => {
+      processError = error;
+    });
+    child.once("close", (code, signal) => {
+      if (!readyObserved) {
+        rejectReady?.(processError ?? new Error("The workspace trust writer closed before ready."));
+      }
+      resolve({ code, signal, stderr, stdout });
+    });
+  });
+  let closePromise: Promise<void> | undefined;
+  return {
+    ready,
+    async run() {
+      child.send("run", (error) => {
+        if (error !== null) {
+          processError = error;
+          child.kill("SIGTERM");
+        }
+      });
+      const result = await closed;
+      if (processError !== undefined) {
+        throw processError;
+      }
+      return result;
+    },
+    close() {
+      closePromise ??= closeWorkspaceTrustWriter(child, closed);
+      return closePromise;
+    },
+  };
+}
+
+async function closeWorkspaceTrustWriter(
+  child: ReturnType<typeof spawn>,
+  closed: Promise<unknown>,
+): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    await closed;
+    return;
+  }
+  child.kill("SIGTERM");
+  let timer: NodeJS.Timeout | undefined;
+  const closedBeforeDeadline = await Promise.race([
+    closed.then(() => true),
+    new Promise<false>((resolve) => {
+      timer = setTimeout(() => resolve(false), 1_000);
+      timer.unref();
+    }),
+  ]);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+  }
+  if (!closedBeforeDeadline) {
+    child.kill("SIGKILL");
+    await closed;
+  }
 }

--- a/packages/testkit/src/user-configuration.test.ts
+++ b/packages/testkit/src/user-configuration.test.ts
@@ -1,19 +1,30 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
   type ContextProfile,
+  createExtensionHost,
   createPermissionPolicy,
   createPresentationSession,
   createReadToolRegistry,
   type ModelTargetIdentity,
   type ModelTargets,
   type PresentationPreferences,
+  type RuntimeEvent,
 } from "@adam-agent/agent";
-import { createPresentationPreferencesWithStorageForTesting } from "@adam-agent/agent/internal-testing";
+import {
+  createPresentationPreferencesWithStorageForTesting,
+  createWorkspaceTrustWithStorageForTesting,
+  mcpTransportFactory,
+} from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
-import { createInMemorySessionLifecycleHarness, FakeModelDriver } from "./index.js";
+import {
+  createInMemorySessionLifecycleHarness,
+  createScriptedMcpTransportFactory,
+  FakeModelDriver,
+} from "./index.js";
 
 const targetIdentity: ModelTargetIdentity = {
   targetId: "deepseek-v4-flash.direct",
@@ -59,6 +70,43 @@ function createInMemoryUserConfiguration(initialText: string | null = null): {
     read: () => text,
     replace(nextText) {
       text = nextText;
+    },
+  };
+}
+
+function createInMemoryWorkspaceTrustConfiguration(
+  workspaceRoot: string,
+  initialText: string | null = null,
+): {
+  readonly controller: ReturnType<typeof createWorkspaceTrustWithStorageForTesting>;
+  read(): string | null;
+  replace(text: string | null): void;
+  failWrites(): void;
+} {
+  let text = initialText;
+  let writesFail = false;
+  const controller = createWorkspaceTrustWithStorageForTesting({
+    workspaceRoot,
+    storage: {
+      async read() {
+        return text === null ? { status: "missing" } : { status: "available", text };
+      },
+      async write(nextText) {
+        if (writesFail) {
+          throw new Error("Injected workspace trust write failure.");
+        }
+        text = nextText;
+      },
+    },
+  });
+  return {
+    controller,
+    read: () => text,
+    replace(nextText) {
+      text = nextText;
+    },
+    failWrites() {
+      writesFail = true;
     },
   };
 }
@@ -630,6 +678,71 @@ test("Presentation mutates one model-policy field and republishes its effective 
   }
 });
 
+test("Presentation exposes workspace trust and rejects a stale trust command", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-presentation-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  let trustDocument: string | null = null;
+  const workspaceTrust = createWorkspaceTrustWithStorageForTesting({
+    workspaceRoot,
+    storage: {
+      async read() {
+        return trustDocument === null
+          ? { status: "missing" as const }
+          : { status: "available" as const, text: trustDocument };
+      },
+      async write(text) {
+        trustDocument = text;
+      },
+    },
+  });
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ workspaceRoot, workspaceTrust });
+  const presentation = await createPresentationSession({
+    lifecycle,
+    openProject: true,
+    projectLabel: "ignored-noncanonical-label",
+    workspaceRoot,
+  });
+
+  try {
+    const project = presentation.getState().authoritative.project;
+    expect(project).toMatchObject({
+      label: "workspace",
+      workspaceTrust: { status: "untrusted", diagnostic: null },
+    });
+    await expect(
+      presentation.dispatch({
+        type: "set_workspace_trust",
+        projectId: `sha256:${"0".repeat(64)}`,
+        trusted: true,
+      }),
+    ).resolves.toEqual({
+      status: "rejected",
+      code: "stale_interaction",
+      message: "The workspace trust command targets a stale project identity.",
+    });
+    expect(trustDocument).toBeNull();
+
+    await expect(
+      presentation.dispatch({
+        type: "set_workspace_trust",
+        projectId: project.id,
+        trusted: true,
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    expect(presentation.getState().authoritative.project).toEqual({
+      id: project.id,
+      label: "workspace",
+      workspaceTrust: { status: "trusted", diagnostic: null },
+    });
+  } finally {
+    await presentation.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("Presentation rejects user-configuration mutation while a model run is active", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-busy-user-configuration-"));
   const workspaceRoot = join(testRoot, "workspace");
@@ -699,6 +812,14 @@ test("Presentation rejects user-configuration mutation while a model run is acti
         field: "maximumOutputTokens",
         value: 12_000,
       }),
+    ).resolves.toEqual({
+      status: "rejected",
+      code: "conflict",
+      message: "User configuration can be changed only while the session is idle.",
+    });
+    const projectId = presentation.getState().authoritative.project.id;
+    await expect(
+      presentation.dispatch({ type: "set_workspace_trust", projectId, trusted: false }),
     ).resolves.toEqual({
       status: "rejected",
       code: "conflict",
@@ -1364,6 +1485,1579 @@ test("a v2 automatic compaction limit is persisted as an absolute effective thre
       ...compactingProfile,
       compactAtTokens: 450,
     });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+const boundedWorkspaceTrustIds = Array.from(
+  { length: 1_025 },
+  (_, index) => `sha256:${index.toString(16).padStart(64, "0")}`,
+);
+
+test.each([
+  { caseName: "empty", text: "" },
+  { caseName: "malformed JSON", text: "{" },
+  {
+    caseName: "duplicate object key",
+    text: '{"schemaVersion":1,"schemaVersion":1,"trustedProjectIds":[]}',
+  },
+  {
+    caseName: "unknown field",
+    text: JSON.stringify({ schemaVersion: 1, trustedProjectIds: [], wildcard: true }),
+  },
+  {
+    caseName: "wrong version",
+    text: JSON.stringify({ schemaVersion: 2, trustedProjectIds: [] }),
+  },
+  {
+    caseName: "uppercase digest",
+    text: JSON.stringify({ schemaVersion: 1, trustedProjectIds: [`sha256:${"A".repeat(64)}`] }),
+  },
+  {
+    caseName: "duplicate digest",
+    text: JSON.stringify({
+      schemaVersion: 1,
+      trustedProjectIds: [boundedWorkspaceTrustIds[0], boundedWorkspaceTrustIds[0]],
+    }),
+  },
+  {
+    caseName: "unsorted digests",
+    text: JSON.stringify({
+      schemaVersion: 1,
+      trustedProjectIds: [boundedWorkspaceTrustIds[1], boundedWorkspaceTrustIds[0]],
+    }),
+  },
+  {
+    caseName: "too many digests",
+    text: JSON.stringify({ schemaVersion: 1, trustedProjectIds: boundedWorkspaceTrustIds }),
+  },
+  { caseName: "oversized bytes", text: "x".repeat(128 * 1024 + 1) },
+])("workspace trust rejects a strict $caseName document", async ({ text }) => {
+  const configuration = createInMemoryWorkspaceTrustConfiguration(process.cwd(), text);
+
+  await expect(configuration.controller.load()).resolves.toMatchObject({
+    status: "untrusted",
+    diagnostic: { code: "workspace_trust_invalid" },
+  });
+});
+
+test("workspace trust persists an exact sorted unique bounded document", async () => {
+  const configuration = createInMemoryWorkspaceTrustConfiguration(
+    process.cwd(),
+    `${JSON.stringify({
+      schemaVersion: 1,
+      trustedProjectIds: [boundedWorkspaceTrustIds[0], boundedWorkspaceTrustIds[1024]],
+    })}\n`,
+  );
+  const current = await configuration.controller.load();
+  if (current.projectId === null) {
+    throw new Error("The fixture requires one canonical project identity.");
+  }
+
+  await configuration.controller.setTrusted({ projectId: current.projectId, trusted: true });
+  const document = JSON.parse(configuration.read() ?? "null") as {
+    readonly schemaVersion: number;
+    readonly trustedProjectIds: readonly string[];
+  };
+  expect(document).toEqual({
+    schemaVersion: 1,
+    trustedProjectIds: [...document.trustedProjectIds].sort(),
+  });
+  expect(new Set(document.trustedProjectIds).size).toBe(3);
+});
+
+test("workspace trust refuses to exceed 1024 project identities", async () => {
+  const configuration = createInMemoryWorkspaceTrustConfiguration(process.cwd());
+  const current = await configuration.controller.load();
+  if (current.projectId === null) {
+    throw new Error("The fixture requires one canonical project identity.");
+  }
+  const full = boundedWorkspaceTrustIds.filter((id) => id !== current.projectId).slice(0, 1_024);
+  configuration.replace(`${JSON.stringify({ schemaVersion: 1, trustedProjectIds: full })}\n`);
+
+  await expect(
+    configuration.controller.setTrusted({ projectId: current.projectId, trusted: true }),
+  ).rejects.toThrow("workspace trust configuration is full");
+  expect(JSON.parse(configuration.read() ?? "null")).toEqual({
+    schemaVersion: 1,
+    trustedProjectIds: full,
+  });
+});
+
+test("a failed workspace trust write publishes no current-process authority", async () => {
+  const preferences = createInMemoryUserConfiguration(
+    `${JSON.stringify({ schemaVersion: 1, defaultTargetId: targetIdentity.targetId })}\n`,
+  );
+  const configuration = createInMemoryWorkspaceTrustConfiguration(process.cwd());
+  const current = await configuration.controller.load();
+  if (current.projectId === null) {
+    throw new Error("The fixture requires one canonical project identity.");
+  }
+  configuration.failWrites();
+
+  await expect(
+    configuration.controller.setTrusted({ projectId: current.projectId, trusted: true }),
+  ).rejects.toThrow("Injected workspace trust write failure");
+  await expect(configuration.controller.load()).resolves.toMatchObject({
+    status: "untrusted",
+    diagnostic: null,
+  });
+  expect(await preferences.preferences.load()).toMatchObject({
+    defaultTargetId: targetIdentity.targetId,
+    diagnostic: null,
+  });
+});
+
+test("an unreadable workspace trust document fails closed", async () => {
+  const controller = createWorkspaceTrustWithStorageForTesting({
+    workspaceRoot: process.cwd(),
+    storage: {
+      async read() {
+        throw new Error("Injected workspace trust read failure.");
+      },
+      async write() {
+        throw new Error("The unavailable document must not be repaired implicitly.");
+      },
+    },
+  });
+
+  await expect(controller.load()).resolves.toMatchObject({
+    status: "untrusted",
+    diagnostic: { code: "workspace_trust_unsafe" },
+  });
+});
+
+test("workspace trust reports unavailable when canonical identity cannot be resolved", async () => {
+  const controller = createWorkspaceTrustWithStorageForTesting({
+    workspaceRoot: join(tmpdir(), `missing-workspace-${randomUUID()}`),
+    storage: {
+      async read() {
+        return { status: "missing" };
+      },
+      async write() {
+        throw new Error("An unavailable identity must not be persisted.");
+      },
+    },
+  });
+
+  await expect(controller.load()).resolves.toMatchObject({
+    projectId: null,
+    status: "unavailable",
+    diagnostic: { code: "workspace_trust_unavailable" },
+  });
+});
+
+test("workspace trust keys aliases to one real canonical project identity", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-canonical-"));
+  const canonicalRoot = join(testRoot, "canonical-project");
+  const aliasRoot = join(testRoot, "project-alias");
+  await mkdir(canonicalRoot);
+  await symlink(canonicalRoot, aliasRoot, "dir");
+  const canonical = createInMemoryWorkspaceTrustConfiguration(canonicalRoot);
+  const alias = createInMemoryWorkspaceTrustConfiguration(aliasRoot);
+
+  try {
+    const [canonicalSnapshot, aliasSnapshot] = await Promise.all([
+      canonical.controller.load(),
+      alias.controller.load(),
+    ]);
+    expect(aliasSnapshot).toEqual({
+      projectId: canonicalSnapshot.projectId,
+      projectLabel: "canonical-project",
+      status: "untrusted",
+      diagnostic: null,
+    });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("workspace revoke and re-trust remain explicit across runtime restart", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-restart-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "AGENTS.md"), "RETRUSTED_PROJECT\n", "utf8");
+  const configuration = createInMemoryWorkspaceTrustConfiguration(workspaceRoot);
+  const harness = createInMemorySessionLifecycleHarness();
+  let lifecycle = harness.createLifecycle({
+    workspaceRoot,
+    workspaceTrust: configuration.controller,
+  });
+
+  try {
+    const initial = await lifecycle.inspectWorkspaceTrust();
+    if (initial.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    await lifecycle.configureWorkspaceTrust({ type: "grant", projectId: initial.projectId });
+    await lifecycle.configureWorkspaceTrust({ type: "revoke", projectId: initial.projectId });
+    await lifecycle.close();
+    lifecycle = harness.createLifecycle({
+      workspaceRoot,
+      workspaceTrust: configuration.controller,
+    });
+    await expect(lifecycle.inspectWorkspaceTrust()).resolves.toMatchObject({
+      projectId: initial.projectId,
+      status: "untrusted",
+    });
+    await lifecycle.configureWorkspaceTrust({ type: "grant", projectId: initial.projectId });
+    const created = await lifecycle.create({ targetIdentity });
+    expect(created.promptContext?.repository.sources).toMatchObject([
+      { selectedName: "AGENTS.md" },
+    ]);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("historical B8 source confirmation never migrates into workspace trust", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-no-migration-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeFile(
+    join(workspaceRoot, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        fixture: { type: "stdio", command: process.execPath, args: ["--version"], env: {} },
+      },
+    }),
+    "utf8",
+  );
+  const configuration = createInMemoryWorkspaceTrustConfiguration(workspaceRoot);
+  const harness = createInMemorySessionLifecycleHarness();
+  let lifecycle = harness.createLifecycle({
+    workspaceRoot,
+    workspaceTrust: configuration.controller,
+  });
+
+  try {
+    const initial = await lifecycle.inspectWorkspaceTrust();
+    if (initial.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    await lifecycle.configureWorkspaceTrust({ type: "grant", projectId: initial.projectId });
+    const created = await lifecycle.create({ targetIdentity });
+    if (created.mcp === undefined) {
+      throw new Error("The fixture requires an MCP configuration snapshot.");
+    }
+    await lifecycle.configureMcp({
+      type: "confirm_workspace",
+      sessionId: created.sessionId,
+      sourceDigest: created.mcp.source.digest,
+    });
+    await lifecycle.close();
+    configuration.replace(null);
+    lifecycle = harness.createLifecycle({
+      workspaceRoot,
+      workspaceTrust: configuration.controller,
+    });
+
+    await expect(lifecycle.inspectWorkspaceTrust()).resolves.toMatchObject({
+      status: "untrusted",
+      diagnostic: null,
+    });
+    await expect(lifecycle.inspect({ sessionId: created.sessionId })).resolves.not.toHaveProperty(
+      "mcp",
+    );
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("explicit durable workspace trust gates new project instructions, Skills, and MCP only", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-admission-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const isolatedHome = join(testRoot, "home");
+  const extensionRoot = join(testRoot, "extension");
+  const projectSkillRoot = join(workspaceRoot, ".agents", "skills", "project-context");
+  const userSkillRoot = join(isolatedHome, ".agents", "skills", "user-context");
+  const extensionSkillRoot = join(extensionRoot, "skills", "extension-context");
+  // biome-ignore lint/complexity/useLiteralKeys: TypeScript requires indexed ProcessEnv access.
+  const previousHome = process.env["HOME"];
+  let trustDocument: string | null = null;
+  await mkdir(projectSkillRoot, { recursive: true });
+  await mkdir(userSkillRoot, { recursive: true });
+  await mkdir(extensionSkillRoot, { recursive: true });
+  await writeFile(join(workspaceRoot, "AGENTS.md"), "PROJECT_INSTRUCTION\n", "utf8");
+  await writeFile(
+    join(projectSkillRoot, "SKILL.md"),
+    "---\nname: project-context\ndescription: Project-owned context.\n---\nPROJECT_SKILL\n",
+    "utf8",
+  );
+  await writeFile(
+    join(userSkillRoot, "SKILL.md"),
+    "---\nname: user-context\ndescription: User-owned context.\n---\nUSER_SKILL\n",
+    "utf8",
+  );
+  await writeFile(
+    join(extensionSkillRoot, "SKILL.md"),
+    "---\nname: extension-context\ndescription: Extension-owned context.\n---\nEXTENSION_SKILL\n",
+    "utf8",
+  );
+  await writeFile(
+    join(extensionRoot, "package.json"),
+    JSON.stringify({
+      name: "@fixture/workspace-trust-extension",
+      version: "1.0.0",
+      type: "module",
+      adamAgent: {
+        id: "fixture.workspace-trust-extension",
+        apiVersion: "^0.3.0",
+        runtime: { entry: "./extension.js" },
+        capabilities: { required: [], optional: [] },
+        contributions: [],
+      },
+    }),
+    "utf8",
+  );
+  await writeFile(join(extensionRoot, "extension.js"), "export async function activate() {}\n");
+  await writeFile(
+    join(workspaceRoot, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        fixture: { type: "stdio", command: process.execPath, args: ["--version"], env: {} },
+      },
+    }),
+    "utf8",
+  );
+  // biome-ignore lint/complexity/useLiteralKeys: TypeScript requires indexed ProcessEnv access.
+  process.env["HOME"] = isolatedHome;
+  const workspaceTrust = createWorkspaceTrustWithStorageForTesting({
+    workspaceRoot,
+    storage: {
+      async read() {
+        return trustDocument === null
+          ? { status: "missing" as const }
+          : { status: "available" as const, text: trustDocument };
+      },
+      async write(text) {
+        trustDocument = text;
+      },
+    },
+  });
+  const extensionHost = createExtensionHost({
+    capabilities: [],
+    extensions: [
+      {
+        enabled: true,
+        extensionId: "fixture.workspace-trust-extension",
+        grants: [],
+        packageName: "@fixture/workspace-trust-extension",
+        packageRoot: extensionRoot,
+        packageVersion: "1.0.0",
+      },
+    ],
+    projectRoot: workspaceRoot,
+    stateRoot,
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      throw new Error("The workspace trust preview does not resolve a model driver.");
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: officialProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  let lifecycle = harness.createLifecycle({
+    extensionHost,
+    modelTargets,
+    workspaceRoot,
+    workspaceTrust,
+  });
+
+  try {
+    const before = await lifecycle.previewNewSession({ targetIdentity });
+    const beforeTrust = await lifecycle.inspectWorkspaceTrust();
+    if (beforeTrust.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    expect({
+      trust: beforeTrust,
+      skillSources: before.skillContext?.catalog.entries.map(
+        (candidate) => candidate.locator.source,
+      ),
+    }).toEqual({
+      trust: {
+        projectId: beforeTrust.projectId,
+        projectLabel: "workspace",
+        status: "untrusted",
+        diagnostic: null,
+      },
+      skillSources: ["extension", "user"],
+    });
+
+    await expect(
+      lifecycle.configureWorkspaceTrust({
+        type: "grant",
+        projectId: beforeTrust.projectId,
+      }),
+    ).resolves.toMatchObject({ status: "updated", snapshot: { status: "trusted" } });
+    expect(trustDocument).toBe(
+      `${JSON.stringify({ schemaVersion: 1, trustedProjectIds: [beforeTrust.projectId] })}\n`,
+    );
+    await lifecycle.close();
+    lifecycle = harness.createLifecycle({
+      extensionHost,
+      modelTargets,
+      workspaceRoot,
+      workspaceTrust,
+    });
+
+    const after = await lifecycle.create({ targetIdentity });
+    expect({
+      trust: await lifecycle.inspectWorkspaceTrust(),
+      repositorySources: after.promptContext?.repository.sources.map(
+        (source) => source.selectedName,
+      ),
+      skillSources: after.skillContext?.catalog.entries.map(
+        (candidate) => candidate.locator.source,
+      ),
+      mcp: after.mcp,
+    }).toEqual({
+      trust: {
+        projectId: after.projectId,
+        projectLabel: "workspace",
+        status: "trusted",
+        diagnostic: null,
+      },
+      repositorySources: ["AGENTS.md"],
+      skillSources: ["extension", "project", "user"],
+      mcp: {
+        schemaVersion: 1,
+        status: "workspace_confirmation_required",
+        workspaceConfirmed: false,
+        source: {
+          path: ".mcp.json",
+          digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+        },
+        servers: [],
+        diagnostics: [],
+      },
+    });
+  } finally {
+    if (previousHome === undefined) {
+      // biome-ignore lint/complexity/useLiteralKeys: TypeScript requires indexed ProcessEnv access.
+      delete process.env["HOME"];
+    } else {
+      // biome-ignore lint/complexity/useLiteralKeys: TypeScript requires indexed ProcessEnv access.
+      process.env["HOME"] = previousHome;
+    }
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("an ordinary prompt in an untrusted workspace fails before project or model dispatch", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-untrusted-prompt-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "AGENTS.md"), "NEVER_LOAD_UNTRUSTED_CONTEXT\n", "utf8");
+  let modelCalls = 0;
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return {
+        identity: targetIdentity,
+        driver: new FakeModelDriver(() => {
+          modelCalls += 1;
+          return [{ type: "finish", reason: "stop" }];
+        }),
+        contextProfile: officialProfile,
+      };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: officialProfile,
+          },
+        ],
+      };
+    },
+  };
+  const workspaceTrust = createWorkspaceTrustWithStorageForTesting({
+    workspaceRoot,
+    storage: {
+      async read() {
+        return { status: "missing" };
+      },
+      async write() {
+        throw new Error("The untrusted admission must not mutate workspace trust.");
+      },
+    },
+  });
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, workspaceRoot, workspaceTrust });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Do not dispatch this untrusted request." },
+      }),
+    ).rejects.toMatchObject({
+      code: "session_workspace_untrusted",
+      message:
+        "This workspace is not trusted. Run adam-agent --trust-workspace in this project, then retry.",
+    });
+    expect({ modelCalls, sessionIds: await harness.sessions.listSessionIds() }).toEqual({
+      modelCalls: 0,
+      sessionIds: [],
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("direct session creation cannot stage a later prompt around the workspace trust gate", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-untrusted-session-create-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const configuration = createInMemoryWorkspaceTrustConfiguration(workspaceRoot);
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    workspaceRoot,
+    workspaceTrust: configuration.controller,
+  });
+
+  try {
+    await expect(lifecycle.create({ targetIdentity })).rejects.toMatchObject({
+      code: "session_workspace_untrusted",
+    });
+    await expect(lifecycle.listProjectSessions({ limit: 10 })).resolves.toMatchObject({
+      items: [],
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("revoking workspace trust preserves historical context but blocks mutable project reloads", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-revoked-project-reload-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const projectSkillRoot = join(workspaceRoot, ".agents", "skills", "project-context");
+  await mkdir(projectSkillRoot, { recursive: true });
+  await writeFile(join(workspaceRoot, "AGENTS.md"), "ORIGINAL_PROJECT_INSTRUCTION\n", "utf8");
+  await writeFile(
+    join(projectSkillRoot, "SKILL.md"),
+    "---\nname: project-context\ndescription: Original project Skill.\n---\n",
+    "utf8",
+  );
+  let trustDocument: string | null = null;
+  const workspaceTrust = createWorkspaceTrustWithStorageForTesting({
+    workspaceRoot,
+    storage: {
+      async read() {
+        return trustDocument === null
+          ? { status: "missing" as const }
+          : { status: "available" as const, text: trustDocument };
+      },
+      async write(text) {
+        trustDocument = text;
+      },
+    },
+  });
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ workspaceRoot, workspaceTrust });
+
+  try {
+    const status = await lifecycle.inspectWorkspaceTrust();
+    if (status.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    await lifecycle.configureWorkspaceTrust({ type: "grant", projectId: status.projectId });
+    const created = await lifecycle.create({ targetIdentity });
+    const originalInstructionDigest = created.promptContext?.repository.sources[0]?.contentDigest;
+    await lifecycle.configureWorkspaceTrust({ type: "revoke", projectId: status.projectId });
+    await writeFile(join(workspaceRoot, "AGENTS.md"), "CHANGED_PROJECT_INSTRUCTION\n", "utf8");
+    await writeFile(
+      join(projectSkillRoot, "SKILL.md"),
+      "---\nname: project-context\ndescription: Changed project Skill.\n---\n",
+      "utf8",
+    );
+
+    await expect(
+      lifecycle.reloadRepositoryInstructions({ sessionId: created.sessionId }),
+    ).rejects.toMatchObject({ code: "session_workspace_untrusted" });
+    await expect(lifecycle.reloadSkills({ sessionId: created.sessionId })).rejects.toMatchObject({
+      code: "session_workspace_untrusted",
+    });
+    const historical = await lifecycle.inspect({ sessionId: created.sessionId });
+    if (historical.schemaVersion !== 3) {
+      throw new Error("The fixture requires a current session snapshot.");
+    }
+    expect({
+      instructionDigest: historical.promptContext?.repository.sources[0]?.contentDigest,
+      skillDescription: historical.skillContext?.catalog.entries[0]?.description,
+    }).toEqual({
+      instructionDigest: originalInstructionDigest,
+      skillDescription: "Original project Skill.",
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("revoked historical sessions cannot activate a project Skill from mutable bytes", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-revoked-project-skill-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const skillRoot = join(workspaceRoot, ".agents", "skills", "revoked-skill");
+  await mkdir(skillRoot, { recursive: true });
+  await writeFile(
+    join(skillRoot, "SKILL.md"),
+    "---\nname: revoked-skill\ndescription: Original project Skill.\n---\nORIGINAL_SKILL_BODY\n",
+    "utf8",
+  );
+  const configuration = createInMemoryWorkspaceTrustConfiguration(workspaceRoot);
+  const model = new FakeModelDriver((request) =>
+    request.messages.at(-1)?.role === "user"
+      ? [
+          { type: "tool_call_start", id: "activate-revoked-skill", name: "activate_skill" },
+          {
+            type: "tool_call_delta",
+            id: "activate-revoked-skill",
+            json: JSON.stringify({ qualifiedId: "skill:v1:project:.:revoked-skill" }),
+          },
+          { type: "tool_call_end", id: "activate-revoked-skill" },
+          { type: "finish", reason: "tool_calls" },
+        ]
+      : [
+          { type: "text_delta", text: "Revoked project Skill stayed unavailable." },
+          { type: "finish", reason: "stop" },
+        ],
+  );
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver: model, contextProfile: officialProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: officialProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    workspaceRoot,
+    workspaceTrust: configuration.controller,
+  });
+  const events: RuntimeEvent[] = [];
+  lifecycle.subscribe((event) => events.push(event));
+
+  try {
+    const status = await lifecycle.inspectWorkspaceTrust();
+    if (status.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    await lifecycle.configureWorkspaceTrust({ type: "grant", projectId: status.projectId });
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.configureWorkspaceTrust({ type: "revoke", projectId: status.projectId });
+    await writeFile(
+      join(skillRoot, "SKILL.md"),
+      "---\nname: revoked-skill\ndescription: Changed project Skill.\n---\nCHANGED_SKILL_BODY\n",
+      "utf8",
+    );
+
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: "Try to activate the historical project Skill." },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "Revoked project Skill stayed unavailable." },
+      snapshot: { skillContext: { active: [] } },
+    });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "tool_failed",
+          callId: "activate-revoked-skill",
+          error: expect.objectContaining({ code: "skill_unavailable" }),
+        }),
+      ]),
+    );
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("revoked historical sessions reject an explicit project Skill before model dispatch", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-revoked-explicit-skill-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const skillRoot = join(workspaceRoot, ".agents", "skills", "explicit-revoked");
+  await mkdir(skillRoot, { recursive: true });
+  await writeFile(
+    join(skillRoot, "SKILL.md"),
+    "---\nname: explicit-revoked\ndescription: Explicit project Skill.\n---\nEXPLICIT_PROJECT_BODY\n",
+    "utf8",
+  );
+  const configuration = createInMemoryWorkspaceTrustConfiguration(workspaceRoot);
+  let providerCalls = 0;
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return {
+        identity: targetIdentity,
+        driver: new FakeModelDriver(() => {
+          providerCalls += 1;
+          return [{ type: "finish", reason: "stop" }];
+        }),
+        contextProfile: officialProfile,
+      };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: officialProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    workspaceRoot,
+    workspaceTrust: configuration.controller,
+  });
+
+  try {
+    const status = await lifecycle.inspectWorkspaceTrust();
+    if (status.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    await lifecycle.configureWorkspaceTrust({ type: "grant", projectId: status.projectId });
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.configureWorkspaceTrust({ type: "revoke", projectId: status.projectId });
+
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: {
+          text: "Try the explicit project Skill after revocation.",
+          skills: ["skill:v1:project:.:explicit-revoked"],
+        },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "failed", error: { code: "skill_activation_failed" } },
+      snapshot: { skillContext: { active: [] } },
+    });
+    expect(providerCalls).toBe(0);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("revoked historical sessions cannot read a live resource from an active project Skill", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-revoked-skill-resource-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const skillRoot = join(workspaceRoot, ".agents", "skills", "resource-revoked");
+  await mkdir(join(skillRoot, "references"), { recursive: true });
+  await writeFile(
+    join(skillRoot, "SKILL.md"),
+    "---\nname: resource-revoked\ndescription: Project Skill with a resource.\n---\nRead references/guide.txt.\n",
+    "utf8",
+  );
+  await writeFile(join(skillRoot, "references", "guide.txt"), "PROJECT_RESOURCE_BYTES\n", "utf8");
+  const configuration = createInMemoryWorkspaceTrustConfiguration(workspaceRoot);
+  const model = new FakeModelDriver((request) => {
+    const latest = request.messages.at(-1);
+    if (latest?.role === "user" && latest.content.includes("Read the active")) {
+      return [
+        { type: "tool_call_start", id: "read-revoked-resource", name: "read_skill_resource" },
+        {
+          type: "tool_call_delta",
+          id: "read-revoked-resource",
+          json: JSON.stringify({
+            qualifiedId: "skill:v1:project:.:resource-revoked",
+            path: "references/guide.txt",
+            offset: 0,
+            maxByteCount: 256,
+          }),
+        },
+        { type: "tool_call_end", id: "read-revoked-resource" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    return [
+      {
+        type: "text_delta",
+        text:
+          latest?.role === "tool"
+            ? "Revoked project resource stayed unavailable."
+            : "Project Skill activated while trusted.",
+      },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver: model, contextProfile: officialProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: officialProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    workspaceRoot,
+    workspaceTrust: configuration.controller,
+  });
+  const events: RuntimeEvent[] = [];
+  lifecycle.subscribe((event) => events.push(event));
+
+  try {
+    const status = await lifecycle.inspectWorkspaceTrust();
+    if (status.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    await lifecycle.configureWorkspaceTrust({ type: "grant", projectId: status.projectId });
+    const created = await lifecycle.create({ targetIdentity });
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: {
+          text: "Activate the project Skill while trusted.",
+          skills: ["skill:v1:project:.:resource-revoked"],
+        },
+      }),
+    ).resolves.toMatchObject({ result: { status: "completed" } });
+    await lifecycle.configureWorkspaceTrust({ type: "revoke", projectId: status.projectId });
+
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: "Read the active project Skill resource after revocation." },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "Revoked project resource stayed unavailable." },
+    });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "tool_failed",
+          callId: "read-revoked-resource",
+          error: expect.objectContaining({ code: "skill_resource_unavailable" }),
+        }),
+      ]),
+    );
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("revoked historical sessions cannot activate descendant project context", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-revoked-descendant-context-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const nestedRoot = join(workspaceRoot, "nested");
+  const nestedSkillRoot = join(nestedRoot, ".agents", "skills", "nested-context");
+  await mkdir(nestedSkillRoot, { recursive: true });
+  await writeFile(join(nestedRoot, "AGENTS.md"), "NESTED_PROJECT_INSTRUCTION\n", "utf8");
+  await writeFile(join(nestedRoot, "target.txt"), "nested target\n", "utf8");
+  await writeFile(
+    join(nestedSkillRoot, "SKILL.md"),
+    "---\nname: nested-context\ndescription: Nested project context.\n---\n",
+    "utf8",
+  );
+  let trustDocument: string | null = null;
+  const workspaceTrust = createWorkspaceTrustWithStorageForTesting({
+    workspaceRoot,
+    storage: {
+      async read() {
+        return trustDocument === null
+          ? { status: "missing" as const }
+          : { status: "available" as const, text: trustDocument };
+      },
+      async write(text) {
+        trustDocument = text;
+      },
+    },
+  });
+  let modelTurn = 0;
+  const model = new FakeModelDriver(() => {
+    modelTurn += 1;
+    return modelTurn === 1
+      ? [
+          { type: "tool_call_start", id: "read-nested", name: "read_file" },
+          {
+            type: "tool_call_delta",
+            id: "read-nested",
+            json: JSON.stringify({ path: "nested/target.txt" }),
+          },
+          { type: "tool_call_end", id: "read-nested" },
+          { type: "finish", reason: "tool_calls" },
+        ]
+      : [
+          { type: "text_delta", text: "Revoked context stayed unavailable." },
+          { type: "finish", reason: "stop" },
+        ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver: model, contextProfile: officialProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: officialProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    tools: createReadToolRegistry({ workspaceRoot }),
+    workspaceRoot,
+    workspaceTrust,
+  });
+  const events: RuntimeEvent[] = [];
+  lifecycle.subscribe((event) => events.push(event));
+
+  try {
+    const status = await lifecycle.inspectWorkspaceTrust();
+    if (status.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    await lifecycle.configureWorkspaceTrust({ type: "grant", projectId: status.projectId });
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.configureWorkspaceTrust({ type: "revoke", projectId: status.projectId });
+
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: "Read the nested target without widening context." },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "Revoked context stayed unavailable." },
+      snapshot: {
+        promptContext: { repository: { activeScopes: ["."] } },
+        skillContext: { activeProjectScopes: ["."] },
+      },
+    });
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "tool_failed",
+          callId: "read-nested",
+          error: expect.objectContaining({ code: "project_context_unavailable" }),
+        }),
+      ]),
+    );
+    expect(events.some((event) => event.type === "repository_instructions_activated")).toBe(false);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("workspace trust never replaces MCP source, server, Profile, or effect authority", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-mcp-authority-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeFile(
+    join(workspaceRoot, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        fixture: { type: "stdio", command: process.execPath, args: ["--version"], env: {} },
+      },
+    }),
+    "utf8",
+  );
+  let trustDocument: string | null = null;
+  const workspaceTrust = createWorkspaceTrustWithStorageForTesting({
+    workspaceRoot,
+    storage: {
+      async read() {
+        return trustDocument === null
+          ? { status: "missing" as const }
+          : { status: "available" as const, text: trustDocument };
+      },
+      async write(text) {
+        trustDocument = text;
+      },
+    },
+  });
+  const peer = createScriptedMcpTransportFactory({
+    fixture: {
+      toolPages: [
+        {
+          tools: [
+            {
+              name: "echo",
+              description: "Echo one value.",
+              inputSchema: {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            },
+          ],
+        },
+      ],
+    },
+  });
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({
+    [mcpTransportFactory]: peer,
+    workspaceRoot,
+    workspaceTrust,
+  });
+
+  try {
+    const status = await lifecycle.inspectWorkspaceTrust();
+    if (status.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    await lifecycle.configureWorkspaceTrust({ type: "grant", projectId: status.projectId });
+    const created = await lifecycle.create({ targetIdentity });
+    if (created.mcp === undefined) {
+      throw new Error("The fixture requires an MCP configuration snapshot.");
+    }
+    const confirmed = await lifecycle.configureMcp({
+      type: "confirm_workspace",
+      sessionId: created.sessionId,
+      sourceDigest: created.mcp.source.digest,
+    });
+    const server = confirmed.snapshot.mcp?.servers[0];
+    if (server === undefined) {
+      throw new Error("The fixture requires one MCP server preview.");
+    }
+    await lifecycle.configureMcp({
+      type: "approve_server",
+      sessionId: created.sessionId,
+      serverId: server.serverId,
+      definitionDigest: server.definitionDigest,
+    });
+    await lifecycle.configureWorkspaceTrust({ type: "revoke", projectId: status.projectId });
+
+    await expect(
+      lifecycle.configureMcp({
+        type: "activate_servers",
+        sessionId: created.sessionId,
+        servers: [{ serverId: server.serverId, definitionDigest: server.definitionDigest }],
+      }),
+    ).rejects.toMatchObject({ code: "session_workspace_untrusted" });
+    expect(peer.requests("fixture")).toEqual([]);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("MCP configuration revalidates trust inside its mutation transaction", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-mcp-race-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeFile(
+    join(workspaceRoot, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        fixture: { type: "stdio", command: process.execPath, args: ["--version"], env: {} },
+      },
+    }),
+    "utf8",
+  );
+  let trustDocument: string | null = null;
+  let revokeAfterRead = false;
+  const workspaceTrust = createWorkspaceTrustWithStorageForTesting({
+    workspaceRoot,
+    storage: {
+      async read() {
+        const current = trustDocument;
+        if (revokeAfterRead && current !== null) {
+          revokeAfterRead = false;
+          trustDocument = `${JSON.stringify({ schemaVersion: 1, trustedProjectIds: [] })}\n`;
+        }
+        return current === null
+          ? { status: "missing" as const }
+          : { status: "available" as const, text: current };
+      },
+      async write(text) {
+        trustDocument = text;
+      },
+    },
+  });
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    workspaceRoot,
+    workspaceTrust,
+  });
+
+  try {
+    const status = await lifecycle.inspectWorkspaceTrust();
+    if (status.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    await lifecycle.configureWorkspaceTrust({ type: "grant", projectId: status.projectId });
+    const trustedDocument = trustDocument;
+    const created = await lifecycle.create({ targetIdentity });
+    if (created.mcp === undefined) {
+      throw new Error("The fixture requires one MCP source preview.");
+    }
+    revokeAfterRead = true;
+
+    await expect(
+      lifecycle.configureMcp({
+        type: "confirm_workspace",
+        sessionId: created.sessionId,
+        sourceDigest: created.mcp.source.digest,
+      }),
+    ).rejects.toMatchObject({ code: "session_workspace_untrusted" });
+    trustDocument = trustedDocument;
+    await expect(lifecycle.inspect({ sessionId: created.sessionId })).resolves.toMatchObject({
+      mcp: { workspaceConfirmed: false },
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("revoking workspace trust closes active MCP before publishing untrusted state", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-mcp-revoke-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeFile(
+    join(workspaceRoot, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        fixture: { type: "stdio", command: process.execPath, args: ["--version"], env: {} },
+      },
+    }),
+    "utf8",
+  );
+  let trustDocument: string | null = null;
+  let requireClosedTransport = false;
+  let peer: ReturnType<typeof createScriptedMcpTransportFactory> | undefined;
+  const workspaceTrust = createWorkspaceTrustWithStorageForTesting({
+    workspaceRoot,
+    storage: {
+      async read() {
+        return trustDocument === null
+          ? { status: "missing" as const }
+          : { status: "available" as const, text: trustDocument };
+      },
+      async write(text) {
+        if (requireClosedTransport && peer?.activeCount("fixture") !== 0) {
+          throw new Error("Workspace trust was published before the MCP transport closed.");
+        }
+        trustDocument = text;
+      },
+    },
+  });
+  peer = createScriptedMcpTransportFactory({
+    fixture: {
+      toolPages: [
+        {
+          tools: [
+            {
+              name: "echo",
+              description: "Echo one value.",
+              inputSchema: {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            },
+          ],
+        },
+      ],
+    },
+  });
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({
+    [mcpTransportFactory]: peer,
+    workspaceRoot,
+    workspaceTrust,
+  });
+
+  try {
+    const status = await lifecycle.inspectWorkspaceTrust();
+    if (status.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    await lifecycle.configureWorkspaceTrust({ type: "grant", projectId: status.projectId });
+    const created = await lifecycle.create({ targetIdentity });
+    if (created.mcp === undefined) {
+      throw new Error("The fixture requires an MCP configuration snapshot.");
+    }
+    const confirmed = await lifecycle.configureMcp({
+      type: "confirm_workspace",
+      sessionId: created.sessionId,
+      sourceDigest: created.mcp.source.digest,
+    });
+    const server = confirmed.snapshot.mcp?.servers[0];
+    if (server === undefined) {
+      throw new Error("The fixture requires one MCP server preview.");
+    }
+    await lifecycle.configureMcp({
+      type: "approve_server",
+      sessionId: created.sessionId,
+      serverId: server.serverId,
+      definitionDigest: server.definitionDigest,
+    });
+    const activated = await lifecycle.configureMcp({
+      type: "activate_servers",
+      sessionId: created.sessionId,
+      servers: [{ serverId: server.serverId, definitionDigest: server.definitionDigest }],
+    });
+    const activeMcp = activated.snapshot.mcp;
+    if (activeMcp?.status !== "tool_selection_required") {
+      throw new Error("The fixture requires one live MCP catalog.");
+    }
+    const echo = activeMcp.catalog?.tools[0];
+    const generationId = activeMcp.activation?.generationId;
+    if (echo === undefined || generationId === undefined) {
+      throw new Error("The fixture requires one discovered MCP tool.");
+    }
+    await lifecycle.configureMcp({
+      type: "commit_tool_profile",
+      sessionId: created.sessionId,
+      generationId,
+      selections: [
+        {
+          qualifiedName: echo.qualifiedName,
+          definitionDigest: echo.definitionDigest,
+          effect: "read",
+        },
+      ],
+    });
+
+    const transportClosed = peer.nextClose("fixture");
+    requireClosedTransport = true;
+    await expect(
+      lifecycle.configureWorkspaceTrust({ type: "revoke", projectId: status.projectId }),
+    ).resolves.toMatchObject({ snapshot: { status: "untrusted" } });
+    await transportClosed;
+    expect(JSON.parse(trustDocument ?? "null")).toEqual({
+      schemaVersion: 1,
+      trustedProjectIds: [],
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a revoked historical session neither reactivates nor dispatches its MCP Profile", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-mcp-history-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeFile(
+    join(workspaceRoot, ".mcp.json"),
+    JSON.stringify({
+      mcpServers: {
+        fixture: { type: "stdio", command: process.execPath, args: ["--version"], env: {} },
+      },
+    }),
+    "utf8",
+  );
+  let trustDocument: string | null = null;
+  const workspaceTrust = createWorkspaceTrustWithStorageForTesting({
+    workspaceRoot,
+    storage: {
+      async read() {
+        return trustDocument === null
+          ? { status: "missing" as const }
+          : { status: "available" as const, text: trustDocument };
+      },
+      async write(text) {
+        trustDocument = text;
+      },
+    },
+  });
+  const peer = createScriptedMcpTransportFactory({
+    fixture: {
+      toolPages: [
+        {
+          tools: [
+            {
+              name: "echo",
+              description: "Echo one value.",
+              inputSchema: {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+                additionalProperties: false,
+              },
+            },
+          ],
+        },
+      ],
+    },
+  });
+  let qualifiedName = "";
+  let modelTurn = 0;
+  const model = new FakeModelDriver(() => {
+    modelTurn += 1;
+    const requestsMcp = modelTurn === 1 || modelTurn === 3;
+    const callId = modelTurn === 1 ? "revoked-mcp" : "retrusted-mcp";
+    return requestsMcp
+      ? [
+          { type: "tool_call_start", id: callId, name: qualifiedName },
+          {
+            type: "tool_call_delta",
+            id: callId,
+            json: JSON.stringify({
+              value: modelTurn === 1 ? "must-not-dispatch" : "dispatch-after-retrust",
+            }),
+          },
+          { type: "tool_call_end", id: callId },
+          { type: "finish", reason: "tool_calls" },
+        ]
+      : [
+          {
+            type: "text_delta",
+            text:
+              modelTurn === 2
+                ? "Historical MCP stayed unavailable."
+                : "Explicit re-trust restored MCP admission.",
+          },
+          { type: "finish", reason: "stop" },
+        ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver: model, contextProfile: officialProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: officialProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({
+    [mcpTransportFactory]: peer,
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    tools: createReadToolRegistry({ workspaceRoot }),
+    workspaceRoot,
+    workspaceTrust,
+  });
+
+  try {
+    const status = await lifecycle.inspectWorkspaceTrust();
+    if (status.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    await lifecycle.configureWorkspaceTrust({ type: "grant", projectId: status.projectId });
+    const created = await lifecycle.create({ targetIdentity });
+    if (created.mcp === undefined) {
+      throw new Error("The fixture requires an MCP configuration snapshot.");
+    }
+    const confirmed = await lifecycle.configureMcp({
+      type: "confirm_workspace",
+      sessionId: created.sessionId,
+      sourceDigest: created.mcp.source.digest,
+    });
+    const server = confirmed.snapshot.mcp?.servers[0];
+    if (server === undefined) {
+      throw new Error("The fixture requires one MCP server preview.");
+    }
+    await lifecycle.configureMcp({
+      type: "approve_server",
+      sessionId: created.sessionId,
+      serverId: server.serverId,
+      definitionDigest: server.definitionDigest,
+    });
+    const activated = await lifecycle.configureMcp({
+      type: "activate_servers",
+      sessionId: created.sessionId,
+      servers: [{ serverId: server.serverId, definitionDigest: server.definitionDigest }],
+    });
+    const activeMcp = activated.snapshot.mcp;
+    if (activeMcp?.status !== "tool_selection_required") {
+      throw new Error("The fixture requires one live MCP catalog.");
+    }
+    const echo = activeMcp.catalog?.tools[0];
+    const generationId = activeMcp.activation?.generationId;
+    if (echo === undefined || generationId === undefined) {
+      throw new Error("The fixture requires one discovered MCP tool.");
+    }
+    qualifiedName = echo.qualifiedName;
+    await lifecycle.configureMcp({
+      type: "commit_tool_profile",
+      sessionId: created.sessionId,
+      generationId,
+      selections: [
+        {
+          qualifiedName,
+          definitionDigest: echo.definitionDigest,
+          effect: "read",
+        },
+      ],
+    });
+    await lifecycle.configureWorkspaceTrust({ type: "revoke", projectId: status.projectId });
+    const requestsBeforeContinue = peer.requests("fixture");
+
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: "Try the historical MCP tool." },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "Historical MCP stayed unavailable." },
+    });
+    expect(peer.requests("fixture")).toEqual(requestsBeforeContinue);
+    await lifecycle.configureWorkspaceTrust({ type: "grant", projectId: status.projectId });
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: "Retry the historical MCP tool after explicit re-trust." },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "Explicit re-trust restored MCP admission." },
+    });
+    expect(peer.requests("fixture")).toContainEqual({
+      method: "tools/call",
+      params: { name: "echo", arguments: { value: "dispatch-after-retrust" } },
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("untrusted historical inspection never reads new mutable MCP configuration", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-mcp-inspection-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  let trustDocument: string | null = null;
+  const workspaceTrust = createWorkspaceTrustWithStorageForTesting({
+    workspaceRoot,
+    storage: {
+      async read() {
+        return trustDocument === null
+          ? { status: "missing" as const }
+          : { status: "available" as const, text: trustDocument };
+      },
+      async write(text) {
+        trustDocument = text;
+      },
+    },
+  });
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ workspaceRoot, workspaceTrust });
+
+  try {
+    const status = await lifecycle.inspectWorkspaceTrust();
+    if (status.projectId === null) {
+      throw new Error("The fixture requires one canonical project identity.");
+    }
+    await lifecycle.configureWorkspaceTrust({ type: "grant", projectId: status.projectId });
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.configureWorkspaceTrust({ type: "revoke", projectId: status.projectId });
+    await writeFile(join(workspaceRoot, ".mcp.json"), "not json\n", "utf8");
+
+    await expect(lifecycle.inspect({ sessionId: created.sessionId })).resolves.toMatchObject({
+      schemaVersion: 3,
+      sessionId: created.sessionId,
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("an untrusted draft preview excludes project Skills", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-workspace-trust-draft-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const projectSkillRoot = join(workspaceRoot, ".agents", "skills", "project-draft");
+  await mkdir(projectSkillRoot, { recursive: true });
+  await writeFile(
+    join(projectSkillRoot, "SKILL.md"),
+    "---\nname: project-draft\ndescription: Must not enter an untrusted draft.\n---\n",
+    "utf8",
+  );
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return {
+        identity: targetIdentity,
+        driver: new FakeModelDriver([]),
+        contextProfile: officialProfile,
+      };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: officialProfile,
+          },
+        ],
+      };
+    },
+  };
+  const workspaceTrust = createWorkspaceTrustWithStorageForTesting({
+    workspaceRoot,
+    storage: {
+      async read() {
+        return { status: "missing" };
+      },
+      async write() {
+        throw new Error("The draft must not mutate workspace trust.");
+      },
+    },
+  });
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, workspaceRoot, workspaceTrust });
+
+  try {
+    const preview = await lifecycle.previewNewSession({ targetIdentity });
+    expect(preview.skillContext.catalog.entries).toEqual([]);
   } finally {
     await lifecycle.close();
     await rm(testRoot, { recursive: true, force: true });


### PR DESCRIPTION
Implements the frozen B10-A2 canonical-project workspace trust checkpoint.\n\n- adds strict owner-local persistent trust with canonical project identity and atomic cross-process mutation\n- gates mutable repository instructions, project Skills, and MCP admission/reactivation without granting server, profile, tool, or effect authority\n- exposes explicit CLI, Presentation, and TUI trust inspection/grant/revoke flows\n- causally fences active MCP runtimes across revoke, concurrent release/reactivation, activation claims, and release failure\n\nValidation: pnpm quality:check (51 files passed, 2 skipped; 1198 tests passed, 10 skipped). Final spec and test-architecture reviews: P0/P1/P2 all zero.