### PR TITLE
feat(agent): add durable linked input resources

### DIFF
--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -306,6 +306,9 @@ function formatPermissionPrompt(
   if (event.subject.type === "mcp_tool") {
     return `Allow ${event.name} from MCP server ${quoteForTerminal(event.subject.serverId)} [y/N] `;
   }
+  if (event.subject.type === "input_resource") {
+    return `Allow ${event.name} for linked input resource ${quoteForTerminal(event.subject.occurrenceId)} [y/N] `;
+  }
   return `Allow ${event.name} for ${quoteForTerminal(event.subject.path)} [y/N] `;
 }
 

--- a/packages/agent/src/agent-session-contracts.ts
+++ b/packages/agent/src/agent-session-contracts.ts
@@ -1,5 +1,6 @@
 import type { ArtifactReference, ChangePreviewArtifactSource } from "./artifact-store.js";
 import type { ContextCallUsage } from "./durable-context.js";
+import type { InputResourceOccurrenceV1 } from "./input-resources.js";
 import type { ModelDriverErrorCategory } from "./model-driver-error.js";
 import type { ThinkingPolicySnapshotV1 } from "./thinking-policy.js";
 import type {
@@ -13,6 +14,7 @@ import type {
 export type UserInput = {
   readonly text: string;
   readonly skills?: readonly string[];
+  readonly inputResources?: readonly InputResourceOccurrenceV1[];
 };
 
 export type RunOptions = {
@@ -115,6 +117,7 @@ export type RunResult =
               | "model_response_too_large"
               | "replay_envelope_too_large"
               | "invalid_run_limits"
+              | "input_resource_invalid"
               | "run_already_active"
               | "session_persistence_failed"
               | "turn_limit_exceeded"

--- a/packages/agent/src/agent-session.ts
+++ b/packages/agent/src/agent-session.ts
@@ -43,6 +43,13 @@ import {
   maximumModelResponseContentBytes,
   maximumReferencedModelResponseArtifactBytes,
 } from "./durable-model-response-policy.js";
+import {
+  createInputResourceProjectionMessageV1,
+  inputResourceLimitsV1,
+  inputResourceOccurrenceV1Schema,
+  inputResourcePageV1Schema,
+  projectInputResourcesV1,
+} from "./input-resources.js";
 import { ModelDriverError } from "./model-driver-error.js";
 import {
   assemblePromptMessagesV1,
@@ -155,6 +162,8 @@ export class AgentSession {
   #referencedModelResponseArtifactBytes: number;
   #skillResourceRunBytes: number;
   #skillResourceLineageBytes: number;
+  #inputResourceRunBytes: number;
+  #inputResourceLineageBytes: number;
   #pendingPermission:
     | {
         readonly requestId: string;
@@ -192,6 +201,8 @@ export class AgentSession {
       this.#durableContext?.referencedModelResponseArtifactBytes ?? 0;
     this.#skillResourceRunBytes = this.#durableContext?.skillResourceRunBytes ?? 0;
     this.#skillResourceLineageBytes = this.#durableContext?.skillResourceLineageBytes ?? 0;
+    this.#inputResourceRunBytes = this.#durableContext?.inputResourceRunBytes ?? 0;
+    this.#inputResourceLineageBytes = this.#durableContext?.inputResourceLineageBytes ?? 0;
     this.#contextProfile = dependencies.contextProfile;
     const maximumOutputTokens =
       dependencies.contextProfile?.maximumOutputTokens ?? dependencies.maximumOutputTokens;
@@ -299,6 +310,15 @@ export class AgentSession {
         },
       };
     }
+    if (!areInputResourcesValid(input.inputResources)) {
+      return {
+        status: "failed",
+        error: {
+          code: "input_resource_invalid",
+          message: "Input resources must use the exact bounded v1 immutable descriptor schema.",
+        },
+      };
+    }
     if (this.#activeAbortController !== undefined) {
       return {
         status: "failed",
@@ -341,6 +361,9 @@ export class AgentSession {
             sequence: logicalRunStartedSequence,
             record: {
               type: "logical_run_started",
+              ...(input.inputResources === undefined || input.inputResources.length === 0
+                ? {}
+                : { recordVersion: 1 as const, inputResources: input.inputResources }),
               runId: this.#activeRunId,
               userMessage: input.text,
               ...(isFirstLogicalRun && !genesisHasFallback
@@ -407,6 +430,7 @@ export class AgentSession {
     explicitSkills: readonly { readonly selection: string; readonly requestId: string }[],
   ): Promise<RunResult> {
     const resume = this.#durableContext?.resume;
+    const projectedUserMessage = projectInputResourcesV1(input.text, input.inputResources);
     if (resume === undefined) {
       await this.#emit({ type: "user_message", text: input.text });
       if (signal.aborted) {
@@ -433,7 +457,10 @@ export class AgentSession {
     }
     const messages: ModelMessage[] =
       resume === undefined
-        ? [...(this.#durableContext?.initialMessages ?? []), { role: "user", content: input.text }]
+        ? [
+            ...(this.#durableContext?.initialMessages ?? []),
+            { role: "user", content: projectedUserMessage },
+          ]
         : resume.messages.map((message) => ({ ...message }));
     const toolResultsById = new Map<
       string,
@@ -1344,7 +1371,16 @@ export class AgentSession {
       } else {
         unknownCalls += 1;
       }
-      const replacementMessages = [...compacted.replacementMessages, ...retainedMessages];
+      const inputResourceMessages =
+        this.#durableContext?.inputResources === undefined ||
+        this.#durableContext.inputResources.length === 0
+          ? []
+          : [createInputResourceProjectionMessageV1(this.#durableContext.inputResources)];
+      const replacementMessages = [
+        ...compacted.replacementMessages,
+        ...inputResourceMessages,
+        ...retainedMessages,
+      ];
       const replacementTooLarge =
         this.#estimatePromptTokens(
           this.#assemblePromptMessages(replacementMessages),
@@ -1424,6 +1460,10 @@ export class AgentSession {
           projectionVersion: 1,
           sourceDigest,
           replacementDigest: digestContextMessages(replacementMessages),
+          ...(durableContext.inputResources === undefined ||
+          durableContext.inputResources.length === 0
+            ? {}
+            : { inputResources: durableContext.inputResources }),
           summary: compacted.summary,
           evidence,
           ...(compacted.usage === undefined ? {} : { usage: compacted.usage }),
@@ -1946,7 +1986,10 @@ export class AgentSession {
       scope: "call",
       subject: preparedCall.permissionSubject,
     };
-    const policyDecision = this.#permissions?.decide(permissionInput) ?? "deny";
+    const policyDecision =
+      preparedPermissionSubject.type === "input_resource"
+        ? "allow"
+        : (this.#permissions?.decide(permissionInput) ?? "deny");
     if (signal.aborted) {
       return this.#settleCancelled();
     }
@@ -2027,7 +2070,11 @@ export class AgentSession {
         ? await this.#activateModelSelectedSkill(call)
         : call.name === "read_skill_resource"
           ? await this.#readSkillResource(call)
-          : await preparedCall.execute({ signal, callId: call.id, toolName: call.name });
+          : call.name === "read_input_resource"
+            ? await this.#readInputResource(call, () =>
+                preparedCall.execute({ signal, callId: call.id, toolName: call.name }),
+              )
+            : await preparedCall.execute({ signal, callId: call.id, toolName: call.name });
     toolResultsById.set(call.id, { call, result });
     await this.#appendToolResult(messages, call, result);
     if (result.status === "failed" && result.error.code === "tool_effect_indeterminate") {
@@ -2363,6 +2410,74 @@ export class AgentSession {
         ...(page.executionToken === undefined ? {} : { executionToken: page.executionToken }),
       },
     };
+  }
+
+  async #readInputResource(
+    call: ToolCall,
+    execute: () => Promise<ToolResult>,
+  ): Promise<ToolResult> {
+    const runId = this.#activeRunId;
+    const result = await execute();
+    if (result.status === "failed") {
+      return result;
+    }
+    const parsed = inputResourcePageV1Schema.safeParse(result.output);
+    const page = parsed.success ? parsed.data : undefined;
+    const occurrence = this.#durableContext?.inputResources?.find(
+      (candidate) => candidate.occurrenceId === page?.occurrenceId,
+    );
+    if (
+      runId === undefined ||
+      page === undefined ||
+      occurrence === undefined ||
+      page.displayName !== occurrence.displayName ||
+      page.digest !== occurrence.digest ||
+      page.totalByteCount !== occurrence.artifact.byteCount ||
+      page.offset + page.byteCount > page.totalByteCount ||
+      page.eof !== (page.offset + page.byteCount === page.totalByteCount) ||
+      Buffer.byteLength(page.content, "utf8") !== page.byteCount ||
+      `sha256:${createHash("sha256").update(page.content, "utf8").digest("hex")}` !==
+        page.pageDigest
+    ) {
+      return inputResourceReadFailure(
+        "input_resource_corrupt",
+        "The immutable input-resource page did not match canonical resource truth.",
+      );
+    }
+    if (
+      this.#inputResourceRunBytes + page.byteCount >
+        inputResourceLimitsV1.maximumMaterializedBytesPerRun ||
+      this.#inputResourceLineageBytes + page.byteCount >
+        inputResourceLimitsV1.maximumMaterializedBytesPerLineage
+    ) {
+      return inputResourceReadFailure(
+        "input_resource_quota_exceeded",
+        "The input-resource materialization quota for this run or session lineage would be exceeded.",
+      );
+    }
+    await this.#appendRecord({
+      schemaVersion: 3,
+      sequence: this.#nextSequence,
+      record: {
+        type: "input_resource_read_committed",
+        recordVersion: 1,
+        runId,
+        callId: call.id,
+        occurrenceId: page.occurrenceId,
+        displayName: page.displayName,
+        offset: page.offset,
+        byteCount: page.byteCount,
+        totalByteCount: page.totalByteCount,
+        eof: page.eof,
+        nextCursor: page.nextCursor,
+        digest: page.digest,
+        pageDigest: page.pageDigest,
+        content: page.content,
+      },
+    });
+    this.#inputResourceRunBytes += page.byteCount;
+    this.#inputResourceLineageBytes += page.byteCount;
+    return { status: "completed", output: page };
   }
 
   async #preflightRepositoryInstructions(
@@ -3493,6 +3608,16 @@ function areSkillSelectionsValid(selections: UserInput["skills"]): boolean {
   );
 }
 
+function areInputResourcesValid(resources: UserInput["inputResources"]): boolean {
+  return (
+    resources === undefined ||
+    (Array.isArray(resources) &&
+      resources.length <= 8 &&
+      resources.every((resource) => inputResourceOccurrenceV1Schema.safeParse(resource).success) &&
+      new Set(resources.map((resource) => resource.occurrenceId)).size === resources.length)
+  );
+}
+
 function skillActivationFailure(
   message: string,
   ambiguity?: {
@@ -3520,6 +3645,13 @@ function skillResourceFailure(
     | "skill_resource_quota_exceeded"
     | "skill_resource_unavailable"
     | "unsupported_binary_resource",
+  message: string,
+): Extract<ToolResult, { readonly status: "failed" }> {
+  return { status: "failed", error: { code, message } };
+}
+
+function inputResourceReadFailure(
+  code: "input_resource_corrupt" | "input_resource_quota_exceeded",
   message: string,
 ): Extract<ToolResult, { readonly status: "failed" }> {
   return { status: "failed", error: { code, message } };

--- a/packages/agent/src/artifact-store.ts
+++ b/packages/agent/src/artifact-store.ts
@@ -69,9 +69,18 @@ export type SkillArtifactSource = {
   readonly provenance: "skill_ingestion";
 };
 
+export type InputResourceArtifactSourceV1 = {
+  readonly type: "input_resource";
+  readonly schemaVersion: 1;
+  readonly occurrenceId: string;
+  readonly runId: string;
+  readonly provenance: "user_local_file";
+};
+
 export type ArtifactSource =
   | ChangePreviewArtifactSource
   | ExtensionArtifactSource
+  | InputResourceArtifactSourceV1
   | McpToolResultArtifactSourceV1
   | ModelResponseArtifactSource
   | SkillArtifactSource

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -48,6 +48,13 @@ export {
   type ExtensionProjectChangesStartOptions,
   type ExtensionStateSnapshot,
 } from "./extension-host.js";
+export {
+  InputResourceError,
+  type InputResourceOccurrenceV1,
+  type InputResourcePageV1,
+  inputResourceLimitsV1,
+  type LocalInputResourceSelectionV1,
+} from "./input-resources.js";
 export { ModelDriverError, type ModelDriverErrorCategory } from "./model-driver-error.js";
 export {
   createModelTargets,

--- a/packages/agent/src/input-resources.ts
+++ b/packages/agent/src/input-resources.ts
@@ -1,0 +1,495 @@
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { open, realpath } from "node:fs/promises";
+import { basename } from "node:path";
+
+import { z } from "zod";
+import type {
+  ArtifactReference,
+  ArtifactStore,
+  InputResourceArtifactSourceV1,
+} from "./artifact-store.js";
+
+export const inputResourceLimitsV1 = {
+  maximumOccurrencesPerRun: 8,
+  maximumOccurrencesPerLineage: 64,
+  maximumSelectedPathBytes: 4_096,
+  maximumDisplayNameBytes: 255,
+  maximumFileBytes: 8 * 1024 * 1024,
+  maximumAggregateBytesPerRun: 16 * 1024 * 1024,
+  maximumAggregateBytesPerLineage: 64 * 1024 * 1024,
+  defaultReadPageBytes: 16 * 1024,
+  maximumReadPageBytes: 64 * 1024,
+  maximumMaterializedBytesPerRun: 1024 * 1024,
+  maximumMaterializedBytesPerLineage: 8 * 1024 * 1024,
+} as const;
+
+export type LocalInputResourceSelectionV1 = {
+  readonly type: "local_file";
+  readonly path: string;
+};
+
+export type InputResourceOccurrenceV1 = {
+  readonly occurrenceId: string;
+  readonly displayName: string;
+  readonly artifact: {
+    readonly id: `sha256:${string}`;
+    readonly mediaType: "application/octet-stream" | "text/plain; charset=utf-8";
+    readonly byteCount: number;
+  };
+  readonly digest: `sha256:${string}`;
+  readonly mediaHint: "binary" | "text";
+  readonly provenance: "user_local_file";
+  readonly support: "unsupported_binary" | "utf8_text";
+  readonly mode: "link";
+};
+
+const digestSchema = z.string().regex(/^sha256:[0-9a-f]{64}$/u) as z.ZodType<`sha256:${string}`>;
+
+export const inputResourceOccurrenceV1Schema: z.ZodType<InputResourceOccurrenceV1> = z.strictObject(
+  {
+    occurrenceId: z.string().min(1).max(256),
+    displayName: z
+      .string()
+      .min(1)
+      .max(inputResourceLimitsV1.maximumDisplayNameBytes)
+      .refine(
+        (value) =>
+          Buffer.byteLength(value, "utf8") <= inputResourceLimitsV1.maximumDisplayNameBytes,
+      ),
+    artifact: z.strictObject({
+      id: digestSchema,
+      mediaType: z.enum(["application/octet-stream", "text/plain; charset=utf-8"]),
+      byteCount: z.number().int().nonnegative().max(inputResourceLimitsV1.maximumFileBytes),
+    }),
+    digest: digestSchema,
+    mediaHint: z.enum(["binary", "text"]),
+    provenance: z.literal("user_local_file"),
+    support: z.enum(["unsupported_binary", "utf8_text"]),
+    mode: z.literal("link"),
+  },
+);
+
+export class InputResourceError extends Error {
+  readonly code:
+    | "input_resource_aggregate_too_large"
+    | "input_resource_count_exceeded"
+    | "input_resource_corrupt"
+    | "input_resource_cursor_invalid"
+    | "input_resource_invalid_selection"
+    | "input_resource_io_failed"
+    | "input_resource_not_visible"
+    | "input_resource_too_large"
+    | "input_resource_unsupported";
+
+  constructor(code: InputResourceError["code"], message: string) {
+    super(message);
+    this.name = "InputResourceError";
+    this.code = code;
+  }
+}
+
+export async function ingestLocalInputResourcesV1(input: {
+  readonly artifactStore: ArtifactStore;
+  readonly afterResolved?: () => Promise<void> | void;
+  readonly afterOpened?: () => Promise<void> | void;
+  readonly runId: string;
+  readonly selections: readonly LocalInputResourceSelectionV1[];
+  readonly signal: AbortSignal;
+}): Promise<readonly InputResourceOccurrenceV1[]> {
+  if (input.selections.length > inputResourceLimitsV1.maximumOccurrencesPerRun) {
+    throw new InputResourceError(
+      "input_resource_count_exceeded",
+      "The selected input-resource count exceeds the v1 run limit.",
+    );
+  }
+  const occurrences: InputResourceOccurrenceV1[] = [];
+  let aggregateBytes = 0;
+  for (const [index, selection] of input.selections.entries()) {
+    input.signal.throwIfAborted();
+    if (
+      selection.type !== "local_file" ||
+      selection.path.length === 0 ||
+      selection.path.includes("\0") ||
+      Buffer.byteLength(selection.path, "utf8") > inputResourceLimitsV1.maximumSelectedPathBytes
+    ) {
+      throw new InputResourceError(
+        "input_resource_invalid_selection",
+        "The selected local input-resource path is invalid.",
+      );
+    }
+    const occurrenceId = `${input.runId}:input:${index + 1}`;
+    const ingested = await ingestOneLocalFile({
+      artifactStore: input.artifactStore,
+      ...(input.afterResolved === undefined ? {} : { afterResolved: input.afterResolved }),
+      ...(input.afterOpened === undefined ? {} : { afterOpened: input.afterOpened }),
+      occurrenceId,
+      path: selection.path,
+      runId: input.runId,
+      signal: input.signal,
+    });
+    aggregateBytes += ingested.artifact.byteCount;
+    if (aggregateBytes > inputResourceLimitsV1.maximumAggregateBytesPerRun) {
+      throw new InputResourceError(
+        "input_resource_aggregate_too_large",
+        "The selected input resources exceed the v1 aggregate run limit.",
+      );
+    }
+    occurrences.push(ingested);
+  }
+  return occurrences;
+}
+
+async function ingestOneLocalFile(input: {
+  readonly artifactStore: ArtifactStore;
+  readonly afterResolved?: () => Promise<void> | void;
+  readonly afterOpened?: () => Promise<void> | void;
+  readonly occurrenceId: string;
+  readonly path: string;
+  readonly runId: string;
+  readonly signal: AbortSignal;
+}): Promise<InputResourceOccurrenceV1> {
+  let resolvedPath: string;
+  try {
+    resolvedPath = await realpath(input.path);
+  } catch {
+    throw new InputResourceError(
+      "input_resource_invalid_selection",
+      "The selected local input resource cannot be resolved.",
+    );
+  }
+  if (Buffer.byteLength(resolvedPath, "utf8") > inputResourceLimitsV1.maximumSelectedPathBytes) {
+    throw new InputResourceError(
+      "input_resource_invalid_selection",
+      "The resolved local input-resource path is too long.",
+    );
+  }
+  await input.afterResolved?.();
+  input.signal.throwIfAborted();
+  let file: Awaited<ReturnType<typeof open>>;
+  try {
+    file = await open(
+      resolvedPath,
+      constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+    );
+  } catch {
+    throw new InputResourceError(
+      "input_resource_invalid_selection",
+      "The selected local input resource cannot be opened safely.",
+    );
+  }
+  try {
+    const identity = await file.stat();
+    if (!identity.isFile()) {
+      throw new InputResourceError(
+        "input_resource_invalid_selection",
+        "The selected input resource is not an ordinary file.",
+      );
+    }
+    if (!Number.isSafeInteger(identity.size) || identity.size < 0) {
+      throw new InputResourceError(
+        "input_resource_invalid_selection",
+        "The selected input-resource size is invalid.",
+      );
+    }
+    if (identity.size > inputResourceLimitsV1.maximumFileBytes) {
+      throw new InputResourceError(
+        "input_resource_too_large",
+        "The selected input resource exceeds the v1 per-file byte limit.",
+      );
+    }
+    await input.afterOpened?.();
+    input.signal.throwIfAborted();
+    const chunks: Buffer[] = [];
+    const decoder = new TextDecoder("utf-8", { fatal: true });
+    let strictUtf8 = true;
+    const readBuffer = Buffer.allocUnsafe(64 * 1024);
+    let position = 0;
+    while (position < identity.size) {
+      input.signal.throwIfAborted();
+      const { bytesRead } = await file.read(
+        readBuffer,
+        0,
+        Math.min(readBuffer.length, identity.size - position),
+        position,
+      );
+      if (bytesRead === 0) {
+        throw new InputResourceError(
+          "input_resource_io_failed",
+          "The selected input resource ended before its validated size.",
+        );
+      }
+      const chunk = Buffer.from(readBuffer.subarray(0, bytesRead));
+      chunks.push(chunk);
+      if (strictUtf8) {
+        try {
+          decoder.decode(chunk, { stream: true });
+        } catch {
+          strictUtf8 = false;
+        }
+      }
+      position += bytesRead;
+    }
+    if (strictUtf8) {
+      try {
+        decoder.decode();
+      } catch {
+        strictUtf8 = false;
+      }
+    }
+    const overflowProbe = Buffer.allocUnsafe(1);
+    if ((await file.read(overflowProbe, 0, 1, identity.size)).bytesRead !== 0) {
+      throw new InputResourceError(
+        "input_resource_io_failed",
+        "The selected input resource changed beyond its validated size during ingest.",
+      );
+    }
+    const bytes = Buffer.concat(chunks, identity.size);
+    input.signal.throwIfAborted();
+    const source: InputResourceArtifactSourceV1 = {
+      type: "input_resource",
+      schemaVersion: 1,
+      occurrenceId: input.occurrenceId,
+      runId: input.runId,
+      provenance: "user_local_file",
+    };
+    const mediaType = strictUtf8
+      ? ("text/plain; charset=utf-8" as const)
+      : ("application/octet-stream" as const);
+    let artifact: ArtifactReference<InputResourceArtifactSourceV1>;
+    try {
+      artifact = await input.artifactStore.write({ bytes, mediaType, source });
+    } catch {
+      throw new InputResourceError(
+        "input_resource_io_failed",
+        "The selected input resource could not be published as an immutable artifact.",
+      );
+    }
+    input.signal.throwIfAborted();
+    const digest = `sha256:${createHash("sha256").update(bytes).digest("hex")}` as const;
+    if (artifact.id !== digest || artifact.byteCount !== identity.size) {
+      throw new InputResourceError(
+        "input_resource_corrupt",
+        "The published input-resource artifact does not match the accepted bytes.",
+      );
+    }
+    return {
+      occurrenceId: input.occurrenceId,
+      displayName: safeDisplayName(input.path),
+      artifact: { id: digest, mediaType, byteCount: identity.size },
+      digest,
+      mediaHint: strictUtf8 ? "text" : "binary",
+      provenance: "user_local_file",
+      support: strictUtf8 ? "utf8_text" : "unsupported_binary",
+      mode: "link",
+    };
+  } finally {
+    await file.close();
+  }
+}
+
+function safeDisplayName(path: string): string {
+  let retained = "";
+  for (const character of basename(path)) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    const displayCharacter =
+      codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f) ? "�" : character;
+    if (
+      Buffer.byteLength(retained + displayCharacter, "utf8") >
+      inputResourceLimitsV1.maximumDisplayNameBytes
+    ) {
+      break;
+    }
+    retained += displayCharacter;
+  }
+  return retained.length === 0 ? "input-resource" : retained;
+}
+
+export function projectInputResourcesV1(
+  text: string,
+  occurrences: readonly InputResourceOccurrenceV1[] | undefined,
+): string {
+  if (occurrences === undefined || occurrences.length === 0) {
+    return text;
+  }
+  return `${text}\n\nLinked input resources (descriptor-only; use read_input_resource to read supported immutable content):\n${JSON.stringify(occurrences)}`;
+}
+
+export function createInputResourceProjectionMessageV1(
+  occurrences: readonly InputResourceOccurrenceV1[],
+) {
+  return {
+    role: "developer" as const,
+    content: `<linked-input-resources schema-version="1">\n${JSON.stringify(occurrences)}\n</linked-input-resources>`,
+  };
+}
+
+export type InputResourcePageV1 = {
+  readonly occurrenceId: string;
+  readonly displayName: string;
+  readonly offset: number;
+  readonly byteCount: number;
+  readonly totalByteCount: number;
+  readonly eof: boolean;
+  readonly nextCursor: string | null;
+  readonly digest: `sha256:${string}`;
+  readonly pageDigest: `sha256:${string}`;
+  readonly content: string;
+};
+
+export const inputResourcePageV1Schema: z.ZodType<InputResourcePageV1> = z.strictObject({
+  occurrenceId: z.string().min(1).max(256),
+  displayName: z.string().min(1).max(inputResourceLimitsV1.maximumDisplayNameBytes),
+  offset: z.number().int().nonnegative().max(inputResourceLimitsV1.maximumFileBytes),
+  byteCount: z.number().int().nonnegative().max(inputResourceLimitsV1.maximumReadPageBytes),
+  totalByteCount: z.number().int().nonnegative().max(inputResourceLimitsV1.maximumFileBytes),
+  eof: z.boolean(),
+  nextCursor: z.string().min(1).max(1_024).nullable(),
+  digest: digestSchema,
+  pageDigest: digestSchema,
+  content: z.string().max(inputResourceLimitsV1.maximumReadPageBytes),
+});
+
+export async function readInputResourcePageV1(input: {
+  readonly artifactStore: ArtifactStore;
+  readonly cursor?: string;
+  readonly maxByteCount?: number;
+  readonly occurrence: InputResourceOccurrenceV1 | undefined;
+  readonly occurrenceId: string;
+}): Promise<InputResourcePageV1> {
+  const occurrence = input.occurrence;
+  if (occurrence === undefined || occurrence.occurrenceId !== input.occurrenceId) {
+    throw new InputResourceError(
+      "input_resource_not_visible",
+      "The requested input-resource occurrence is not visible in this session history.",
+    );
+  }
+  if (occurrence.support !== "utf8_text") {
+    throw new InputResourceError(
+      "input_resource_unsupported",
+      "The requested input resource is not supported as strict UTF-8 text.",
+    );
+  }
+  const maximumBytes = input.maxByteCount ?? inputResourceLimitsV1.defaultReadPageBytes;
+  if (
+    !Number.isSafeInteger(maximumBytes) ||
+    maximumBytes < 1 ||
+    maximumBytes > inputResourceLimitsV1.maximumReadPageBytes
+  ) {
+    throw new InputResourceError(
+      "input_resource_cursor_invalid",
+      "The input-resource page size is invalid.",
+    );
+  }
+  const offset = decodeInputResourceCursorV1(input.cursor, occurrence.occurrenceId);
+  let bytes: Uint8Array | undefined;
+  try {
+    bytes = await input.artifactStore.read(occurrence.artifact.id, {
+      maximumBytes: inputResourceLimitsV1.maximumFileBytes,
+    });
+  } catch {
+    throw new InputResourceError(
+      "input_resource_corrupt",
+      "The immutable input-resource artifact failed integrity validation.",
+    );
+  }
+  if (bytes === undefined) {
+    throw new InputResourceError(
+      "input_resource_corrupt",
+      "The immutable input-resource artifact is unavailable.",
+    );
+  }
+  const complete = Buffer.from(bytes);
+  if (
+    complete.byteLength !== occurrence.artifact.byteCount ||
+    `sha256:${createHash("sha256").update(complete).digest("hex")}` !== occurrence.digest
+  ) {
+    throw new InputResourceError(
+      "input_resource_corrupt",
+      "The immutable input-resource artifact does not match its descriptor.",
+    );
+  }
+  try {
+    new TextDecoder("utf-8", { fatal: true }).decode(complete);
+  } catch {
+    throw new InputResourceError(
+      "input_resource_unsupported",
+      "The immutable input resource is not complete strict UTF-8 text.",
+    );
+  }
+  if (offset > complete.byteLength) {
+    throw new InputResourceError(
+      "input_resource_cursor_invalid",
+      "The input-resource cursor is outside the immutable content.",
+    );
+  }
+  let end = Math.min(complete.byteLength, offset + maximumBytes);
+  let content: string | undefined;
+  while (end >= offset) {
+    try {
+      content = new TextDecoder("utf-8", { fatal: true }).decode(complete.subarray(offset, end));
+      break;
+    } catch {
+      end -= 1;
+    }
+  }
+  if (content === undefined || (end === offset && offset < complete.byteLength)) {
+    throw new InputResourceError(
+      "input_resource_cursor_invalid",
+      "The input-resource page cannot begin or end at the requested UTF-8 boundary.",
+    );
+  }
+  const page = complete.subarray(offset, end);
+  return {
+    occurrenceId: occurrence.occurrenceId,
+    displayName: occurrence.displayName,
+    offset,
+    byteCount: page.byteLength,
+    totalByteCount: complete.byteLength,
+    eof: end === complete.byteLength,
+    nextCursor:
+      end === complete.byteLength
+        ? null
+        : encodeInputResourceCursorV1(occurrence.occurrenceId, end),
+    digest: occurrence.digest,
+    pageDigest: `sha256:${createHash("sha256").update(page).digest("hex")}`,
+    content,
+  };
+}
+
+export function encodeInputResourceCursorV1(occurrenceId: string, offset: number): string {
+  return `input-resource:v1:${Buffer.from(JSON.stringify([occurrenceId, offset]), "utf8").toString("base64url")}`;
+}
+
+export function decodeInputResourceCursorV1(
+  cursor: string | undefined,
+  occurrenceId: string,
+): number {
+  if (cursor === undefined) {
+    return 0;
+  }
+  const prefix = "input-resource:v1:";
+  try {
+    if (!cursor.startsWith(prefix) || cursor.length > 1_024) {
+      throw new Error("invalid cursor");
+    }
+    const decoded: unknown = JSON.parse(
+      Buffer.from(cursor.slice(prefix.length), "base64url").toString("utf8"),
+    );
+    if (
+      !Array.isArray(decoded) ||
+      decoded.length !== 2 ||
+      decoded[0] !== occurrenceId ||
+      !Number.isSafeInteger(decoded[1]) ||
+      (decoded[1] as number) < 0
+    ) {
+      throw new Error("invalid cursor");
+    }
+    return decoded[1] as number;
+  } catch {
+    throw new InputResourceError(
+      "input_resource_cursor_invalid",
+      "The input-resource continuation cursor is invalid for this occurrence.",
+    );
+  }
+}

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -63,6 +63,8 @@ export {
   sessionDurableOutputLimits,
 } from "./session-durable-context.js";
 export {
+  type InputResourceIngestBarrier,
+  inputResourceIngestBarrier,
   type McpActivationSettlementBarrier,
   type McpCatalogStaleDurableBarrier,
   type McpCatalogStaleObservationBarrier,

--- a/packages/agent/src/prompt-assembly.ts
+++ b/packages/agent/src/prompt-assembly.ts
@@ -641,14 +641,10 @@ export function isPromptContextCompatible(
 ): boolean {
   try {
     const supported = promptContextSnapshot(createPromptContextV1(tools));
-    const toolProfileCompatible =
-      context.profileVersion === 1
-        ? context.toolProfile.definitions.every((recorded) =>
-            supported.toolProfile.definitions.some(
-              (current) => current.name === recorded.name && current.digest === recorded.digest,
-            ),
-          )
-        : canonicalJson(context.toolProfile) === canonicalJson(supported.toolProfile);
+    const toolProfileCompatible = isOrderedToolProfileSubset(
+      context.toolProfile.definitions,
+      supported.toolProfile.definitions,
+    );
     return (
       (context.profileVersion === 1 ||
         context.profileVersion === 2 ||
@@ -669,18 +665,33 @@ export function isPromptContextRecordCompatible(
 ): boolean {
   try {
     const currentToolProfile = createPromptContextV1(tools).toolProfile;
-    const compatibleTools =
-      context.recordVersion === 1
-        ? context.toolProfile.definitions.every((recorded) =>
-            currentToolProfile.definitions.some(
-              (current) => current.name === recorded.name && current.digest === recorded.digest,
-            ),
-          )
-        : canonicalJson(context.toolProfile) === canonicalJson(currentToolProfile);
+    const compatibleTools = isOrderedToolProfileSubset(
+      context.toolProfile.definitions,
+      currentToolProfile.definitions,
+    );
     return isPromptContextRecordValid(context) && compatibleTools;
   } catch {
     return false;
   }
+}
+
+function isOrderedToolProfileSubset(
+  recordedDefinitions: readonly { readonly name: string; readonly digest: string }[],
+  currentDefinitions: readonly { readonly name: string; readonly digest: string }[],
+): boolean {
+  let currentIndex = 0;
+  for (const recorded of recordedDefinitions) {
+    let current = currentDefinitions[currentIndex];
+    while (current !== undefined && current.name !== recorded.name) {
+      currentIndex += 1;
+      current = currentDefinitions[currentIndex];
+    }
+    if (current === undefined || current.digest !== recorded.digest) {
+      return false;
+    }
+    currentIndex += 1;
+  }
+  return true;
 }
 
 export function isPromptContextRecordValid(context: PromptContextRecord): boolean {

--- a/packages/agent/src/session-durable-context.ts
+++ b/packages/agent/src/session-durable-context.ts
@@ -1,5 +1,6 @@
 import type { ModelMessage } from "./agent-session-contracts.js";
 import type { ContextEvidenceV1 } from "./durable-context.js";
+import type { InputResourceOccurrenceV1 } from "./input-resources.js";
 import type { ModelTargetIdentity } from "./model-targets.js";
 import type { PromptContextRecord } from "./prompt-assembly.js";
 import type {
@@ -22,6 +23,9 @@ export type AgentSessionDurableOutputLimits = {
 export type AgentSessionDurableContext = {
   readonly hasInheritedMessages?: boolean | undefined;
   readonly inheritedEvidence?: ContextEvidenceV1 | undefined;
+  readonly inputResources?: readonly InputResourceOccurrenceV1[] | undefined;
+  readonly inputResourceLineageBytes?: number;
+  readonly inputResourceRunBytes?: number;
   readonly initialMessages?: readonly ModelMessage[];
   readonly nextSequence: number;
   readonly newRunId?: string;

--- a/packages/agent/src/session-history-replay.ts
+++ b/packages/agent/src/session-history-replay.ts
@@ -1,5 +1,9 @@
 import type { ModelMessage } from "./agent-session-contracts.js";
 import { createContextProjectionMessage, digestContextMessages } from "./durable-context.js";
+import {
+  createInputResourceProjectionMessageV1,
+  projectInputResourcesV1,
+} from "./input-resources.js";
 import { SessionLifecycleError } from "./session-lifecycle-error.js";
 import type { SessionModelResponseField, SessionRecord } from "./session-store.js";
 
@@ -22,6 +26,10 @@ export function modelMessagesFromCompleteRecords(
     );
     const replacement = [
       createContextProjectionMessage(checkpointRecord.summary, checkpointRecord.evidence),
+      ...(checkpointRecord.inputResources === undefined ||
+      checkpointRecord.inputResources.length === 0
+        ? []
+        : [createInputResourceProjectionMessageV1(checkpointRecord.inputResources)]),
       ...modelMessagesFromCanonicalRecords(retainedRecords),
     ];
     if (digestContextMessages(replacement) !== checkpointRecord.replacementDigest) {
@@ -41,7 +49,10 @@ export function modelMessagesFromCanonicalRecords(
   const messages: ModelMessage[] = [];
   for (const record of currentRecords) {
     if (record.record.type === "logical_run_started") {
-      messages.push({ role: "user", content: record.record.userMessage });
+      messages.push({
+        role: "user",
+        content: projectInputResourcesV1(record.record.userMessage, record.record.inputResources),
+      });
       continue;
     }
     if (record.record.type !== "model_response_completed") {

--- a/packages/agent/src/session-history-validation.ts
+++ b/packages/agent/src/session-history-validation.ts
@@ -11,6 +11,13 @@ import {
   digestContextRecordPrefix,
   reduceContextEvidence,
 } from "./durable-context.js";
+import {
+  createInputResourceProjectionMessageV1,
+  decodeInputResourceCursorV1,
+  encodeInputResourceCursorV1,
+  type InputResourceOccurrenceV1,
+  inputResourceLimitsV1,
+} from "./input-resources.js";
 import { isMcpToolProfileV1Valid } from "./mcp-profile-contracts.js";
 import { sameModelTargetIdentity } from "./model-targets.js";
 import {
@@ -136,9 +143,12 @@ export function validateCurrentSessionHistory(
     }
   >();
   const committedSkillResourceReads = new Set<string>();
+  const committedInputResourceReads = new Set<string>();
+  const visibleInputResources = new Map<string, InputResourceOccurrenceV1>();
   const publishedSkillActivations = new Set<number>();
   const publishedSkillRevocations = new Set<number>();
   let skillResourceRunBytes = 0;
+  let inputResourceRunBytes = 0;
   let manualSessionName: string | null = null;
   let automaticTitleEligible = false;
   let automaticTitleSlotClosed = false;
@@ -417,7 +427,9 @@ export function validateCurrentSessionHistory(
         toolStates = new Map();
         skillPermissions.clear();
         committedSkillResourceReads.clear();
+        committedInputResourceReads.clear();
         skillResourceRunBytes = 0;
+        inputResourceRunBytes = 0;
       }
       if (
         run !== undefined ||
@@ -425,9 +437,13 @@ export function validateCurrentSessionHistory(
         sawUserMessage ||
         record.skills?.some(
           (selection, index) => selection.requestId !== `${record.runId}:skill:${index + 1}`,
-        )
+        ) ||
+        !areLogicalInputResourcesValid(record, visibleInputResources)
       ) {
         throw new SessionLifecycleError("session_invalid");
+      }
+      for (const resource of record.inputResources ?? []) {
+        visibleInputResources.set(resource.occurrenceId, resource);
       }
       run = record;
       continue;
@@ -781,6 +797,73 @@ export function validateCurrentSessionHistory(
         throw new SessionLifecycleError("session_invalid");
       }
       committedSkillResourceReads.add(record.callId);
+      continue;
+    }
+    if (record.type === "input_resource_read_committed") {
+      const toolState = toolStates.get(record.callId);
+      const occurrence = visibleInputResources.get(record.occurrenceId);
+      let argumentsValue:
+        | { occurrenceId?: unknown; cursor?: unknown; maxByteCount?: unknown }
+        | undefined;
+      try {
+        argumentsValue = JSON.parse(toolState?.call.argumentsJson ?? "") as typeof argumentsValue;
+      } catch {
+        argumentsValue = undefined;
+      }
+      let requestedOffset: number | undefined;
+      try {
+        requestedOffset =
+          typeof argumentsValue?.occurrenceId === "string" &&
+          (argumentsValue.cursor === undefined || typeof argumentsValue.cursor === "string")
+            ? decodeInputResourceCursorV1(argumentsValue.cursor, argumentsValue.occurrenceId)
+            : undefined;
+      } catch {
+        requestedOffset = undefined;
+      }
+      const requestedMaximum =
+        typeof argumentsValue?.maxByteCount === "number"
+          ? argumentsValue.maxByteCount
+          : inputResourceLimitsV1.defaultReadPageBytes;
+      if (
+        run === undefined ||
+        record.runId !== run.runId ||
+        attemptState?.status !== "completed" ||
+        attemptState.response?.response.finishReason !== "tool_calls" ||
+        toolState?.call.name !== "read_input_resource" ||
+        !toolState.requested ||
+        !toolState.started ||
+        toolState.terminal ||
+        toolState.decision !== "allow" ||
+        committedInputResourceReads.has(record.callId) ||
+        argumentsValue?.occurrenceId !== record.occurrenceId ||
+        requestedOffset !== record.offset ||
+        !Number.isSafeInteger(requestedMaximum) ||
+        record.byteCount > requestedMaximum ||
+        (occurrence === undefined
+          ? genesis.record.lineage === undefined
+          : record.displayName !== occurrence.displayName ||
+            record.digest !== occurrence.digest ||
+            record.totalByteCount !== occurrence.artifact.byteCount) ||
+        record.offset + record.byteCount > record.totalByteCount ||
+        record.eof !== (record.offset + record.byteCount === record.totalByteCount) ||
+        record.nextCursor !==
+          (record.eof
+            ? null
+            : encodeInputResourceCursorV1(record.occurrenceId, record.offset + record.byteCount)) ||
+        Buffer.byteLength(record.content, "utf8") !== record.byteCount ||
+        `sha256:${createHash("sha256").update(record.content, "utf8").digest("hex")}` !==
+          record.pageDigest
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      inputResourceRunBytes += record.byteCount;
+      if (
+        !Number.isSafeInteger(inputResourceRunBytes) ||
+        inputResourceRunBytes > inputResourceLimitsV1.maximumMaterializedBytesPerRun
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      committedInputResourceReads.add(record.callId);
       continue;
     }
     if (record.type === "session_manual_name_set") {
@@ -1459,6 +1542,9 @@ function validateContextCompactionHistory(
     );
     const replacement = [
       createContextProjectionMessage(record.summary, record.evidence),
+      ...(record.inputResources === undefined || record.inputResources.length === 0
+        ? []
+        : [createInputResourceProjectionMessageV1(record.inputResources)]),
       ...modelMessagesFromCanonicalRecords(retainedRecords),
     ];
     if (
@@ -1558,6 +1644,39 @@ function hasNonEmptyModelResponseText(field: string | SessionModelResponseField)
     : field.storage === "inline"
       ? field.text.length > 0
       : field.reference.byteCount > 0;
+}
+
+function areLogicalInputResourcesValid(
+  record: SessionLogicalRunStartedRecord["record"],
+  visible: ReadonlyMap<string, InputResourceOccurrenceV1>,
+): boolean {
+  const resources = record.inputResources ?? [];
+  if (resources.length === 0) {
+    return true;
+  }
+  if (record.recordVersion !== 1) {
+    return false;
+  }
+  const combined = [...visible.values(), ...resources];
+  const occurrenceIds = new Set(combined.map((resource) => resource.occurrenceId));
+  const aggregateBytes = combined.reduce((sum, resource) => sum + resource.artifact.byteCount, 0);
+  return (
+    occurrenceIds.size === combined.length &&
+    combined.length <= inputResourceLimitsV1.maximumOccurrencesPerLineage &&
+    Number.isSafeInteger(aggregateBytes) &&
+    aggregateBytes <= inputResourceLimitsV1.maximumAggregateBytesPerLineage &&
+    resources.every(
+      (resource, index) =>
+        resource.occurrenceId === `${record.runId}:input:${index + 1}` &&
+        resource.artifact.id === resource.digest &&
+        ((resource.support === "utf8_text" &&
+          resource.mediaHint === "text" &&
+          resource.artifact.mediaType === "text/plain; charset=utf-8") ||
+          (resource.support === "unsupported_binary" &&
+            resource.mediaHint === "binary" &&
+            resource.artifact.mediaType === "application/octet-stream")),
+    )
+  );
 }
 
 function isMatchingStartedAttempt(

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -31,6 +31,13 @@ import {
   withInternalExtensionSkillSourcesCurrent,
 } from "./extension-host.js";
 import {
+  InputResourceError,
+  type InputResourceOccurrenceV1,
+  ingestLocalInputResourcesV1,
+  inputResourceLimitsV1,
+  type LocalInputResourceSelectionV1,
+} from "./input-resources.js";
+import {
   createMcpRuntimeHost,
   inspectMcpConfiguration,
   type McpBeforeToolDispatchBarrier,
@@ -159,6 +166,7 @@ import {
   type ThinkingPolicySnapshotV1,
 } from "./thinking-policy.js";
 import {
+  bindInputResourceToolRegistry,
   createCodingToolRegistry,
   type PermissionPolicy,
   type ToolEffect,
@@ -258,6 +266,14 @@ export type SessionRuntimeNotificationTransform = {
   project(notification: SessionRuntimeNotification): readonly SessionRuntimeNotification[];
 };
 
+/** Tests only. Production input-resource ingest has no observation barrier. */
+export const inputResourceIngestBarrier = Symbol("adam-agent.input-resource-ingest-barrier");
+
+export type InputResourceIngestBarrier = {
+  afterResolved?(): Promise<void> | void;
+  afterOpened?(): Promise<void> | void;
+};
+
 /** Tests only. Production MCP lease transitions have no observation barrier. */
 export const workspaceMcpLeaseTransitionBarrier = Symbol(
   "adam-agent.workspace-mcp-lease-transition-barrier",
@@ -296,6 +312,7 @@ export type SessionLifecycleOptions = {
   readonly [sessionProjectLifecycleOwner]?: ProjectLifecycleOwner;
   readonly [sessionStoreDirectory]?: SessionStoreDirectory<SessionRecord>;
   readonly [sessionRuntimeNotificationTransform]?: SessionRuntimeNotificationTransform;
+  readonly [inputResourceIngestBarrier]?: InputResourceIngestBarrier;
   readonly [workspaceMcpLeaseTransitionBarrier]?: WorkspaceMcpLeaseTransitionBarrier;
 };
 
@@ -463,6 +480,7 @@ export type SessionCommand =
       readonly runId?: string;
       readonly signal?: AbortSignal;
       readonly thinkingSelection?: ThinkingPolicySelectionV1;
+      readonly resourceSelections?: readonly LocalInputResourceSelectionV1[];
     }
   | ({
       readonly type: "branch";
@@ -479,6 +497,7 @@ export interface SessionLifecycle {
     readonly runId?: string;
     readonly signal?: AbortSignal;
     readonly thinkingSelection?: ThinkingPolicySelectionV1;
+    readonly resourceSelections?: readonly LocalInputResourceSelectionV1[];
     readonly onAdmitted?: (receipt: SessionAdmissionReceipt) => void;
   }): Promise<SessionContinueResult>;
   branch(input: SessionBranchInput): Promise<CurrentSessionSnapshot>;
@@ -490,6 +509,7 @@ export interface SessionLifecycle {
     readonly runId?: string;
     readonly signal?: AbortSignal;
     readonly thinkingSelection?: ThinkingPolicySelectionV1;
+    readonly resourceSelections?: readonly LocalInputResourceSelectionV1[];
   }): Promise<SessionContinueResult>;
   configureMcp(command: McpConfigurationCommand): Promise<McpConfigurationResult>;
   configureWorkspaceTrust(
@@ -1934,6 +1954,9 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           runId,
           ...(input.limits === undefined ? {} : { limits: input.limits }),
           ...(input.signal === undefined ? {} : { signal: input.signal }),
+          ...(input.resourceSelections === undefined
+            ? {}
+            : { resourceSelections: input.resourceSelections }),
           ...(input.thinkingSelection === undefined
             ? {}
             : { thinkingSelection: input.thinkingSelection }),
@@ -2361,9 +2384,15 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       });
     },
     async continue(input) {
-      if (input.runId !== undefined && !z.uuid().safeParse(input.runId).success) {
+      if (
+        (input.runId !== undefined && !z.uuid().safeParse(input.runId).success) ||
+        (input.resourceSelections !== undefined && input.input === undefined) ||
+        input.input?.inputResources !== undefined
+      ) {
         throw new SessionLifecycleError("session_invalid");
       }
+      const effectiveRunId =
+        input.resourceSelections === undefined ? input.runId : (input.runId ?? randomUUID());
       disarmMcpIdle(input.sessionId);
       await waitForMcpIdleOperation(input.sessionId);
       const continued = await withOwner(async () => {
@@ -2677,6 +2706,18 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           first,
           replayRecords,
         );
+        const inputResourceLineageBytes = await inputResourceBytesFromLineage(
+          lineage,
+          first,
+          replayRecords,
+        );
+        const visibleInputResources = await inputResourcesFromLineage(
+          lineage,
+          first,
+          replayRecords,
+        );
+        await validateCompactionInputResources(lineage, first, replayRecords);
+        validateInputResourceReadLineage(replayRecords, visibleInputResources);
         const [inheritedMessages, inheritedEvidence] = await Promise.all([
           createBranchMessages(options, lineage, records, artifactCache),
           lineage.createInheritedContextEvidence(records),
@@ -2690,14 +2731,14 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             ? undefined
             : requireRecoveredThinkingPolicy(resolved, resumeState.thinkingPolicy);
         if (
-          input.runId !== undefined &&
+          effectiveRunId !== undefined &&
           (input.input === undefined ||
             resumeState !== undefined ||
             replayRecords.some(
               (record) =>
                 record.schemaVersion === 3 &&
                 "runId" in record.record &&
-                record.record.runId === input.runId,
+                record.record.runId === effectiveRunId,
             ))
         ) {
           throw new SessionLifecycleError("session_invalid");
@@ -2729,6 +2770,47 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         const artifactStore = await createFileArtifactStore({
           root: join(effectiveSessionStateRoot(options.stateRoot), "artifacts"),
         });
+        await validateVisibleInputResourceArtifacts(artifactStore, visibleInputResources);
+        const inputResources =
+          input.resourceSelections === undefined
+            ? []
+            : await ingestLocalInputResourcesV1({
+                artifactStore,
+                ...(options[inputResourceIngestBarrier]?.afterResolved === undefined
+                  ? {}
+                  : { afterResolved: options[inputResourceIngestBarrier].afterResolved }),
+                ...(options[inputResourceIngestBarrier]?.afterOpened === undefined
+                  ? {}
+                  : { afterOpened: options[inputResourceIngestBarrier].afterOpened }),
+                runId: effectiveRunId as string,
+                selections: input.resourceSelections,
+                signal: input.signal ?? new AbortController().signal,
+              });
+        input.signal?.throwIfAborted();
+        const runInput =
+          input.input === undefined || inputResources.length === 0
+            ? input.input
+            : { ...input.input, inputResources };
+        const runtimeInputResources = [...visibleInputResources, ...inputResources];
+        if (runtimeInputResources.length > inputResourceLimitsV1.maximumOccurrencesPerLineage) {
+          throw new InputResourceError(
+            "input_resource_count_exceeded",
+            "The selected input resources exceed the v1 session-lineage occurrence limit.",
+          );
+        }
+        const runtimeInputResourceBytes = runtimeInputResources.reduce(
+          (total, occurrence) => total + occurrence.artifact.byteCount,
+          0,
+        );
+        if (
+          !Number.isSafeInteger(runtimeInputResourceBytes) ||
+          runtimeInputResourceBytes > inputResourceLimitsV1.maximumAggregateBytesPerLineage
+        ) {
+          throw new InputResourceError(
+            "input_resource_aggregate_too_large",
+            "The selected input resources exceed the v1 session-lineage aggregate byte limit.",
+          );
+        }
         const sessionDependencies = {
           artifactStore,
           model: resolved.driver,
@@ -2736,13 +2818,21 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           [sessionDurableContext]: {
             ...(initialMessages.length === 0 ? {} : { hasInheritedMessages: true }),
             nextSequence: (replayRecords.at(-1)?.sequence ?? resumed.snapshot.lastSequence) + 1,
-            ...(input.runId === undefined ? {} : { newRunId: input.runId }),
+            ...(effectiveRunId === undefined ? {} : { newRunId: effectiveRunId }),
+            ...(runtimeInputResources.length === 0
+              ? {}
+              : { inputResources: runtimeInputResources }),
             projectId: resumed.snapshot.projectId,
             referencedModelResponseArtifactBytes,
             skillResourceLineageBytes,
+            inputResourceLineageBytes,
             ...(resumeState === undefined
               ? {}
               : {
+                  inputResourceRunBytes: inputResourceBytesForRun(
+                    replayRecords,
+                    resumeState.agentState.runId,
+                  ),
                   skillResourceRunBytes: skillResourceBytesForRun(
                     replayRecords,
                     resumeState.agentState.runId,
@@ -2819,7 +2909,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           ...(options.tools === undefined
             ? {}
             : {
-                tools:
+                tools: bindInputResourceToolRegistry(
                   activePromptContext?.recordVersion === 3 && activePromptContext.mcp !== undefined
                     ? combineToolRegistries(
                         options.tools,
@@ -2834,6 +2924,8 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
                             ),
                       )
                     : options.tools,
+                  { artifactStore, occurrences: runtimeInputResources },
+                ),
               }),
           ...(options.permissions === undefined ? {} : { permissions: options.permissions }),
         };
@@ -2869,13 +2961,10 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         activeSessionSettlement = sessionSettlement;
         try {
           const runLimits = resumeState?.limits ?? input.limits;
-          const result = await session.run(
-            input.input ?? { text: resumeState?.userMessage ?? "" },
-            {
-              ...(input.signal === undefined ? {} : { signal: input.signal }),
-              ...(runLimits === undefined ? {} : { limits: runLimits }),
-            },
-          );
+          const result = await session.run(runInput ?? { text: resumeState?.userMessage ?? "" }, {
+            ...(input.signal === undefined ? {} : { signal: input.signal }),
+            ...(runLimits === undefined ? {} : { limits: runLimits }),
+          });
           await flushPendingMcpCatalogChanges(input.sessionId);
           const snapshot = await inspectSession({ sessionId: input.sessionId }, artifactCache);
           if (snapshot.schemaVersion !== 3) {
@@ -5572,36 +5661,59 @@ function createAgentResumeState(
                 subject: permissionEvent.subject,
               }
             : undefined;
-        const committedResource = currentRecords.find(
+        const committedSkillResource = currentRecords.find(
           (candidate) =>
             candidate.sequence > responseRecord.sequence &&
             candidate.record.type === "skill_resource_read_committed" &&
             candidate.record.runId === runId &&
             candidate.record.callId === call.id,
         );
+        const committedInputResource = currentRecords.find(
+          (candidate) =>
+            candidate.sequence > responseRecord.sequence &&
+            candidate.record.type === "input_resource_read_committed" &&
+            candidate.record.runId === runId &&
+            candidate.record.callId === call.id,
+        );
         const replayResult =
-          committedResource?.record.type === "skill_resource_read_committed"
+          committedSkillResource?.record.type === "skill_resource_read_committed"
             ? {
                 status: "completed" as const,
                 output: {
-                  qualifiedId: committedResource.record.qualifiedId,
-                  activationIndex: committedResource.record.activationIndex,
-                  catalogRevision: committedResource.record.catalogRevision,
-                  manifestRevision: committedResource.record.manifestRevision,
-                  path: committedResource.record.path,
-                  offset: committedResource.record.offset,
-                  byteCount: committedResource.record.byteCount,
-                  totalByteCount: committedResource.record.totalByteCount,
-                  eof: committedResource.record.eof,
-                  fileDigest: committedResource.record.fileDigest,
-                  pageDigest: committedResource.record.pageDigest,
-                  content: committedResource.record.content,
-                  ...(committedResource.record.executionToken === undefined
+                  qualifiedId: committedSkillResource.record.qualifiedId,
+                  activationIndex: committedSkillResource.record.activationIndex,
+                  catalogRevision: committedSkillResource.record.catalogRevision,
+                  manifestRevision: committedSkillResource.record.manifestRevision,
+                  path: committedSkillResource.record.path,
+                  offset: committedSkillResource.record.offset,
+                  byteCount: committedSkillResource.record.byteCount,
+                  totalByteCount: committedSkillResource.record.totalByteCount,
+                  eof: committedSkillResource.record.eof,
+                  fileDigest: committedSkillResource.record.fileDigest,
+                  pageDigest: committedSkillResource.record.pageDigest,
+                  content: committedSkillResource.record.content,
+                  ...(committedSkillResource.record.executionToken === undefined
                     ? {}
-                    : { executionToken: committedResource.record.executionToken }),
+                    : { executionToken: committedSkillResource.record.executionToken }),
                 },
               }
-            : undefined;
+            : committedInputResource?.record.type === "input_resource_read_committed"
+              ? {
+                  status: "completed" as const,
+                  output: {
+                    occurrenceId: committedInputResource.record.occurrenceId,
+                    displayName: committedInputResource.record.displayName,
+                    offset: committedInputResource.record.offset,
+                    byteCount: committedInputResource.record.byteCount,
+                    totalByteCount: committedInputResource.record.totalByteCount,
+                    eof: committedInputResource.record.eof,
+                    nextCursor: committedInputResource.record.nextCursor,
+                    digest: committedInputResource.record.digest,
+                    pageDigest: committedInputResource.record.pageDigest,
+                    content: committedInputResource.record.content,
+                  },
+                }
+              : undefined;
         pendingToolCalls.push({
           call,
           requested,
@@ -5734,6 +5846,166 @@ async function skillResourceBytesFromLineage(
     throw new SessionLifecycleError("session_invalid");
   }
   return total;
+}
+
+function inputResourceBytesForRun(records: readonly SessionRecord[], runId: string): number {
+  const total = records.reduce(
+    (sum, record) =>
+      record.schemaVersion === 3 &&
+      record.record.type === "input_resource_read_committed" &&
+      record.record.runId === runId
+        ? sum + record.record.byteCount
+        : sum,
+    0,
+  );
+  if (
+    !Number.isSafeInteger(total) ||
+    total < 0 ||
+    total > inputResourceLimitsV1.maximumMaterializedBytesPerRun
+  ) {
+    throw new SessionLifecycleError("session_invalid");
+  }
+  return total;
+}
+
+async function inputResourceBytesFromLineage(
+  lineage: SessionLineageTraversal,
+  genesis: SessionGenesisRecord,
+  records: readonly SessionRecord[],
+): Promise<number> {
+  const ownBytes = records.reduce(
+    (sum, record) =>
+      record.schemaVersion === 3 && record.record.type === "input_resource_read_committed"
+        ? sum + record.record.byteCount
+        : sum,
+    0,
+  );
+  const inheritedBytes =
+    genesis.record.lineage === undefined
+      ? 0
+      : await (async () => {
+          const { parentGenesis, prefixRecords } =
+            await lineage.readValidatedLineagePrefix(genesis);
+          return inputResourceBytesFromLineage(lineage, parentGenesis, prefixRecords);
+        })();
+  const total = inheritedBytes + ownBytes;
+  if (
+    !Number.isSafeInteger(total) ||
+    total < 0 ||
+    total > inputResourceLimitsV1.maximumMaterializedBytesPerLineage
+  ) {
+    throw new SessionLifecycleError("session_invalid");
+  }
+  return total;
+}
+
+async function inputResourcesFromLineage(
+  lineage: SessionLineageTraversal,
+  genesis: SessionGenesisRecord,
+  records: readonly SessionRecord[],
+): Promise<readonly InputResourceOccurrenceV1[]> {
+  const inherited =
+    genesis.record.lineage === undefined
+      ? []
+      : await (async () => {
+          const { parentGenesis, prefixRecords } =
+            await lineage.readValidatedLineagePrefix(genesis);
+          return inputResourcesFromLineage(lineage, parentGenesis, prefixRecords);
+        })();
+  const own = records.flatMap((record) =>
+    record.schemaVersion === 3 && record.record.type === "logical_run_started"
+      ? (record.record.inputResources ?? [])
+      : [],
+  );
+  const visible = [...inherited, ...own];
+  const occurrenceIds = new Set(visible.map((occurrence) => occurrence.occurrenceId));
+  const aggregateBytes = visible.reduce(
+    (total, occurrence) => total + occurrence.artifact.byteCount,
+    0,
+  );
+  if (
+    visible.length > inputResourceLimitsV1.maximumOccurrencesPerLineage ||
+    occurrenceIds.size !== visible.length ||
+    !Number.isSafeInteger(aggregateBytes) ||
+    aggregateBytes > inputResourceLimitsV1.maximumAggregateBytesPerLineage
+  ) {
+    throw new SessionLifecycleError("session_invalid");
+  }
+  return visible;
+}
+
+async function validateCompactionInputResources(
+  lineage: SessionLineageTraversal,
+  genesis: SessionGenesisRecord,
+  records: readonly SessionRecord[],
+): Promise<void> {
+  for (const checkpoint of records) {
+    if (
+      checkpoint.schemaVersion !== 3 ||
+      checkpoint.record.type !== "context_compaction_committed"
+    ) {
+      continue;
+    }
+    const checkpointRecord = checkpoint.record;
+    const expected = await inputResourcesFromLineage(
+      lineage,
+      genesis,
+      records.filter((record) => record.sequence <= checkpointRecord.sourceThrough),
+    );
+    if (!isDeepStrictEqual(checkpointRecord.inputResources ?? [], expected)) {
+      throw new SessionLifecycleError("session_invalid");
+    }
+  }
+}
+
+function validateInputResourceReadLineage(
+  records: readonly SessionRecord[],
+  visible: readonly InputResourceOccurrenceV1[],
+): void {
+  const occurrences = new Map(visible.map((occurrence) => [occurrence.occurrenceId, occurrence]));
+  for (const record of records) {
+    if (record.schemaVersion !== 3 || record.record.type !== "input_resource_read_committed") {
+      continue;
+    }
+    const occurrence = occurrences.get(record.record.occurrenceId);
+    if (
+      occurrence === undefined ||
+      record.record.displayName !== occurrence.displayName ||
+      record.record.digest !== occurrence.digest ||
+      record.record.totalByteCount !== occurrence.artifact.byteCount
+    ) {
+      throw new SessionLifecycleError("session_invalid");
+    }
+  }
+}
+
+async function validateVisibleInputResourceArtifacts(
+  artifactStore: ArtifactStore,
+  occurrences: readonly InputResourceOccurrenceV1[],
+): Promise<void> {
+  for (const occurrence of occurrences) {
+    let bytes: Uint8Array | undefined;
+    try {
+      bytes = await artifactStore.read(occurrence.artifact.id, {
+        maximumBytes: inputResourceLimitsV1.maximumFileBytes,
+      });
+    } catch {
+      throw new InputResourceError(
+        "input_resource_corrupt",
+        "An immutable input-resource artifact failed integrity validation.",
+      );
+    }
+    if (
+      bytes === undefined ||
+      bytes.byteLength !== occurrence.artifact.byteCount ||
+      `sha256:${createHash("sha256").update(bytes).digest("hex")}` !== occurrence.digest
+    ) {
+      throw new InputResourceError(
+        "input_resource_corrupt",
+        "An immutable input-resource artifact is missing or does not match its descriptor.",
+      );
+    }
+  }
 }
 
 async function canonicalProjectId(workspaceRoot: string): Promise<string> {

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -10,6 +10,11 @@ import type { ArtifactReference, ModelResponseArtifactSource } from "./artifact-
 import type { ContextProfile } from "./context-profile.js";
 import type { ContextCallUsage, ContextEvidenceV1, ContextSummaryV1 } from "./durable-context.js";
 import { maximumInlineModelResponseFieldBytes } from "./durable-model-response-policy.js";
+import {
+  type InputResourceOccurrenceV1,
+  inputResourceLimitsV1,
+  inputResourceOccurrenceV1Schema,
+} from "./input-resources.js";
 import type { McpToolProfileV1 } from "./mcp-profile-contracts.js";
 import { modelDriverErrorCategories } from "./model-driver-error.js";
 import type { ModelTargetIdentity } from "./model-targets.js";
@@ -258,6 +263,7 @@ export type SessionLogicalRunStartedRecord = {
   readonly sequence: number;
   readonly record: {
     readonly type: "logical_run_started";
+    readonly recordVersion?: 1;
     readonly runId: string;
     readonly userMessage: string;
     readonly naming?: {
@@ -273,6 +279,7 @@ export type SessionLogicalRunStartedRecord = {
       readonly maxTokens?: number;
     };
     readonly thinkingPolicy?: ThinkingPolicySnapshotV1;
+    readonly inputResources?: readonly InputResourceOccurrenceV1[];
   };
 };
 
@@ -488,6 +495,27 @@ export type SessionSkillResourceReadCommittedRecord = {
   };
 };
 
+export type SessionInputResourceReadCommittedRecord = {
+  readonly schemaVersion: 3;
+  readonly sequence: number;
+  readonly record: {
+    readonly type: "input_resource_read_committed";
+    readonly recordVersion: 1;
+    readonly runId: string;
+    readonly callId: string;
+    readonly occurrenceId: string;
+    readonly displayName: string;
+    readonly offset: number;
+    readonly byteCount: number;
+    readonly totalByteCount: number;
+    readonly eof: boolean;
+    readonly nextCursor: string | null;
+    readonly digest: Sha256Digest;
+    readonly pageDigest: Sha256Digest;
+    readonly content: string;
+  };
+};
+
 export type SessionProviderAttemptStartedRecord = {
   readonly schemaVersion: 3;
   readonly sequence: number;
@@ -652,6 +680,7 @@ export type SessionContextCompactionCommittedRecord = {
     readonly projectionVersion: 1;
     readonly sourceDigest: `sha256:${string}`;
     readonly replacementDigest: `sha256:${string}`;
+    readonly inputResources?: readonly InputResourceOccurrenceV1[];
     readonly summary: ContextSummaryV1;
     readonly evidence: ContextEvidenceV1;
     readonly usage?: ContextCallUsage;
@@ -760,6 +789,7 @@ export type SessionV3Record =
   | SessionPathContextCommittedRecord
   | SessionPathContextFailedRecord
   | SessionSkillResourceReadCommittedRecord
+  | SessionInputResourceReadCommittedRecord
   | SessionProviderAttemptStartedRecord
   | SessionProviderAttemptInterruptedRecord
   | SessionModelResponseCompletedRecord
@@ -822,6 +852,7 @@ const ordinaryRunErrorCodeSchema = z.enum([
   "model_response_too_large",
   "replay_envelope_too_large",
   "invalid_run_limits",
+  "input_resource_invalid",
   "run_already_active",
   "session_persistence_failed",
   "turn_limit_exceeded",
@@ -1003,6 +1034,16 @@ const v2ToolErrorSchema = z.discriminatedUnion("code", [
 const currentToolErrorSchema = z.union([
   v2ToolErrorSchema,
   z.strictObject({
+    code: z.enum([
+      "input_resource_corrupt",
+      "input_resource_cursor_invalid",
+      "input_resource_not_visible",
+      "input_resource_quota_exceeded",
+      "input_resource_unsupported",
+    ]),
+    message: z.string(),
+  }),
+  z.strictObject({
     code: z.literal("tool_effect_indeterminate"),
     reason: z.enum([
       "mcp_request_timeout",
@@ -1121,6 +1162,10 @@ const mcpPermissionSubjectSchema = z.strictObject({
   definitionDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
   argumentsDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
 });
+const inputResourcePermissionSubjectSchema = z.strictObject({
+  type: z.literal("input_resource"),
+  occurrenceId: z.string().min(1).max(256),
+});
 const currentPermissionSubjectSchema = z.discriminatedUnion("type", [
   z.strictObject({ type: z.literal("file"), path: z.string() }),
   z.strictObject({ type: z.literal("workspace_path"), path: z.string() }),
@@ -1128,6 +1173,7 @@ const currentPermissionSubjectSchema = z.discriminatedUnion("type", [
   patchPermissionSubjectSchema,
   skillPermissionSubjectSchema,
   mcpPermissionSubjectSchema,
+  inputResourcePermissionSubjectSchema,
   z.strictObject({
     type: z.literal("command"),
     command: z.string(),
@@ -1674,6 +1720,7 @@ const sessionV3RecordSchema = z.union([
   }),
   z.strictObject({
     type: z.literal("logical_run_started"),
+    recordVersion: z.literal(1).optional(),
     runId: z.uuid(),
     userMessage: z.string().max(512 * 1024),
     naming: z
@@ -1701,6 +1748,11 @@ const sessionV3RecordSchema = z.union([
       .optional(),
     limits: sessionRunLimitsSchema.optional(),
     thinkingPolicy: thinkingPolicySnapshotV1Schema.optional(),
+    inputResources: z
+      .array(inputResourceOccurrenceV1Schema)
+      .min(1)
+      .max(inputResourceLimitsV1.maximumOccurrencesPerRun)
+      .optional(),
   }),
   z.strictObject({
     type: z.literal("session_manual_name_set"),
@@ -1875,6 +1927,22 @@ const sessionV3RecordSchema = z.union([
     executionToken: z.string().max(16_384).optional(),
   }),
   z.strictObject({
+    type: z.literal("input_resource_read_committed"),
+    recordVersion: z.literal(1),
+    runId: z.uuid(),
+    callId: z.string().min(1).max(256),
+    occurrenceId: z.string().min(1).max(256),
+    displayName: z.string().min(1).max(inputResourceLimitsV1.maximumDisplayNameBytes),
+    offset: z.number().int().nonnegative().max(inputResourceLimitsV1.maximumFileBytes),
+    byteCount: z.number().int().nonnegative().max(inputResourceLimitsV1.maximumReadPageBytes),
+    totalByteCount: z.number().int().nonnegative().max(inputResourceLimitsV1.maximumFileBytes),
+    eof: z.boolean(),
+    nextCursor: z.string().min(1).max(1_024).nullable(),
+    digest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+    pageDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+    content: z.string().max(inputResourceLimitsV1.maximumReadPageBytes),
+  }),
+  z.strictObject({
     type: z.literal("provider_attempt_started"),
     runId: z.uuid(),
     turn: z.number().int().positive(),
@@ -2018,6 +2086,7 @@ const sessionV3RecordSchema = z.union([
     projectionVersion: z.literal(1),
     sourceDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
     replacementDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+    inputResources: z.array(inputResourceOccurrenceV1Schema).optional(),
     summary: contextSummarySchema,
     evidence: contextEvidenceSchema,
     usage: responseUsageSchema.optional(),

--- a/packages/agent/src/tool-runtime.ts
+++ b/packages/agent/src/tool-runtime.ts
@@ -8,6 +8,13 @@ import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { z } from "zod";
 
 import type { ArtifactStore } from "./artifact-store.js";
+import {
+  InputResourceError,
+  type InputResourceOccurrenceV1,
+  inputResourceLimitsV1,
+  inputResourcePageV1Schema,
+  readInputResourcePageV1,
+} from "./input-resources.js";
 import { createMutationCoordinator, type MutationCoordinator } from "./mutation-coordinator.js";
 import { createPatchRecoveryStore } from "./patch-recovery-store.js";
 import {
@@ -77,6 +84,11 @@ export type ToolResult =
               | "unsupported_binary_resource"
               | "resource_page_too_small"
               | "skill_resource_quota_exceeded"
+              | "input_resource_corrupt"
+              | "input_resource_cursor_invalid"
+              | "input_resource_not_visible"
+              | "input_resource_quota_exceeded"
+              | "input_resource_unsupported"
               | "artifact_store_failed"
               | "mcp_protocol_error"
               | "mcp_output_invalid"
@@ -238,6 +250,10 @@ export type PermissionSubject =
       readonly operation: "activate" | "read_resource";
       readonly qualifiedId: string;
       readonly path?: string | undefined;
+    }
+  | {
+      readonly type: "input_resource";
+      readonly occurrenceId: string;
     }
   | {
       readonly type: "mcp_tool";
@@ -904,6 +920,10 @@ function createCodingToolRegistryInternal(options: {
     },
     "safe",
   );
+  const inputResourceAdapter = createInputResourceToolAdapter({
+    artifactStore: options.artifactStore,
+    occurrences: [],
+  });
   const adapters = [
     requireAdapter(readTools, "read_file"),
     requireAdapter(mutationTools, "write_file"),
@@ -911,6 +931,7 @@ function createCodingToolRegistryInternal(options: {
     shellAdapter,
     activateSkillAdapter,
     readSkillResourceAdapter,
+    inputResourceAdapter,
   ];
   const adaptersByName = new Map(adapters.map((adapter) => [adapter.definition.name, adapter]));
 
@@ -920,6 +941,116 @@ function createCodingToolRegistryInternal(options: {
     },
     resolve(name) {
       return adaptersByName.get(name);
+    },
+  };
+}
+
+const inputResourceOccurrenceIdSchema = z.string().min(1).max(256);
+const readInputResourceInputSchema = z.strictObject({
+  occurrenceId: inputResourceOccurrenceIdSchema,
+  cursor: z.string().min(1).max(1_024).optional(),
+  maxByteCount: z.number().int().min(1).max(inputResourceLimitsV1.maximumReadPageBytes).optional(),
+});
+function createInputResourceToolAdapter(options: {
+  readonly artifactStore: ArtifactStore | undefined;
+  readonly occurrences: readonly InputResourceOccurrenceV1[];
+}): ToolAdapter {
+  const occurrences = new Map(options.occurrences.map((entry) => [entry.occurrenceId, entry]));
+  return identifyToolAdapter(
+    {
+      definition: {
+        name: "read_input_resource",
+        description:
+          "Read one bounded strict UTF-8 page from an immutable linked input resource visible in this session history.",
+        inputSchema: z.toJSONSchema(readInputResourceInputSchema),
+      },
+      outputSchema: inputResourcePageV1Schema,
+      effect: "read",
+      cancellation: "abort_signal",
+      maximumResult: { maximumBytes: inputResourceLimitsV1.maximumReadPageBytes },
+      prepare(argumentsJson) {
+        const parsedArguments = parseInput(readInputResourceInputSchema, argumentsJson);
+        if (!parsedArguments.success) {
+          return invalidToolInput();
+        }
+        const occurrence = occurrences.get(parsedArguments.data.occurrenceId);
+        return {
+          status: "ready",
+          permissionSubject: {
+            type: "input_resource",
+            occurrenceId: parsedArguments.data.occurrenceId,
+          },
+          async execute(context) {
+            context.signal.throwIfAborted();
+            if (options.artifactStore === undefined) {
+              return inputResourceFailure(
+                new InputResourceError(
+                  "input_resource_corrupt",
+                  "The immutable input-resource artifact store is unavailable.",
+                ),
+              );
+            }
+            try {
+              const output = await readInputResourcePageV1({
+                artifactStore: options.artifactStore,
+                occurrence,
+                occurrenceId: parsedArguments.data.occurrenceId,
+                ...(parsedArguments.data.cursor === undefined
+                  ? {}
+                  : { cursor: parsedArguments.data.cursor }),
+                ...(parsedArguments.data.maxByteCount === undefined
+                  ? {}
+                  : { maxByteCount: parsedArguments.data.maxByteCount }),
+              });
+              context.signal.throwIfAborted();
+              return { status: "completed", output };
+            } catch (error) {
+              if (error instanceof InputResourceError) {
+                return inputResourceFailure(error);
+              }
+              return inputResourceFailure(
+                new InputResourceError(
+                  "input_resource_corrupt",
+                  "The immutable input resource could not be read safely.",
+                ),
+              );
+            }
+          },
+        };
+      },
+    },
+    "safe",
+  );
+}
+
+function inputResourceFailure(error: InputResourceError): FailedToolResult {
+  const code =
+    error.code === "input_resource_cursor_invalid"
+      ? "input_resource_cursor_invalid"
+      : error.code === "input_resource_not_visible"
+        ? "input_resource_not_visible"
+        : error.code === "input_resource_unsupported"
+          ? "input_resource_unsupported"
+          : "input_resource_corrupt";
+  return { status: "failed", error: { code, message: error.message } };
+}
+
+export function bindInputResourceToolRegistry(
+  registry: ToolRegistry,
+  options: {
+    readonly artifactStore: ArtifactStore;
+    readonly occurrences: readonly InputResourceOccurrenceV1[];
+  },
+): ToolRegistry {
+  const adapter = createInputResourceToolAdapter(options);
+  const definitions = registry.definitions();
+  if (!definitions.some((definition) => definition.name === adapter.definition.name)) {
+    return registry;
+  }
+  return {
+    definitions: () => definitions,
+    resolve(name) {
+      return name === adapter.definition.name ? adapter : registry.resolve(name);
     },
   };
 }

--- a/packages/testkit/src/agent-session.test.ts
+++ b/packages/testkit/src/agent-session.test.ts
@@ -3270,6 +3270,7 @@ describe("AgentSession", () => {
           "run_shell",
           "activate_skill",
           "read_skill_resource",
+          "read_input_resource",
         ],
         commitOrder: ["first-started", "first-released", "write-completed"],
         results: [

--- a/packages/testkit/src/context-compaction.test.ts
+++ b/packages/testkit/src/context-compaction.test.ts
@@ -18,6 +18,7 @@ import {
   OpenAICompatibleModelDriver,
   type RuntimeEvent,
   type SessionStore,
+  type ToolRegistry,
 } from "@adam-agent/agent";
 import {
   type ContextProfile,
@@ -3476,6 +3477,131 @@ test("AgentSession never retries a context overflow after ordinary output has be
       (record) => record.schemaVersion === 3 && record.record.type === "context_compaction_started",
     ),
   ).toHaveLength(0);
+});
+
+test("SessionLifecycle retains canonical input-resource identity for reread after compaction", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-input-resource-compaction-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const selectedPath = join(testRoot, "compaction-resource.txt");
+  const content = "Canonical resource bytes survive compaction.\n";
+  const runId = "50000000-0000-4000-8000-000000000011";
+  const occurrenceId = `${runId}:input:1`;
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, content, "utf8");
+  const compactionProfile: ContextProfile = {
+    ...contextProfile,
+    compactAtTokens: 900,
+    postCompactTargetTokens: 800,
+    retainedTargetTokens: 0,
+  };
+  let compactionCalls = 0;
+  let ordinaryCalls = 0;
+  const model: ModelDriver = {
+    async *stream(request) {
+      if (request.tools.length === 0) {
+        compactionCalls += 1;
+        yield {
+          type: "text_delta",
+          text: JSON.stringify({
+            schemaVersion: 1,
+            objective: "Read the linked evidence after compaction.",
+            constraints: [],
+            progress: [],
+            unresolvedQuestions: [],
+            failures: [],
+            remainingVerification: ["Read the linked evidence."],
+            nextSafeAction: "Use the resource tool.",
+          }),
+        };
+        yield { type: "usage", inputTokens: 600, outputTokens: 30 };
+        yield { type: "finish", reason: "stop" };
+        return;
+      }
+      ordinaryCalls += 1;
+      expect(JSON.stringify(request.messages)).toContain(occurrenceId);
+      if (ordinaryCalls === 1) {
+        yield {
+          type: "tool_call_start",
+          id: "resource-after-compaction",
+          name: "read_input_resource",
+        };
+        yield {
+          type: "tool_call_delta",
+          id: "resource-after-compaction",
+          json: JSON.stringify({ occurrenceId }),
+        };
+        yield { type: "tool_call_end", id: "resource-after-compaction" };
+        yield { type: "finish", reason: "tool_calls" };
+        return;
+      }
+      expect(request.messages.at(-1)).toMatchObject({
+        role: "tool",
+        callId: "resource-after-compaction",
+        name: "read_input_resource",
+        result: { status: "completed", output: { occurrenceId, content } },
+      });
+      yield { type: "text_delta", text: "The canonical resource remained readable." };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver: model, contextProfile: compactionProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "test" },
+            contextProfile: compactionProfile,
+          },
+        ],
+      };
+    },
+  };
+  const currentTools = createCodingToolRegistry({ stateRoot, workspaceRoot });
+  const tools: ToolRegistry = {
+    definitions: () =>
+      currentTools.definitions().filter((definition) => definition.name === "read_input_resource"),
+    resolve: (name) => (name === "read_input_resource" ? currentTools.resolve(name) : undefined),
+  };
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, tools, workspaceRoot });
+
+  try {
+    const admitted = await lifecycle.admit({
+      targetIdentity,
+      input: {
+        text: `Keep the linked resource canonical. ${"Summarize this filler. ".repeat(220)}`,
+      },
+      resourceSelections: [{ type: "local_file", path: selectedPath }],
+      runId,
+    });
+    expect(admitted).toMatchObject({
+      result: { status: "completed", answer: "The canonical resource remained readable." },
+      snapshot: { context: { checkpoint: { status: "committed" } } },
+    });
+    expect({ compactionCalls, ordinaryCalls }).toEqual({ compactionCalls: 1, ordinaryCalls: 2 });
+    const store = await openJsonlSessionStore({
+      stateRoot,
+      workspaceRoot,
+      sessionId: admitted.snapshot.sessionId,
+    });
+    expect(await store.read()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          record: expect.objectContaining({
+            type: "context_compaction_committed",
+            inputResources: [expect.objectContaining({ occurrenceId })],
+          }),
+        }),
+      ]),
+    );
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
 });
 
 test("SessionLifecycle restarts and branches from one committed context checkpoint", async () => {

--- a/packages/testkit/src/prompt-assembly.test.ts
+++ b/packages/testkit/src/prompt-assembly.test.ts
@@ -207,10 +207,26 @@ const expectedCodingTools = [
       additionalProperties: false,
     },
   },
+  {
+    name: "read_input_resource",
+    description:
+      "Read one bounded strict UTF-8 page from an immutable linked input resource visible in this session history.",
+    inputSchema: {
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      properties: {
+        occurrenceId: { type: "string", minLength: 1, maxLength: 256 },
+        cursor: { type: "string", minLength: 1, maxLength: 1_024 },
+        maxByteCount: { type: "integer", minimum: 1, maximum: 65_536 },
+      },
+      required: ["occurrenceId"],
+      additionalProperties: false,
+    },
+  },
 ] as const;
 const expectedHistoricalCodingTools = expectedCodingTools.slice(0, 4);
 
-test("a newly created v3 session sends code-owned prompts before the current user request with the exact six-tool profile", async () => {
+test("a newly created v3 session sends code-owned prompts before the current user request with the exact seven-tool profile", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-prompt-assembly-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
@@ -403,8 +419,12 @@ test("a new v3 session persists bounded prompt and Skill identity without exposi
           name: "read_skill_resource",
           digest: "sha256:f587f4937385fe2b264838ba6ba6518ee133b7e242dd65c5fb5c1641dbbc35f9",
         },
+        {
+          name: "read_input_resource",
+          digest: "sha256:682b2ff206b5456ecaa4fc96384c3a9531475cca89b70776f13619ee80492d52",
+        },
       ],
-      digest: "sha256:27247bbcab93568bbd415d0a22e9360ab04f36a0c4f4ad253aa40c5e8ab68824",
+      digest: "sha256:b25da1fc060ca3e6f923e946f0f54bdfd7e7c7732ef9703d23da468ef95fb194",
     },
     repository: {
       version: 1,
@@ -528,6 +548,7 @@ test("v3 accounting compacts for the assembled messages and tools while keeping 
         "run_shell",
         "activate_skill",
         "read_skill_resource",
+        "read_input_resource",
       ],
     ]);
     expect(requests[0]?.messages[0]).not.toEqual({ role: "system", content: basePrompt });
@@ -939,7 +960,7 @@ test("a v1 branch inherits its parent prompt identity across a cold continuation
   }
 });
 
-test("resume rejects a changed historical v1 Tool Profile before model use", async () => {
+test("resume rejects a changed historical v1 Tool Profile entry before model use", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-prompt-tool-mismatch-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
@@ -948,12 +969,25 @@ test("resume rejects a changed historical v1 Tool Profile before model use", asy
   const created = await createSessionLifecycle({ stateRoot, workspaceRoot, tools }).create({
     targetIdentity,
   });
-  const reorderedTools: ToolRegistry = {
+  const changedReadDefinition = {
+    ...(tools
+      .definitions()
+      .find((definition) => definition.name === "read_file") as ModelRequest["tools"][number]),
+    description: "Changed historical read definition.",
+  };
+  const changedTools: ToolRegistry = {
     definitions() {
-      return [...tools.definitions()].reverse();
+      return tools
+        .definitions()
+        .map((definition) =>
+          definition.name === "read_file" ? changedReadDefinition : definition,
+        );
     },
     resolve(name) {
-      return tools.resolve(name);
+      const adapter = tools.resolve(name);
+      return name === "read_file" && adapter !== undefined
+        ? { ...adapter, definition: changedReadDefinition }
+        : adapter;
     },
   };
   let modelWasResolved = false;
@@ -981,7 +1015,7 @@ test("resume rejects a changed historical v1 Tool Profile before model use", asy
         modelTargets,
         stateRoot,
         workspaceRoot,
-        tools: reorderedTools,
+        tools: changedTools,
       }).resume({ sessionId: created.sessionId }),
     ).resolves.toMatchObject({
       status: "rejected",
@@ -989,6 +1023,65 @@ test("resume rejects a changed historical v1 Tool Profile before model use", asy
         code: "prompt_profile_incompatible",
         message: "The exact recorded prompt and tool profile is not supported by this runtime.",
       },
+    });
+    expect(modelWasResolved).toBe(false);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("resume rejects a reordered historical Tool Profile before model use", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-prompt-tool-reordered-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  const tools = createCodingToolRegistry({ stateRoot, workspaceRoot });
+  const created = await createSessionLifecycle({ stateRoot, workspaceRoot, tools }).create({
+    targetIdentity,
+  });
+  const reorderedTools: ToolRegistry = {
+    definitions() {
+      const definitions = tools.definitions();
+      return [definitions[1], definitions[0], ...definitions.slice(2)].filter(
+        (definition): definition is ModelRequest["tools"][number] => definition !== undefined,
+      );
+    },
+    resolve(name) {
+      return tools.resolve(name);
+    },
+  };
+  let modelWasResolved = false;
+
+  try {
+    await expect(
+      createSessionLifecycle({
+        modelTargets: {
+          async resolve() {
+            modelWasResolved = true;
+            throw new Error("The reordered prompt profile must fail before model resolution.");
+          },
+          async snapshot() {
+            return {
+              targets: [
+                {
+                  identity: targetIdentity,
+                  readiness: {
+                    status: "available",
+                    credentialSource: "deterministic test",
+                  },
+                  contextProfile,
+                },
+              ],
+            };
+          },
+        },
+        stateRoot,
+        workspaceRoot,
+        tools: reorderedTools,
+      }).resume({ sessionId: created.sessionId }),
+    ).resolves.toMatchObject({
+      status: "rejected",
+      error: { code: "prompt_profile_incompatible" },
     });
     expect(modelWasResolved).toBe(false);
   } finally {
@@ -1292,11 +1385,11 @@ test("a v3 provider attempt persists only the safe exact request projection dige
     expect({ continuedPromptContext, inspectedPromptContext }).toMatchObject({
       continuedPromptContext: {
         lastRequestProjectionDigest:
-          "sha256:3dc6acf2688749a8dab86df0305ff06ceb3554529b63aabf374e91bcb3a1c298",
+          "sha256:9e981d5b1658c5ab788d702d2ac4c8c76d018ac4ea1a299e06ca3992360cd8f3",
       },
       inspectedPromptContext: {
         lastRequestProjectionDigest:
-          "sha256:3dc6acf2688749a8dab86df0305ff06ceb3554529b63aabf374e91bcb3a1c298",
+          "sha256:9e981d5b1658c5ab788d702d2ac4c8c76d018ac4ea1a299e06ca3992360cd8f3",
       },
     });
     expect(JSON.stringify({ continued, inspected })).not.toContain("Inspect the project.");

--- a/packages/testkit/src/repository-instructions.test.ts
+++ b/packages/testkit/src/repository-instructions.test.ts
@@ -214,8 +214,12 @@ test("root AGENTS.md is frozen in revision 1 and projected as untrusted user con
             name: "read_skill_resource",
             digest: "sha256:f587f4937385fe2b264838ba6ba6518ee133b7e242dd65c5fb5c1641dbbc35f9",
           },
+          {
+            name: "read_input_resource",
+            digest: "sha256:682b2ff206b5456ecaa4fc96384c3a9531475cca89b70776f13619ee80492d52",
+          },
         ],
-        digest: "sha256:27247bbcab93568bbd415d0a22e9360ab04f36a0c4f4ad253aa40c5e8ab68824",
+        digest: "sha256:b25da1fc060ca3e6f923e946f0f54bdfd7e7c7732ef9703d23da468ef95fb194",
       },
       repository: {
         version: 1,

--- a/packages/testkit/src/session-lifecycle-test-topology.test.ts
+++ b/packages/testkit/src/session-lifecycle-test-topology.test.ts
@@ -14,7 +14,18 @@ const testkitSourcePath = fileURLToPath(new URL(".", import.meta.url));
 
 const operatingSystemTestNames = [
   "SessionLifecycle cold resume keeps a Direct DeepSeek v2 session on its historical profile",
+  "SessionLifecycle cold resume reads an immutable input resource after its source is deleted",
+  "SessionLifecycle follows one selected symlink without persisting its source path",
   "SessionLifecycle rejects a competing project writer before model dispatch and takes over after owner death",
+  "SessionLifecycle rejects a corrupt immutable input resource before cold provider projection",
+  "SessionLifecycle rejects a dangling selected symlink before provider dispatch",
+  "SessionLifecycle rejects a final symlink substituted after controlled resolution",
+  "SessionLifecycle rejects a looping selected symlink before provider dispatch",
+  "SessionLifecycle rejects a missing immutable input resource before cold provider projection",
+  "SessionLifecycle rejects a selected FIFO without waiting for a writer",
+  "SessionLifecycle rejects an input resource above the exact eight MiB file bound",
+  "SessionLifecycle rejects input resources above the exact sixteen MiB run aggregate",
+  "SessionLifecycle rejects input resources above the exact sixty-four MiB lineage aggregate",
   "SessionLifecycle real-process continuation preserves a completed safe read and starts a new attempt",
   "SessionLifecycle real-process restart marks a killed structured patch as indeterminate without replay",
   "SessionLifecycle real-process branch writes independently, survives restart, and stays project-scoped",
@@ -45,10 +56,12 @@ test("SessionLifecycle behavior and OS contracts keep separate environment owner
   expect
     .soft(uniqueRuntimeModuleSpecifiers(operatingSystemSource))
     .toEqual([
+      "./index.js",
       "./session-lifecycle.test-support.js",
       "@adam-agent/agent",
       "@adam-agent/agent/internal-testing",
       "node:child_process",
+      "node:crypto",
       "node:fs/promises",
       "node:os",
       "node:path",
@@ -59,7 +72,7 @@ test("SessionLifecycle behavior and OS contracts keep separate environment owner
   expect.soft(runtimeImportedBindings(operatingSystemSource, "vitest")).toEqual(["expect", "test"]);
   expect
     .soft(runtimeImportedBindings(operatingSystemSource, "node:child_process"))
-    .toEqual(["spawn"]);
+    .toEqual(["execFileSync", "spawn"]);
   expect
     .soft(uniqueRuntimeModuleSpecifiers(supportSource))
     .toEqual(["@adam-agent/agent", "@adam-agent/agent/internal-testing"]);
@@ -133,9 +146,9 @@ test("SessionLifecycle behavior and OS contracts keep separate environment owner
 
   const behaviorNames = declaredTestNames(behaviorSource);
   const operatingSystemNames = declaredTestNames(operatingSystemSource);
-  expect.soft(behaviorNames).toHaveLength(58);
+  expect.soft(behaviorNames).toHaveLength(70);
   expect.soft(operatingSystemNames).toEqual([...operatingSystemTestNames].sort());
-  expect.soft(operatingSystemNames).toHaveLength(5);
+  expect.soft(operatingSystemNames).toHaveLength(16);
   expect.soft(operatingSystemTestNames.filter((name) => behaviorNames.includes(name))).toEqual([]);
   const combinedNames = [...behaviorNames, ...operatingSystemNames];
   expect.soft(new Set(combinedNames).size).toBe(combinedNames.length);

--- a/packages/testkit/src/session-lifecycle.os.test.ts
+++ b/packages/testkit/src/session-lifecycle.os.test.ts
@@ -1,5 +1,16 @@
-import { type ChildProcess, spawn } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { type ChildProcess, execFileSync, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  truncate,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,10 +20,17 @@ import {
   createModelTargets,
   createPermissionPolicy,
   createReadToolRegistry,
+  type ModelTargets,
   SessionLifecycleError,
+  type ToolRegistry,
 } from "@adam-agent/agent";
-import { openJsonlSessionStore, type SessionRecord } from "@adam-agent/agent/internal-testing";
+import {
+  inputResourceIngestBarrier,
+  openJsonlSessionStore,
+  type SessionRecord,
+} from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
+import { FakeModelDriver } from "./index.js";
 import {
   sessionLifecycleAnswerOnlyDeepSeekStream as answerOnlyDeepSeekStream,
   sessionLifecycleBasePrompt as basePrompt,
@@ -32,6 +50,622 @@ type ChildObservation = {
 
 const childObservations = new WeakMap<ChildProcess, ChildObservation>();
 
+test("SessionLifecycle cold resume reads an immutable input resource after its source is deleted", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-input-resource-cold-resume-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "cold-source.txt");
+  const runId = "30000000-0000-4000-8000-000000000011";
+  const occurrenceId = `${runId}:input:1`;
+  const content = "Cold resume keeps these immutable bytes.\n";
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, content, "utf8");
+  let providerCalls = 0;
+  const driver = new FakeModelDriver((request) => {
+    providerCalls += 1;
+    if (providerCalls === 1) {
+      return [
+        { type: "text_delta", text: "The immutable resource is linked." },
+        { type: "finish", reason: "stop" },
+      ];
+    }
+    if (providerCalls === 2) {
+      expect(request.messages.filter((message) => message.role === "user")[0]?.content).toContain(
+        occurrenceId,
+      );
+      return [
+        { type: "tool_call_start", id: "cold-resource-call", name: "read_input_resource" },
+        {
+          type: "tool_call_delta",
+          id: "cold-resource-call",
+          json: JSON.stringify({ occurrenceId }),
+        },
+        { type: "tool_call_end", id: "cold-resource-call" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    expect(request.messages.at(-1)).toMatchObject({
+      role: "tool",
+      name: "read_input_resource",
+      result: { status: "completed", output: { occurrenceId, content } },
+    });
+    return [
+      { type: "text_delta", text: "The deleted source is still readable." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return {
+        identity: targetIdentity,
+        driver,
+        contextProfile: {
+          version: 1,
+          contextWindowTokens: 1_000_000,
+          maximumOutputTokens: 32_768,
+          compactAtTokens: 800_000,
+          postCompactTargetTokens: 200_000,
+          retainedTargetTokens: 20_000,
+          estimatorVersion: 1,
+        },
+      };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: {
+              version: 1,
+              contextWindowTokens: 1_000_000,
+              maximumOutputTokens: 32_768,
+              compactAtTokens: 800_000,
+              postCompactTargetTokens: 200_000,
+              retainedTargetTokens: 20_000,
+              estimatorVersion: 1,
+            },
+          },
+        ],
+      };
+    },
+  };
+  const first = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  let cold: ReturnType<typeof createSessionLifecycle> | undefined;
+
+  try {
+    const admitted = await first.admit({
+      targetIdentity,
+      input: { text: "Link this source." },
+      resourceSelections: [{ type: "local_file", path: selectedPath }],
+      runId,
+    });
+    await first.close();
+    await unlink(selectedPath);
+
+    cold = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    await expect(
+      cold.continue({
+        sessionId: admitted.snapshot.sessionId,
+        input: { text: "Read the linked source after restart." },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "The deleted source is still readable." },
+    });
+    expect(providerCalls).toBe(3);
+  } finally {
+    await cold?.close();
+    await first.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects a corrupt immutable input resource before cold provider projection", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-input-resource-corrupt-resume-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "corrupt-source.txt");
+  const content = "Integrity must remain exact.\n";
+  const digest = createHash("sha256").update(content, "utf8").digest("hex");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, content, "utf8");
+  let providerCalls = 0;
+  const driver = new FakeModelDriver(() => {
+    providerCalls += 1;
+    return [
+      { type: "text_delta", text: "Linked." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const contextProfile = {
+    version: 1 as const,
+    contextWindowTokens: 1_000_000,
+    maximumOutputTokens: 32_768,
+    compactAtTokens: 800_000,
+    postCompactTargetTokens: 200_000,
+    retainedTargetTokens: 20_000,
+    estimatorVersion: 1 as const,
+  };
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const first = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  let cold: ReturnType<typeof createSessionLifecycle> | undefined;
+
+  try {
+    const admitted = await first.admit({
+      targetIdentity,
+      input: { text: "Link integrity evidence." },
+      resourceSelections: [{ type: "local_file", path: selectedPath }],
+    });
+    await first.close();
+    const artifactPath = join(stateRoot, "artifacts", digest);
+    await chmod(artifactPath, 0o600);
+    await writeFile(artifactPath, "same-size-corrupt-bytes!!\n", "utf8");
+
+    cold = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    await expect(
+      cold.continue({
+        sessionId: admitted.snapshot.sessionId,
+        input: { text: "Do not project corrupt bytes." },
+      }),
+    ).rejects.toMatchObject({ code: "input_resource_corrupt" });
+    expect(providerCalls).toBe(1);
+  } finally {
+    await cold?.close();
+    await first.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects a missing immutable input resource before cold provider projection", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-input-resource-missing-resume-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "missing-source.txt");
+  const content = "The immutable artifact must remain present.\n";
+  const digest = createHash("sha256").update(content, "utf8").digest("hex");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, content, "utf8");
+  let providerCalls = 0;
+  const driver = new FakeModelDriver(() => {
+    providerCalls += 1;
+    return [
+      { type: "text_delta", text: "Linked." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const contextProfile = {
+    version: 1 as const,
+    contextWindowTokens: 1_000_000,
+    maximumOutputTokens: 32_768,
+    compactAtTokens: 800_000,
+    postCompactTargetTokens: 200_000,
+    retainedTargetTokens: 20_000,
+    estimatorVersion: 1 as const,
+  };
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const first = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  let cold: ReturnType<typeof createSessionLifecycle> | undefined;
+
+  try {
+    const admitted = await first.admit({
+      targetIdentity,
+      input: { text: "Link presence evidence." },
+      resourceSelections: [{ type: "local_file", path: selectedPath }],
+    });
+    await first.close();
+    await unlink(join(stateRoot, "artifacts", digest));
+
+    cold = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+    await expect(
+      cold.continue({
+        sessionId: admitted.snapshot.sessionId,
+        input: { text: "Do not project a missing artifact." },
+      }),
+    ).rejects.toMatchObject({ code: "input_resource_corrupt" });
+    expect(providerCalls).toBe(1);
+  } finally {
+    await cold?.close();
+    await first.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects a selected FIFO without waiting for a writer", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-input-resource-fifo-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const fifoPath = join(testRoot, "selected.pipe");
+  await mkdir(workspaceRoot);
+  execFileSync("mkfifo", [fifoPath]);
+  let providerCalls = 0;
+  const contextProfile = {
+    version: 1 as const,
+    contextWindowTokens: 1_000_000,
+    maximumOutputTokens: 32_768,
+    compactAtTokens: 800_000,
+    postCompactTargetTokens: 200_000,
+    retainedTargetTokens: 20_000,
+    estimatorVersion: 1 as const,
+  };
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return {
+        identity: targetIdentity,
+        driver: new FakeModelDriver(() => {
+          providerCalls += 1;
+          return [{ type: "finish", reason: "stop" }];
+        }),
+        contextProfile,
+      };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Reject the FIFO." },
+        resourceSelections: [{ type: "local_file", path: fifoPath }],
+      }),
+    ).rejects.toMatchObject({ code: "input_resource_invalid_selection" });
+    expect(providerCalls).toBe(0);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects an input resource above the exact eight MiB file bound", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-input-resource-file-bound-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "too-large.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "", "utf8");
+  await truncate(selectedPath, 8 * 1024 * 1024 + 1);
+  let providerCalls = 0;
+  const modelTargets = createModelTargets({
+    environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
+    fetch: async () => {
+      providerCalls += 1;
+      throw new Error("Provider dispatch is forbidden for an over-limit resource.");
+    },
+  });
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Reject this over-limit resource." },
+        resourceSelections: [{ type: "local_file", path: selectedPath }],
+      }),
+    ).rejects.toMatchObject({ code: "input_resource_too_large" });
+    expect(providerCalls).toBe(0);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects input resources above the exact sixteen MiB run aggregate", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-input-resource-aggregate-bound-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const firstPath = join(testRoot, "first.txt");
+  const secondPath = join(testRoot, "second.txt");
+  const overflowPath = join(testRoot, "overflow.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(firstPath, "", "utf8");
+  await writeFile(secondPath, "", "utf8");
+  await writeFile(overflowPath, "x", "utf8");
+  await truncate(firstPath, 8 * 1024 * 1024);
+  await truncate(secondPath, 8 * 1024 * 1024);
+  let providerCalls = 0;
+  const modelTargets = createModelTargets({
+    environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
+    fetch: async () => {
+      providerCalls += 1;
+      throw new Error("Provider dispatch is forbidden for aggregate overflow.");
+    },
+  });
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Reject the aggregate overflow." },
+        resourceSelections: [
+          { type: "local_file", path: firstPath },
+          { type: "local_file", path: secondPath },
+          { type: "local_file", path: overflowPath },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "input_resource_aggregate_too_large" });
+    expect(providerCalls).toBe(0);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects input resources above the exact sixty-four MiB lineage aggregate", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-input-resource-lineage-aggregate-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const firstPath = join(testRoot, "first.txt");
+  const secondPath = join(testRoot, "second.txt");
+  const overflowPath = join(testRoot, "overflow.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(firstPath, "", "utf8");
+  await writeFile(secondPath, "", "utf8");
+  await writeFile(overflowPath, "x", "utf8");
+  await truncate(firstPath, 8 * 1024 * 1024);
+  await truncate(secondPath, 8 * 1024 * 1024);
+  let providerCalls = 0;
+  const driver = new FakeModelDriver(() => {
+    providerCalls += 1;
+    return [
+      { type: "text_delta", text: "Accepted the exact lineage byte boundary." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const contextProfile = {
+    version: 1 as const,
+    contextWindowTokens: 1_000_000,
+    maximumOutputTokens: 32_768,
+    compactAtTokens: 800_000,
+    postCompactTargetTokens: 200_000,
+    retainedTargetTokens: 20_000,
+    estimatorVersion: 1 as const,
+  };
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    let lastSequence = created.lastSequence;
+    for (let index = 0; index < 4; index += 1) {
+      const continued = await lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: `Commit lineage byte batch ${index + 1}.` },
+        resourceSelections: [
+          { type: "local_file", path: firstPath },
+          { type: "local_file", path: secondPath },
+        ],
+      });
+      lastSequence = continued.snapshot.lastSequence;
+    }
+
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: "Reject the lineage aggregate overflow." },
+        resourceSelections: [{ type: "local_file", path: overflowPath }],
+      }),
+    ).rejects.toMatchObject({ code: "input_resource_aggregate_too_large" });
+    await expect(lifecycle.inspect({ sessionId: created.sessionId })).resolves.toMatchObject({
+      lastSequence,
+    });
+    expect(providerCalls).toBe(4);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle follows one selected symlink without persisting its source path", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-input-resource-symlink-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const targetPath = join(testRoot, "private-target.txt");
+  const selectedPath = join(testRoot, "selected-link.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(targetPath, "selected through one controlled symlink\n", "utf8");
+  await symlink(targetPath, selectedPath);
+  const requests: unknown[] = [];
+  const modelTargets = createModelTargets({
+    environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
+    fetch: async (_input, init) => {
+      requests.push(JSON.parse(String(init?.body)));
+      return new Response(answerOnlyDeepSeekStream, {
+        headers: { "content-type": "text/event-stream" },
+        status: 200,
+      });
+    },
+  });
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const admitted = await lifecycle.admit({
+      targetIdentity,
+      input: { text: "Link the explicitly selected file." },
+      resourceSelections: [{ type: "local_file", path: selectedPath }],
+    });
+    expect(admitted.result).toMatchObject({ status: "completed" });
+    expect(JSON.stringify(requests)).not.toContain(testRoot);
+    const store = await openJsonlSessionStore({
+      stateRoot,
+      workspaceRoot,
+      sessionId: admitted.snapshot.sessionId,
+    });
+    const serializedRecords = JSON.stringify(await store.read());
+    expect(serializedRecords).not.toContain(testRoot);
+    expect(serializedRecords).toContain('"displayName":"selected-link.txt"');
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects a dangling selected symlink before provider dispatch", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-input-resource-dangling-symlink-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "dangling-link.txt");
+  await mkdir(workspaceRoot);
+  await symlink(join(testRoot, "missing-target.txt"), selectedPath);
+  let providerCalls = 0;
+  const modelTargets = createModelTargets({
+    environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
+    fetch: async () => {
+      providerCalls += 1;
+      throw new Error("Provider dispatch is forbidden for a dangling symlink.");
+    },
+  });
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Reject the dangling selection." },
+        resourceSelections: [{ type: "local_file", path: selectedPath }],
+      }),
+    ).rejects.toMatchObject({ code: "input_resource_invalid_selection" });
+    expect(providerCalls).toBe(0);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects a looping selected symlink before provider dispatch", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-input-resource-looping-symlink-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "looping-link.txt");
+  await mkdir(workspaceRoot);
+  await symlink(selectedPath, selectedPath);
+  let providerCalls = 0;
+  const modelTargets = createModelTargets({
+    environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
+    fetch: async () => {
+      providerCalls += 1;
+      throw new Error("Provider dispatch is forbidden for a looping symlink.");
+    },
+  });
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Reject the looping selection." },
+        resourceSelections: [{ type: "local_file", path: selectedPath }],
+      }),
+    ).rejects.toMatchObject({ code: "input_resource_invalid_selection" });
+    expect(providerCalls).toBe(0);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects a final symlink substituted after controlled resolution", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-input-resource-symlink-race-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const targetPath = join(testRoot, "accepted-target.txt");
+  const replacementPath = join(testRoot, "replacement.txt");
+  const selectedPath = join(testRoot, "selected-link.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(targetPath, "accepted target\n", "utf8");
+  await writeFile(replacementPath, "must not be followed\n", "utf8");
+  await symlink(targetPath, selectedPath);
+  let providerCalls = 0;
+  const modelTargets = createModelTargets({
+    environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
+    fetch: async () => {
+      providerCalls += 1;
+      throw new Error("Provider dispatch is forbidden after final-path substitution.");
+    },
+  });
+  const lifecycle = createSessionLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+    [inputResourceIngestBarrier]: {
+      async afterResolved() {
+        await unlink(targetPath);
+        await symlink(replacementPath, targetPath);
+      },
+    },
+  });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Do not follow a substituted final symlink." },
+        resourceSelections: [{ type: "local_file", path: selectedPath }],
+      }),
+    ).rejects.toMatchObject({ code: "input_resource_invalid_selection" });
+    expect(providerCalls).toBe(0);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("SessionLifecycle cold resume keeps a Direct DeepSeek v2 session on its historical profile", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-deepseek-v2-cold-resume-"));
   const stateRoot = join(testRoot, "state");
@@ -49,8 +683,26 @@ test("SessionLifecycle cold resume keeps a Direct DeepSeek v2 session on its his
       });
     },
   });
-  const tools = createCodingToolRegistry({ stateRoot, workspaceRoot });
-  const first = createSessionLifecycle({ modelTargets, stateRoot, tools, workspaceRoot });
+  const currentTools = createCodingToolRegistry({ stateRoot, workspaceRoot });
+  const historicalToolNames = new Set([
+    "read_file",
+    "write_file",
+    "edit_file",
+    "run_shell",
+    "activate_skill",
+    "read_skill_resource",
+  ]);
+  const historicalTools: ToolRegistry = {
+    definitions: () =>
+      currentTools.definitions().filter((definition) => historicalToolNames.has(definition.name)),
+    resolve: (name) => (historicalToolNames.has(name) ? currentTools.resolve(name) : undefined),
+  };
+  const first = createSessionLifecycle({
+    modelTargets,
+    stateRoot,
+    tools: historicalTools,
+    workspaceRoot,
+  });
   let cold: ReturnType<typeof createSessionLifecycle> | undefined;
 
   try {
@@ -66,7 +718,7 @@ test("SessionLifecycle cold resume keeps a Direct DeepSeek v2 session on its his
     });
     await first.close();
 
-    cold = createSessionLifecycle({ modelTargets, stateRoot, tools, workspaceRoot });
+    cold = createSessionLifecycle({ modelTargets, stateRoot, tools: currentTools, workspaceRoot });
     await expect(
       cold.continue({
         sessionId: created.sessionId,

--- a/packages/testkit/src/session-lifecycle.test.ts
+++ b/packages/testkit/src/session-lifecycle.test.ts
@@ -1,5 +1,15 @@
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  truncate,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -10,6 +20,7 @@ import {
   createMutationToolRegistry,
   createPermissionPolicy,
   createReadToolRegistry,
+  type LocalInputResourceSelectionV1,
   type ModelDriver,
   type ModelMessage,
   type ModelTargetIdentity,
@@ -20,14 +31,19 @@ import {
   type ThinkingPolicySelectionV1,
 } from "@adam-agent/agent";
 import {
+  createInMemorySessionStoreDirectory,
+  inputResourceIngestBarrier,
   openJsonlSessionStore,
   type ProjectLifecycleOwner,
   ProjectLifecycleOwnerError,
   preparedDirectDeepSeekV2ContextProfile,
   type SessionRecord,
+  type SessionStoreDirectory,
+  sessionAutomaticTitlesEnabled,
   sessionCloseDrainBarrier,
   sessionLogicalRunStartedBarrier,
   sessionProjectLifecycleOwner,
+  sessionStoreDirectory,
 } from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
 import { createInMemorySessionLifecycleHarness, FakeModelDriver } from "./index.js";
@@ -423,7 +439,7 @@ function snapshotWithLastPromptProjection<Snapshot extends { readonly promptCont
 }
 
 const introductionRequestDigest =
-  "sha256:b8f5b0a402f635a8353c4f77a332c8acd7a44399820db9848a1f8d3678961adb" as const;
+  "sha256:0782707796dafcb2988d1eadadddc3de09e48ef4a1760ab57a4be9a983b9a181" as const;
 const permissionRequestDigest =
   "sha256:341baabb2a66d516430fc49f39c3c408a15dae8a47608ad543a3bb888431b01c" as const;
 
@@ -1236,6 +1252,1198 @@ test("SessionLifecycle freezes draft Skill resources before allocating durable s
   }
 });
 
+test("SessionLifecycle commits one selected input resource before its descriptor reaches the model", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-input-resource-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "Aurora notes.txt");
+  const content = "Aurora Compass is ready.\n";
+  const bytes = Buffer.from(content, "utf8");
+  const digest = `sha256:${createHash("sha256").update(bytes).digest("hex")}` as const;
+  const artifactId = digest;
+  const runId = "10000000-0000-4000-8000-000000000011";
+  const occurrenceId = `${runId}:input:1`;
+  const descriptor = {
+    occurrenceId,
+    displayName: "Aurora notes.txt",
+    artifact: {
+      id: artifactId,
+      mediaType: "text/plain; charset=utf-8",
+      byteCount: bytes.byteLength,
+    },
+    digest,
+    mediaHint: "text" as const,
+    provenance: "user_local_file" as const,
+    support: "utf8_text" as const,
+    mode: "link" as const,
+  };
+  const descriptorProjection = `Linked input resources (descriptor-only; use read_input_resource to read supported immutable content):\n${JSON.stringify([descriptor])}`;
+  const pageDigest = `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, bytes);
+  const harness = createInMemorySessionLifecycleHarness();
+  let durableCommitSettled = false;
+  let providerCalls = 0;
+  const driver = new FakeModelDriver((request) => {
+    providerCalls += 1;
+    expect(durableCommitSettled).toBe(true);
+    if (providerCalls === 1) {
+      expect(request.messages.at(-1)).toEqual({
+        role: "user",
+        content: `Read the linked note.\n\n${descriptorProjection}`,
+      });
+      expect(request.tools.map((tool) => tool.name)).toContain("read_input_resource");
+      return [
+        { type: "tool_call_start", id: "resource-call-1", name: "read_input_resource" },
+        {
+          type: "tool_call_delta",
+          id: "resource-call-1",
+          json: JSON.stringify({ occurrenceId, maxByteCount: 64 }),
+        },
+        { type: "tool_call_end", id: "resource-call-1" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    expect(request.messages.at(-1)).toEqual({
+      role: "tool",
+      callId: "resource-call-1",
+      name: "read_input_resource",
+      result: {
+        status: "completed",
+        output: {
+          occurrenceId,
+          displayName: "Aurora notes.txt",
+          offset: 0,
+          byteCount: bytes.byteLength,
+          totalByteCount: bytes.byteLength,
+          eof: true,
+          nextCursor: null,
+          digest,
+          pageDigest,
+          content,
+        },
+      },
+    });
+    return [
+      { type: "text_delta", text: "The linked note says Aurora Compass is ready." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = harness.createLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+    [sessionLogicalRunStartedBarrier]: {
+      async afterDurableRecord(started) {
+        const store = await harness.sessions.open(started.sessionId);
+        if (store === undefined) {
+          throw new Error("Expected the admitted input-resource session store.");
+        }
+        expect(await store.read()).toEqual(
+          expect.arrayContaining([
+            {
+              schemaVersion: 3,
+              sequence: started.sequence,
+              record: {
+                type: "logical_run_started",
+                recordVersion: 1,
+                runId,
+                userMessage: "Read the linked note.",
+                naming: {
+                  profileVersion: 1,
+                  fallbackTitle: "Read the linked note.",
+                },
+                inputResources: [descriptor],
+              },
+            },
+          ]),
+        );
+        await expect(
+          readFile(join(stateRoot, "artifacts", artifactId.slice("sha256:".length))),
+        ).resolves.toEqual(bytes);
+        durableCommitSettled = true;
+      },
+    },
+  });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Read the linked note." },
+        resourceSelections: [{ type: "local_file", path: selectedPath }],
+        runId,
+      }),
+    ).resolves.toMatchObject({
+      result: {
+        status: "completed",
+        answer: "The linked note says Aurora Compass is ready.",
+      },
+    });
+    expect(providerCalls).toBe(2);
+    const store = await harness.sessions.open(
+      (await harness.sessions.listSessionIds())[0] as string,
+    );
+    expect(await store?.read()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          record: {
+            type: "input_resource_read_committed",
+            recordVersion: 1,
+            runId,
+            callId: "resource-call-1",
+            occurrenceId,
+            displayName: "Aurora notes.txt",
+            offset: 0,
+            byteCount: bytes.byteLength,
+            totalByteCount: bytes.byteLength,
+            eof: true,
+            nextCursor: null,
+            digest,
+            pageDigest,
+            content,
+          },
+        }),
+      ]),
+    );
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle follows a stable byte cursor across strict UTF-8 input-resource pages", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-input-resource-pages-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "multibyte.txt");
+  const content = "A界BC好D";
+  const runId = "10000000-0000-4000-8000-000000000012";
+  const occurrenceId = `${runId}:input:1`;
+  const cursor = `input-resource:v1:${Buffer.from(JSON.stringify([occurrenceId, 5]), "utf8").toString("base64url")}`;
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, content, "utf8");
+  let providerCalls = 0;
+  const driver = new FakeModelDriver((request) => {
+    providerCalls += 1;
+    if (providerCalls === 1) {
+      return [
+        { type: "tool_call_start", id: "page-1", name: "read_input_resource" },
+        {
+          type: "tool_call_delta",
+          id: "page-1",
+          json: JSON.stringify({ occurrenceId, maxByteCount: 5 }),
+        },
+        { type: "tool_call_end", id: "page-1" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    if (providerCalls === 2) {
+      expect(request.messages.at(-1)).toMatchObject({
+        role: "tool",
+        callId: "page-1",
+        result: {
+          status: "completed",
+          output: {
+            occurrenceId,
+            offset: 0,
+            byteCount: 5,
+            totalByteCount: 10,
+            eof: false,
+            nextCursor: cursor,
+            content: "A界B",
+          },
+        },
+      });
+      return [
+        { type: "tool_call_start", id: "page-2", name: "read_input_resource" },
+        {
+          type: "tool_call_delta",
+          id: "page-2",
+          json: JSON.stringify({ occurrenceId, cursor, maxByteCount: 5 }),
+        },
+        { type: "tool_call_end", id: "page-2" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    expect(request.messages.at(-1)).toMatchObject({
+      role: "tool",
+      callId: "page-2",
+      result: {
+        status: "completed",
+        output: {
+          occurrenceId,
+          offset: 5,
+          byteCount: 5,
+          totalByteCount: 10,
+          eof: true,
+          nextCursor: null,
+          content: "C好D",
+        },
+      },
+    });
+    return [
+      { type: "text_delta", text: "Both pages were stable." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Read both byte pages." },
+        resourceSelections: [{ type: "local_file", path: selectedPath }],
+        runId,
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "Both pages were stable." },
+    });
+    expect(providerCalls).toBe(3);
+    const store = await harness.sessions.open(
+      (await harness.sessions.listSessionIds())[0] as string,
+    );
+    expect(
+      (await store?.read())?.filter(
+        (record) =>
+          record.schemaVersion === 3 && record.record.type === "input_resource_read_committed",
+      ),
+    ).toMatchObject([
+      { record: { callId: "page-1", offset: 0, byteCount: 5, nextCursor: cursor } },
+      { record: { callId: "page-2", offset: 5, byteCount: 5, nextCursor: null } },
+    ]);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle enforces the exact one MiB materialized-output budget per run", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-input-resource-quota-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "quota.txt");
+  const content = "q".repeat(64 * 1024);
+  const runId = "10000000-0000-4000-8000-000000000013";
+  const occurrenceId = `${runId}:input:1`;
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, content, "utf8");
+  let providerCalls = 0;
+  const driver = new FakeModelDriver((request) => {
+    providerCalls += 1;
+    if (providerCalls === 1) {
+      return [
+        ...Array.from({ length: 17 }, (_, index) => {
+          const callId = `quota-${index + 1}`;
+          return [
+            { type: "tool_call_start" as const, id: callId, name: "read_input_resource" },
+            {
+              type: "tool_call_delta" as const,
+              id: callId,
+              json: JSON.stringify({ occurrenceId, maxByteCount: 64 * 1024 }),
+            },
+            { type: "tool_call_end" as const, id: callId },
+          ];
+        }).flat(),
+        { type: "finish" as const, reason: "tool_calls" as const },
+      ];
+    }
+    const toolMessages = request.messages.filter((message) => message.role === "tool");
+    expect(toolMessages).toHaveLength(17);
+    expect(toolMessages.at(-1)).toEqual({
+      role: "tool",
+      callId: "quota-17",
+      name: "read_input_resource",
+      result: {
+        status: "failed",
+        error: {
+          code: "input_resource_quota_exceeded",
+          message:
+            "The input-resource materialization quota for this run or session lineage would be exceeded.",
+        },
+      },
+    });
+    return [
+      { type: "text_delta", text: "The seventeenth page was rejected." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Exercise the exact materialized-output budget." },
+        resourceSelections: [{ type: "local_file", path: selectedPath }],
+        runId,
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "The seventeenth page was rejected." },
+    });
+    const store = await harness.sessions.open(
+      (await harness.sessions.listSessionIds())[0] as string,
+    );
+    expect(
+      (await store?.read())?.filter(
+        (record) =>
+          record.schemaVersion === 3 && record.record.type === "input_resource_read_committed",
+      ),
+    ).toHaveLength(16);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle enforces the exact eight MiB materialized-output budget per lineage", async () => {
+  const testRoot = await mkdtemp(
+    join(tmpdir(), "adam-agent-session-input-resource-lineage-quota-"),
+  );
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "lineage-quota.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "q".repeat(64 * 1024), "utf8");
+  let activeOccurrenceId = "";
+  let activeReadCount = 0;
+  let expectQuotaFailure = false;
+  let activeBatchIssued = false;
+  let ordinaryProviderCalls = 0;
+  let compactionProviderCalls = 0;
+  let toolCallOrdinal = 0;
+  const driver = new FakeModelDriver((request) => {
+    if (request.tools.length === 0) {
+      compactionProviderCalls += 1;
+      return [
+        {
+          type: "text_delta",
+          text: JSON.stringify({
+            schemaVersion: 1,
+            objective: "Preserve the linked input-resource lineage quota.",
+            constraints: [],
+            progress: [],
+            unresolvedQuestions: [],
+            failures: [],
+            remainingVerification: ["Continue exact quota accounting."],
+            nextSafeAction: "Continue the next bounded run.",
+          }),
+        },
+        { type: "usage", inputTokens: 700_000, outputTokens: 32 },
+        { type: "finish", reason: "stop" },
+      ];
+    }
+    ordinaryProviderCalls += 1;
+    if (!activeBatchIssued) {
+      activeBatchIssued = true;
+      return [
+        ...Array.from({ length: activeReadCount }, () => {
+          toolCallOrdinal += 1;
+          const callId = `lineage-quota-${toolCallOrdinal}`;
+          return [
+            { type: "tool_call_start" as const, id: callId, name: "read_input_resource" },
+            {
+              type: "tool_call_delta" as const,
+              id: callId,
+              json: JSON.stringify({
+                occurrenceId: activeOccurrenceId,
+                maxByteCount: 64 * 1024,
+              }),
+            },
+            { type: "tool_call_end" as const, id: callId },
+          ];
+        }).flat(),
+        { type: "finish" as const, reason: "tool_calls" as const },
+      ];
+    }
+    return [
+      {
+        type: "text_delta",
+        text: expectQuotaFailure
+          ? "The lineage quota rejected another page."
+          : "The run materialized one MiB.",
+      },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    for (let index = 1; index <= 8; index += 1) {
+      const runId = `20000000-0000-4000-8000-${index.toString().padStart(12, "0")}`;
+      activeOccurrenceId = `${runId}:input:1`;
+      activeReadCount = 16;
+      expectQuotaFailure = false;
+      activeBatchIssued = false;
+      await expect(
+        lifecycle.continue({
+          sessionId: created.sessionId,
+          input: { text: `Materialize lineage MiB ${index}.` },
+          resourceSelections: [{ type: "local_file", path: selectedPath }],
+          runId,
+        }),
+      ).resolves.toMatchObject({ result: { status: "completed" } });
+    }
+    const overflowRunId = "20000000-0000-4000-8000-000000000009";
+    activeOccurrenceId = `${overflowRunId}:input:1`;
+    activeReadCount = 1;
+    expectQuotaFailure = true;
+    activeBatchIssued = false;
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: "Reject another lineage materialization page." },
+        resourceSelections: [{ type: "local_file", path: selectedPath }],
+        runId: overflowRunId,
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "The lineage quota rejected another page." },
+    });
+    const store = await openJsonlSessionStore({
+      stateRoot,
+      workspaceRoot,
+      sessionId: created.sessionId,
+    });
+    const records = await store.read();
+    expect(
+      records.filter(
+        (record) =>
+          record.schemaVersion === 3 && record.record.type === "input_resource_read_committed",
+      ),
+    ).toHaveLength(128);
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          record: expect.objectContaining({
+            type: "runtime_event",
+            event: expect.objectContaining({
+              type: "tool_failed",
+              error: expect.objectContaining({ code: "input_resource_quota_exceeded" }),
+            }),
+          }),
+        }),
+      ]),
+    );
+    expect(ordinaryProviderCalls).toBe(18);
+    expect(compactionProviderCalls).toBeGreaterThan(0);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle preserves duplicate selections as ordered occurrences over one artifact", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-input-resource-duplicate-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "shared.txt");
+  const content = "same immutable bytes\n";
+  const digest = `sha256:${createHash("sha256").update(content, "utf8").digest("hex")}`;
+  const runId = "20000000-0000-4000-8000-000000000011";
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, content, "utf8");
+  let projectedOccurrences: readonly {
+    readonly occurrenceId: string;
+    readonly artifact: { readonly id: string };
+  }[] = [];
+  const driver = new FakeModelDriver((request) => {
+    const user = request.messages.at(-1);
+    if (user?.role !== "user") {
+      throw new Error("Expected the duplicate resource descriptor request.");
+    }
+    projectedOccurrences = JSON.parse(user.content.split("\n").at(-1) ?? "[]") as readonly {
+      readonly occurrenceId: string;
+      readonly artifact: { readonly id: string };
+    }[];
+    return [
+      { type: "text_delta", text: "Both occurrences are visible." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const admitted = await lifecycle.admit({
+      targetIdentity,
+      input: { text: "Keep both links." },
+      resourceSelections: [
+        { type: "local_file", path: selectedPath },
+        { type: "local_file", path: selectedPath },
+      ],
+      runId,
+    });
+    expect(projectedOccurrences).toHaveLength(2);
+    expect(projectedOccurrences.map((entry) => entry.occurrenceId)).toEqual([
+      `${runId}:input:1`,
+      `${runId}:input:2`,
+    ]);
+    expect(projectedOccurrences.map((entry) => entry.artifact.id)).toEqual([digest, digest]);
+    const store = await harness.sessions.open(admitted.snapshot.sessionId);
+    const logicalRun = (await store?.read())?.find(
+      (record) => record.schemaVersion === 3 && record.record.type === "logical_run_started",
+    );
+    const durableOccurrences =
+      logicalRun?.schemaVersion === 3 && logicalRun.record.type === "logical_run_started"
+        ? logicalRun.record.inputResources
+        : undefined;
+    expect(durableOccurrences).toHaveLength(2);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects a ninth input-resource occurrence before provider dispatch", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-input-resource-count-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "bounded.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "bounded\n", "utf8");
+  let providerCalls = 0;
+  const driver = new FakeModelDriver(() => {
+    providerCalls += 1;
+    return [{ type: "finish", reason: "stop" }];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Reject the ninth link." },
+        resourceSelections: Array.from({ length: 9 }, () => ({
+          type: "local_file" as const,
+          path: selectedPath,
+        })),
+      }),
+    ).rejects.toMatchObject({ code: "input_resource_count_exceeded" });
+    expect(providerCalls).toBe(0);
+    const sessionIds = await harness.sessions.listSessionIds();
+    expect(sessionIds).toHaveLength(1);
+    const store = await harness.sessions.open(sessionIds[0] as string);
+    expect(await store?.read()).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          record: expect.objectContaining({ type: "logical_run_started" }),
+        }),
+      ]),
+    );
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects a sixty-fifth lineage input-resource occurrence before logical commit", async () => {
+  const testRoot = await mkdtemp(
+    join(tmpdir(), "adam-agent-session-input-resource-lineage-count-"),
+  );
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const selectedPath = join(testRoot, "lineage-resource.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "lineage\n", "utf8");
+  let providerCalls = 0;
+  const driver = new FakeModelDriver(() => {
+    providerCalls += 1;
+    return [
+      { type: "text_delta", text: "Accepted bounded lineage resources." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    const selections = Array.from(
+      { length: 8 },
+      (): LocalInputResourceSelectionV1 => ({ type: "local_file", path: selectedPath }),
+    );
+    let lastSequence = created.lastSequence;
+    for (let index = 0; index < 8; index += 1) {
+      const continued = await lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: `Commit lineage resource batch ${index + 1}.` },
+        resourceSelections: selections,
+      });
+      lastSequence = continued.snapshot.lastSequence;
+    }
+
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: "Reject lineage occurrence 65." },
+        resourceSelections: [{ type: "local_file", path: selectedPath }],
+      }),
+    ).rejects.toMatchObject({ code: "input_resource_count_exceeded" });
+    await expect(lifecycle.inspect({ sessionId: created.sessionId })).resolves.toMatchObject({
+      lastSequence,
+    });
+    expect(providerCalls).toBe(8);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle leaves only a safe orphan when input-resource logical commit fails", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-input-resource-orphan-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "orphan.txt");
+  const content = "Published before the failed reference.\n";
+  const digest = createHash("sha256").update(content, "utf8").digest("hex");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, content, "utf8");
+  let providerCalls = 0;
+  const driver = new FakeModelDriver(() => {
+    providerCalls += 1;
+    return [{ type: "finish", reason: "stop" }];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const backing = createInMemorySessionStoreDirectory<SessionRecord>();
+  const wrapStore = (
+    store: Awaited<ReturnType<SessionStoreDirectory<SessionRecord>["create"]>>,
+  ) => ({
+    async append(record: SessionRecord) {
+      if (record.schemaVersion === 3 && record.record.type === "logical_run_started") {
+        throw new Error("logical commit failed");
+      }
+      await store.append(record);
+    },
+    read: () => store.read(),
+  });
+  const failingDirectory: SessionStoreDirectory<SessionRecord> = {
+    async create(sessionId) {
+      return wrapStore(await backing.create(sessionId));
+    },
+    listSessionEntries: () => backing.listSessionEntries(),
+    listSessionIds: () => backing.listSessionIds(),
+    async open(sessionId) {
+      const store = await backing.open(sessionId);
+      return store === undefined ? undefined : wrapStore(store);
+    },
+  };
+  const lifecycle = createSessionLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+    [sessionAutomaticTitlesEnabled]: false,
+    [sessionStoreDirectory]: failingDirectory,
+  });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Fail this logical reference." },
+        resourceSelections: [{ type: "local_file", path: selectedPath }],
+      }),
+    ).resolves.toMatchObject({
+      result: {
+        status: "failed",
+        error: { code: "session_persistence_failed" },
+      },
+    });
+    expect(providerCalls).toBe(0);
+    await expect(readFile(join(stateRoot, "artifacts", digest))).resolves.toEqual(
+      Buffer.from(content, "utf8"),
+    );
+    const sessionIds = await backing.listSessionIds();
+    const store = await backing.open(sessionIds[0] as string);
+    expect(await store?.read()).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          record: expect.objectContaining({ type: "logical_run_started" }),
+        }),
+      ]),
+    );
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle cancellation settles input-resource ingest without a durable reference", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-input-resource-cancel-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "cancel.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "cancel before resource bytes are published\n", "utf8");
+  const entered = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const controller = new AbortController();
+  let providerCalls = 0;
+  const driver = new FakeModelDriver(() => {
+    providerCalls += 1;
+    return [{ type: "finish", reason: "stop" }];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+    [inputResourceIngestBarrier]: {
+      async afterOpened() {
+        entered.resolve();
+        await release.promise;
+      },
+    },
+  });
+
+  try {
+    const admission = lifecycle.admit({
+      targetIdentity,
+      input: { text: "Cancel this resource ingest." },
+      resourceSelections: [{ type: "local_file", path: selectedPath }],
+      signal: controller.signal,
+    });
+    await entered.promise;
+    controller.abort();
+    release.resolve();
+    await expect(admission).rejects.toMatchObject({ name: "AbortError" });
+    expect(providerCalls).toBe(0);
+    await expect(readdir(join(stateRoot, "artifacts"))).resolves.toEqual([]);
+    const sessionIds = await harness.sessions.listSessionIds();
+    const store = await harness.sessions.open(sessionIds[0] as string);
+    expect(await store?.read()).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          record: expect.objectContaining({ type: "logical_run_started" }),
+        }),
+      ]),
+    );
+  } finally {
+    release.resolve();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects a source truncated after its accepted descriptor is opened", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-input-resource-short-read-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "changing.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "accepted size then truncated\n", "utf8");
+  let providerCalls = 0;
+  const driver = new FakeModelDriver(() => {
+    providerCalls += 1;
+    return [{ type: "finish", reason: "stop" }];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+    [inputResourceIngestBarrier]: {
+      async afterOpened() {
+        await truncate(selectedPath, 0);
+      },
+    },
+  });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Do not admit a changing resource." },
+        resourceSelections: [{ type: "local_file", path: selectedPath }],
+      }),
+    ).rejects.toMatchObject({ code: "input_resource_io_failed" });
+    expect(providerCalls).toBe(0);
+    await expect(readdir(join(stateRoot, "artifacts"))).resolves.toEqual([]);
+    const sessionIds = await harness.sessions.listSessionIds();
+    const store = await harness.sessions.open(sessionIds[0] as string);
+    expect(await store?.read()).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          record: expect.objectContaining({ type: "logical_run_started" }),
+        }),
+      ]),
+    );
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle prefix branch exposes only input-resource occurrences inside its boundary", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-input-resource-branch-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const firstPath = join(testRoot, "first.txt");
+  const laterPath = join(testRoot, "later.txt");
+  const firstRunId = "40000000-0000-4000-8000-000000000011";
+  const laterRunId = "40000000-0000-4000-8000-000000000012";
+  const firstOccurrenceId = `${firstRunId}:input:1`;
+  const laterOccurrenceId = `${laterRunId}:input:1`;
+  await mkdir(workspaceRoot);
+  await writeFile(firstPath, "first prefix bytes\n", "utf8");
+  await writeFile(laterPath, "later parent bytes\n", "utf8");
+  let providerCalls = 0;
+  const driver = new FakeModelDriver((request) => {
+    providerCalls += 1;
+    if (providerCalls <= 2) {
+      return [
+        { type: "text_delta", text: `Parent turn ${providerCalls}.` },
+        { type: "finish", reason: "stop" },
+      ];
+    }
+    if (providerCalls === 3) {
+      const userDescriptors = request.messages
+        .filter((message) => message.role === "user")
+        .map((message) => message.content)
+        .join("\n");
+      expect(userDescriptors).toContain(firstOccurrenceId);
+      expect(userDescriptors).not.toContain(laterOccurrenceId);
+      return [
+        { type: "tool_call_start", id: "prefix-visible", name: "read_input_resource" },
+        {
+          type: "tool_call_delta",
+          id: "prefix-visible",
+          json: JSON.stringify({ occurrenceId: firstOccurrenceId }),
+        },
+        { type: "tool_call_end", id: "prefix-visible" },
+        { type: "tool_call_start", id: "prefix-hidden", name: "read_input_resource" },
+        {
+          type: "tool_call_delta",
+          id: "prefix-hidden",
+          json: JSON.stringify({ occurrenceId: laterOccurrenceId }),
+        },
+        { type: "tool_call_end", id: "prefix-hidden" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    const results = request.messages.filter((message) => message.role === "tool");
+    expect(results).toEqual([
+      expect.objectContaining({
+        callId: "prefix-visible",
+        result: expect.objectContaining({
+          status: "completed",
+          output: expect.objectContaining({ content: "first prefix bytes\n" }),
+        }),
+      }),
+      expect.objectContaining({
+        callId: "prefix-hidden",
+        result: {
+          status: "failed",
+          error: {
+            code: "input_resource_not_visible",
+            message:
+              "The requested input-resource occurrence is not visible in this session history.",
+          },
+        },
+      }),
+    ]);
+    return [
+      { type: "text_delta", text: "Only the prefix resource is available." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const first = await lifecycle.admit({
+      targetIdentity,
+      input: { text: "Link the prefix resource." },
+      resourceSelections: [{ type: "local_file", path: firstPath }],
+      runId: firstRunId,
+    });
+    await lifecycle.continue({
+      sessionId: first.snapshot.sessionId,
+      input: { text: "Link the later resource." },
+      resourceSelections: [{ type: "local_file", path: laterPath }],
+      runId: laterRunId,
+    });
+    const branch = await lifecycle.branch({
+      parentSessionId: first.snapshot.sessionId,
+      atSequence: first.snapshot.lastSequence,
+    });
+    await expect(
+      lifecycle.continue({
+        sessionId: branch.sessionId,
+        input: { text: "Read only the prefix resource." },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "Only the prefix resource is available." },
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle links binary bytes but returns typed unsupported materialization", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-input-resource-binary-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "binary.dat");
+  const runId = "50000000-0000-4000-8000-000000000011";
+  const occurrenceId = `${runId}:input:1`;
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, Buffer.from([0xff, 0xfe, 0x00, 0x41]));
+  let providerCalls = 0;
+  const driver = new FakeModelDriver((request) => {
+    providerCalls += 1;
+    if (providerCalls === 1) {
+      const user = request.messages.at(-1);
+      expect(user?.role === "user" ? user.content : "").toContain('"support":"unsupported_binary"');
+      return [
+        { type: "tool_call_start", id: "binary-resource", name: "read_input_resource" },
+        {
+          type: "tool_call_delta",
+          id: "binary-resource",
+          json: JSON.stringify({ occurrenceId }),
+        },
+        { type: "tool_call_end", id: "binary-resource" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    expect(request.messages.at(-1)).toEqual({
+      role: "tool",
+      callId: "binary-resource",
+      name: "read_input_resource",
+      result: {
+        status: "failed",
+        error: {
+          code: "input_resource_unsupported",
+          message: "The requested input resource is not supported as strict UTF-8 text.",
+        },
+      },
+    });
+    return [
+      { type: "text_delta", text: "The linked resource is unsupported binary." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity,
+        input: { text: "Inspect the binary link." },
+        resourceSelections: [{ type: "local_file", path: selectedPath }],
+        runId,
+      }),
+    ).resolves.toMatchObject({
+      result: {
+        status: "completed",
+        answer: "The linked resource is unsupported binary.",
+      },
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("SessionLifecycle rejects invalid draft run limits before allocating durable session identity", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-lifecycle-draft-limits-"));
   const workspaceRoot = join(testRoot, "workspace");
@@ -1342,7 +2550,7 @@ test("SessionLifecycle paginates prompt-admitted sessions while hiding genesis-o
   }
 });
 
-test("SessionLifecycle creates a prompt-v3 genesis with an empty bounded Skill snapshot and six tools", async () => {
+test("SessionLifecycle creates a prompt-v3 genesis with an empty bounded Skill snapshot and seven tools", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-skills-genesis-"));
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
@@ -1381,6 +2589,7 @@ test("SessionLifecycle creates a prompt-v3 genesis with an empty bounded Skill s
               { name: "run_shell" },
               { name: "activate_skill" },
               { name: "read_skill_resource" },
+              { name: "read_input_resource" },
             ],
           },
         },

--- a/packages/testkit/src/session-store.test.ts
+++ b/packages/testkit/src/session-store.test.ts
@@ -297,6 +297,38 @@ test("SessionStore adapters read legacy v1 records and current v2 patch records"
   }
 });
 
+test("SessionStore adapters do not widen the historical v2 tool-error schema", async () => {
+  const { testRoot, stores } = await createContractStores(
+    "adam-agent-session-v2-input-resource-error-",
+    "session-v2-input-resource-error",
+  );
+  const invalidRecord = {
+    schemaVersion: 2,
+    runId,
+    sequence: 1,
+    event: {
+      type: "tool_failed",
+      callId: "historical-call",
+      name: "read_input_resource",
+      error: {
+        code: "input_resource_not_visible",
+        message: "This error did not exist in the historical v2 contract.",
+      },
+    },
+  } as const;
+
+  try {
+    for (const [name, store] of stores) {
+      await expect(store.append(invalidRecord), name).rejects.toMatchObject({
+        name: "SessionStoreError",
+        code: "session_log_invalid",
+      });
+    }
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("SessionStore adapters keep the v1 event contract unchanged", async () => {
   const { testRoot, stores } = await createContractStores(
     "adam-agent-session-v1-contract-",

--- a/packages/testkit/src/shell-session.test.ts
+++ b/packages/testkit/src/shell-session.test.ts
@@ -16,7 +16,7 @@ import { expect, test } from "vitest";
 
 import { FakeModelDriver } from "./index.js";
 
-test("the default coding registry exposes the six prompt-v2 tools", async () => {
+test("the default coding registry exposes the seven current prompt tools", async () => {
   const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-coding-registry-"));
 
   try {
@@ -50,6 +50,7 @@ test("the default coding registry exposes the six prompt-v2 tools", async () => 
         "run_shell",
         "activate_skill",
         "read_skill_resource",
+        "read_input_resource",
       ],
       listFiles: undefined,
       searchText: undefined,

--- a/packages/testkit/src/skills.test.ts
+++ b/packages/testkit/src/skills.test.ts
@@ -623,6 +623,7 @@ test("SessionLifecycle bounds unknown frontmatter fields and reports allowed-too
       "run_shell",
       "activate_skill",
       "read_skill_resource",
+      "read_input_resource",
     ]);
   } finally {
     await rm(testRoot, { recursive: true, force: true });
@@ -680,6 +681,7 @@ test("SessionLifecycle admits audited Skill metadata arrays without granting lis
       "run_shell",
       "activate_skill",
       "read_skill_resource",
+      "read_input_resource",
     ]);
   } finally {
     if (previousHome === undefined) {

--- a/packages/testkit/src/trusted-mcp-host.test.ts
+++ b/packages/testkit/src/trusted-mcp-host.test.ts
@@ -5007,6 +5007,7 @@ test("SessionLifecycle keeps user-assigned MCP effect authority over server anno
       "run_shell",
       "activate_skill",
       "read_skill_resource",
+      "read_input_resource",
       qualifiedName,
     ]);
     expect(requests[0]?.tools.find((tool) => tool.name === qualifiedName)?.description).toBe(


### PR DESCRIPTION
## Summary

- ingest explicitly selected local files into immutable bounded artifacts before durable descriptor commit
- add descriptor-only linked resource projection and bounded strict UTF-8 read_input_resource materialization
- preserve canonical resource truth across cold resume, prefix branches, compaction, cancellation, corruption checks, and exact lineage budgets
- keep pre-B11 Tool Profiles authoritative through ordered A-prime subset compatibility

## Scope

This closes only the B11a1 product checkpoint. It does not add Presentation/TUI draft staging, image projection, or B11a2/B11b behavior.

## Verification

- pnpm quality:check
- 50 test files passed, 1274 tests passed, 11 skipped; 2 opt-in files skipped