### PR TITLE
test: causally settle TUI reasoning assertions

### DIFF
--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -323,6 +323,7 @@ test("real PTY streams Ctrl+T reasoning and restores application mouse modes on 
     const beforeAnswer = fixture.output().length;
     await writeFile(join(controlRoot, "release-model"), "release\n", "utf8");
     await waitForPath(join(controlRoot, "reasoning-session-settled"));
+    await fixture.waitForCompleteFrameAfter(" · idle", beforeAnswer);
     fixture.write("\u001b[F");
     await fixture.waitForCompleteFrameAfter("Reasoning answer.", beforeAnswer);
     fixture.write("\u0011");

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -3673,6 +3673,7 @@ test("repeated completed reasoning folds keep the selected block visible without
     await writeFile(join(controlRoot, "release-reasoning"), "release\n", "utf8");
     await writeFile(join(controlRoot, "release-model"), "release\n", "utf8");
     await waitForPath(join(controlRoot, "reasoning-session-settled"));
+    await waitForPhysicalText(terminal, "Adam · Streaming session");
     const durableStateBeforeFolds = await readFilesRecursively(stateRoot);
 
     for (let cycle = 0; cycle < 4; cycle += 1) {
@@ -3880,6 +3881,7 @@ test("live reasoning growth preserves reading until the user returns to the tail
     await writeFile(join(controlRoot, "release-live-completion"), "release\n", "utf8");
     await waitForPath(join(controlRoot, "reasoning-live-completed"));
     await terminal.nextFrame(beforeCompletionFrame);
+    await waitForPhysicalText(terminal, "Live reasoning answer.");
     await waitForPhysicalText(terminal, " · idle");
     expect(terminal.lines().join("\n")).toContain("Live reasoning answer.");
   } finally {


### PR DESCRIPTION
## Summary

- wait for the persisted automatic title before snapshotting durable reasoning state
- wait for the final live-reasoning answer to enter a physical frame before asserting viewport content
- keep timeouts and concurrency unchanged

## Verification

- `pnpm quality:check`
- 50 test files passed; 1290 tests passed; 11 conditionally skipped
