### PR TITLE
Synchronize TUI session-name clear test

### DIFF
--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -4626,24 +4626,30 @@ test("the production editor clears a manual session name through canonical Prese
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-clear-name-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
   await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
 
   try {
-    const fixture = startFixture({ stateRoot, workspaceRoot });
+    const fixture = startFixture({ controlRoot, stateRoot, workspaceRoot });
     await fixture.waitFor("Adam · New session");
     fixture.write("/name Temporary name\r");
     await fixture.waitFor("Adam · Temporary name");
     const beforeClear = fixture.output().length;
     fixture.write("/name --");
     await fixture.waitForCompleteFrameAfter("--generate", beforeClear);
-    fixture.write("\t\r");
-    const outcome = await Promise.race([
-      fixture.waitForAfter("Adam · New session", beforeClear).then(() => "cleared" as const),
-      fixture.waitForAfter("Adam · --clear", beforeClear).then(() => "literal" as const),
-    ]);
+    fixture.write("\t");
+    await fixture.resize(81, 24);
+    await fixture.waitForCompleteFrameAfter("/name --clear", beforeClear);
+    const beforeSubmit = fixture.output().length;
+    fixture.write("\r");
+    await expect(
+      waitForFileContents(join(controlRoot, "clear-session-name-dispatch-settled"), "admitted\n"),
+    ).resolves.toBe("admitted\n");
+    await fixture.waitForCompleteFrameAfter("Adam · New session", beforeSubmit);
     fixture.write("\u0011");
     await fixture.closed;
-    expect(outcome).toBe("cleared");
+    expect(fixture.screen()?.join("\n") ?? "").not.toContain("Adam · --clear");
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -806,6 +806,15 @@ function observeTuiDispatch(
         );
         return settled;
       }
+      if (command.type === "clear_session_manual_name" && controlRoot !== undefined) {
+        const settled = await receipt;
+        await writeFile(
+          join(controlRoot, "clear-session-name-dispatch-settled"),
+          `${settled.status}\n`,
+          "utf8",
+        );
+        return settled;
+      }
       if (!observeDispatch) {
         return receipt;
       }


### PR DESCRIPTION
## Summary

- separate finite argument completion from command submission through an observed complete frame
- synchronize session-name clearing on the admitted Presentation dispatch receipt before asserting canonical title truth
- replace competing output waiters with one ordered causal path

## Testing

- focused test in four concurrent processes
- `apps/tui/src/main.test.ts` (180 passed)
- `pnpm quality:check` (1248 passed, 11 skipped)