### PR TITLE
fix(tui): scope tool disclosure per card

### DIFF
--- a/apps/tui/src/fixture-scenario.ts
+++ b/apps/tui/src/fixture-scenario.ts
@@ -43,6 +43,7 @@ export const fixtureScenarios = [
   "streaming",
   "target-navigation",
   "tool-artifact",
+  "tool-multiple",
   "unsafe-history",
   "unsafe-output",
   "write",

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -1370,6 +1370,46 @@ test("Kitty Ctrl+C repeat and release phases cannot confirm an armed exit", asyn
   }
 });
 
+test("Kitty Ctrl+O repeat and release phases expand one tool card only once", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-kitty-tool-phases-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  await writeFile(
+    join(workspaceRoot, "README.md"),
+    `${Array.from({ length: 12 }, (_, index) => `line${String(index + 1).padStart(2, "0")}`).join(
+      "\n",
+    )}\n`,
+    "utf8",
+  );
+
+  try {
+    const fixture = startFixture({
+      external: true,
+      noColor: true,
+      scenario: "read",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Read the README\r");
+    await fixture.waitFor("Read complete.");
+    const beforeToolView = fixture.output().length;
+    fixture.write("\u001b[5~");
+    await fixture.waitForAfter("\u001b[?2026l", beforeToolView);
+    expect(fixture.screen()?.join("\n") ?? "").toContain("read README.md · Ctrl+O expand");
+    const beforeToggle = fixture.output().length;
+    fixture.write("\u001b[111;5:1u\u001b[111;5:2u\u001b[111;5:2u\u001b[111;5:3ux");
+    await fixture.waitForAfter("x", beforeToggle);
+    const screen = fixture.screen()?.join("\n") ?? "";
+    expect(screen).toContain("read README.md · Ctrl+O fold");
+    fixture.write("\u0015\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("unsupported clipboard is reported after terminal restoration without blocking exit", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-clipboard-unsupported-"));
   const workspaceRoot = join(testRoot, "workspace");

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -5514,6 +5514,9 @@ test("an older asynchronous copy receipt cannot replace newer Usage feedback", a
     await terminal.whenStarted();
     terminal.input("Read the README\r");
     await terminal.nextSynchronizedFrameContaining("Read complete");
+    const resultOccurrence = terminal.output().lastIndexOf("Read complete");
+    expect(resultOccurrence).toBeGreaterThanOrEqual(0);
+    await terminal.nextSynchronizedFrameContaining(" · idle", resultOccurrence);
     terminal.input("/copy\r");
     await copyStarted.promise;
     terminal.input("/exit extra\r");
@@ -5565,6 +5568,9 @@ test("an older asynchronous copy receipt cannot survive a newer overlay action",
     await terminal.whenStarted();
     terminal.input("Read the README\r");
     await terminal.nextSynchronizedFrameContaining("Read complete");
+    const resultOccurrence = terminal.output().lastIndexOf("Read complete");
+    expect(resultOccurrence).toBeGreaterThanOrEqual(0);
+    await terminal.nextSynchronizedFrameContaining(" · idle", resultOccurrence);
     terminal.input("/copy\r");
     await copyStarted.promise;
     terminal.input("/session\r");

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -5203,7 +5203,7 @@ test("a real read tool is rendered as a bounded Pi-style tool card", async () =>
   }
 });
 
-test("Ctrl+O toggles bounded authoritative tool details", async () => {
+test("Kitty Ctrl+O repeat and release phases toggle bounded tool details only once", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-tool-details-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
@@ -5224,13 +5224,21 @@ test("Ctrl+O toggles bounded authoritative tool details", async () => {
     expect(fixture.output()).toContain("10 │ line10");
     expect(fixture.output()).not.toContain("11 │ line11");
     expect(fixture.output()).not.toContain("provider model response");
+    let beforeResize = fixture.output().length;
+    await fixture.resize(80, 40);
+    const resizedFrame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    expect(resizedFrame.match(/Ctrl\+O expand/gu)).toHaveLength(1);
+    beforeResize = fixture.output().length;
+    await fixture.resize(80, 24);
+    await fixture.waitForAfter("\u001b[?2026l", beforeResize);
     const beforeToolView = fixture.output().length;
     fixture.write("\u001b[5~");
     await fixture.waitForAfter("\u001b[?2026l", beforeToolView);
     const collapsedToolRow = fixture.screen()?.findIndex((line) => line.includes("read README.md"));
     expect(collapsedToolRow).toBeGreaterThanOrEqual(0);
+    expect((fixture.screen()?.join("\n") ?? "").match(/Ctrl\+O expand/gu)).toHaveLength(1);
     const beforeExpand = fixture.output().length;
-    fixture.write("\u000f");
+    fixture.write("\u001b[111;5:1u\u001b[111;5:2u\u001b[111;5:2u\u001b[111;5:3u");
     await fixture.waitForAfter("\u001b[?2026l", beforeExpand);
     let screen = fixture.screen()?.join("\n") ?? "";
     expect(fixture.screen()?.findIndex((line) => line.includes("read README.md"))).toBe(
@@ -5256,11 +5264,128 @@ test("Ctrl+O toggles bounded authoritative tool details", async () => {
     fixture.write("\u000f");
     await fixture.waitForAfter("\u001b[?2026l", beforeCollapse);
     screen = fixture.screen()?.join("\n") ?? "";
-    expect(screen).toContain("84 bytes");
+    expect(screen).toContain("read README.md · Ctrl+O expand");
     expect(screen).not.toContain("provider model response");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("Ctrl+O targets the visible tool card and keeps other cards independently collapsed", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-tool-target-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  for (let card = 1; card <= 3; card += 1) {
+    await writeFile(
+      join(workspaceRoot, `tool-${card}.txt`),
+      `${Array.from(
+        { length: 12 },
+        (_, index) => `tool${card}-line${String(index + 1).padStart(2, "0")}`,
+      ).join("\n")}\n`,
+      "utf8",
+    );
+  }
+  const terminal = new AppliedViewportTerminal({ columns: 80, rows: 18 });
+  const execution = runTuiFixture({
+    scenario: "tool-multiple",
+    stateRoot,
+    terminal,
+    workspaceRoot,
+  });
+
+  try {
+    await terminal.nextFrame(0);
+    await waitForPhysicalText(terminal, "Multiple tool answer 3.");
+    await inputAndWaitForPhysicalFrame(terminal, "\u001b[H");
+    await inputAndWaitForPhysicalFrame(terminal, "\u001b[6~");
+    let screen = terminal.lines().join("\n");
+    expect(screen).toContain("read tool-1.txt · Ctrl+O expand");
+    expect(screen.match(/Ctrl\+O expand/gu)).toHaveLength(1);
+    expect(screen).not.toContain("read tool-3.txt");
+    const collapsedToolRow = terminal.lines().findIndex((line) => line.includes("read tool-1.txt"));
+
+    await inputAndWaitForPhysicalFrame(terminal, "\u000f");
+    screen = terminal.lines().join("\n");
+    expect(terminal.lines().findIndex((line) => line.includes("read tool-1.txt"))).toBe(
+      collapsedToolRow,
+    );
+    expect(screen).toContain("read tool-1.txt · Ctrl+O fold");
+    for (let page = 0; page < 4; page += 1) {
+      await inputAndWaitForPhysicalFrame(terminal, "\u001b[6~");
+    }
+    screen = terminal.lines().join("\n");
+    expect(screen).toContain("tool1-line12");
+
+    await inputAndWaitForPhysicalFrame(terminal, "\u001b[F");
+    screen = terminal.lines().join("\n");
+    expect(screen).toContain("Multiple tool answer 3.");
+    expect(screen).toContain("2 more projected lines");
+    expect(screen).not.toContain("tool3-line12");
+  } finally {
+    if (terminal.running()) {
+      terminal.input("\u0011");
+    }
+    await execution.catch(() => undefined);
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("tool disclosure resets across session switches without changing durable JSONL", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-tool-session-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  for (let card = 1; card <= 3; card += 1) {
+    await writeFile(
+      join(workspaceRoot, `tool-${card}.txt`),
+      `${Array.from(
+        { length: 12 },
+        (_, index) => `tool${card}-line${String(index + 1).padStart(2, "0")}`,
+      ).join("\n")}\n`,
+      "utf8",
+    );
+  }
+  const terminal = new AppliedViewportTerminal({ columns: 80, rows: 18 });
+  const execution = runTuiFixture({
+    scenario: "tool-multiple",
+    stateRoot,
+    terminal,
+    workspaceRoot,
+  });
+
+  try {
+    await terminal.nextFrame(0);
+    await waitForPhysicalText(terminal, "Adam · Tool disclosure source session");
+    const durableStateBeforeDisclosure = await readFilesRecursively(stateRoot);
+    await inputAndWaitForPhysicalFrame(terminal, "\u000f");
+    expect(terminal.lines().join("\n")).toContain("Ctrl+O fold");
+
+    await inputAndWaitForPhysicalFrame(terminal, "\u001b[F");
+    await inputAndWaitForPhysicalFrame(terminal, "/resume");
+    await inputAndWaitForPhysicalFrame(terminal, "\r");
+    await waitForPhysicalText(terminal, "Select a project session");
+    await inputAndWaitForPhysicalFrame(terminal, "Tool disclosure switch session");
+    await inputAndWaitForPhysicalFrame(terminal, "\r");
+    await waitForPhysicalText(terminal, "Adam · Tool disclosure switch session");
+
+    await inputAndWaitForPhysicalFrame(terminal, "/resume");
+    await inputAndWaitForPhysicalFrame(terminal, "\r");
+    await waitForPhysicalText(terminal, "Select a project session");
+    await inputAndWaitForPhysicalFrame(terminal, "Tool disclosure source session");
+    await inputAndWaitForPhysicalFrame(terminal, "\r");
+    await waitForPhysicalText(terminal, "Adam · Tool disclosure source session");
+    await inputAndWaitForPhysicalFrame(terminal, "\u000f");
+    const screen = terminal.lines().join("\n");
+    expect(screen).toContain("read tool-3.txt · Ctrl+O fold");
+    expect(await readFilesRecursively(stateRoot)).toBe(durableStateBeforeDisclosure);
+  } finally {
+    if (terminal.running()) {
+      terminal.input("\u0011");
+    }
+    await execution.catch(() => undefined);
     await rm(testRoot, { recursive: true, force: true });
   }
 });
@@ -5613,8 +5738,10 @@ test("tool subjects keep their full bounded value only in the 120-column layout"
 
     let beforeResize = fixture.output().length;
     await fixture.resize(120, 40);
-    let frame = latestSynchronizedFrame(fixture.output().slice(beforeResize)).join("\n");
+    const wideFrameLines = latestSynchronizedFrame(fixture.output().slice(beforeResize));
+    let frame = wideFrameLines.join("\n");
     expect(frame).toContain("bounded-secondary-provenance-and-wide-tail");
+    expect(wideFrameLines.find((line) => line.includes("$ printf"))).toContain("Ctrl+O expand");
 
     beforeResize = fixture.output().length;
     await fixture.resize(80, 24);
@@ -5624,7 +5751,14 @@ test("tool subjects keep their full bounded value only in the 120-column layout"
     expect(frameLines.find((line) => line.includes("$ printf"))).not.toContain(
       "bounded-secondary-provenance-and-wide-tail",
     );
+    expect(frameLines.find((line) => line.includes("$ printf"))).toContain("Ctrl+O expand");
     expect(frame).toContain("shell-card-fixture-with-bounded-secondary-provenance-and-wide-tail");
+
+    beforeResize = fixture.output().length;
+    await fixture.resize(40, 40);
+    await fixture.waitForAfter("\u001b[?2026l", beforeResize);
+    const narrowFrameLines = latestSynchronizedFrame(fixture.output().slice(beforeResize));
+    expect(narrowFrameLines.find((line) => line.includes("$ printf"))).toContain("Ctrl+O expand");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -264,6 +264,17 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
         name: "Switch target session",
       });
     }
+    if (options.scenario === "tool-multiple") {
+      const switchTarget = await lifecycle.create({ targetIdentity });
+      await lifecycle.continue({
+        sessionId: switchTarget.sessionId,
+        input: { text: "Seeded project session for tool disclosure switch" },
+      });
+      await lifecycle.setSessionManualName({
+        sessionId: switchTarget.sessionId,
+        name: "Tool disclosure switch session",
+      });
+    }
     const resumedSessionId =
       options.scenario === "resume" ||
       options.scenario === "history" ||
@@ -273,6 +284,7 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
       options.scenario === "reasoning-large-multiple" ||
       options.scenario === "reasoning-artifact-session-race" ||
       options.scenario === "target-navigation" ||
+      options.scenario === "tool-multiple" ||
       options.scenario === "unsafe-history"
         ? await lifecycle.create({ targetIdentity }).then(async (created) => {
             if (options.scenario === "history") {
@@ -311,6 +323,17 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
                   input: { text: `Inspect seeded reasoning block ${block}` },
                 });
               }
+            } else if (options.scenario === "tool-multiple") {
+              for (let card = 1; card <= 3; card += 1) {
+                await lifecycle.continue({
+                  sessionId: created.sessionId,
+                  input: { text: `Inspect seeded tool card ${card}` },
+                });
+              }
+              await lifecycle.setSessionManualName({
+                sessionId: created.sessionId,
+                name: "Tool disclosure source session",
+              });
             } else if (options.scenario === "reasoning-artifact-session-race") {
               await lifecycle.continue({
                 sessionId: created.sessionId,
@@ -930,6 +953,7 @@ function createFixtureModelTargets(options: {
   }
   let artifactResponseOrdinal = 0;
   let reasoningViewportOrdinal = 0;
+  let toolPreviewOrdinal = 0;
   const model: ModelDriver = {
     async *stream(request) {
       if (request.tools.length === 0) {
@@ -971,6 +995,25 @@ function createFixtureModelTargets(options: {
           return;
         }
         yield { type: "text_delta", text: "Read complete." };
+      } else if (options.scenario === "tool-multiple") {
+        const latest = request.messages.at(-1);
+        if (latest?.role === "user") {
+          toolPreviewOrdinal += 1;
+          yield {
+            type: "tool_call_start",
+            id: `read-multiple-${toolPreviewOrdinal}`,
+            name: "read_file",
+          };
+          yield {
+            type: "tool_call_delta",
+            id: `read-multiple-${toolPreviewOrdinal}`,
+            json: JSON.stringify({ path: `tool-${toolPreviewOrdinal}.txt` }),
+          };
+          yield { type: "tool_call_end", id: `read-multiple-${toolPreviewOrdinal}` };
+          yield { type: "finish", reason: "tool_calls" };
+          return;
+        }
+        yield { type: "text_delta", text: `Multiple tool answer ${toolPreviewOrdinal}.` };
       } else if (options.scenario === "write") {
         const latest = request.messages.at(-1);
         if (latest?.role === "user") {

--- a/apps/tui/src/tool-preview.test.ts
+++ b/apps/tui/src/tool-preview.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from "vitest";
 import { createAdamTuiTheme } from "./theme.js";
 import { ToolPreview } from "./tool-preview.js";
 
-test("ToolPreview shows ten numbered code lines before the global expansion", () => {
+test("ToolPreview shows ten numbered code lines in its collapsed view", () => {
   const preview: ToolPreviewDisplay = {
     kind: "read_text",
     language: "typescript",
@@ -20,7 +20,8 @@ test("ToolPreview shows ten numbered code lines before the global expansion", ()
   expect(collapsed.join("\n")).toContain(" 1 │ const value1 = 1;");
   expect(collapsed.join("\n")).toContain("10 │ const value10 = 10;");
   expect(collapsed.join("\n")).not.toContain("value11");
-  expect(collapsed.join("\n")).toContain("2 more projected lines · Ctrl+O expand");
+  expect(collapsed.join("\n")).toContain("2 more projected lines");
+  expect(collapsed.join("\n")).not.toContain("Ctrl+O");
 
   const expanded = new ToolPreview(preview, true, createAdamTuiTheme(true)).render(32);
   expect(expanded.join("\n")).toContain("12 │ const value12 = 12;");

--- a/apps/tui/src/tool-preview.ts
+++ b/apps/tui/src/tool-preview.ts
@@ -65,7 +65,7 @@ export class ToolPreview implements Component {
         ? [
             this.#expanded
               ? `${hiddenLines} projected lines omitted`
-              : `${hiddenLines} more projected lines · Ctrl+O expand`,
+              : `${hiddenLines} more projected lines`,
           ]
         : []),
       ...(preview.omittedBytes > 0
@@ -116,7 +116,7 @@ export class ToolPreview implements Component {
         ? [
             boundedLine(
               this.#theme.muted(
-                `… ${hiddenLines} more diff lines${this.#expanded ? " omitted" : " · Ctrl+O expand"}`,
+                `… ${hiddenLines} more diff lines${this.#expanded ? " omitted" : ""}`,
               ),
               width,
             ),

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -26,6 +26,7 @@ import {
   type Terminal,
   Text,
   TuiAltScreen,
+  truncateToWidth,
   VStack,
 } from "@earendil-works/pi-tui";
 import {
@@ -296,7 +297,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   const exitArm = new ExitArm(deadlineScheduler, () => requestPolicyRender());
   const legacyDuplicateGuard = new LegacyDuplicateGuard(deadlineScheduler);
   let previousRunActive: boolean | undefined;
-  let toolDetailsExpanded = false;
+  const expandedToolIds = new Set<string>();
   let pendingOperationBaseline: {
     readonly sessionId: string;
     readonly operationIds: ReadonlySet<string>;
@@ -617,6 +618,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       transcriptViewport.followEnd();
       pendingOperationBaseline = null;
       expandedReasoningIds.clear();
+      expandedToolIds.clear();
       reasoningArtifactReads.clear();
       reasoningArtifactTexts.clear();
       largeReasoningViews.clear();
@@ -1077,10 +1079,11 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         renderReasoning(item, item.artifact);
         previousWasAssistant = false;
       } else if (item.type === "tool_call") {
+        const expanded = expandedToolIds.has(item.id);
         const tool = new Box(1, 1, theme.toolBackground);
         const subject = item.subject?.value;
         const label = safeTerminalText(item.label);
-        const title =
+        const baseTitle =
           item.kind === "shell"
             ? subject === undefined
               ? "$"
@@ -1088,15 +1091,24 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
             : subject === undefined
               ? label
               : `${label} ${safeTerminalText(subject)}`;
-        tool.addChild(new ResponsiveLine(theme.toolTitle(title)));
+        const action = `Ctrl+O ${expanded ? "fold" : "expand"}`;
+        const titleWithAction = (baseWidth: number): string =>
+          theme.toolTitle(`${truncateToWidth(baseTitle, baseWidth)} · ${action}`);
+        const toolTitle = new ResponsiveText(() => physicalTerminal.columns);
+        toolTitle.setText({
+          narrow: titleWithAction(14),
+          standard: titleWithAction(32),
+          wide: theme.toolTitle(`${baseTitle} · ${action}`),
+        });
+        tool.addChild(toolTitle);
         if (item.preview !== null) {
-          tool.addChild(new ToolPreview(item.preview, toolDetailsExpanded, theme));
+          tool.addChild(new ToolPreview(item.preview, expanded, theme));
         }
         const detail = item.resultSummary ?? toolStatusText(item.status, item.outcome?.status);
         if (detail !== null) {
           tool.addChild(new ResponsiveLine(theme.toolOutput(safeTerminalText(detail))));
         }
-        if (toolDetailsExpanded) {
+        if (expanded) {
           const replay = item.source?.replay ?? "unavailable";
           tool.addChild(
             new Text(theme.muted(safeTerminalText(`safe summary · ${detail ?? "unavailable"}`))),
@@ -3316,16 +3328,29 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       return { consume: true };
     }
     if (commandRegistry.matchesInput(data, "toggle_tool_details")) {
-      const latestTool = options.presentation
-        .getState()
-        .authoritative.active?.transcript.items.findLast((item) => item.type === "tool_call");
-      if (latestTool !== undefined) {
-        const anchorId = toolAnchorId(latestTool.id);
-        if (!transcriptViewport.preserveAnchorRow(anchorId, terminal.columns)) {
-          transcriptViewport.focusOnNextLayout(anchorId);
-        }
+      if (isKeyRepeat(data) || isKeyRelease(data)) {
+        return { consume: true };
       }
-      toolDetailsExpanded = !toolDetailsExpanded;
+      const tools =
+        options.presentation
+          .getState()
+          .authoritative.active?.transcript.items.filter((item) => item.type === "tool_call") ?? [];
+      const visibleAnchorId = transcriptViewport.selectVisibleAnchor(
+        tools.map((tool) => toolAnchorId(tool.id)),
+        terminal.columns,
+      );
+      const tool =
+        tools.find((candidate) => toolAnchorId(candidate.id) === visibleAnchorId) ?? tools.at(-1);
+      if (tool === undefined) {
+        return { consume: true };
+      }
+      const anchorId = toolAnchorId(tool.id);
+      if (!transcriptViewport.preserveAnchorRow(anchorId, terminal.columns)) {
+        transcriptViewport.focusOnNextLayout(anchorId);
+      }
+      if (!expandedToolIds.delete(tool.id)) {
+        expandedToolIds.add(tool.id);
+      }
       renderState();
       tui.renderNow();
       return { consume: true };


### PR DESCRIPTION
## Summary

- replace the global tool-detail toggle with stable per-tool disclosure state
- ignore Kitty repeat/release phases and target the centered or nearest visible tool card before the newest fallback
- preserve the selected card row, clear disclosure on session changes, and show one responsive local Ctrl+O expand/fold action
- keep preview, runtime, Presentation, permission, trust, and JSONL contracts unchanged

## Verification

- pnpm quality:check: 50 files passed, 2 opt-in files skipped; 1,244 tests passed, 10 opt-in tests skipped
- pnpm test:tui:os: 27/27 passed
- focused TUI behavior and topology: 189/189 passed
- caller-visible coverage includes Kitty press/repeat/release, visible multi-card targeting, independent state, title-row preservation, 40/80/120 layouts, NO_COLOR, session cleanup, and byte-for-byte durable-state non-mutation