### PR TITLE
test(tui): await complete admission receipts

### DIFF
--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -1284,12 +1284,10 @@ test("the production TUI admits owner-local workspace trust before session or ta
     expect(fixture.screen()?.join("\n") ?? "").toContain("> Yes — Trust and continue");
     fixture.write("\r");
     const trustReceiptPath = join(controlRoot, "workspace-trust-dispatch-settled");
-    await waitForPath(trustReceiptPath);
-    await expect(readFile(trustReceiptPath, "utf8")).resolves.toBe("admitted\n");
+    await expect(waitForFileContents(trustReceiptPath, "admitted\n")).resolves.toBe("admitted\n");
     await waitForPath(join(configRoot, "adam-agent", "workspace-trust.json"));
     const createReceiptPath = join(controlRoot, "create-session-dispatch-settled");
-    await waitForPath(createReceiptPath);
-    await expect(readFile(createReceiptPath, "utf8")).resolves.toBe("admitted\n");
+    await expect(waitForFileContents(createReceiptPath, "admitted\n")).resolves.toBe("admitted\n");
     await fixture.resize(42, 12);
     const admittedNarrow = fixture.screen()?.join("\n") ?? "";
     expect(admittedNarrow).not.toContain("Workspace trust required");


### PR DESCRIPTION
## Summary

- wait for complete trust and session-creation receipt contents instead of file-name visibility
- remove the create-before-write race exposed by exact-main Quality after the Ctrl+O disclosure merge
- keep product behavior and persistence unchanged

## Verification

- focused admission test: 5/5 independent runs
- pnpm quality:check: 50 passed test files, 2 skipped; 1244 passed tests, 10 opt-in skipped