### PR TITLE
Advance Direct DeepSeek target profiles

### DIFF
--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -58,7 +58,7 @@ const launchTargetIdentities: readonly ModelTargetIdentity[] = [
     vendor: "deepseek",
     modelId: "deepseek-v4-flash",
     route: "direct",
-    profileVersion: 2,
+    profileVersion: 3,
     certification: "certified",
   },
   {
@@ -66,7 +66,7 @@ const launchTargetIdentities: readonly ModelTargetIdentity[] = [
     vendor: "deepseek",
     modelId: "deepseek-v4-pro",
     route: "direct",
-    profileVersion: 2,
+    profileVersion: 3,
     certification: "certified",
   },
 ];
@@ -79,7 +79,7 @@ const fixtureThinkingCapabilities = new Map(
       targetIdentity: identity,
       providerProfile: {
         id: "@ai-sdk/deepseek/chat" as const,
-        version: "3.0.28" as const,
+        version: identity.profileVersion >= 3 ? ("3.0.30" as const) : ("3.0.28" as const),
         requestPath: "provider_options.deepseek" as const,
       },
       supportsOff: true as const,
@@ -1475,7 +1475,7 @@ function createFixtureModelTargets(options: {
         identity,
         driver: model,
         contextProfile:
-          identity.profileVersion === 2 ? preparedDirectDeepSeekV2ContextProfile : contextProfile,
+          identity.profileVersion >= 2 ? preparedDirectDeepSeekV2ContextProfile : contextProfile,
         ...(thinkingCapability === undefined ? {} : { thinkingCapability }),
       };
     },

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@adam-agent/extension-api": "workspace:*",
     "@adam-agent/presentation": "workspace:*",
-    "@ai-sdk/deepseek": "3.0.28",
+    "@ai-sdk/deepseek": "3.0.30",
     "@ai-sdk/gateway": "4.0.52",
     "@ai-sdk/provider": "4.0.7",
     "@biomejs/biome": "2.5.8",

--- a/packages/agent/src/model-targets.ts
+++ b/packages/agent/src/model-targets.ts
@@ -157,8 +157,12 @@ const directDeepSeekV1Targets: readonly ModelTargetIdentity[] = Object.freeze([
 const directDeepSeekV2Targets: readonly ModelTargetIdentity[] = Object.freeze(
   directDeepSeekV1Targets.map((identity) => Object.freeze({ ...identity, profileVersion: 2 })),
 );
-const currentDirectDeepSeekTargets = directDeepSeekV2Targets;
+const directDeepSeekV3Targets: readonly ModelTargetIdentity[] = Object.freeze(
+  directDeepSeekV2Targets.map((identity) => Object.freeze({ ...identity, profileVersion: 3 })),
+);
+const currentDirectDeepSeekTargets = directDeepSeekV3Targets;
 const supportedDirectDeepSeekTargets = Object.freeze([
+  ...directDeepSeekV3Targets,
   ...directDeepSeekV2Targets,
   ...directDeepSeekV1Targets,
 ]);
@@ -350,7 +354,7 @@ function directDeepSeekContextProfileFor(identity: ModelTargetIdentity): Context
   if (identity.profileVersion === 1) {
     return directDeepSeekContextProfileV1;
   }
-  if (identity.profileVersion === 2) {
+  if (identity.profileVersion === 2 || identity.profileVersion === 3) {
     return preparedDirectDeepSeekV2ContextProfile;
   }
   throw new RangeError("The Direct DeepSeek context profile is not supported.");
@@ -369,4 +373,18 @@ export function sameModelTargetIdentity(
     left.profileVersion === right.profileVersion &&
     left.certification === right.certification
   );
+}
+
+export function modelTargetUsesContextProfile(
+  identity: ModelTargetIdentity,
+  contextProfile: ContextProfile,
+): boolean {
+  const expectedContextProfileVersion =
+    identity.vendor === "deepseek" &&
+    identity.route === "direct" &&
+    (identity.modelId === "deepseek-v4-flash" || identity.modelId === "deepseek-v4-pro") &&
+    identity.profileVersion === 3
+      ? 2
+      : identity.profileVersion;
+  return contextProfile.version === expectedContextProfileVersion;
 }

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -58,6 +58,7 @@ import type { McpToolProfileV1 } from "./mcp-profile-contracts.js";
 import {
   type ModelTargetIdentity,
   type ModelTargets,
+  modelTargetUsesContextProfile,
   sameModelTargetIdentity,
 } from "./model-targets.js";
 import {
@@ -1636,7 +1637,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       );
       if (
         target === undefined ||
-        target.contextProfile.version !== snapshot.targetIdentity.profileVersion ||
+        !modelTargetUsesContextProfile(snapshot.targetIdentity, target.contextProfile) ||
         !isContextProfileSupported(target.contextProfile)
       ) {
         return {
@@ -1893,7 +1894,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         if (
           resolved === undefined ||
           !sameModelTargetIdentity(resolved.identity, input.targetIdentity) ||
-          resolved.contextProfile.version !== input.targetIdentity.profileVersion ||
+          !modelTargetUsesContextProfile(input.targetIdentity, resolved.contextProfile) ||
           !isContextProfileSupported(resolved.contextProfile)
         ) {
           throw new SessionLifecycleError("session_model_target_incompatible");
@@ -2430,7 +2431,10 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         }
         if (
           !sameModelTargetIdentity(resolved.identity, resumed.snapshot.targetIdentity) ||
-          resolved.contextProfile.version !== resumed.snapshot.targetIdentity.profileVersion ||
+          !modelTargetUsesContextProfile(
+            resumed.snapshot.targetIdentity,
+            resolved.contextProfile,
+          ) ||
           !isContextProfileSupported(resolved.contextProfile)
         ) {
           throw new SessionLifecycleError("session_model_target_incompatible");
@@ -3679,7 +3683,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           throw new SessionLifecycleError("session_model_target_unavailable");
         }
         if (
-          target.contextProfile.version !== input.targetIdentity.profileVersion ||
+          !modelTargetUsesContextProfile(input.targetIdentity, target.contextProfile) ||
           !isContextProfileSupported(target.contextProfile)
         ) {
           throw new SessionLifecycleError("session_model_target_incompatible");

--- a/packages/agent/src/thinking-policy.ts
+++ b/packages/agent/src/thinking-policy.ts
@@ -22,7 +22,7 @@ export type ThinkingCapabilityV1 = {
   readonly targetIdentity: ModelTargetIdentity;
   readonly providerProfile: {
     readonly id: "@ai-sdk/deepseek/chat";
-    readonly version: "3.0.28";
+    readonly version: "3.0.28" | "3.0.30";
     readonly requestPath: "provider_options.deepseek";
   };
   readonly supportsOff: true;
@@ -91,7 +91,7 @@ export function createDirectDeepSeekThinkingCapability(
     targetIdentity,
     providerProfile: {
       id: "@ai-sdk/deepseek/chat" as const,
-      version: "3.0.28" as const,
+      version: targetIdentity.profileVersion >= 3 ? ("3.0.30" as const) : ("3.0.28" as const),
       requestPath: "provider_options.deepseek" as const,
     },
     supportsOff: true as const,

--- a/packages/testkit/src/model-targets.test.ts
+++ b/packages/testkit/src/model-targets.test.ts
@@ -56,7 +56,7 @@ test("an exact Direct DeepSeek target returns a public answer-only model driver"
       vendor: "deepseek",
       modelId: "deepseek-v4-flash",
       route: "direct",
-      profileVersion: 2,
+      profileVersion: 3,
       certification: "certified",
     },
     requests: [
@@ -95,12 +95,12 @@ test("an exact Direct DeepSeek target exposes only its real thinking policy choi
 
   expect(target.thinkingCapability).toMatchObject({
     schemaVersion: 1,
-    capabilityId: "deepseek-chat-thinking:deepseek-v4-flash.direct:target-profile-2",
+    capabilityId: "deepseek-chat-thinking:deepseek-v4-flash.direct:target-profile-3",
     capabilityVersion: 1,
     targetIdentity: target.identity,
     providerProfile: {
       id: "@ai-sdk/deepseek/chat",
-      version: "3.0.28",
+      version: "3.0.30",
       requestPath: "provider_options.deepseek",
     },
     supportsOff: true,
@@ -113,7 +113,7 @@ test("an exact Direct DeepSeek target exposes only its real thinking policy choi
       { id: "max", label: "Max", effectiveLevelId: "max" },
     ],
     reasoningArtifact: "provider_reasoning",
-    capabilityDigest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+    capabilityDigest: "sha256:0af69c6828ddc0f68e6ae38c0203c855288df76ac56c2431b4570b96b7603287",
   });
   expect(target.thinkingCapability.levels.map((level) => level.id)).not.toEqual(
     expect.arrayContaining(["medium", "xhigh"]),
@@ -437,6 +437,247 @@ test.each(["deepseek-v4-flash", "deepseek-v4-pro"] as const)(
   },
 );
 
+test.each([
+  {
+    label: "Flash",
+    targetId: "deepseek-v4-flash.direct",
+    modelId: "deepseek-v4-flash",
+    capabilityId: "deepseek-chat-thinking:deepseek-v4-flash.direct:target-profile-2",
+    v2Digest: "sha256:81aa965c6378ee4995f6e7e1dab30e6086ab0508ced7b55b4b63a3dd5da913a8",
+    v1Digest: "sha256:66929505ba3695e601c820a2bb1213c2959045813f5f91a74755622b3032c31f",
+  },
+  {
+    label: "Pro",
+    targetId: "deepseek-v4-pro.direct",
+    modelId: "deepseek-v4-pro",
+    capabilityId: "deepseek-chat-thinking:deepseek-v4-pro.direct:target-profile-2",
+    v2Digest: "sha256:ab5c6d78a323ef6092af2a09dfd83c2d098e14fb02eaa50606e3f25e867771f0",
+    v1Digest: "sha256:a2ffdfea3729204de7a348287e0e2bb43c949f88881433ab9e77210da326ba5a",
+  },
+] as const)(
+  "the historical Direct DeepSeek $label v2 capability and reasoning-tool contract remain fixed",
+  async ({ targetId, modelId, capabilityId, v2Digest, v1Digest }) => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-deepseek-v2-characterization-"));
+    await writeFile(join(workspaceRoot, "README.md"), "# Adam Agent\n", "utf8");
+    const requests: unknown[] = [];
+    let requestCount = 0;
+    const targets = createModelTargets({
+      environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
+      fetch: async (_input, init) => {
+        requests.push(JSON.parse(String(init?.body)));
+        requestCount += 1;
+        return new Response(
+          requestCount === 1 ? reasoningToolDeepSeekStream : finalAnswerDeepSeekStream,
+          { headers: { "content-type": "text/event-stream" }, status: 200 },
+        );
+      },
+    });
+    const historicalV2Identity: ModelTargetIdentity = {
+      targetId,
+      vendor: "deepseek",
+      modelId,
+      route: "direct",
+      profileVersion: 2,
+      certification: "certified",
+    };
+    const resolved = await targets.resolve({
+      targetId,
+      targetIdentity: historicalV2Identity,
+      allowExperimental: false,
+      signal: new AbortController().signal,
+    });
+    const historicalV1 = await targets.resolve({
+      targetId,
+      targetIdentity: { ...historicalV2Identity, profileVersion: 1 },
+      allowExperimental: false,
+      signal: new AbortController().signal,
+    });
+    const events: RuntimeEvent[] = [];
+    const session = new AgentSession({
+      maximumOutputTokens: resolved.contextProfile.maximumOutputTokens,
+      model: resolved.driver,
+      tools: createReadToolRegistry({ workspaceRoot }),
+      permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      store: createInMemorySessionStore(),
+    });
+    session.subscribe((event) => events.push(event));
+
+    try {
+      await expect(session.run({ text: "Read the project name" })).resolves.toEqual({
+        status: "completed",
+        answer: "The project is Adam Agent.",
+      });
+      expect(resolved.thinkingCapability).toEqual({
+        schemaVersion: 1,
+        capabilityId,
+        capabilityVersion: 1,
+        capabilityDigest: v2Digest,
+        targetIdentity: historicalV2Identity,
+        providerProfile: {
+          id: "@ai-sdk/deepseek/chat",
+          version: "3.0.28",
+          requestPath: "provider_options.deepseek",
+        },
+        supportsOff: true,
+        defaultLevelId: "high",
+        providerDefault: { effectiveLevelId: "high", mutable: true },
+        levels: [
+          {
+            id: "off",
+            label: "Off",
+            effectiveLevelId: "off",
+            mapping: {
+              requestPath: "provider_options.deepseek",
+              thinkingType: "disabled",
+            },
+          },
+          {
+            id: "low",
+            label: "Low",
+            effectiveLevelId: "low",
+            mapping: {
+              requestPath: "provider_options.deepseek",
+              thinkingType: "enabled",
+              reasoningEffort: "low",
+            },
+          },
+          {
+            id: "high",
+            label: "High",
+            effectiveLevelId: "high",
+            mapping: {
+              requestPath: "provider_options.deepseek",
+              thinkingType: "enabled",
+              reasoningEffort: "high",
+            },
+          },
+          {
+            id: "max",
+            label: "Max",
+            effectiveLevelId: "max",
+            mapping: {
+              requestPath: "provider_options.deepseek",
+              thinkingType: "enabled",
+              reasoningEffort: "max",
+            },
+          },
+        ],
+        reasoningArtifact: "provider_reasoning",
+      });
+      expect(historicalV1.thinkingCapability).toMatchObject({
+        capabilityDigest: v1Digest,
+        providerProfile: { id: "@ai-sdk/deepseek/chat", version: "3.0.28" },
+        targetIdentity: { ...historicalV2Identity, profileVersion: 1 },
+      });
+      expect(requests).toEqual([
+        expect.objectContaining({
+          model: modelId,
+          max_tokens: 384_000,
+          messages: expect.arrayContaining([{ role: "user", content: "Read the project name" }]),
+        }),
+        expect.objectContaining({
+          model: modelId,
+          max_tokens: 384_000,
+          messages: expect.arrayContaining([
+            expect.objectContaining({
+              role: "assistant",
+              reasoning_content: "I need the README.",
+            }),
+            {
+              role: "tool",
+              tool_call_id: "read-project",
+              content:
+                '{"status":"completed","output":{"path":"README.md","content":"# Adam Agent\\n","truncated":false}}',
+            },
+          ]),
+        }),
+      ]);
+      expect(events).toContainEqual({
+        type: "tool_completed",
+        callId: "read-project",
+        name: "read_file",
+        output: { path: "README.md", content: "# Adam Agent\n", truncated: false },
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test("AgentSession uses current Direct DeepSeek Flash v3 while historical profiles remain exact", async () => {
+  const requests: unknown[] = [];
+  const targets = createModelTargets({
+    environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
+    fetch: async (_input, init) => {
+      requests.push(JSON.parse(String(init?.body)));
+      return new Response(answerOnlyDeepSeekStream, {
+        headers: { "content-type": "text/event-stream" },
+        status: 200,
+      });
+    },
+  });
+  const current = await targets.resolve({
+    targetId: "deepseek-v4-flash.direct",
+    allowExperimental: false,
+    signal: new AbortController().signal,
+  });
+  const historicalV2 = await targets.resolve({
+    targetId: "deepseek-v4-flash.direct",
+    targetIdentity: { ...current.identity, profileVersion: 2 },
+    allowExperimental: false,
+    signal: new AbortController().signal,
+  });
+  const historicalV1 = await targets.resolve({
+    targetId: "deepseek-v4-flash.direct",
+    targetIdentity: { ...current.identity, profileVersion: 1 },
+    allowExperimental: false,
+    signal: new AbortController().signal,
+  });
+  const session = new AgentSession({
+    maximumOutputTokens: current.contextProfile.maximumOutputTokens,
+    model: current.driver,
+    store: createInMemorySessionStore(),
+  });
+
+  await expect(session.run({ text: "Introduce yourself" })).resolves.toEqual({
+    status: "completed",
+    answer: "Hello, Adam.",
+  });
+  expect(current).toMatchObject({
+    identity: { profileVersion: 3 },
+    contextProfile: { version: 2, maximumOutputTokens: 384_000 },
+    thinkingCapability: {
+      capabilityId: "deepseek-chat-thinking:deepseek-v4-flash.direct:target-profile-3",
+      providerProfile: { id: "@ai-sdk/deepseek/chat", version: "3.0.30" },
+    },
+  });
+  expect(historicalV2).toMatchObject({
+    identity: { profileVersion: 2 },
+    contextProfile: { version: 2, maximumOutputTokens: 384_000 },
+    thinkingCapability: {
+      capabilityId: "deepseek-chat-thinking:deepseek-v4-flash.direct:target-profile-2",
+      capabilityDigest: "sha256:81aa965c6378ee4995f6e7e1dab30e6086ab0508ced7b55b4b63a3dd5da913a8",
+      providerProfile: { id: "@ai-sdk/deepseek/chat", version: "3.0.28" },
+    },
+  });
+  expect(historicalV1).toMatchObject({
+    identity: { profileVersion: 1 },
+    contextProfile: { version: 1, maximumOutputTokens: 32_768 },
+    thinkingCapability: {
+      capabilityId: "deepseek-chat-thinking:deepseek-v4-flash.direct:target-profile-1",
+      capabilityDigest: "sha256:66929505ba3695e601c820a2bb1213c2959045813f5f91a74755622b3032c31f",
+      providerProfile: { id: "@ai-sdk/deepseek/chat", version: "3.0.28" },
+    },
+  });
+  expect(requests).toEqual([
+    expect.objectContaining({
+      model: "deepseek-v4-flash",
+      max_tokens: 384_000,
+      messages: expect.arrayContaining([{ role: "user", content: "Introduce yourself" }]),
+    }),
+  ]);
+});
+
 test("AgentSession keeps tool execution and replay state while using the unified driver", async () => {
   const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-model-target-"));
   await writeFile(join(workspaceRoot, "README.md"), "# Adam Agent\n", "utf8");
@@ -453,11 +694,12 @@ test("AgentSession keeps tool execution and replay state while using the unified
       );
     },
   });
-  const { driver } = await targets.resolve({
+  const resolved = await targets.resolve({
     targetId: "deepseek-v4-pro.direct",
     allowExperimental: false,
     signal: new AbortController().signal,
   });
+  const { driver } = resolved;
   const store = createInMemorySessionStore();
   const session = new AgentSession({
     maximumOutputTokens: 32_768,
@@ -475,6 +717,15 @@ test("AgentSession keeps tool execution and replay state while using the unified
     expect({ result, requestCount }).toEqual({
       result: { status: "completed", answer: "The project is Adam Agent." },
       requestCount: 2,
+    });
+    expect(resolved).toMatchObject({
+      identity: { profileVersion: 3 },
+      contextProfile: { version: 2, maximumOutputTokens: 384_000 },
+      thinkingCapability: {
+        capabilityId: "deepseek-chat-thinking:deepseek-v4-pro.direct:target-profile-3",
+        capabilityDigest: "sha256:5deb10622dcda4511c80faa9bb8920fe0750f67c4b63c18b4bf75975bb4fa5f2",
+        providerProfile: { id: "@ai-sdk/deepseek/chat", version: "3.0.30" },
+      },
     });
     expect(events).toContainEqual({
       type: "tool_completed",
@@ -1351,7 +1602,7 @@ test("the target snapshot reports exact Certified identities and safe credential
           vendor: "deepseek",
           modelId: "deepseek-v4-flash",
           route: "direct",
-          profileVersion: 2,
+          profileVersion: 3,
           certification: "certified",
         },
         readiness: { status: "available", credentialSource: "DEEPSEEK_API_KEY" },
@@ -1371,7 +1622,7 @@ test("the target snapshot reports exact Certified identities and safe credential
           vendor: "deepseek",
           modelId: "deepseek-v4-flash",
           route: "direct",
-          profileVersion: 2,
+          profileVersion: 3,
           certification: "certified",
         }),
       },
@@ -1381,7 +1632,7 @@ test("the target snapshot reports exact Certified identities and safe credential
           vendor: "deepseek",
           modelId: "deepseek-v4-pro",
           route: "direct",
-          profileVersion: 2,
+          profileVersion: 3,
           certification: "certified",
         },
         readiness: { status: "available", credentialSource: "DEEPSEEK_API_KEY" },
@@ -1401,7 +1652,7 @@ test("the target snapshot reports exact Certified identities and safe credential
           vendor: "deepseek",
           modelId: "deepseek-v4-pro",
           route: "direct",
-          profileVersion: 2,
+          profileVersion: 3,
           certification: "certified",
         }),
       },
@@ -1441,7 +1692,7 @@ function expectedDirectDeepSeekThinkingCapability(targetIdentity: ModelTargetIde
     targetIdentity,
     providerProfile: {
       id: "@ai-sdk/deepseek/chat",
-      version: "3.0.28",
+      version: targetIdentity.profileVersion >= 3 ? "3.0.30" : "3.0.28",
       requestPath: "provider_options.deepseek",
     },
     supportsOff: true,
@@ -1492,7 +1743,7 @@ function expectedDirectDeepSeekThinkingCapability(targetIdentity: ModelTargetIde
   };
 }
 
-test("current Direct DeepSeek v2 selection retains exact historical v1 resolution", async () => {
+test("current Direct DeepSeek v3 selection retains exact historical v2 and v1 resolution", async () => {
   const targets = createModelTargets({
     environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
   });
@@ -1501,7 +1752,16 @@ test("current Direct DeepSeek v2 selection retains exact historical v1 resolutio
     allowExperimental: false,
     signal: new AbortController().signal,
   });
-  const historical = await targets.resolve({
+  const historicalV2 = await targets.resolve({
+    targetId: "deepseek-v4-flash.direct",
+    targetIdentity: {
+      ...current.identity,
+      profileVersion: 2,
+    },
+    allowExperimental: false,
+    signal: new AbortController().signal,
+  });
+  const historicalV1 = await targets.resolve({
     targetId: "deepseek-v4-flash.direct",
     targetIdentity: {
       ...current.identity,
@@ -1512,10 +1772,14 @@ test("current Direct DeepSeek v2 selection retains exact historical v1 resolutio
   });
 
   expect(current).toMatchObject({
+    identity: { profileVersion: 3 },
+    contextProfile: { version: 2, maximumOutputTokens: 384_000 },
+  });
+  expect(historicalV2).toMatchObject({
     identity: { profileVersion: 2 },
     contextProfile: { version: 2, maximumOutputTokens: 384_000 },
   });
-  expect(historical).toMatchObject({
+  expect(historicalV1).toMatchObject({
     identity: { profileVersion: 1 },
     contextProfile: { version: 1, maximumOutputTokens: 32_768 },
   });
@@ -1523,6 +1787,8 @@ test("current Direct DeepSeek v2 selection retains exact historical v1 resolutio
     targets.snapshot({ includeHistoricalProfiles: true, signal: new AbortController().signal }),
   ).resolves.toMatchObject({
     targets: [
+      { identity: { targetId: "deepseek-v4-flash.direct", profileVersion: 3 } },
+      { identity: { targetId: "deepseek-v4-pro.direct", profileVersion: 3 } },
       { identity: { targetId: "deepseek-v4-flash.direct", profileVersion: 2 } },
       { identity: { targetId: "deepseek-v4-pro.direct", profileVersion: 2 } },
       { identity: { targetId: "deepseek-v4-flash.direct", profileVersion: 1 } },

--- a/packages/testkit/src/openai-compatible-model-driver.live.test.ts
+++ b/packages/testkit/src/openai-compatible-model-driver.live.test.ts
@@ -13,6 +13,7 @@ import {
   type RuntimeEvent,
 } from "@adam-agent/agent";
 import { expect, test } from "vitest";
+import { createSessionLifecycleForTests as createSessionLifecycle } from "./session-lifecycle.test-support.js";
 
 const {
   DEEPSEEK_API_KEY: apiKey,
@@ -110,6 +111,84 @@ liveTest(
     }
   },
   120_000,
+);
+
+liveTest(
+  "current Direct DeepSeek Flash v3 completes one reasoning and read-tool round trip",
+  async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-live-deepseek-v3-"));
+    const stateRoot = join(testRoot, "state");
+    const workspaceRoot = join(testRoot, "workspace");
+    const events: RuntimeEvent[] = [];
+    try {
+      await mkdir(workspaceRoot);
+      await writeFile(join(workspaceRoot, "README.md"), "# Aurora Compass\n", "utf8");
+      const modelTargets = createModelTargets({
+        environment: { DEEPSEEK_API_KEY: liveApiKey },
+        deadlineMs: 90_000,
+      });
+      const target = (
+        await modelTargets.snapshot({ signal: new AbortController().signal })
+      ).targets.find(({ identity }) => identity.targetId === "deepseek-v4-flash.direct");
+      if (target === undefined) {
+        throw new Error("Expected the current Direct DeepSeek Flash target.");
+      }
+      const lifecycle = createSessionLifecycle({
+        modelTargets,
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+        stateRoot,
+        tools: createReadToolRegistry({ workspaceRoot }),
+        workspaceRoot,
+      });
+      lifecycle.subscribe((event) => events.push(event));
+
+      try {
+        const created = await lifecycle.create({ targetIdentity: target.identity });
+        const continued = await lifecycle.continue({
+          sessionId: created.sessionId,
+          input: {
+            text: "Use read_file to read README.md, then reply with only the H1 project name.",
+          },
+        });
+
+        expect({
+          result: continued.result,
+          targetIdentity: continued.snapshot.targetIdentity,
+        }).toEqual({
+          result: { status: "completed", answer: expect.stringContaining("Aurora Compass") },
+          targetIdentity: expect.objectContaining({
+            targetId: "deepseek-v4-flash.direct",
+            profileVersion: 3,
+          }),
+        });
+        expect(events).toContainEqual({
+          type: "tool_requested",
+          callId: expect.any(String),
+          name: "read_file",
+        });
+        expect(events).toContainEqual({
+          type: "model_reasoning_started",
+          id: expect.any(String),
+          artifactType: "provider_reasoning",
+        });
+        expect(
+          events.some(
+            (event) => event.type === "model_reasoning_updated" && event.text.trim().length > 0,
+          ),
+        ).toBe(true);
+        expect(events).toContainEqual({
+          type: "model_reasoning_settled",
+          id: expect.any(String),
+          status: "completed",
+        });
+      } finally {
+        await lifecycle.close();
+      }
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  },
+  180_000,
 );
 
 liveTest(

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -138,7 +138,7 @@ async function createThinkingPolicyPresentationFixture(prefix: string) {
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
-  const policyTargetIdentity: ModelTargetIdentity = { ...targetIdentity, profileVersion: 2 };
+  const policyTargetIdentity: ModelTargetIdentity = { ...targetIdentity, profileVersion: 3 };
   const productionTargets = createModelTargets({
     environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
   });

--- a/packages/testkit/src/session-lifecycle-test-topology.test.ts
+++ b/packages/testkit/src/session-lifecycle-test-topology.test.ts
@@ -13,6 +13,7 @@ const topologySuitePath = fileURLToPath(import.meta.url);
 const testkitSourcePath = fileURLToPath(new URL(".", import.meta.url));
 
 const operatingSystemTestNames = [
+  "SessionLifecycle cold resume keeps a Direct DeepSeek v2 session on its historical profile",
   "SessionLifecycle rejects a competing project writer before model dispatch and takes over after owner death",
   "SessionLifecycle real-process continuation preserves a completed safe read and starts a new attempt",
   "SessionLifecycle real-process restart marks a killed structured patch as indeterminate without replay",
@@ -134,7 +135,7 @@ test("SessionLifecycle behavior and OS contracts keep separate environment owner
   const operatingSystemNames = declaredTestNames(operatingSystemSource);
   expect.soft(behaviorNames).toHaveLength(58);
   expect.soft(operatingSystemNames).toEqual([...operatingSystemTestNames].sort());
-  expect.soft(operatingSystemNames).toHaveLength(4);
+  expect.soft(operatingSystemNames).toHaveLength(5);
   expect.soft(operatingSystemTestNames.filter((name) => behaviorNames.includes(name))).toEqual([]);
   const combinedNames = [...behaviorNames, ...operatingSystemNames];
   expect.soft(new Set(combinedNames).size).toBe(combinedNames.length);

--- a/packages/testkit/src/session-lifecycle.os.test.ts
+++ b/packages/testkit/src/session-lifecycle.os.test.ts
@@ -32,6 +32,103 @@ type ChildObservation = {
 
 const childObservations = new WeakMap<ChildProcess, ChildObservation>();
 
+test("SessionLifecycle cold resume keeps a Direct DeepSeek v2 session on its historical profile", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-deepseek-v2-cold-resume-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const historicalIdentity = { ...targetIdentity, profileVersion: 2 } as const;
+  const requests: unknown[] = [];
+  const modelTargets = createModelTargets({
+    environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
+    fetch: async (_input, init) => {
+      requests.push(JSON.parse(String(init?.body)));
+      return new Response(answerOnlyDeepSeekStream, {
+        headers: { "content-type": "text/event-stream" },
+        status: 200,
+      });
+    },
+  });
+  const tools = createCodingToolRegistry({ stateRoot, workspaceRoot });
+  const first = createSessionLifecycle({ modelTargets, stateRoot, tools, workspaceRoot });
+  let cold: ReturnType<typeof createSessionLifecycle> | undefined;
+
+  try {
+    const created = await first.create({ targetIdentity: historicalIdentity });
+    await expect(
+      first.continue({
+        sessionId: created.sessionId,
+        input: { text: "Record one historical turn." },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "Hello, Adam." },
+      snapshot: { targetIdentity: historicalIdentity },
+    });
+    await first.close();
+
+    cold = createSessionLifecycle({ modelTargets, stateRoot, tools, workspaceRoot });
+    await expect(
+      cold.continue({
+        sessionId: created.sessionId,
+        input: { text: "Continue the historical session." },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "Hello, Adam." },
+      snapshot: { targetIdentity: historicalIdentity },
+    });
+
+    expect(
+      requests.map((request) => {
+        const body = request as {
+          readonly max_tokens?: number;
+          readonly messages?: readonly { readonly role?: string; readonly content?: string }[];
+          readonly model?: string;
+          readonly tools?: readonly { readonly function?: { readonly name?: string } }[];
+        };
+        return {
+          maxTokens: body.max_tokens,
+          model: body.model,
+          toolNames: body.tools?.map((tool) => tool.function?.name),
+          userMessages: body.messages
+            ?.filter((message) => message.role === "user")
+            .map((message) => message.content),
+        };
+      }),
+    ).toEqual([
+      {
+        maxTokens: 384_000,
+        model: "deepseek-v4-flash",
+        toolNames: [
+          "read_file",
+          "write_file",
+          "edit_file",
+          "run_shell",
+          "activate_skill",
+          "read_skill_resource",
+        ],
+        userMessages: ["Record one historical turn."],
+      },
+      {
+        maxTokens: 384_000,
+        model: "deepseek-v4-flash",
+        toolNames: [
+          "read_file",
+          "write_file",
+          "edit_file",
+          "run_shell",
+          "activate_skill",
+          "read_skill_resource",
+        ],
+        userMessages: ["Record one historical turn.", "Continue the historical session."],
+      },
+    ]);
+  } finally {
+    await cold?.close();
+    await first.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("SessionLifecycle rejects a competing project writer before model dispatch and takes over after owner death", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-lifecycle-owner-"));
   const stateRoot = join(testRoot, "state");

--- a/packages/testkit/src/session-lifecycle.test.ts
+++ b/packages/testkit/src/session-lifecycle.test.ts
@@ -502,7 +502,7 @@ test("SessionLifecycle snapshots one thinking policy and reuses it across tool c
   await writeFile(join(workspaceRoot, "README.md"), "# Adam\n", "utf8");
   const policyTargetIdentity: ModelTargetIdentity = {
     ...targetIdentity,
-    profileVersion: 2,
+    profileVersion: 3,
   };
   const productionTargets = createModelTargets({
     environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
@@ -617,7 +617,7 @@ test("SessionLifecycle rejects an unsupported thinking level before draft persis
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
-  const policyTargetIdentity: ModelTargetIdentity = { ...targetIdentity, profileVersion: 2 };
+  const policyTargetIdentity: ModelTargetIdentity = { ...targetIdentity, profileVersion: 3 };
   const productionTargets = createModelTargets({
     environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
   });
@@ -686,7 +686,7 @@ test("SessionLifecycle rejects a thinking capability minted for another exact ta
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
-  const policyTargetIdentity: ModelTargetIdentity = { ...targetIdentity, profileVersion: 2 };
+  const policyTargetIdentity: ModelTargetIdentity = { ...targetIdentity, profileVersion: 3 };
   const productionTargets = createModelTargets({
     environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
   });
@@ -755,7 +755,7 @@ test("SessionLifecycle cold recovery reuses the durable thinking snapshot withou
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
-  const policyTargetIdentity: ModelTargetIdentity = { ...targetIdentity, profileVersion: 2 };
+  const policyTargetIdentity: ModelTargetIdentity = { ...targetIdentity, profileVersion: 3 };
   const productionTargets = createModelTargets({
     environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
   });
@@ -854,7 +854,7 @@ test("SessionLifecycle rejects a stale durable thinking profile before recovery 
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
-  const policyTargetIdentity: ModelTargetIdentity = { ...targetIdentity, profileVersion: 2 };
+  const policyTargetIdentity: ModelTargetIdentity = { ...targetIdentity, profileVersion: 3 };
   const productionTargets = createModelTargets({
     environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
   });
@@ -2033,7 +2033,7 @@ test("SessionLifecycle branches to an explicit compatible exact target only when
         status: 200,
       }),
   });
-  const currentTargetIdentity = { ...targetIdentity, profileVersion: 2 };
+  const currentTargetIdentity = { ...targetIdentity, profileVersion: 3 };
   const harness = createInMemorySessionLifecycleHarness();
 
   try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: workspace:*
         version: link:../presentation
       '@ai-sdk/deepseek':
-        specifier: 3.0.28
-        version: 3.0.28(zod@4.4.3)
+        specifier: 3.0.30
+        version: 3.0.30(zod@4.4.3)
       '@ai-sdk/gateway':
         specifier: 4.0.52
         version: 4.0.52(zod@4.4.3)
@@ -122,8 +122,8 @@ packages:
     resolution: {integrity: sha512-ijWL5/NhP0Gvd0fNJGkfzNoL6MSKmdo48RcQRnTN2GqhcJnnOaFqCBr3iywxekbstPe7wxx5bs59aCI2ETdxWA==}
     engines: {node: '>=24.0.0 <25'}
 
-  '@ai-sdk/deepseek@3.0.28':
-    resolution: {integrity: sha512-ySiafZL/1KQq8NF49eGWmVRYP4ezBjxAwAlMK+hhTV+9ee37LcCxlSIbURe4C4KFq8kYaTFKsTGI2poLFLOu0w==}
+  '@ai-sdk/deepseek@3.0.30':
+    resolution: {integrity: sha512-rm/5yDM7jqXOaffo4grTFfCnoj7YVF8hPuFeFyYfxSrpCpCoWGkR0MeqJnGQId5wdLno9+Q1vqgiq40h6Ag0DQ==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -136,6 +136,12 @@ packages:
 
   '@ai-sdk/provider-utils@5.0.27':
     resolution: {integrity: sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.28':
+    resolution: {integrity: sha512-TnHUyd/rCYQqHg5RuiOaz/hUql6U+kbUaBW0Rp+0N5UhnAInA9CzzV0HXvuAAPwppDsK6fAx9Rd+tRawpJ/3pg==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1242,10 +1248,10 @@ snapshots:
       semver: 7.8.5
       zod: 4.4.3
 
-  '@ai-sdk/deepseek@3.0.28(zod@4.4.3)':
+  '@ai-sdk/deepseek@3.0.30(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.7
-      '@ai-sdk/provider-utils': 5.0.27(zod@4.4.3)
+      '@ai-sdk/provider-utils': 5.0.28(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/gateway@4.0.52(zod@4.4.3)':
@@ -1256,6 +1262,15 @@ snapshots:
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@5.0.27(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.7
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.1
+      undici: 7.29.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.28(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.7
       '@standard-schema/spec': 1.1.0


### PR DESCRIPTION
## Summary

- exact-pin `@ai-sdk/deepseek` at `3.0.30` and advance current Direct Flash and Pro targets to profile v3
- retain exact historical v2/v1 target, context, thinking-capability, and digest resolution
- validate current and historical reasoning/tool replay plus real cold resume through the production lifecycle

## Testing

- `pnpm quality:check`
- opt-in current Direct DeepSeek Flash v3 reasoning and read-tool live smoke