### PR TITLE
B11a2: add turn composer resource staging

### DIFF
--- a/apps/tui/src/command-autocomplete.ts
+++ b/apps/tui/src/command-autocomplete.ts
@@ -15,6 +15,7 @@ type SkillCompletion = {
 
 export class AdamAutocompleteProvider implements AutocompleteProvider {
   readonly triggerCharacters = ["$"];
+  readonly #getAttachmentsAvailable: () => boolean;
   readonly #getProjectPaths: () => readonly string[];
   readonly #getRunActive: () => boolean;
   readonly #getSkills: () => readonly SkillCompletion[];
@@ -23,6 +24,7 @@ export class AdamAutocompleteProvider implements AutocompleteProvider {
   readonly #registry: AdamCommandRegistry;
 
   constructor(options: {
+    readonly getAttachmentsAvailable?: () => boolean;
     readonly getProjectPaths: () => readonly string[];
     readonly getRunActive: () => boolean;
     readonly getSkills: () => readonly SkillCompletion[];
@@ -30,6 +32,7 @@ export class AdamAutocompleteProvider implements AutocompleteProvider {
     readonly keyword?: (text: string) => string;
     readonly registry?: AdamCommandRegistry;
   }) {
+    this.#getAttachmentsAvailable = options.getAttachmentsAvailable ?? (() => true);
     this.#getProjectPaths = options.getProjectPaths;
     this.#getRunActive = options.getRunActive;
     this.#getSkills = options.getSkills;
@@ -55,11 +58,12 @@ export class AdamAutocompleteProvider implements AutocompleteProvider {
       !beforeCursor.includes("\t")
     ) {
       const query = beforeCursor.slice(1);
-      const availableCommands = this.#registry
-        .entries()
-        .filter((command) =>
-          this.#registry.isAvailable(command, { runActive: this.#getRunActive() }),
-        );
+      const availableCommands = this.#registry.entries().filter((command) =>
+        this.#registry.isAvailable(command, {
+          attachmentsAvailable: this.#getAttachmentsAvailable(),
+          runActive: this.#getRunActive(),
+        }),
+      );
       const prefixMatches = availableCommands.filter(
         (command) =>
           command.name.startsWith(query) ||
@@ -97,10 +101,17 @@ export class AdamAutocompleteProvider implements AutocompleteProvider {
       const argumentsText = argumentMatch[2] ?? "";
       const runActive = this.#getRunActive();
       const parsed = this.#registry.parse(`/${commandName}`);
-      if (parsed.kind !== "known" || !this.#registry.isAvailable(parsed.command, { runActive })) {
+      if (
+        parsed.kind !== "known" ||
+        !this.#registry.isAvailable(parsed.command, {
+          attachmentsAvailable: this.#getAttachmentsAvailable(),
+          runActive,
+        })
+      ) {
         return Promise.resolve(null);
       }
       const resolution = this.#registry.argumentCompletions(commandName, argumentsText, {
+        attachmentsAvailable: this.#getAttachmentsAvailable(),
         runActive,
         thinkingLevelIds: this.#getThinkingLevelIds(),
       });

--- a/apps/tui/src/command-registry.test.ts
+++ b/apps/tui/src/command-registry.test.ts
@@ -1,5 +1,28 @@
 import { expect, test } from "vitest";
-import { createAdamCommandRegistryFromContributions } from "./command-registry.js";
+import {
+  adamCommandRegistry,
+  createAdamCommandRegistryFromContributions,
+} from "./command-registry.js";
+
+test("the TUI Registry hides attachment actions for a historical text-only session", () => {
+  const attachmentCommands = adamCommandRegistry
+    .entries()
+    .filter(
+      (command) =>
+        command.id === "attach" || command.id === "detach" || command.id === "cancelattach",
+    );
+
+  expect(attachmentCommands).toHaveLength(3);
+  expect(
+    attachmentCommands.every(
+      (command) =>
+        !adamCommandRegistry.isAvailable(command, {
+          attachmentsAvailable: false,
+          runActive: false,
+        }),
+    ),
+  ).toBe(true);
+});
 
 test("the TUI Registry exposes only descriptor commands backed by project changes", () => {
   const registry = createAdamCommandRegistryFromContributions([

--- a/apps/tui/src/command-registry.ts
+++ b/apps/tui/src/command-registry.ts
@@ -8,9 +8,12 @@ export type AdamCommandDefinition = {
   readonly availability: "always" | "idle";
   readonly id:
     | "artifacts"
+    | "attach"
+    | "cancelattach"
     | "clone"
     | "config"
     | "copy"
+    | "detach"
     | "diffs"
     | "exit"
     | "extension"
@@ -122,7 +125,11 @@ export class AdamCommandRegistry {
   argumentCompletions(
     commandName: string,
     argumentsText: string,
-    context: { readonly runActive: boolean; readonly thinkingLevelIds: readonly string[] },
+    context: {
+      readonly attachmentsAvailable?: boolean;
+      readonly runActive: boolean;
+      readonly thinkingLevelIds: readonly string[];
+    },
   ): AdamArgumentCompletionResolution {
     const command = this.#commandsByName.get(commandName);
     if (command === undefined || !finiteArgumentCommandIds.has(command.id)) {
@@ -179,7 +186,13 @@ export class AdamCommandRegistry {
       : { argumentsText, command, kind: "known" };
   }
 
-  isAvailable(command: AdamCommandDefinition, state: { readonly runActive: boolean }): boolean {
+  isAvailable(
+    command: AdamCommandDefinition,
+    state: { readonly attachmentsAvailable?: boolean; readonly runActive: boolean },
+  ): boolean {
+    if (composerCommandIds.has(command.id) && state.attachmentsAvailable === false) {
+      return false;
+    }
     return command.availability === "always" || !state.runActive;
   }
 
@@ -203,7 +216,37 @@ export class AdamCommandRegistry {
   }
 }
 
+const composerCommandIds = new Set<AdamCommandDefinition["id"]>([
+  "attach",
+  "detach",
+  "cancelattach",
+]);
+
 const builtInCommands: readonly AdamCommandDefinition[] = [
+  {
+    aliases: [],
+    availability: "idle",
+    id: "attach",
+    name: "attach",
+    summary: "Stage one exact local file as a linked input resource.",
+    usage: "/attach <path>",
+  },
+  {
+    aliases: [],
+    availability: "idle",
+    id: "detach",
+    name: "detach",
+    summary: "Remove one staged input resource by its visible index.",
+    usage: "/detach <index>",
+  },
+  {
+    aliases: [],
+    availability: "idle",
+    id: "cancelattach",
+    name: "cancelattach",
+    summary: "Cancel one copying input resource by its visible index.",
+    usage: "/cancelattach <index>",
+  },
   {
     aliases: [],
     availability: "always",

--- a/apps/tui/src/fixture-scenario.ts
+++ b/apps/tui/src/fixture-scenario.ts
@@ -10,6 +10,7 @@ export const fixtureScenarios = [
   "deadline",
   "draft-admission-cancellation",
   "history",
+  "input-resource-copying",
   "mcp-close-unconfirmed",
   "mutation",
   "mutation-long-preview",

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -38,6 +38,38 @@ afterEach(async () => {
   await cleanupActiveTuiFixtures();
 });
 
+test("the real TUI process restores the terminal after staging one input resource", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-resource-process-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const selectedPath = join(testRoot, "process-notes.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "process resource bytes\n", "utf8");
+
+  try {
+    const fixture = startFixture({
+      external: true,
+      noColor: true,
+      scenario: "provider-no-usage",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write(`/attach ${selectedPath}\r`);
+    await fixture.waitFor("ready · process-notes.txt · 23 bytes");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain("\u001b[?2004h");
+    expect(result.stdout).toContain("\u001b[?2004l");
+    expect(result.stdout.indexOf("\u001b[?2004h")).toBeLessThan(
+      result.stdout.lastIndexOf("\u001b[?2004l"),
+    );
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 async function trustWorkspace(configRoot: string, workspaceRoot: string): Promise<void> {
   const workspaceTrust = createWorkspaceTrust({
     environment: { XDG_CONFIG_HOME: configRoot },
@@ -1465,10 +1497,13 @@ test("the real terminal delivers Ctrl+C interruption without arming exit", async
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-cancel-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
   await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
 
   try {
     const fixture = startFixture({
+      controlRoot,
       external: true,
       scenario: "cancellation",
       stateRoot,
@@ -1477,6 +1512,7 @@ test("the real terminal delivers Ctrl+C interruption without arming exit", async
     await fixture.waitFor("Adam · New session");
     fixture.write("Cancel this run\r");
     await fixture.waitFor("Working");
+    await waitForPath(join(controlRoot, "model-started"));
     fixture.write("\u0003\u0003");
     await fixture.waitFor("cancelled");
     expect(fixture.output()).not.toContain("Press Ctrl+C again");

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -480,13 +480,21 @@ test("minimum-size Ctrl+C still aborts one active run without arming exit", asyn
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-minimum-abort-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
   await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
 
   try {
-    const fixture = startFixture({ scenario: "cancellation", stateRoot, workspaceRoot });
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "cancellation",
+      stateRoot,
+      workspaceRoot,
+    });
     await fixture.waitFor("Adam · New session");
     fixture.write("Cancel from minimum mode\r");
     await fixture.waitFor("Working");
+    await waitForPath(join(controlRoot, "model-started"));
     await fixture.resize(39, 11);
     fixture.write("\u0003");
     const beforeRestore = fixture.output().length;
@@ -726,7 +734,12 @@ test("the production TUI selects an exact available target before creating an em
   await mkdir(workspaceRoot);
 
   try {
-    const fixture = startFixture({ launch: {}, stateRoot, workspaceRoot });
+    const fixture = startFixture({
+      launch: {},
+      scenario: "provider-no-usage",
+      stateRoot,
+      workspaceRoot,
+    });
     await fixture.waitForCompleteFrameAfter("Select an exact model target", 0);
     expectFramedOverlay(fixture.output(), "Select an exact model target");
     await fixture.waitFor("deepseek-v4-flash.direct");
@@ -954,6 +967,180 @@ test("the production TUI keeps an edited new-session draft out of persistence un
     expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
     expect(result.stdout).toContain("deepseek-v4-flash.direct · Certified");
     expect(await readFilesRecursively(stateRoot)).not.toContain('"type":"session_genesis"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI stages and sends one linked input resource", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-linked-input-resource-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const selectedPath = join(testRoot, "outside-notes.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "linked TUI bytes\n", "utf8");
+
+  try {
+    const fixture = startFixture({
+      launch: {},
+      scenario: "provider-no-usage",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    const beforeAttach = fixture.output().length;
+    fixture.write(`/attach ${selectedPath}\r`);
+    await expect(
+      Promise.race([
+        fixture
+          .waitForCompleteFrameAfter("ready · outside-notes.txt · 17 bytes", beforeAttach)
+          .then(() => "ready" as const),
+        fixture
+          .waitForAfter("Unknown command /attach", beforeAttach)
+          .then(() => "unknown" as const),
+      ]),
+    ).resolves.toBe("ready");
+
+    const beforePrompt = fixture.output().length;
+    fixture.write("Use the linked notes if needed.\r");
+    await fixture.waitForAfter("Provider usage unavailable.", beforePrompt);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    const durable = await readFilesRecursively(stateRoot);
+    expect(durable).toContain('"displayName":"outside-notes.txt"');
+    expect(durable).not.toContain(selectedPath);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI removes a ready linked input resource by its visible index", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-remove-input-resource-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const selectedPath = join(testRoot, "discard-notes.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "discard these bytes\n", "utf8");
+
+  try {
+    const fixture = startFixture({
+      launch: {},
+      scenario: "provider-no-usage",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    fixture.write(`/attach ${selectedPath}\r`);
+    await fixture.waitFor("ready · discard-notes.txt · 20 bytes");
+
+    const beforeRemove = fixture.output().length;
+    fixture.write("/detach 1\r");
+    await expect(
+      Promise.race([
+        fixture
+          .waitForAfter("Input resource removed.", beforeRemove)
+          .then(() => "removed" as const),
+        fixture
+          .waitForAfter("Unknown command /detach", beforeRemove)
+          .then(() => "unknown" as const),
+      ]),
+    ).resolves.toBe("removed");
+    expect(fixture.screen()?.join("\n") ?? "").not.toContain("discard-notes.txt");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI cancels a copying input resource by its visible index", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-cancel-input-resource-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  const selectedPath = join(testRoot, "slow-notes.txt");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+  await writeFile(selectedPath, "slow linked bytes\n", "utf8");
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      launch: {},
+      scenario: "input-resource-copying",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    fixture.write(`/attach ${selectedPath}\r`);
+    await waitForPath(join(controlRoot, "input-resource-copying"));
+    await fixture.waitFor("copying · slow-notes.txt · size pending");
+
+    const beforeCancel = fixture.output().length;
+    fixture.write("/cancelattach 1\r");
+    await expect(
+      Promise.race([
+        fixture
+          .waitForAfter("cancelled · slow-notes.txt", beforeCancel)
+          .then(() => "cancelled" as const),
+        fixture
+          .waitForAfter("Unknown command /cancelattach", beforeCancel)
+          .then(() => "unknown" as const),
+      ]),
+    ).resolves.toBe("cancelled");
+    await writeFile(join(controlRoot, "release-input-resource-copy"), "release\n", "utf8");
+    await fixture.waitFor("Input resource cancelled.");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await writeFile(join(controlRoot, "release-input-resource-copy"), "release\n", "utf8").catch(
+      () => undefined,
+    );
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("linked input resources stay sanitized, colorless, and bounded at supported widths", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-safe-input-resource-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const selectedPath = join(testRoot, "unsafe\u0085name.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "safe display bytes\n", "utf8");
+
+  try {
+    const fixture = startFixture({
+      launch: {},
+      noColor: true,
+      scenario: "provider-no-usage",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    fixture.write(`/attach ${selectedPath}\r`);
+    await fixture.waitFor("ready · unsafe�name.txt · 19 bytes");
+
+    for (const columns of [40, 80, 120]) {
+      const beforeResize = fixture.output().length;
+      await fixture.resize(columns, 40);
+      const frame = latestSynchronizedFrame(fixture.output().slice(beforeResize));
+      expect(frame.join("\n")).toContain("Linked input resources");
+      expect(frame.join("\n")).not.toContain("\u0085");
+      expect(frame.join("\n")).not.toContain("\u001b[38;2;");
+      expect(frame.join("\n")).not.toContain("\u001b[48;2;");
+      expect(frame.every((line) => visibleWidth(line) <= columns)).toBe(true);
+    }
+
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }
@@ -6163,13 +6350,21 @@ test("Ctrl+C cancels one active run and repeated input cannot arm exit while set
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-cancel-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
   await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
 
   try {
-    const fixture = startFixture({ scenario: "cancellation", stateRoot, workspaceRoot });
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "cancellation",
+      stateRoot,
+      workspaceRoot,
+    });
     await fixture.waitFor("Adam · New session");
     fixture.write("Cancel this run\r");
     await fixture.waitFor("Working");
+    await waitForPath(join(controlRoot, "model-started"));
     fixture.write("\u0003\u0003");
     await fixture.waitFor("cancelled");
     expect(fixture.output()).not.toContain("Press Ctrl+C again");

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -27,6 +27,7 @@ import {
   preparedDirectDeepSeekV2ContextProfile,
   presentationArtifactReadBarrier,
   presentationHistoryPageSize,
+  turnComposerStageBarrier,
 } from "@adam-agent/agent/internal-testing";
 import type { PresentationSession } from "@adam-agent/presentation";
 import { ProcessTerminal, type Terminal } from "@earendil-works/pi-tui";
@@ -233,6 +234,18 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
 
   try {
     const previewBarrier = previewReadBarrier(options);
+    const composerBarrier =
+      options.scenario === "input-resource-copying" && options.controlRoot !== undefined
+        ? {
+            async afterOpen() {
+              await writeFile(
+                join(options.controlRoot as string, "input-resource-copying"),
+                "copying\n",
+              );
+              await waitForFile(options.controlRoot as string, "release-input-resource-copy");
+            },
+          }
+        : undefined;
     for (const seedTargetId of options.launch?.seedTargetIds ?? []) {
       const seeded = await lifecycle.create({
         targetIdentity: requireLaunchTargetIdentity(seedTargetId),
@@ -377,6 +390,9 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
             projectLabel: "workspace",
             stateRoot: options.stateRoot,
             workspaceRoot: options.workspaceRoot,
+            ...(composerBarrier === undefined
+              ? {}
+              : { [turnComposerStageBarrier]: composerBarrier }),
           }
         : options.scenario === "session-selection-history"
           ? {
@@ -392,6 +408,9 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
               projectLabel: "workspace",
               stateRoot: options.stateRoot,
               workspaceRoot: options.workspaceRoot,
+              ...(composerBarrier === undefined
+                ? {}
+                : { [turnComposerStageBarrier]: composerBarrier }),
             }
           : resumedSessionId === undefined
             ? {
@@ -410,6 +429,9 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
                 ...(previewBarrier === undefined
                   ? {}
                   : { [presentationArtifactReadBarrier]: previewBarrier }),
+                ...(composerBarrier === undefined
+                  ? {}
+                  : { [turnComposerStageBarrier]: composerBarrier }),
               }
             : {
                 lifecycle,
@@ -432,6 +454,9 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
                 ...(previewBarrier === undefined
                   ? {}
                   : { [presentationArtifactReadBarrier]: previewBarrier }),
+                ...(composerBarrier === undefined
+                  ? {}
+                  : { [turnComposerStageBarrier]: composerBarrier }),
               },
     );
     const clipboard = options.clipboard ?? clipboardAdapter(options);
@@ -1114,6 +1139,9 @@ function createFixtureModelTargets(options: {
         }
         yield { type: "text_delta", text: "Edit complete." };
       } else if (options.scenario === "cancellation") {
+        if (options.controlRoot !== undefined) {
+          await writeFile(join(options.controlRoot, "model-started"), "started\n", "utf8");
+        }
         await new Promise<void>((resolve) => {
           if (request.signal.aborted) {
             resolve();

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -36,7 +36,11 @@ import {
 } from "./artifact-navigator.js";
 import { ChronologyPicker, completeChronologyBoundaries } from "./chronology-picker.js";
 import { AdamAutocompleteProvider } from "./command-autocomplete.js";
-import { type AdamCommandRegistry, adamCommandRegistry } from "./command-registry.js";
+import {
+  type AdamCommandParseResult,
+  type AdamCommandRegistry,
+  adamCommandRegistry,
+} from "./command-registry.js";
 import { type ConfigurationField, ConfigurationPage } from "./configuration-page.js";
 import {
   type ClipboardAdapter,
@@ -241,6 +245,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     const created = new Editor(tui, theme.editor, { paddingX: 1 });
     created.setAutocompleteProvider(
       new AdamAutocompleteProvider({
+        getAttachmentsAvailable: () => options.presentation.getState().composer.attachmentAvailable,
         getProjectPaths: () =>
           options.presentation.getState().authoritative.active?.projectPaths.items ??
           options.presentation.getState().draft?.projectPaths.items ??
@@ -1279,6 +1284,33 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         transcriptViewport.focus(operationAnchorId(operation.operationId), terminal.columns);
       }
     }
+    if (state.composer.resources.length > 0) {
+      transcript.addChild(new Spacer(1));
+      const resources = new Box(1, 1, theme.toolBackground);
+      resources.addChild(new ResponsiveLine(theme.toolTitle("Linked input resources")));
+      for (const [index, resource] of state.composer.resources.entries()) {
+        const size = resource.byteCount === null ? "size pending" : `${resource.byteCount} bytes`;
+        const support = resource.support === null ? "support pending" : resource.support;
+        resources.addChild(
+          new ResponsiveLine(
+            theme.toolOutput(
+              safeTerminalText(
+                `${index + 1} · ${resource.state} · ${resource.displayName} · ${size} · ${support}`,
+              ),
+            ),
+          ),
+        );
+        if (resource.diagnostic !== null) {
+          resources.addChild(
+            new ResponsiveLine(theme.muted(safeTerminalText(resource.diagnostic))),
+          );
+        }
+      }
+      resources.addChild(
+        new ResponsiveLine(theme.muted("/detach <index> · /cancelattach <index>")),
+      );
+      transcript.addChild(resources);
+    }
     const transientReasoning = state.transient?.reasoning;
     if (
       transientReasoning !== null &&
@@ -1545,6 +1577,10 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     tui.requestRender();
   };
   editor.onChange = () => {
+    void options.presentation.dispatch({
+      type: "update_draft_text",
+      text: editor.getExpandedText(),
+    });
     if (statusNotice?.lifetime === "until_edit" || statusNotice?.lifetime === "until_next_action") {
       clearNotice();
       renderState();
@@ -2110,6 +2146,139 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     editor.setText("");
     stopFromCommand?.();
   };
+  const handleAttachCommand = (path: string, sessionId?: string): void => {
+    const composer = options.presentation.getState().composer;
+    if (path.length === 0) {
+      showNotice("warning", "Usage: /attach <path>", "until_edit", sessionId);
+      editor.disableSubmit = false;
+      renderState();
+      return;
+    }
+    if (!composer.attachmentAvailable) {
+      showNotice(
+        "warning",
+        composer.unavailableReason ?? "Input resources are unavailable for this session.",
+        "until_edit",
+        sessionId,
+      );
+      editor.disableSubmit = false;
+      renderState();
+      return;
+    }
+    editor.setText("");
+    editor.disableSubmit = false;
+    const actionId = showNotice("progress", "Staging input resource…", "until_replaced", sessionId);
+    void options.presentation
+      .dispatch({ type: "stage_input_resource", path })
+      .then((receipt) => {
+        if (receipt.status === "admitted") {
+          settleNotice(
+            actionId,
+            "success",
+            "Input resource staged.",
+            "until_next_action",
+            sessionId,
+          );
+        } else {
+          settleNotice(actionId, "error", receipt.message, "until_edit", sessionId);
+        }
+      })
+      .catch(() => {
+        settleNotice(
+          actionId,
+          "error",
+          "The selected input resource could not be staged.",
+          "until_edit",
+          sessionId,
+        );
+      })
+      .finally(() => {
+        renderState();
+      });
+    renderState();
+  };
+  const handleStagedResourceCommand = (command: {
+    readonly action: "remove_input_resource" | "cancel_input_resource";
+    readonly failure: string;
+    readonly indexText: string;
+    readonly progress: string;
+    readonly sessionId: string | undefined;
+    readonly success: string;
+    readonly usage: string;
+  }): void => {
+    const index = Number(command.indexText);
+    const resource = options.presentation.getState().composer.resources[index - 1];
+    if (!Number.isSafeInteger(index) || index < 1 || resource === undefined) {
+      showNotice("warning", command.usage, "until_edit", command.sessionId);
+      editor.disableSubmit = false;
+      renderState();
+      return;
+    }
+    editor.setText("");
+    const actionId = showNotice("progress", command.progress, "until_replaced", command.sessionId);
+    void options.presentation
+      .dispatch({ type: command.action, resourceId: resource.id })
+      .then((receipt) => {
+        if (receipt.status === "admitted") {
+          settleNotice(
+            actionId,
+            "success",
+            command.success,
+            "until_next_action",
+            command.sessionId,
+          );
+        } else {
+          settleNotice(actionId, "error", receipt.message, "until_edit", command.sessionId);
+        }
+      })
+      .catch(() => {
+        settleNotice(actionId, "error", command.failure, "until_edit", command.sessionId);
+      })
+      .finally(() => {
+        editor.disableSubmit = false;
+        renderState();
+      });
+  };
+  const handleDetachCommand = (indexText: string, sessionId?: string): void => {
+    handleStagedResourceCommand({
+      action: "remove_input_resource",
+      failure: "The input resource could not be removed.",
+      indexText,
+      progress: "Removing input resource…",
+      sessionId,
+      success: "Input resource removed.",
+      usage: "Usage: /detach <visible-index>",
+    });
+  };
+  const handleCancelAttachmentCommand = (indexText: string, sessionId?: string): void => {
+    handleStagedResourceCommand({
+      action: "cancel_input_resource",
+      failure: "The input resource could not be cancelled.",
+      indexText,
+      progress: "Cancelling input resource…",
+      sessionId,
+      success: "Input resource cancelled.",
+      usage: "Usage: /cancelattach <visible-index>",
+    });
+  };
+  const handleAttachmentCommand = (parsed: AdamCommandParseResult, sessionId?: string): boolean => {
+    if (parsed.kind !== "known") {
+      return false;
+    }
+    if (parsed.command.id === "attach") {
+      handleAttachCommand(parsed.argumentsText, sessionId);
+      return true;
+    }
+    if (parsed.command.id === "detach") {
+      handleDetachCommand(parsed.argumentsText, sessionId);
+      return true;
+    }
+    if (parsed.command.id === "cancelattach") {
+      handleCancelAttachmentCommand(parsed.argumentsText, sessionId);
+      return true;
+    }
+    return false;
+  };
   editor.onSubmit = (text) => {
     const state = options.presentation.getState();
     const active = state.authoritative.active;
@@ -2136,6 +2305,9 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       }
       if (parsedDraft.kind === "known" && parsedDraft.command.id === "trust") {
         handleWorkspaceTrustCommand(parsedDraft.argumentsText);
+        return;
+      }
+      if (handleAttachmentCommand(parsedDraft)) {
         return;
       }
       if (
@@ -2300,11 +2472,21 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     }
     if (
       parsedCommand.kind === "known" &&
-      !commandRegistry.isAvailable(parsedCommand.command, { runActive })
+      !commandRegistry.isAvailable(parsedCommand.command, {
+        attachmentsAvailable: state.composer.attachmentAvailable,
+        runActive,
+      })
     ) {
+      const attachmentUnavailable =
+        parsedCommand.command.id === "attach" ||
+        parsedCommand.command.id === "detach" ||
+        parsedCommand.command.id === "cancelattach";
       showNotice(
         "warning",
-        `/${parsedCommand.command.name} is unavailable while a run is active.`,
+        attachmentUnavailable
+          ? (state.composer.unavailableReason ??
+              "Input resources are unavailable for this session.")
+          : `/${parsedCommand.command.name} is unavailable while a run is active.`,
         "until_edit",
         active.session.id,
       );
@@ -2770,6 +2952,9 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         .finally(() => {
           tui.requestRender();
         });
+      return;
+    }
+    if (handleAttachmentCommand(parsedCommand, active.session.id)) {
       return;
     }
     if (

--- a/packages/agent/src/artifact-store.ts
+++ b/packages/agent/src/artifact-store.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
-import { chmod, link, mkdir, open, readFile, unlink } from "node:fs/promises";
+import { constants } from "node:fs";
+import { chmod, link, mkdir, open, readFile, rmdir, unlink } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
 import type { ModelTargetIdentity } from "./model-targets.js";
@@ -101,6 +102,125 @@ export type ArtifactStore = {
   }): Promise<ArtifactReference<TSource>>;
   read(id: string, options?: { readonly maximumBytes?: number }): Promise<Uint8Array | undefined>;
 };
+
+export type StagedArtifactReference = {
+  readonly stagingId: string;
+  readonly id: `sha256:${string}`;
+  readonly mediaType: string;
+  readonly byteCount: number;
+};
+
+export type ArtifactStagingStore = {
+  write(input: {
+    readonly bytes: Uint8Array;
+    readonly mediaType: string;
+  }): Promise<StagedArtifactReference>;
+  discard(reference: StagedArtifactReference): Promise<void>;
+  close(): Promise<void>;
+};
+
+export async function createFileArtifactStagingStore(options: {
+  readonly root: string;
+}): Promise<ArtifactStagingStore> {
+  const root = resolve(options.root);
+  const stagingRoot = join(root, ".input-resource-staging");
+  const owned = new Set<string>();
+
+  return {
+    async write(input) {
+      await mkdir(stagingRoot, { recursive: true, mode: 0o700 });
+      await chmod(stagingRoot, 0o700);
+      const bytes = Buffer.from(input.bytes);
+      const digest = createHash("sha256").update(bytes).digest("hex");
+      const stagingId = randomUUID();
+      const file = await open(join(stagingRoot, stagingId), "wx", 0o600);
+      try {
+        await file.writeFile(bytes);
+        await file.chmod(0o400);
+        await file.sync();
+      } finally {
+        await file.close();
+      }
+      owned.add(stagingId);
+      return {
+        stagingId,
+        id: `sha256:${digest}`,
+        mediaType: input.mediaType,
+        byteCount: bytes.byteLength,
+      };
+    },
+    async discard(reference) {
+      requireStagingId(reference.stagingId);
+      owned.delete(reference.stagingId);
+      await unlinkTemporary(join(stagingRoot, reference.stagingId));
+      await removeEmptyDirectory(stagingRoot);
+    },
+    async close() {
+      const retained = [...owned];
+      owned.clear();
+      await Promise.all(retained.map((stagingId) => unlinkTemporary(join(stagingRoot, stagingId))));
+      await removeEmptyDirectory(stagingRoot);
+    },
+  };
+}
+
+export async function publishFileArtifactStage<TSource extends ArtifactSource>(options: {
+  readonly artifactStore: ArtifactStore;
+  readonly root: string;
+  readonly staged: StagedArtifactReference;
+  readonly source: TSource;
+}): Promise<ArtifactReference<TSource>> {
+  requireStagingId(options.staged.stagingId);
+  const expectedDigest = parseArtifactId(options.staged.id);
+  const stagingPath = join(
+    resolve(options.root),
+    ".input-resource-staging",
+    options.staged.stagingId,
+  );
+  let bytes: Uint8Array | undefined;
+  let file: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    file = await open(
+      stagingPath,
+      constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+    );
+    const identity = await file.stat();
+    if (!identity.isFile() || identity.size !== options.staged.byteCount) {
+      throw new Error("The provisional artifact does not match its sealed size.");
+    }
+    bytes = await file.readFile();
+  } catch (error) {
+    if (!isNodeError(error) || error.code !== "ENOENT") {
+      throw error;
+    }
+    bytes = await options.artifactStore.read(options.staged.id, {
+      maximumBytes: options.staged.byteCount,
+    });
+  } finally {
+    await file?.close();
+  }
+  if (
+    bytes === undefined ||
+    bytes.byteLength !== options.staged.byteCount ||
+    createHash("sha256").update(bytes).digest("hex") !== expectedDigest
+  ) {
+    throw new Error("The provisional artifact does not match its sealed digest.");
+  }
+  const published = await options.artifactStore.write({
+    bytes,
+    mediaType: options.staged.mediaType,
+    source: options.source,
+  });
+  if (
+    published.id !== options.staged.id ||
+    published.byteCount !== options.staged.byteCount ||
+    published.mediaType !== options.staged.mediaType
+  ) {
+    throw new Error("The promoted artifact does not match its provisional reference.");
+  }
+  await unlinkTemporary(stagingPath);
+  return published;
+}
 
 export async function createFileArtifactStore(options: {
   readonly root: string;
@@ -315,6 +435,14 @@ async function unlinkTemporary(path: string): Promise<void> {
   });
 }
 
+async function removeEmptyDirectory(path: string): Promise<void> {
+  await rmdir(path).catch((error: unknown) => {
+    if (!isNodeError(error) || (error.code !== "ENOENT" && error.code !== "ENOTEMPTY")) {
+      throw error;
+    }
+  });
+}
+
 async function syncDirectory(path: string): Promise<void> {
   const directory = await open(path, "r");
   try {
@@ -330,6 +458,12 @@ function parseArtifactId(id: string): string {
     throw new Error("The artifact ID is invalid.");
   }
   return match[1];
+}
+
+function requireStagingId(id: string): void {
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u.test(id)) {
+    throw new Error("The provisional artifact staging ID is invalid.");
+  }
 }
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -52,8 +52,10 @@ export {
   InputResourceError,
   type InputResourceOccurrenceV1,
   type InputResourcePageV1,
+  type InputResourceSelectionV1,
   inputResourceLimitsV1,
   type LocalInputResourceSelectionV1,
+  type StagedInputResourceSelectionV1,
 } from "./input-resources.js";
 export { ModelDriverError, type ModelDriverErrorCategory } from "./model-driver-error.js";
 export {

--- a/packages/agent/src/input-resource-staging.ts
+++ b/packages/agent/src/input-resource-staging.ts
@@ -1,0 +1,86 @@
+import {
+  type ArtifactStore,
+  createFileArtifactStagingStore,
+  type StagedArtifactReference,
+} from "./artifact-store.js";
+import {
+  ingestLocalInputResourcesV1,
+  type StagedInputResourceSelectionV1,
+} from "./input-resources.js";
+
+export const turnComposerStageBarrier = Symbol("adam-agent.turn-composer-stage-barrier");
+
+export type TurnComposerStageBarrier = {
+  afterOpen(input: { readonly signal: AbortSignal }): Promise<void> | void;
+};
+
+export type TurnComposerResourceStager = {
+  stage(input: {
+    readonly id: string;
+    readonly path: string;
+    readonly signal: AbortSignal;
+  }): Promise<StagedInputResourceSelectionV1>;
+  discard(selection: StagedInputResourceSelectionV1): Promise<void>;
+  close(): Promise<void>;
+};
+
+export async function createFileTurnComposerResourceStager(options: {
+  readonly artifactRoot: string;
+  readonly stageBarrier?: TurnComposerStageBarrier;
+}): Promise<TurnComposerResourceStager> {
+  const staging = await createFileArtifactStagingStore({ root: options.artifactRoot });
+
+  return {
+    async stage(input) {
+      let staged: StagedArtifactReference | undefined;
+      const stagingArtifactStore: ArtifactStore = {
+        async write(writeInput) {
+          const written = await staging.write({
+            bytes: writeInput.bytes,
+            mediaType: writeInput.mediaType,
+          });
+          staged = written;
+          return { ...written, source: writeInput.source };
+        },
+        async read() {
+          return undefined;
+        },
+      };
+      try {
+        const [occurrence] = await ingestLocalInputResourcesV1({
+          artifactStore: stagingArtifactStore,
+          ...(options.stageBarrier === undefined
+            ? {}
+            : {
+                afterOpened: () => options.stageBarrier?.afterOpen({ signal: input.signal }),
+              }),
+          runId: input.id,
+          selections: [{ type: "local_file", path: input.path }],
+          signal: input.signal,
+        });
+        if (occurrence === undefined || staged === undefined) {
+          throw new TypeError("The provisional input resource did not settle.");
+        }
+        return {
+          type: "staged_artifact",
+          staged,
+          displayName: occurrence.displayName,
+          digest: occurrence.digest,
+          mediaHint: occurrence.mediaHint,
+          support: occurrence.support,
+        };
+      } catch (error) {
+        if (staged !== undefined) {
+          await staging.discard(staged);
+        }
+        throw error;
+      }
+    },
+    discard(selection) {
+      return staging.discard(selection.staged);
+    },
+    close() {
+      return staging.close();
+    },
+  };
+}

--- a/packages/agent/src/input-resources.ts
+++ b/packages/agent/src/input-resources.ts
@@ -4,10 +4,12 @@ import { open, realpath } from "node:fs/promises";
 import { basename } from "node:path";
 
 import { z } from "zod";
-import type {
-  ArtifactReference,
-  ArtifactStore,
-  InputResourceArtifactSourceV1,
+import {
+  type ArtifactReference,
+  type ArtifactStore,
+  type InputResourceArtifactSourceV1,
+  publishFileArtifactStage,
+  type StagedArtifactReference,
 } from "./artifact-store.js";
 
 export const inputResourceLimitsV1 = {
@@ -28,6 +30,19 @@ export type LocalInputResourceSelectionV1 = {
   readonly type: "local_file";
   readonly path: string;
 };
+
+export type StagedInputResourceSelectionV1 = {
+  readonly type: "staged_artifact";
+  readonly staged: StagedArtifactReference;
+  readonly displayName: string;
+  readonly digest: `sha256:${string}`;
+  readonly mediaHint: "binary" | "text";
+  readonly support: "unsupported_binary" | "utf8_text";
+};
+
+export type InputResourceSelectionV1 =
+  | LocalInputResourceSelectionV1
+  | StagedInputResourceSelectionV1;
 
 export type InputResourceOccurrenceV1 = {
   readonly occurrenceId: string;
@@ -90,11 +105,12 @@ export class InputResourceError extends Error {
 }
 
 export async function ingestLocalInputResourcesV1(input: {
+  readonly artifactRoot?: string;
   readonly artifactStore: ArtifactStore;
   readonly afterResolved?: () => Promise<void> | void;
   readonly afterOpened?: () => Promise<void> | void;
   readonly runId: string;
-  readonly selections: readonly LocalInputResourceSelectionV1[];
+  readonly selections: readonly InputResourceSelectionV1[];
   readonly signal: AbortSignal;
 }): Promise<readonly InputResourceOccurrenceV1[]> {
   if (input.selections.length > inputResourceLimitsV1.maximumOccurrencesPerRun) {
@@ -107,27 +123,27 @@ export async function ingestLocalInputResourcesV1(input: {
   let aggregateBytes = 0;
   for (const [index, selection] of input.selections.entries()) {
     input.signal.throwIfAborted();
-    if (
-      selection.type !== "local_file" ||
-      selection.path.length === 0 ||
-      selection.path.includes("\0") ||
-      Buffer.byteLength(selection.path, "utf8") > inputResourceLimitsV1.maximumSelectedPathBytes
-    ) {
-      throw new InputResourceError(
-        "input_resource_invalid_selection",
-        "The selected local input-resource path is invalid.",
-      );
-    }
     const occurrenceId = `${input.runId}:input:${index + 1}`;
-    const ingested = await ingestOneLocalFile({
-      artifactStore: input.artifactStore,
-      ...(input.afterResolved === undefined ? {} : { afterResolved: input.afterResolved }),
-      ...(input.afterOpened === undefined ? {} : { afterOpened: input.afterOpened }),
-      occurrenceId,
-      path: selection.path,
-      runId: input.runId,
-      signal: input.signal,
-    });
+    const ingested =
+      selection.type === "staged_artifact"
+        ? await promoteStagedInputResource({
+            ...(input.afterOpened === undefined ? {} : { afterOpened: input.afterOpened }),
+            artifactRoot: input.artifactRoot,
+            artifactStore: input.artifactStore,
+            occurrenceId,
+            runId: input.runId,
+            selection,
+            signal: input.signal,
+          })
+        : await ingestSelectedLocalFile({
+            artifactStore: input.artifactStore,
+            ...(input.afterResolved === undefined ? {} : { afterResolved: input.afterResolved }),
+            ...(input.afterOpened === undefined ? {} : { afterOpened: input.afterOpened }),
+            occurrenceId,
+            selection,
+            runId: input.runId,
+            signal: input.signal,
+          });
     aggregateBytes += ingested.artifact.byteCount;
     if (aggregateBytes > inputResourceLimitsV1.maximumAggregateBytesPerRun) {
       throw new InputResourceError(
@@ -138,6 +154,107 @@ export async function ingestLocalInputResourcesV1(input: {
     occurrences.push(ingested);
   }
   return occurrences;
+}
+
+async function ingestSelectedLocalFile(input: {
+  readonly artifactStore: ArtifactStore;
+  readonly afterResolved?: () => Promise<void> | void;
+  readonly afterOpened?: () => Promise<void> | void;
+  readonly occurrenceId: string;
+  readonly selection: LocalInputResourceSelectionV1;
+  readonly runId: string;
+  readonly signal: AbortSignal;
+}): Promise<InputResourceOccurrenceV1> {
+  if (
+    input.selection.path.length === 0 ||
+    input.selection.path.includes("\0") ||
+    Buffer.byteLength(input.selection.path, "utf8") > inputResourceLimitsV1.maximumSelectedPathBytes
+  ) {
+    throw new InputResourceError(
+      "input_resource_invalid_selection",
+      "The selected local input-resource path is invalid.",
+    );
+  }
+  return ingestOneLocalFile({
+    artifactStore: input.artifactStore,
+    ...(input.afterResolved === undefined ? {} : { afterResolved: input.afterResolved }),
+    ...(input.afterOpened === undefined ? {} : { afterOpened: input.afterOpened }),
+    occurrenceId: input.occurrenceId,
+    path: input.selection.path,
+    runId: input.runId,
+    signal: input.signal,
+  });
+}
+
+async function promoteStagedInputResource(input: {
+  readonly artifactRoot: string | undefined;
+  readonly artifactStore: ArtifactStore;
+  readonly afterOpened?: () => Promise<void> | void;
+  readonly occurrenceId: string;
+  readonly runId: string;
+  readonly selection: StagedInputResourceSelectionV1;
+  readonly signal: AbortSignal;
+}): Promise<InputResourceOccurrenceV1> {
+  const { selection } = input;
+  const validMedia =
+    (selection.support === "utf8_text" &&
+      selection.mediaHint === "text" &&
+      selection.staged.mediaType === "text/plain; charset=utf-8") ||
+    (selection.support === "unsupported_binary" &&
+      selection.mediaHint === "binary" &&
+      selection.staged.mediaType === "application/octet-stream");
+  if (
+    input.artifactRoot === undefined ||
+    selection.displayName.length === 0 ||
+    Buffer.byteLength(selection.displayName, "utf8") >
+      inputResourceLimitsV1.maximumDisplayNameBytes ||
+    selection.staged.id !== selection.digest ||
+    selection.staged.byteCount > inputResourceLimitsV1.maximumFileBytes ||
+    !validMedia
+  ) {
+    throw new InputResourceError(
+      "input_resource_invalid_selection",
+      "The provisional input-resource selection is invalid.",
+    );
+  }
+  input.signal.throwIfAborted();
+  await input.afterOpened?.();
+  input.signal.throwIfAborted();
+  const source: InputResourceArtifactSourceV1 = {
+    type: "input_resource",
+    schemaVersion: 1,
+    occurrenceId: input.occurrenceId,
+    runId: input.runId,
+    provenance: "user_local_file",
+  };
+  try {
+    await publishFileArtifactStage({
+      artifactStore: input.artifactStore,
+      root: input.artifactRoot,
+      source,
+      staged: selection.staged,
+    });
+  } catch {
+    throw new InputResourceError(
+      "input_resource_io_failed",
+      "The provisional input resource could not be promoted safely.",
+    );
+  }
+  input.signal.throwIfAborted();
+  return {
+    occurrenceId: input.occurrenceId,
+    displayName: selection.displayName,
+    artifact: {
+      id: selection.digest,
+      mediaType: selection.staged.mediaType as InputResourceOccurrenceV1["artifact"]["mediaType"],
+      byteCount: selection.staged.byteCount,
+    },
+    digest: selection.digest,
+    mediaHint: selection.mediaHint,
+    provenance: "user_local_file",
+    support: selection.support,
+    mode: "link",
+  };
 }
 
 async function ingestOneLocalFile(input: {
@@ -275,7 +392,7 @@ async function ingestOneLocalFile(input: {
     }
     return {
       occurrenceId: input.occurrenceId,
-      displayName: safeDisplayName(input.path),
+      displayName: safeInputResourceDisplayNameV1(input.path),
       artifact: { id: digest, mediaType, byteCount: identity.size },
       digest,
       mediaHint: strictUtf8 ? "text" : "binary",
@@ -288,7 +405,7 @@ async function ingestOneLocalFile(input: {
   }
 }
 
-function safeDisplayName(path: string): string {
+export function safeInputResourceDisplayNameV1(path: string): string {
   let retained = "";
   for (const character of basename(path)) {
     const codePoint = character.codePointAt(0) ?? 0;

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -105,3 +105,7 @@ export {
   type SessionV3Record,
 } from "./session-store.js";
 export { createCodingToolRegistryForTesting } from "./tool-runtime.js";
+export {
+  type TurnComposerStageBarrier,
+  turnComposerStageBarrier,
+} from "./turn-composer.js";

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -24,6 +24,7 @@ import type { RuntimeEvent } from "./agent-session-contracts.js";
 import { readFileArtifact, readFileArtifactRange } from "./artifact-store.js";
 import { maximumModelResponseContentBytes } from "./durable-model-response-policy.js";
 import type { ExtensionHost } from "./extension-host.js";
+import { createFileTurnComposerResourceStager } from "./input-resource-staging.js";
 import {
   type ModelTargetIdentity,
   type ModelTargetSnapshot,
@@ -57,6 +58,7 @@ import {
 } from "./session-history-folds.js";
 import {
   type CurrentSessionSnapshot,
+  effectiveSessionStateRoot,
   type SessionContextUsageSnapshot,
   type SessionLifecycle,
   SessionLifecycleError,
@@ -64,6 +66,13 @@ import {
   type SessionRuntimeNotification,
 } from "./session-lifecycle.js";
 import { readJsonlSessionRecords, type SessionRecord } from "./session-store.js";
+import {
+  createTurnComposer,
+  type TurnComposer,
+  TurnComposerError,
+  type TurnComposerStageBarrier,
+  turnComposerStageBarrier,
+} from "./turn-composer.js";
 
 /** Tests only. Production hydration has no artificial publication barrier. */
 export const presentationHydrationBarrier = Symbol("adam-agent.presentation-hydration-barrier");
@@ -114,6 +123,7 @@ type PresentationSessionBaseOptions = {
   readonly [presentationSessionRecordReader]?: PresentationSessionRecordReader;
   readonly [presentationHistoryPageSize]?: number;
   readonly [presentationCatalogPageSize]?: number;
+  readonly [turnComposerStageBarrier]?: TurnComposerStageBarrier;
 };
 
 type PresentationSessionRecordOptions = Pick<
@@ -473,6 +483,10 @@ export async function createPresentationSession(
               mcp: projectMcp(created),
             },
     };
+    let attachmentAvailable = initialDraft !== null || sessionSupportsInputResources(created);
+    let attachmentUnavailableReason = attachmentAvailable
+      ? null
+      : "New session required for attachments";
     let state: PresentationDisplayState = {
       revision: 1,
       authoritative,
@@ -484,6 +498,12 @@ export async function createPresentationSession(
               skills: projectSkillContext(initialDraft.skillContext, false),
               projectPaths,
             },
+      composer: {
+        attachmentAvailable,
+        unavailableReason: attachmentUnavailableReason,
+        sealed: false,
+        resources: [],
+      },
       transient: null,
     };
     let draftTargetIdentity: ModelTargetIdentity | null = initialDraft?.targetIdentity ?? null;
@@ -493,6 +513,7 @@ export async function createPresentationSession(
       metadataThrough.set(`mcp_configuration_changed:${created.sessionId}`, created.lastSequence);
     }
     const listeners = new Set<() => void>();
+    let closed = false;
     const publishStateChange = (): void => {
       for (const listener of listeners) {
         try {
@@ -502,7 +523,35 @@ export async function createPresentationSession(
         }
       }
     };
-    let closed = false;
+    let turnComposer: TurnComposer;
+    const projectTurnComposer = (): PresentationDisplayState["composer"] => {
+      const snapshot = turnComposer?.snapshot() ?? { sealed: false, resources: [] };
+      return {
+        attachmentAvailable,
+        unavailableReason: attachmentUnavailableReason,
+        sealed: snapshot.sealed,
+        resources: snapshot.resources,
+      };
+    };
+    turnComposer = await createTurnComposer({
+      onChange() {
+        if (closed) {
+          return;
+        }
+        state = {
+          ...state,
+          revision: state.revision + 1,
+          composer: projectTurnComposer(),
+        };
+        publishStateChange();
+      },
+      stager: await createFileTurnComposerResourceStager({
+        artifactRoot: join(effectiveSessionStateRoot(options.stateRoot), "artifacts"),
+        ...(options[turnComposerStageBarrier] === undefined
+          ? {}
+          : { stageBarrier: options[turnComposerStageBarrier] }),
+      }),
+    });
     const operationAdmissions = new Set<Promise<void>>();
     const operationRefreshes = new Set<Promise<void>>();
     const operationObservers = new Map<string, AbortController>();
@@ -544,6 +593,7 @@ export async function createPresentationSession(
           },
         },
         draft: state.draft,
+        composer: state.composer,
         transient: state.transient,
       };
       publishStateChange();
@@ -583,6 +633,7 @@ export async function createPresentationSession(
             active: { ...active, linkedOperationsTruncated: true },
           },
           draft: state.draft,
+          composer: state.composer,
           transient: state.transient,
         };
         publishStateChange();
@@ -628,6 +679,7 @@ export async function createPresentationSession(
           },
         },
         draft: state.draft,
+        composer: state.composer,
         transient: state.transient,
       };
       publishStateChange();
@@ -702,6 +754,7 @@ export async function createPresentationSession(
               continuity: { status: "repairing", reason: "reconnect" },
             },
             draft: state.draft,
+            composer: state.composer,
             transient: state.transient,
           };
           publishStateChange();
@@ -748,6 +801,7 @@ export async function createPresentationSession(
               },
             },
             draft: state.draft,
+            composer: state.composer,
             transient: state.transient,
           };
           publishStateChange();
@@ -770,6 +824,7 @@ export async function createPresentationSession(
               },
             },
             draft: state.draft,
+            composer: state.composer,
             transient: state.transient,
           };
           publishStateChange();
@@ -813,6 +868,7 @@ export async function createPresentationSession(
             },
           },
           draft: state.draft,
+          composer: state.composer,
           transient: state.transient,
         };
         publishStateChange();
@@ -862,7 +918,7 @@ export async function createPresentationSession(
       | {
           sessionId: string | null;
           readonly controller: AbortController;
-          readonly settlement: Promise<void>;
+          settlement: Promise<void> | null;
         }
       | undefined;
     let snapshotActivationQueue = Promise.resolve();
@@ -930,6 +986,10 @@ export async function createPresentationSession(
       activeSessionThroughSequence = activeSequence;
       transcript = activatedTranscript;
       loadedTranscriptStart = activatedLoadedTranscriptStart;
+      attachmentAvailable = sessionSupportsInputResources(snapshot);
+      attachmentUnavailableReason = attachmentAvailable
+        ? null
+        : "New session required for attachments";
       state = {
         revision: state.revision + 1,
         authoritative: {
@@ -965,6 +1025,7 @@ export async function createPresentationSession(
           },
         },
         draft: null,
+        composer: projectTurnComposer(),
         transient: null,
       };
       draftTargetIdentity = null;
@@ -1023,6 +1084,7 @@ export async function createPresentationSession(
           active: { ...current, session: refreshedSummary },
         },
         draft: state.draft,
+        composer: state.composer,
         transient: state.transient,
       };
       publishStateChange();
@@ -1057,6 +1119,7 @@ export async function createPresentationSession(
           active: { ...current, mcp: projectMcp(inspected) },
         },
         draft: state.draft,
+        composer: state.composer,
         transient: state.transient,
       };
       publishStateChange();
@@ -1100,6 +1163,7 @@ export async function createPresentationSession(
                 revision: state.revision + 1,
                 authoritative: state.authoritative,
                 draft: state.draft,
+                composer: state.composer,
                 transient: { activity: "working", assistant: null, reasoning: null },
               };
               publishStateChange();
@@ -1108,6 +1172,7 @@ export async function createPresentationSession(
                 revision: state.revision + 1,
                 authoritative: state.authoritative,
                 draft: state.draft,
+                composer: state.composer,
                 transient: { activity: "using_tool", assistant: null, reasoning: null },
               };
               publishStateChange();
@@ -1117,6 +1182,7 @@ export async function createPresentationSession(
                 revision: state.revision + 1,
                 authoritative: state.authoritative,
                 draft: state.draft,
+                composer: state.composer,
                 transient: {
                   activity: "working",
                   assistant: state.transient?.assistant ?? null,
@@ -1144,6 +1210,7 @@ export async function createPresentationSession(
                   revision: state.revision + 1,
                   authoritative: state.authoritative,
                   draft: state.draft,
+                  composer: state.composer,
                   transient: {
                     activity: state.transient?.activity ?? "working",
                     assistant: state.transient?.assistant ?? null,
@@ -1214,6 +1281,7 @@ export async function createPresentationSession(
                     },
                   },
                   draft: state.draft,
+                  composer: state.composer,
                   transient: state.transient,
                 };
                 publishStateChange();
@@ -1238,6 +1306,7 @@ export async function createPresentationSession(
                   continuity: { status: "repairing", reason: "gap" },
                 },
                 draft: state.draft,
+                composer: state.composer,
                 transient: null,
               };
               publishStateChange();
@@ -1285,6 +1354,7 @@ export async function createPresentationSession(
                   continuity: { status: "repairing", reason: "gap" },
                 },
                 draft: state.draft,
+                composer: state.composer,
                 transient: null,
               };
               publishStateChange();
@@ -1363,6 +1433,7 @@ export async function createPresentationSession(
                 },
               },
               draft: state.draft,
+              composer: state.composer,
               transient: isAssistantTerminalEvent(event)
                 ? null
                 : recoveredReasoning === undefined
@@ -1396,6 +1467,7 @@ export async function createPresentationSession(
                 },
               },
               draft: state.draft,
+              composer: state.composer,
               transient: null,
             };
             publishStateChange();
@@ -1455,6 +1527,7 @@ export async function createPresentationSession(
               },
             },
             draft: state.draft,
+            composer: state.composer,
             transient: null,
           };
           publishStateChange();
@@ -1534,6 +1607,7 @@ export async function createPresentationSession(
               },
             },
             draft: state.draft,
+            composer: state.composer,
             transient: state.transient,
           };
           publishStateChange();
@@ -1579,6 +1653,7 @@ export async function createPresentationSession(
               targets,
             },
             draft: state.draft,
+            composer: state.composer,
             transient: state.transient,
           };
           publishStateChange();
@@ -1610,6 +1685,7 @@ export async function createPresentationSession(
             revision: state.revision + 1,
             authoritative: { ...state.authoritative, targets },
             draft: state.draft,
+            composer: state.composer,
             transient: state.transient,
           };
           publishStateChange();
@@ -1654,6 +1730,9 @@ export async function createPresentationSession(
         operationRepairs.clear();
         operationCursors.clear();
         activeSessionThroughSequence = 0;
+        await turnComposer.clear();
+        attachmentAvailable = true;
+        attachmentUnavailableReason = null;
         state = {
           revision: state.revision + 1,
           authoritative: {
@@ -1670,6 +1749,7 @@ export async function createPresentationSession(
             skills: projectSkillContext(preview.skillContext, false),
             projectPaths,
           },
+          composer: projectTurnComposer(),
           transient: null,
         };
         draftTargetIdentity = targetIdentity;
@@ -1705,6 +1785,7 @@ export async function createPresentationSession(
             }
             snapshot = resumed.snapshot;
           }
+          await turnComposer.clear();
           await activateSnapshot(snapshot);
           return { status: "admitted", commandId: randomUUID(), resource: null };
         } catch {
@@ -1714,6 +1795,75 @@ export async function createPresentationSession(
             message: "The session could not be selected.",
           };
         }
+      }
+      if (command.type === "stage_input_resource") {
+        if (!attachmentAvailable) {
+          return {
+            status: "rejected",
+            code: "not_available",
+            message: attachmentUnavailableReason ?? "Input resources are not available.",
+          };
+        }
+        if (activeRun !== undefined || state.composer.sealed) {
+          return {
+            status: "rejected",
+            code: "conflict",
+            message: "An input resource cannot be staged while the current turn is sealed.",
+          };
+        }
+        try {
+          await turnComposer.stage(command.path);
+          return { status: "admitted", commandId: randomUUID(), resource: null };
+        } catch {
+          return {
+            status: "rejected",
+            code: "not_available",
+            message: "The selected input resource could not be staged.",
+          };
+        }
+      }
+      if (command.type === "update_draft_text") {
+        if (activeRun !== undefined || state.composer.sealed) {
+          return {
+            status: "rejected",
+            code: "conflict",
+            message: "The current turn text cannot change while the turn is sealed.",
+          };
+        }
+        turnComposer.setText(command.text);
+        return { status: "admitted", commandId: randomUUID(), resource: null };
+      }
+      if (command.type === "remove_input_resource") {
+        if (activeRun !== undefined || state.composer.sealed) {
+          return {
+            status: "rejected",
+            code: "conflict",
+            message: "An input resource cannot be removed while the current turn is sealed.",
+          };
+        }
+        return (await turnComposer.remove(command.resourceId))
+          ? { status: "admitted", commandId: randomUUID(), resource: null }
+          : {
+              status: "rejected",
+              code: "stale_interaction",
+              message: "The input resource is no longer present in the current composer.",
+            };
+      }
+      if (command.type === "cancel_input_resource") {
+        if (activeRun !== undefined || state.composer.sealed) {
+          return {
+            status: "rejected",
+            code: "conflict",
+            message: "An input resource cannot be cancelled while the current turn is sealed.",
+          };
+        }
+        return (await turnComposer.cancel(command.resourceId))
+          ? { status: "admitted", commandId: randomUUID(), resource: null }
+          : {
+              status: "rejected",
+              code: "stale_interaction",
+              message: "The input resource is no longer cancellable in the current composer.",
+            };
       }
       if (command.type === "submit_prompt") {
         if (
@@ -1743,6 +1893,37 @@ export async function createPresentationSession(
         }
         const controller = new AbortController();
         const commandId = randomUUID();
+        const runState = {
+          sessionId: command.sessionId,
+          controller,
+          settlement: null as Promise<void> | null,
+        };
+        activeRun = runState;
+        state = {
+          ...state,
+          revision: state.revision + 1,
+          transient: { activity: "working", assistant: null, reasoning: null },
+        };
+        publishStateChange();
+        let sealedDraft: Awaited<ReturnType<TurnComposer["seal"]>>;
+        try {
+          turnComposer.setText(command.text);
+          sealedDraft = await turnComposer.seal(controller.signal);
+        } catch (error) {
+          if (activeRun === runState) {
+            activeRun = undefined;
+          }
+          state = { ...state, revision: state.revision + 1, transient: null };
+          publishStateChange();
+          return {
+            status: "rejected",
+            code: "not_available",
+            message:
+              error instanceof TurnComposerError
+                ? error.message
+                : "The current turn could not be sealed safely.",
+          };
+        }
         const admission = Promise.withResolvers<void>();
         const admissionAfterSequence =
           state.authoritative.continuity.status === "current"
@@ -1754,7 +1935,7 @@ export async function createPresentationSession(
             notification.runId === commandId &&
             notification.throughSequence > admissionAfterSequence &&
             notification.event.type === "user_message" &&
-            notification.event.text === command.text
+            notification.event.text === sealedDraft.text
           ) {
             admission.resolve();
           }
@@ -1763,13 +1944,16 @@ export async function createPresentationSession(
         const continuation = options.lifecycle.continue({
           sessionId: command.sessionId,
           input: {
-            text: command.text,
+            text: sealedDraft.text,
             ...(skillResolution.qualifiedIds.length === 0
               ? {}
               : { skills: skillResolution.qualifiedIds }),
           },
           runId: commandId,
           signal: controller.signal,
+          ...(sealedDraft.selections.length === 0
+            ? {}
+            : { resourceSelections: sealedDraft.selections }),
           ...(command.thinkingSelection === null
             ? {}
             : { thinkingSelection: command.thinkingSelection }),
@@ -1790,15 +1974,11 @@ export async function createPresentationSession(
             }
           })
           .finally(() => {
-            if (activeRun?.settlement === settlement) {
+            if (activeRun === runState) {
               activeRun = undefined;
             }
           });
-        activeRun = {
-          sessionId: command.sessionId,
-          controller,
-          settlement,
-        };
+        runState.settlement = settlement;
         const admitted = await Promise.race([
           admission.promise.then(() => ({ status: "admitted" as const })),
           continuation.then(
@@ -1816,6 +1996,7 @@ export async function createPresentationSession(
         unsubscribeAdmission();
         if (admitted.status === "rejected") {
           await settlement;
+          turnComposer.unseal();
           return (
             thinkingPolicyAdmissionRejection(admissionFailure) ?? {
               status: "rejected",
@@ -1824,6 +2005,7 @@ export async function createPresentationSession(
             }
           );
         }
+        await turnComposer.clear();
         return { status: "admitted", commandId, resource: null };
       }
       if (command.type === "submit_draft_prompt") {
@@ -1860,24 +2042,52 @@ export async function createPresentationSession(
         }
         const controller = new AbortController();
         const commandId = randomUUID();
-        const admission = Promise.withResolvers<string>();
-        let admittedSessionId: string | null = null;
+        const runState = {
+          sessionId: null as string | null,
+          controller,
+          settlement: null as Promise<void> | null,
+        };
+        activeRun = runState;
         state = {
           ...state,
           revision: state.revision + 1,
           transient: { activity: "working", assistant: null, reasoning: null },
         };
         publishStateChange();
+        let sealedDraft: Awaited<ReturnType<TurnComposer["seal"]>>;
+        try {
+          turnComposer.setText(command.text);
+          sealedDraft = await turnComposer.seal(controller.signal);
+        } catch (error) {
+          if (activeRun === runState) {
+            activeRun = undefined;
+          }
+          state = { ...state, revision: state.revision + 1, transient: null };
+          publishStateChange();
+          return {
+            status: "rejected",
+            code: "not_available",
+            message:
+              error instanceof TurnComposerError
+                ? error.message
+                : "The current turn could not be sealed safely.",
+          };
+        }
+        const admission = Promise.withResolvers<string>();
+        let admittedSessionId: string | null = null;
         const continuation = options.lifecycle.admit({
           targetIdentity,
           input: {
-            text: command.text,
+            text: sealedDraft.text,
             ...(skillResolution.qualifiedIds.length === 0
               ? {}
               : { skills: skillResolution.qualifiedIds }),
           },
           runId: commandId,
           signal: controller.signal,
+          ...(sealedDraft.selections.length === 0
+            ? {}
+            : { resourceSelections: sealedDraft.selections }),
           ...(command.thinkingSelection === null
             ? {}
             : { thinkingSelection: command.thinkingSelection }),
@@ -1906,7 +2116,7 @@ export async function createPresentationSession(
             }
           })
           .finally(() => {
-            if (activeRun?.settlement === settlement) {
+            if (activeRun === runState) {
               activeRun = undefined;
             }
             if (
@@ -1919,11 +2129,7 @@ export async function createPresentationSession(
               publishStateChange();
             }
           });
-        activeRun = {
-          sessionId: null,
-          controller,
-          settlement,
-        };
+        runState.settlement = settlement;
         let admissionFailure: unknown;
         const admitted = await Promise.race([
           admission.promise.then((sessionId) => ({ status: "admitted" as const, sessionId })),
@@ -1941,20 +2147,23 @@ export async function createPresentationSession(
         ]);
         if (admitted.status === "rejected") {
           await settlement;
+          turnComposer.unseal();
           return draftAdmissionRejection(admissionFailure);
         }
-        if (activeRun?.settlement === settlement) {
-          activeRun.sessionId = admitted.sessionId;
+        if (activeRun === runState) {
+          runState.sessionId = admitted.sessionId;
         }
         const admittedSnapshot = await options.lifecycle.inspect({ sessionId: admitted.sessionId });
         if (admittedSnapshot.schemaVersion !== 3) {
           await settlement;
+          turnComposer.unseal();
           return {
             status: "rejected",
             code: "persistence_failed",
             message: "The admitted draft session could not be read from durable history.",
           };
         }
+        await turnComposer.clear();
         await activateSnapshot(admittedSnapshot);
         return { status: "admitted", commandId, resource: null };
       }
@@ -1988,6 +2197,7 @@ export async function createPresentationSession(
               : { sourceBoundary: command.sourceBoundary }),
             ...(command.targetId === null ? {} : { targetId: command.targetId }),
           });
+          await turnComposer.clear();
           await activateSnapshot(snapshot);
           return { status: "admitted", commandId: randomUUID(), resource: null };
         } catch {
@@ -2042,7 +2252,10 @@ export async function createPresentationSession(
             };
       }
       if (command.type === "cancel_run") {
-        if (activeRun?.sessionId !== command.sessionId) {
+        if (
+          activeRun === undefined ||
+          (state.authoritative.active?.session.id ?? null) !== command.sessionId
+        ) {
           return {
             status: "rejected",
             code: "stale_interaction",
@@ -2193,6 +2406,7 @@ export async function createPresentationSession(
                     },
                   },
                   draft: state.draft,
+                  composer: state.composer,
                   transient: state.transient,
                 };
                 publishStateChange();
@@ -2231,6 +2445,7 @@ export async function createPresentationSession(
             },
           },
           draft: state.draft,
+          composer: state.composer,
           transient: state.transient,
         };
         publishStateChange();
@@ -2277,6 +2492,7 @@ export async function createPresentationSession(
               },
             },
             draft: state.draft,
+            composer: state.composer,
             transient: state.transient,
           };
           publishStateChange();
@@ -2746,6 +2962,7 @@ export async function createPresentationSession(
         }
         closed = true;
         activeRun?.controller.abort();
+        await turnComposer.close();
         for (const observer of operationObservers.values()) {
           observer.abort();
         }
@@ -2800,6 +3017,14 @@ async function settleOwnedOperationForClose(
   if (settled.status === "running" || settled.status === "cancel_requested") {
     throw new Error("The owned extension operation did not reach durable settlement on close.");
   }
+}
+
+function sessionSupportsInputResources(snapshot: CurrentSessionSnapshot | undefined): boolean {
+  return (
+    snapshot?.promptContext?.toolProfile.definitions.some(
+      (definition) => definition.name === "read_input_resource",
+    ) === true
+  );
 }
 
 type ProjectedOperationCollection = {

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -33,9 +33,9 @@ import {
 import {
   InputResourceError,
   type InputResourceOccurrenceV1,
+  type InputResourceSelectionV1,
   ingestLocalInputResourcesV1,
   inputResourceLimitsV1,
-  type LocalInputResourceSelectionV1,
 } from "./input-resources.js";
 import {
   createMcpRuntimeHost,
@@ -480,7 +480,7 @@ export type SessionCommand =
       readonly runId?: string;
       readonly signal?: AbortSignal;
       readonly thinkingSelection?: ThinkingPolicySelectionV1;
-      readonly resourceSelections?: readonly LocalInputResourceSelectionV1[];
+      readonly resourceSelections?: readonly InputResourceSelectionV1[];
     }
   | ({
       readonly type: "branch";
@@ -497,7 +497,7 @@ export interface SessionLifecycle {
     readonly runId?: string;
     readonly signal?: AbortSignal;
     readonly thinkingSelection?: ThinkingPolicySelectionV1;
-    readonly resourceSelections?: readonly LocalInputResourceSelectionV1[];
+    readonly resourceSelections?: readonly InputResourceSelectionV1[];
     readonly onAdmitted?: (receipt: SessionAdmissionReceipt) => void;
   }): Promise<SessionContinueResult>;
   branch(input: SessionBranchInput): Promise<CurrentSessionSnapshot>;
@@ -509,7 +509,7 @@ export interface SessionLifecycle {
     readonly runId?: string;
     readonly signal?: AbortSignal;
     readonly thinkingSelection?: ThinkingPolicySelectionV1;
-    readonly resourceSelections?: readonly LocalInputResourceSelectionV1[];
+    readonly resourceSelections?: readonly InputResourceSelectionV1[];
   }): Promise<SessionContinueResult>;
   configureMcp(command: McpConfigurationCommand): Promise<McpConfigurationResult>;
   configureWorkspaceTrust(
@@ -2767,14 +2767,14 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             readonly [sessionDurableOutputLimits]?: AgentSessionDurableOutputLimits;
           }
         )[sessionDurableOutputLimits];
-        const artifactStore = await createFileArtifactStore({
-          root: join(effectiveSessionStateRoot(options.stateRoot), "artifacts"),
-        });
+        const artifactRoot = join(effectiveSessionStateRoot(options.stateRoot), "artifacts");
+        const artifactStore = await createFileArtifactStore({ root: artifactRoot });
         await validateVisibleInputResourceArtifacts(artifactStore, visibleInputResources);
         const inputResources =
           input.resourceSelections === undefined
             ? []
             : await ingestLocalInputResourcesV1({
+                artifactRoot,
                 artifactStore,
                 ...(options[inputResourceIngestBarrier]?.afterResolved === undefined
                   ? {}
@@ -6406,7 +6406,7 @@ async function materializeModelResponseArtifacts(
   return { contents, logicalReferencedBytes, records: materialized };
 }
 
-function effectiveSessionStateRoot(configured: string | undefined): string {
+export function effectiveSessionStateRoot(configured: string | undefined): string {
   if (configured !== undefined) {
     return configured;
   }

--- a/packages/agent/src/turn-composer.ts
+++ b/packages/agent/src/turn-composer.ts
@@ -1,0 +1,298 @@
+import { randomUUID } from "node:crypto";
+import type { TurnComposerResourceStager } from "./input-resource-staging.js";
+import {
+  type InputResourceOccurrenceV1,
+  inputResourceLimitsV1,
+  type StagedInputResourceSelectionV1,
+  safeInputResourceDisplayNameV1,
+} from "./input-resources.js";
+
+export {
+  type TurnComposerStageBarrier,
+  turnComposerStageBarrier,
+} from "./input-resource-staging.js";
+
+export type TurnComposerResourceSnapshot = {
+  readonly id: string;
+  readonly displayName: string;
+  readonly state: "queued" | "copying" | "ready" | "failed" | "cancelled" | "removed";
+  readonly byteCount: number | null;
+  readonly support: InputResourceOccurrenceV1["support"] | null;
+  readonly diagnostic: string | null;
+};
+
+type TurnComposerResource = {
+  readonly id: string;
+  displayName: string;
+  state: TurnComposerResourceSnapshot["state"];
+  byteCount: number | null;
+  support: InputResourceOccurrenceV1["support"] | null;
+  diagnostic: string | null;
+  readonly controller: AbortController;
+  staged: StagedInputResourceSelectionV1 | null;
+  settlement: Promise<void> | null;
+};
+
+export class TurnComposerError extends Error {
+  readonly code: "cancelled" | "failed" | "limit_exceeded" | "unsupported";
+
+  constructor(code: TurnComposerError["code"], message: string) {
+    super(message);
+    this.name = "TurnComposerError";
+    this.code = code;
+  }
+}
+
+export type TurnComposer = {
+  stage(path: string): Promise<string>;
+  cancel(id: string): Promise<boolean>;
+  remove(id: string): Promise<boolean>;
+  setText(text: string): void;
+  seal(signal: AbortSignal): Promise<{
+    readonly text: string;
+    readonly selections: readonly StagedInputResourceSelectionV1[];
+  }>;
+  unseal(): void;
+  clear(): Promise<void>;
+  close(): Promise<void>;
+  snapshot(): {
+    readonly sealed: boolean;
+    readonly resources: readonly TurnComposerResourceSnapshot[];
+  };
+};
+
+export async function createTurnComposer(options: {
+  readonly onChange: () => void;
+  readonly stager: TurnComposerResourceStager;
+}): Promise<TurnComposer> {
+  const resources = new Map<string, TurnComposerResource>();
+  let text = "";
+  let sealed = false;
+  let closed = false;
+
+  const publish = (): void => {
+    if (!closed) {
+      options.onChange();
+    }
+  };
+
+  const discardStaging = async (resource: TurnComposerResource): Promise<void> => {
+    if (resource.staged !== null) {
+      const staged = resource.staged;
+      resource.staged = null;
+      await options.stager.discard(staged);
+    }
+  };
+
+  return {
+    async cancel(id) {
+      if (closed || sealed) {
+        return false;
+      }
+      const resource = resources.get(id);
+      if (
+        resource === undefined ||
+        resource.state === "cancelled" ||
+        resource.state === "removed"
+      ) {
+        return false;
+      }
+      resource.state = "cancelled";
+      resource.diagnostic = null;
+      resource.controller.abort();
+      publish();
+      await resource.settlement;
+      await discardStaging(resource);
+      return true;
+    },
+    async remove(id) {
+      if (closed || sealed) {
+        return false;
+      }
+      const resource = resources.get(id);
+      if (resource === undefined) {
+        return false;
+      }
+      resource.state = "removed";
+      resource.controller.abort();
+      publish();
+      await resource.settlement;
+      await discardStaging(resource);
+      resources.delete(id);
+      publish();
+      return true;
+    },
+    async stage(path) {
+      if (closed || sealed) {
+        throw new TypeError("The turn composer is not accepting input resources.");
+      }
+      const retainedCount = [...resources.values()].filter(
+        (resource) => resource.state !== "cancelled" && resource.state !== "removed",
+      ).length;
+      if (retainedCount >= inputResourceLimitsV1.maximumOccurrencesPerRun) {
+        throw new TypeError("The turn composer input-resource count exceeds the v1 run limit.");
+      }
+      const id = randomUUID();
+      const resource: TurnComposerResource = {
+        id,
+        displayName: safeInputResourceDisplayNameV1(path),
+        state: "queued",
+        byteCount: null,
+        support: null,
+        diagnostic: null,
+        controller: new AbortController(),
+        staged: null,
+        settlement: null,
+      };
+      resources.set(id, resource);
+      publish();
+      resource.state = "copying";
+      publish();
+      const settlement = (async () => {
+        try {
+          const staged = await options.stager.stage({
+            id,
+            path,
+            signal: resource.controller.signal,
+          });
+          if (closed || resource.state === "cancelled" || !resources.has(id)) {
+            await options.stager.discard(staged);
+            return;
+          }
+          resource.displayName = staged.displayName;
+          resource.byteCount = staged.staged.byteCount;
+          resource.support = staged.support;
+          resource.staged = staged;
+          resource.state = "ready";
+          publish();
+        } catch (error) {
+          if (resource.state === "cancelled" || closed || !resources.has(id)) {
+            return;
+          }
+          resource.state = "failed";
+          resource.diagnostic =
+            error instanceof Error ? error.message : "The selected input resource failed.";
+          publish();
+        }
+      })();
+      resource.settlement = settlement;
+      await settlement;
+      return id;
+    },
+    async seal(signal) {
+      if (closed || sealed) {
+        throw new TurnComposerError("failed", "The turn composer cannot be sealed.");
+      }
+      sealed = true;
+      publish();
+      const cancelStaging = (): void => {
+        for (const resource of resources.values()) {
+          if (resource.state === "queued" || resource.state === "copying") {
+            resource.state = "cancelled";
+            resource.diagnostic = null;
+            resource.controller.abort();
+          }
+        }
+        publish();
+      };
+      signal.addEventListener("abort", cancelStaging, { once: true });
+      try {
+        await Promise.all([...resources.values()].map((resource) => resource.settlement));
+      } finally {
+        signal.removeEventListener("abort", cancelStaging);
+      }
+      if (signal.aborted) {
+        sealed = false;
+        publish();
+        throw new TurnComposerError("cancelled", "Input-resource sealing was cancelled.");
+      }
+      const retained = [...resources.values()].filter(
+        (resource) => resource.state !== "cancelled" && resource.state !== "removed",
+      );
+      const failed = retained.find((resource) => resource.state !== "ready");
+      if (failed !== undefined) {
+        sealed = false;
+        publish();
+        throw new TurnComposerError(
+          "failed",
+          "Every retained input resource must be ready before send.",
+        );
+      }
+      const aggregateBytes = retained.reduce(
+        (total, resource) => total + (resource.byteCount ?? 0),
+        0,
+      );
+      if (aggregateBytes > inputResourceLimitsV1.maximumAggregateBytesPerRun) {
+        sealed = false;
+        publish();
+        throw new TurnComposerError(
+          "limit_exceeded",
+          "The retained input resources exceed the v1 aggregate run limit.",
+        );
+      }
+      if (retained.some((resource) => resource.support !== "utf8_text")) {
+        sealed = false;
+        publish();
+        throw new TurnComposerError(
+          "unsupported",
+          "Every retained input resource must have supported immutable content.",
+        );
+      }
+      return {
+        text,
+        selections: retained.map((resource) => resource.staged as StagedInputResourceSelectionV1),
+      };
+    },
+    async clear() {
+      const retained = [...resources.values()];
+      sealed = false;
+      for (const resource of retained) {
+        if (resource.state === "queued" || resource.state === "copying") {
+          resource.state = "cancelled";
+          resource.diagnostic = null;
+          resource.controller.abort();
+        }
+      }
+      await Promise.allSettled(retained.map((resource) => resource.settlement));
+      resources.clear();
+      await Promise.all(retained.map(discardStaging));
+      text = "";
+      publish();
+    },
+    setText(nextText) {
+      if (closed || sealed) {
+        throw new TypeError("The sealed turn composer cannot change draft text.");
+      }
+      if (text !== nextText) {
+        text = nextText;
+        publish();
+      }
+    },
+    unseal() {
+      if (!closed && sealed) {
+        sealed = false;
+        publish();
+      }
+    },
+    async close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      for (const resource of resources.values()) {
+        resource.controller.abort();
+      }
+      await Promise.allSettled([...resources.values()].map((resource) => resource.settlement));
+      await options.stager.close();
+      resources.clear();
+    },
+    snapshot() {
+      return {
+        sealed,
+        resources: [...resources.values()].map(
+          ({ controller: _controller, settlement: _settlement, staged: _staged, ...item }) => item,
+        ),
+      };
+    },
+  };
+}

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -654,6 +654,20 @@ export type NewSessionDraftDisplay = {
   readonly projectPaths: ProjectPathCatalogDisplay;
 };
 
+export type TurnComposerDisplay = {
+  readonly attachmentAvailable: boolean;
+  readonly unavailableReason: string | null;
+  readonly sealed: boolean;
+  readonly resources: readonly {
+    readonly id: string;
+    readonly displayName: string;
+    readonly state: "queued" | "copying" | "ready" | "failed" | "cancelled" | "removed";
+    readonly byteCount: number | null;
+    readonly support: "unsupported_binary" | "utf8_text" | null;
+    readonly diagnostic: string | null;
+  }[];
+};
+
 export type AuthoritativePresentationSnapshot = {
   readonly schemaVersion: 1;
   readonly continuity:
@@ -692,6 +706,7 @@ export type PresentationDisplayState = {
   readonly revision: number;
   readonly authoritative: AuthoritativePresentationSnapshot;
   readonly draft: NewSessionDraftDisplay | null;
+  readonly composer: TurnComposerDisplay;
   readonly transient: PresentationTransientState | null;
 };
 
@@ -850,6 +865,18 @@ export type PresentationCommand =
       readonly thinkingSelection: ThinkingPolicySelectionDisplay | null;
     }
   | {
+      readonly type: "stage_input_resource";
+      readonly path: string;
+    }
+  | {
+      readonly type: "update_draft_text";
+      readonly text: string;
+    }
+  | {
+      readonly type: "remove_input_resource" | "cancel_input_resource";
+      readonly resourceId: string;
+    }
+  | {
       readonly type: "cancel_run";
       readonly sessionId: string | null;
     }
@@ -899,6 +926,7 @@ export function reconcilePresentationUpdate(
       revision: state.revision + 1,
       authoritative: update.snapshot,
       draft: update.snapshot.active === null ? state.draft : null,
+      composer: state.composer,
       transient: null,
     };
   }
@@ -914,6 +942,7 @@ export function reconcilePresentationUpdate(
         continuity: { status: "repairing", reason: "gap" },
       },
       draft: state.draft,
+      composer: state.composer,
       transient: null,
     };
   }
@@ -923,6 +952,7 @@ export function reconcilePresentationUpdate(
       revision: state.revision + 1,
       authoritative: state.authoritative,
       draft: state.draft,
+      composer: state.composer,
       transient: {
         activity: state.transient?.activity ?? "working",
         assistant: state.transient?.assistant ?? null,
@@ -935,6 +965,7 @@ export function reconcilePresentationUpdate(
     revision: state.revision + 1,
     authoritative: state.authoritative,
     draft: state.draft,
+    composer: state.composer,
     transient: {
       activity: "replying",
       assistant: {

--- a/packages/presentation/src/presentation.test.ts
+++ b/packages/presentation/src/presentation.test.ts
@@ -63,12 +63,20 @@ const emptySnapshot: AuthoritativePresentationSnapshot = {
   },
 };
 
+const emptyComposer = {
+  attachmentAvailable: false,
+  unavailableReason: "New session required for attachments",
+  sealed: false,
+  resources: [],
+} as const;
+
 describe("presentation reconciliation", () => {
   it("replaces a transient assistant delta with durable completion", () => {
     const initial: PresentationDisplayState = {
       revision: 1,
       authoritative: emptySnapshot,
       draft: null,
+      composer: emptyComposer,
       transient: null,
     };
 
@@ -83,6 +91,7 @@ describe("presentation reconciliation", () => {
       revision: 2,
       authoritative: emptySnapshot,
       draft: null,
+      composer: emptyComposer,
       transient: {
         activity: "replying",
         assistant: {
@@ -149,6 +158,7 @@ describe("presentation reconciliation", () => {
       revision: 3,
       authoritative: completedSnapshot,
       draft: null,
+      composer: emptyComposer,
       transient: null,
     });
   });
@@ -158,6 +168,7 @@ describe("presentation reconciliation", () => {
       revision: 7,
       authoritative: emptySnapshot,
       draft: null,
+      composer: emptyComposer,
       transient: null,
     };
 
@@ -175,6 +186,7 @@ describe("presentation reconciliation", () => {
         continuity: { status: "repairing", reason: "gap" },
       },
       draft: null,
+      composer: emptyComposer,
       transient: null,
     });
   });
@@ -184,6 +196,7 @@ describe("presentation reconciliation", () => {
       revision: 3,
       authoritative: emptySnapshot,
       draft: null,
+      composer: emptyComposer,
       transient: {
         activity: "working",
         assistant: null,

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -34,12 +34,14 @@ import {
   type OperationSnapshot,
   type OperationStore,
   type SessionLifecycle,
+  type ToolRegistry,
 } from "@adam-agent/agent";
 import {
   assemblePromptMessagesV1,
   createInMemorySessionStoreDirectory,
   createTrustedWorkspaceTrustForTesting,
   digestPromptRequestV1,
+  inputResourceIngestBarrier,
   mcpCatalogStaleDurableBarrier,
   mcpTransportFactory,
   openJsonlSessionStore,
@@ -58,6 +60,7 @@ import {
   sessionRuntimeNotificationTransform,
   sessionStoreDirectory,
   sessionTitleDeadlineScheduler,
+  turnComposerStageBarrier,
 } from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
 import {
@@ -807,6 +810,12 @@ test("PresentationSession opens an empty project catalog without creating a sess
         active: null,
       },
       draft: null,
+      composer: {
+        attachmentAvailable: false,
+        unavailableReason: "New session required for attachments",
+        sealed: false,
+        resources: [],
+      },
       transient: null,
     });
     expect(state.authoritative.project.id).toMatch(/^sha256:[0-9a-f]{64}$/u);
@@ -1011,6 +1020,729 @@ test("PresentationSession admits exact thinking choices for draft and active pro
   } finally {
     await presentation?.close();
     await fixture.close();
+  }
+});
+
+test("PresentationSession stages one draft resource before sealing the admitted turn", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-turn-composer-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "outside notes.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "sealed composer bytes\n", "utf8");
+  const copying = Promise.withResolvers<void>();
+  const releaseCopy = Promise.withResolvers<void>();
+  const requests: Parameters<ModelDriver["stream"]>[0][] = [];
+  const driver = new FakeModelDriver((request) => {
+    requests.push(request);
+    return [
+      { type: "text_delta", text: "Composer fixture answer." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  let sourceResolutionsDuringAdmission = 0;
+  const lifecycle = harness.createLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+    [inputResourceIngestBarrier]: {
+      afterResolved() {
+        sourceResolutionsDuringAdmission += 1;
+      },
+    },
+  });
+  const presentation = await createPresentationSession({
+    lifecycle,
+    modelTargets,
+    openProject: true,
+    projectLabel: "workspace",
+    stateRoot,
+    workspaceRoot,
+    [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    [turnComposerStageBarrier]: {
+      async afterOpen() {
+        copying.resolve();
+        await releaseCopy.promise;
+      },
+    },
+  });
+
+  try {
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+    const stage = presentation.dispatch({ type: "stage_input_resource", path: selectedPath });
+    await expect(
+      Promise.race([
+        copying.promise.then(() => "copying" as const),
+        stage.then(() => "settled" as const),
+      ]),
+    ).resolves.toBe("copying");
+    expect(presentation.getState().composer).toMatchObject({
+      attachmentAvailable: true,
+      sealed: false,
+      resources: [{ displayName: "outside notes.txt", state: "copying" }],
+    });
+
+    releaseCopy.resolve();
+    await expect(stage).resolves.toMatchObject({ status: "admitted" });
+    expect(presentation.getState().composer).toMatchObject({
+      attachmentAvailable: true,
+      sealed: false,
+      resources: [
+        {
+          byteCount: 22,
+          displayName: "outside notes.txt",
+          state: "ready",
+          support: "utf8_text",
+        },
+      ],
+    });
+    await rm(selectedPath);
+
+    await expect(
+      presentation.dispatch({
+        type: "submit_draft_prompt",
+        text: "Read the linked notes only if needed.",
+        skills: [],
+        thinkingSelection: null,
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    expect(sourceResolutionsDuringAdmission).toBe(0);
+    expect(requests.at(0)?.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "user",
+          content: expect.stringContaining('"displayName":"outside notes.txt"'),
+        }),
+      ]),
+    );
+    expect(presentation.getState().composer.resources).toEqual([]);
+  } finally {
+    releaseCopy.resolve();
+    await presentation.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession removes a ready resource before sealing the draft", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-remove-resource-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "remove-me.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "must not be linked\n", "utf8");
+  const requests: Parameters<ModelDriver["stream"]>[0][] = [];
+  const driver = new FakeModelDriver((request) => {
+    requests.push(request);
+    return [
+      { type: "text_delta", text: "Removal fixture answer." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const presentation = await createPresentationSession({
+    lifecycle,
+    modelTargets,
+    openProject: true,
+    projectLabel: "workspace",
+    stateRoot,
+    workspaceRoot,
+    [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+  });
+
+  try {
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+    await expect(
+      presentation.dispatch({ type: "stage_input_resource", path: selectedPath }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    const resourceId = presentation.getState().composer.resources[0]?.id;
+    if (resourceId === undefined) {
+      throw new Error("Expected one ready resource in the composer.");
+    }
+
+    await expect(
+      presentation.dispatch({ type: "remove_input_resource", resourceId }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    expect(presentation.getState().composer.resources).toEqual([]);
+
+    await presentation.dispatch({
+      type: "submit_draft_prompt",
+      text: "Send without the removed resource.",
+      skills: [],
+      thinkingSelection: null,
+    });
+    expect(requests.at(0)?.messages).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ content: expect.stringContaining("remove-me.txt") }),
+      ]),
+    );
+  } finally {
+    await presentation.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession cancels a copying resource and excludes it from seal", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-cancel-resource-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "cancel-me.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "cancelled composer bytes\n", "utf8");
+  const copying = Promise.withResolvers<void>();
+  const releaseCopy = Promise.withResolvers<void>();
+  const modelTargets = settledModelTargets("Cancellation fixture answer.");
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const presentation = await createPresentationSession({
+    lifecycle,
+    modelTargets,
+    openProject: true,
+    projectLabel: "workspace",
+    stateRoot,
+    workspaceRoot,
+    [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    [turnComposerStageBarrier]: {
+      async afterOpen() {
+        copying.resolve();
+        await releaseCopy.promise;
+      },
+    },
+  });
+
+  try {
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+    const stage = presentation.dispatch({ type: "stage_input_resource", path: selectedPath });
+    await copying.promise;
+    const resourceId = presentation.getState().composer.resources[0]?.id;
+    if (resourceId === undefined) {
+      throw new Error("Expected one copying resource in the composer.");
+    }
+
+    const cancellation = presentation.dispatch({
+      type: "cancel_input_resource",
+      resourceId,
+    });
+    expect(presentation.getState().composer.resources).toMatchObject([
+      { id: resourceId, state: "cancelled" },
+    ]);
+    releaseCopy.resolve();
+    await expect(cancellation).resolves.toMatchObject({ status: "admitted" });
+    await stage;
+
+    await expect(
+      presentation.dispatch({
+        type: "submit_draft_prompt",
+        text: "Send after cancelling the resource.",
+        skills: [],
+        thinkingSelection: null,
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    expect(presentation.getState().composer.resources).toEqual([]);
+  } finally {
+    releaseCopy.resolve();
+    await presentation.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession keeps a failed resource visible until a fresh selection replaces it", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-retry-resource-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "retry-notes.txt");
+  await mkdir(workspaceRoot);
+  let providerCalls = 0;
+  const driver = new FakeModelDriver(() => {
+    providerCalls += 1;
+    return [
+      { type: "text_delta", text: "Retry fixture answer." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const presentation = await createPresentationSession({
+    lifecycle,
+    modelTargets,
+    openProject: true,
+    projectLabel: "workspace",
+    stateRoot,
+    workspaceRoot,
+    [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+  });
+
+  try {
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+    await presentation.dispatch({ type: "stage_input_resource", path: selectedPath });
+    expect(presentation.getState().composer.resources).toMatchObject([
+      { displayName: "retry-notes.txt", state: "failed" },
+    ]);
+    await expect(
+      presentation.dispatch({
+        type: "submit_draft_prompt",
+        text: "Do not send a failed selection.",
+        skills: [],
+        thinkingSelection: null,
+      }),
+    ).resolves.toMatchObject({ status: "rejected" });
+    expect(providerCalls).toBe(0);
+
+    const failedId = presentation.getState().composer.resources[0]?.id;
+    if (failedId === undefined) {
+      throw new Error("Expected the failed resource identity.");
+    }
+    await presentation.dispatch({ type: "remove_input_resource", resourceId: failedId });
+    await writeFile(selectedPath, "fresh retry bytes\n", "utf8");
+    await presentation.dispatch({ type: "stage_input_resource", path: selectedPath });
+    expect(presentation.getState().composer.resources).toMatchObject([
+      { displayName: "retry-notes.txt", state: "ready", support: "utf8_text" },
+    ]);
+    await expect(
+      presentation.dispatch({
+        type: "submit_draft_prompt",
+        text: "Send the fresh selection.",
+        skills: [],
+        thinkingSelection: null,
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    expect(providerCalls).toBeGreaterThan(0);
+  } finally {
+    await presentation.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession cancels stale copying work before publishing a newer draft", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-stale-resource-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "stale-notes.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "stale composer bytes\n", "utf8");
+  const copying = Promise.withResolvers<void>();
+  const aborted = Promise.withResolvers<void>();
+  const releaseCopy = Promise.withResolvers<void>();
+  const modelTargets = settledModelTargets();
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const presentation = await createPresentationSession({
+    lifecycle,
+    modelTargets,
+    openProject: true,
+    projectLabel: "workspace",
+    stateRoot,
+    workspaceRoot,
+    [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    [turnComposerStageBarrier]: {
+      async afterOpen({ signal }) {
+        copying.resolve();
+        await Promise.race([
+          new Promise<void>((resolve) => {
+            signal.addEventListener(
+              "abort",
+              () => {
+                aborted.resolve();
+                resolve();
+              },
+              { once: true },
+            );
+          }),
+          releaseCopy.promise,
+        ]);
+      },
+    },
+  });
+
+  try {
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+    const staleStage = presentation.dispatch({
+      type: "stage_input_resource",
+      path: selectedPath,
+    });
+    await copying.promise;
+    const newerDraft = presentation.dispatch({
+      type: "create_session",
+      targetId: targetIdentity.targetId,
+    });
+
+    await expect(
+      Promise.race([
+        aborted.promise.then(() => "aborted" as const),
+        newerDraft.then(() => "switched" as const),
+      ]),
+    ).resolves.toBe("aborted");
+    releaseCopy.resolve();
+    await staleStage;
+    await expect(newerDraft).resolves.toMatchObject({ status: "admitted" });
+    expect(presentation.getState().composer.resources).toEqual([]);
+  } finally {
+    releaseCopy.resolve();
+    await presentation.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession rejects input-resource mutations after sealing the draft", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-sealed-resource-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "sealed-notes.txt");
+  const otherPath = join(testRoot, "other-notes.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "sealed composer bytes\n", "utf8");
+  await writeFile(otherPath, "must remain unstaged\n", "utf8");
+  const ingestOpened = Promise.withResolvers<void>();
+  const releaseIngest = Promise.withResolvers<void>();
+  const modelTargets = settledModelTargets("Sealed composer fixture answer.");
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+    [inputResourceIngestBarrier]: {
+      async afterOpened() {
+        ingestOpened.resolve();
+        await releaseIngest.promise;
+      },
+    },
+  });
+  const presentation = await createPresentationSession({
+    lifecycle,
+    modelTargets,
+    openProject: true,
+    projectLabel: "workspace",
+    stateRoot,
+    workspaceRoot,
+    [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+  });
+
+  try {
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+    await presentation.dispatch({ type: "stage_input_resource", path: selectedPath });
+    const resourceId = presentation.getState().composer.resources[0]?.id;
+    if (resourceId === undefined) {
+      throw new Error("Expected one ready resource before sealing the draft.");
+    }
+
+    const submission = presentation.dispatch({
+      type: "submit_draft_prompt",
+      text: "Seal this exact resource selection.",
+      skills: [],
+      thinkingSelection: null,
+    });
+    await ingestOpened.promise;
+    expect(presentation.getState().composer.sealed).toBe(true);
+    await expect(
+      presentation.dispatch({ type: "stage_input_resource", path: otherPath }),
+    ).resolves.toMatchObject({ status: "rejected", code: "conflict" });
+    await expect(
+      presentation.dispatch({ type: "remove_input_resource", resourceId }),
+    ).resolves.toMatchObject({ status: "rejected", code: "conflict" });
+    await expect(
+      presentation.dispatch({ type: "cancel_input_resource", resourceId }),
+    ).resolves.toMatchObject({ status: "rejected", code: "conflict" });
+
+    releaseIngest.resolve();
+    await expect(submission).resolves.toMatchObject({ status: "admitted" });
+  } finally {
+    releaseIngest.resolve();
+    await presentation.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession cancels resource staging while a turn is sealing", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-cancel-seal-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "slow-seal-notes.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "cancel before canonical admission\n", "utf8");
+  const copying = Promise.withResolvers<void>();
+  const aborted = Promise.withResolvers<void>();
+  const releaseCopy = Promise.withResolvers<void>();
+  const requests: Parameters<ModelDriver["stream"]>[0][] = [];
+  const driver = new FakeModelDriver((request) => {
+    requests.push(request);
+    return [
+      { type: "text_delta", text: "Cancellation fixture answer." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const created = await lifecycle.create({ targetIdentity });
+  await lifecycle.continue({ sessionId: created.sessionId, input: { text: "Initial turn." } });
+  const presentation = await createPresentationSession({
+    lifecycle,
+    modelTargets,
+    projectLabel: "workspace",
+    sessionId: created.sessionId,
+    stateRoot,
+    workspaceRoot,
+    [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    [turnComposerStageBarrier]: {
+      async afterOpen({ signal }) {
+        copying.resolve();
+        await Promise.race([
+          new Promise<void>((resolve) => {
+            signal.addEventListener(
+              "abort",
+              () => {
+                aborted.resolve();
+                resolve();
+              },
+              { once: true },
+            );
+          }),
+          releaseCopy.promise,
+        ]);
+      },
+    },
+  });
+
+  try {
+    const stage = presentation.dispatch({ type: "stage_input_resource", path: selectedPath });
+    await copying.promise;
+    const submission = presentation.dispatch({
+      type: "submit_prompt",
+      sessionId: created.sessionId,
+      text: "This turn must never be admitted.",
+      skills: [],
+      thinkingSelection: null,
+    });
+    expect(presentation.getState().composer.sealed).toBe(true);
+
+    await expect(
+      presentation.dispatch({ type: "cancel_run", sessionId: created.sessionId }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    await aborted.promise;
+    releaseCopy.resolve();
+    await stage;
+    await expect(submission).resolves.toEqual({
+      status: "rejected",
+      code: "not_available",
+      message: "Input-resource sealing was cancelled.",
+    });
+    expect(requests.some((request) => JSON.stringify(request).includes("must never"))).toBe(false);
+    const records = (await (await harness.sessions.open(created.sessionId))?.read()) ?? [];
+    expect(records.some((record) => JSON.stringify(record).includes("must never"))).toBe(false);
+  } finally {
+    releaseCopy.resolve();
+    await presentation.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession clears staged resources when selecting another session", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-select-resource-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "session-local-notes.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "belongs only to the first session\n", "utf8");
+  const modelTargets = settledModelTargets("Session selection fixture answer.");
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const first = await lifecycle.create({ targetIdentity });
+  const second = await lifecycle.create({ targetIdentity });
+  await lifecycle.continue({
+    sessionId: first.sessionId,
+    input: { text: "First session." },
+  });
+  await lifecycle.continue({
+    sessionId: second.sessionId,
+    input: { text: "Second session." },
+  });
+  const presentation = await createPresentationSession({
+    lifecycle,
+    modelTargets,
+    projectLabel: "workspace",
+    sessionId: first.sessionId,
+    stateRoot,
+    workspaceRoot,
+    [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+  });
+
+  try {
+    await presentation.dispatch({ type: "stage_input_resource", path: selectedPath });
+    expect(presentation.getState().composer.resources).toHaveLength(1);
+
+    await expect(
+      presentation.dispatch({ type: "select_session", sessionId: second.sessionId }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    expect(presentation.getState().composer.resources).toEqual([]);
+  } finally {
+    await presentation.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession keeps a historical six-tool session attachment-disabled", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-historical-attachments-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const modelTargets = settledModelTargets("Historical fixture answer.");
+  const currentTools = createCodingToolRegistry({ stateRoot, workspaceRoot });
+  const historicalTools: ToolRegistry = {
+    definitions: () =>
+      currentTools.definitions().filter((definition) => definition.name !== "read_input_resource"),
+    resolve(name) {
+      return name === "read_input_resource" ? undefined : currentTools.resolve(name);
+    },
+  };
+  const historicalLifecycle = createSessionLifecycle({
+    modelTargets,
+    stateRoot,
+    tools: historicalTools,
+    workspaceRoot,
+  });
+  const created = await historicalLifecycle.create({ targetIdentity });
+  await historicalLifecycle.continue({
+    sessionId: created.sessionId,
+    input: { text: "Historical text-only session." },
+  });
+  await historicalLifecycle.close();
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const presentation = await createPresentationSession({
+    lifecycle,
+    modelTargets,
+    projectLabel: "workspace",
+    sessionId: created.sessionId,
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    expect(presentation.getState().composer).toMatchObject({
+      attachmentAvailable: false,
+      unavailableReason: "New session required for attachments",
+      resources: [],
+    });
+    await expect(
+      presentation.dispatch({ type: "stage_input_resource", path: join(testRoot, "ignored.txt") }),
+    ).resolves.toEqual({
+      status: "rejected",
+      code: "not_available",
+      message: "New session required for attachments",
+    });
+  } finally {
+    await presentation.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession rejects a staged occurrence beyond the composer run bound", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-resource-count-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "bounded-notes.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "one bounded occurrence\n", "utf8");
+  const modelTargets = settledModelTargets("Resource-count fixture answer.");
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const presentation = await createPresentationSession({
+    lifecycle,
+    modelTargets,
+    openProject: true,
+    projectLabel: "workspace",
+    stateRoot,
+    workspaceRoot,
+    [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+  });
+
+  try {
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+    for (let index = 0; index < 8; index += 1) {
+      await expect(
+        presentation.dispatch({ type: "stage_input_resource", path: selectedPath }),
+      ).resolves.toMatchObject({ status: "admitted" });
+    }
+    await expect(
+      presentation.dispatch({ type: "stage_input_resource", path: selectedPath }),
+    ).resolves.toMatchObject({ status: "rejected", code: "not_available" });
+    expect(presentation.getState().composer.resources).toHaveLength(8);
+  } finally {
+    await presentation.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
   }
 });
 
@@ -2332,6 +3064,12 @@ test("PresentationSession opens an exact target as a process-local draft", async
         targetId: targetIdentity.targetId,
         projectPaths: expect.objectContaining({ items: [], omittedCount: 0 }),
         skills: expect.objectContaining({ items: [], reloadAvailable: false }),
+      },
+      composer: {
+        attachmentAvailable: true,
+        unavailableReason: null,
+        sealed: false,
+        resources: [],
       },
       transient: null,
     });


### PR DESCRIPTION
## Summary

- add a TurnComposer-owned draft and ordered input-resource staging lifecycle
- stage provisional bytes through Artifact Store ownership and promote without reopening source paths
- expose attach, detach, cancellation, sealing, historical-profile availability, and safe bounded TUI rendering
- preserve durable SessionLifecycle admission and cancellation semantics

## Verification

- `pnpm quality:check`
- 50 test files passed; 1290 tests passed; 11 conditionally skipped
- two-axis code review: no blocking Standards or B11a2 specification findings
