### PR TITLE
fix(tui): contain transcript search and preserve exit privacy

### DIFF
--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -21,6 +21,7 @@ import {
 } from "./tui-filesystem.test-support.js";
 import {
   cleanupActiveTuiFixtures,
+  outputAfterFinalAltScreenExit,
   startTuiFixture as startFixture,
 } from "./tui-fixture.test-support.js";
 
@@ -370,6 +371,9 @@ test.each([
         workspaceRoot,
       });
       await fixture.waitFor("Adam · New session");
+      const privateDraftSentinel = `PRIVATE_${signal}_DRAFT_SENTINEL`;
+      fixture.write(privateDraftSentinel);
+      await fixture.waitFor(privateDraftSentinel);
       await fixture.terminate(signal);
       const result = await fixture.closed;
       expect(result).toMatchObject({ code, signal: null, stderr: "" });
@@ -378,6 +382,9 @@ test.each([
       );
       expect(result.stdout).toContain("\u001b[?2004l");
       expect(result.stdout).toContain("\u001b[?25h");
+      const afterExit = outputAfterFinalAltScreenExit(result.stdout);
+      expect(afterExit).toBe("\u001b[?25h\u001b[?2026l");
+      expect(afterExit).not.toContain(privateDraftSentinel);
     } finally {
       await rm(testRoot, { recursive: true, force: true });
     }
@@ -1362,8 +1369,12 @@ test("idle Ctrl+C preserves a CJK draft and copies it only on the confirming pre
     await fixture.waitFor("Press Ctrl+C again within two seconds to exit · draft will be copied");
     expect(fixture.output()).not.toContain("clipboard copied");
     fixture.write("\u0003");
-    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
     await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe(draft);
+    const afterExit = outputAfterFinalAltScreenExit(result.stdout);
+    expect(afterExit).toBe("\u001b[?25h\u001b[?2026l");
+    expect(afterExit).not.toContain(draft);
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -23,6 +23,7 @@ import {
 } from "./tui-filesystem.test-support.js";
 import {
   cleanupActiveTuiFixtures,
+  outputAfterFinalAltScreenExit,
   startTuiFixture as startFixture,
 } from "./tui-fixture.test-support.js";
 import { VirtualTerminal } from "./virtual-terminal.test-support.js";
@@ -108,6 +109,49 @@ test("minimum-size mode consumes ordinary editor input while preserving safe exi
   }
 });
 
+test("Ctrl+Q explicitly preserves the pre-Adam screen without printing the transcript or draft", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-preserve-screen-ctrl-q-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const terminal = new VirtualTerminal();
+  const previousScreenSentinel = "PRE_ADAM_SCREEN_SENTINEL";
+  const privateDraftSentinel = "PRIVATE_DRAFT_SENTINEL";
+  await mkdir(workspaceRoot);
+  terminal.write(previousScreenSentinel);
+
+  const execution = runTuiFixture({
+    clipboard: {
+      async writeText() {
+        return "copied";
+      },
+    },
+    stateRoot,
+    terminal,
+    workspaceRoot,
+  });
+
+  try {
+    await terminal.whenStarted();
+    terminal.input(privateDraftSentinel);
+    await terminal.nextSynchronizedFrameContaining(privateDraftSentinel);
+    terminal.input("\u0011");
+    await expect(execution).resolves.toBeUndefined();
+
+    const output = terminal.output();
+    expect(output.startsWith(previousScreenSentinel)).toBe(true);
+    const afterExit = outputAfterFinalAltScreenExit(output);
+    expect(afterExit).toBe("\u001b[?25h\u001b[?2026l");
+    expect(afterExit).not.toContain("Adam ·");
+    expect(afterExit).not.toContain(privateDraftSentinel);
+  } finally {
+    if (terminal.running()) {
+      terminal.input("\u0011");
+    }
+    await execution.catch(() => undefined);
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("/exit clears its literal input and reaches the existing TUI cleanup without submission", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-slash-exit-"));
   const workspaceRoot = join(testRoot, "workspace");
@@ -127,12 +171,16 @@ test("/exit clears its literal input and reaches the existing TUI cleanup withou
     },
     controlRoot,
     presentationCloseMarker,
+    scenario: "provider-no-usage",
     stateRoot,
     terminal,
     workspaceRoot,
   });
   try {
     await terminal.whenStarted();
+    const privateTranscriptSentinel = "PRIVATE_TRANSCRIPT_SENTINEL";
+    terminal.input(`${privateTranscriptSentinel}\r`);
+    await terminal.nextSynchronizedFrameContaining("Provider usage unavailable.");
     terminal.input("/exit extra\r");
     await terminal.nextOutputContaining("Usage: /exit");
     expect(terminal.running()).toBe(true);
@@ -152,6 +200,9 @@ test("/exit clears its literal input and reaches the existing TUI cleanup withou
     });
     expect(await readFilesRecursively(stateRoot)).not.toContain('"text":"/exit');
     expect(terminal.lifecycle()).toEqual(["started", "stopped"]);
+    const afterExit = outputAfterFinalAltScreenExit(terminal.output());
+    expect(afterExit).toBe("\u001b[?25h\u001b[?2026l");
+    expect(afterExit).not.toContain(privateTranscriptSentinel);
   } finally {
     if (terminal.running()) {
       terminal.input("\u0011");
@@ -6281,6 +6332,50 @@ test("a mutation permission shows its canonical diff and Enter allows the exact 
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a mandatory permission keeps input ownership when the inherited transcript-search chord is pressed", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-permission-search-chord-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "edit.txt"), "before\n", "utf8");
+  const terminal = new AppliedViewportTerminal({ columns: 80, rows: 24 });
+  const execution = runTuiFixture({
+    scenario: "mutation",
+    stateRoot,
+    terminal,
+    workspaceRoot,
+  });
+
+  try {
+    await terminal.nextFrame(0);
+    terminal.input("Edit the file\r");
+    await waitForPhysicalText(terminal, "Permission required");
+    const transcriptHeaderRow = terminal
+      .lines()
+      .findIndex((line) => line.includes("Adam · New session"));
+    expect(transcriptHeaderRow).toBeGreaterThanOrEqual(0);
+
+    await inputAndWaitForPhysicalFrame(terminal, "\u001b[102;6u");
+
+    const frame = terminal.lines().join("\n");
+    expect(frame).toContain("Permission required");
+    expect(frame).not.toContain("Find transcript");
+    expect(terminal.lines().findIndex((line) => line.includes("Adam · New session"))).toBe(
+      transcriptHeaderRow,
+    );
+
+    terminal.input("\u001b");
+    await waitForPhysicalText(terminal, "denied");
+    await expect(readFile(join(workspaceRoot, "edit.txt"), "utf8")).resolves.toBe("before\n");
+  } finally {
+    if (terminal.running()) {
+      terminal.input("\u0011");
+    }
+    await execution.catch(() => undefined);
     await rm(testRoot, { recursive: true, force: true });
   }
 });

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -186,6 +186,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   let requestPolicyRender: () => void = () => undefined;
   const tui = new TuiAltScreen(terminal, true, undefined, {
     mouse: options.mouse ?? true,
+    transcriptSearch: false,
     async copySelection(text) {
       const actionId = beginNoticeAction();
       const result = await copySelectionToClipboard(text, options.clipboard, deadlineScheduler);
@@ -3581,7 +3582,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       attempt(() => loader.stop());
     }
     operationLoaders.clear();
-    attempt(() => tui.stop());
+    attempt(() => tui.stop({ preserveScreen: true }));
     try {
       if (copyDraft) {
         const clipboardResult = await copyDraftToClipboard(

--- a/apps/tui/src/tui-fixture.test-support.ts
+++ b/apps/tui/src/tui-fixture.test-support.ts
@@ -70,6 +70,17 @@ export async function cleanupActiveTuiFixtures(): Promise<void> {
   activeFixtures.clear();
 }
 
+export function outputAfterFinalAltScreenExit(output: string): string {
+  const enterAltScreen = "\u001b[?1049h";
+  const exitAltScreen = "\u001b[?1049l";
+  const enterOffset = output.indexOf(enterAltScreen);
+  const exitOffset = output.lastIndexOf(exitAltScreen);
+  if (enterOffset < 0 || exitOffset <= enterOffset) {
+    throw new Error("The TUI output did not contain one ordered alternate-screen lifecycle.");
+  }
+  return output.slice(exitOffset + exitAltScreen.length);
+}
+
 function startInProcessTuiFixture(input: StartTuiFixtureOptions): TuiFixture {
   const terminal = new VirtualTerminal();
   const execution = withTuiColorEnvironment(input.noColor === true, () =>

--- a/patches/@earendil-works__pi-tui@0.84.2.patch
+++ b/patches/@earendil-works__pi-tui@0.84.2.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/components/select-list.js b/dist/components/select-list.js
-index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..a3e433040844ff81205ed55edb7713241410bcc3 100644
+index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..0b8964d09635714a7e5872c653883e064f59df14 100644
 --- a/dist/components/select-list.js
 +++ b/dist/components/select-list.js
 @@ -88,7 +88,7 @@ export class SelectList {
@@ -11,3 +11,53 @@ index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..a3e433040844ff81205ed55edb771324
          const prefixWidth = visibleWidth(prefix);
          if (descriptionSingleLine && width > 40) {
              const effectivePrimaryColumnWidth = Math.max(1, Math.min(primaryColumnWidth, width - prefixWidth - 4));
+diff --git a/dist/tui-alt-screen.d.ts b/dist/tui-alt-screen.d.ts
+index 848119411c1ff2885b8d1efe97f2f297bd4cd470..9acf1cd67d25554e9e4986f5ac738f2dac1b10ea 100644
+--- a/dist/tui-alt-screen.d.ts
++++ b/dist/tui-alt-screen.d.ts
+@@ -5,6 +5,8 @@ export interface TuiAltScreenOptions {
+     wheelScrollLines?: number;
+     /** Capture mouse events for viewport scrolling and application-owned text selection. */
+     mouse?: boolean;
++    /** Enable the built-in transcript-search keybindings. Defaults to true. */
++    transcriptSearch?: boolean;
+     /** Style a non-current transcript search match. */
+     searchMatchStyle?: (text: string) => string;
+     /** Style the current transcript search match. */
+@@ -52,6 +54,7 @@ export declare class TuiAltScreen extends TuiBase implements ViewportTUI {
+     private selectionDragged;
+     private readonly wheelScrollLines;
+     private readonly mouseEnabled;
++    private readonly transcriptSearchEnabled;
+     private readonly searchMatchStyle;
+     private readonly searchCurrentMatchStyle;
+     private readonly openUrl?;
+diff --git a/dist/tui-alt-screen.js b/dist/tui-alt-screen.js
+index 4edcf845ba7866782a8ec7219508a2dce0073a91..3aecee4ed79adc5a0586fb6d8a95364e31966f09 100644
+--- a/dist/tui-alt-screen.js
++++ b/dist/tui-alt-screen.js
+@@ -59,6 +59,7 @@ export class TuiAltScreen extends TuiBase {
+     selectionDragged = false;
+     wheelScrollLines;
+     mouseEnabled;
++    transcriptSearchEnabled;
+     searchMatchStyle;
+     searchCurrentMatchStyle;
+     openUrl;
+@@ -77,6 +78,7 @@ export class TuiAltScreen extends TuiBase {
+         this.flashes = new AltScreenFlashContainer(() => this.requestRender());
+         this.wheelScrollLines = Math.max(1, Math.floor(options.wheelScrollLines ?? 1));
+         this.mouseEnabled = options.mouse ?? true;
++        this.transcriptSearchEnabled = options.transcriptSearch ?? true;
+         this.searchMatchStyle = options.searchMatchStyle ?? ((text) => `\x1b[4m${text}\x1b[24m`);
+         this.searchCurrentMatchStyle = options.searchCurrentMatchStyle ?? ((text) => `\x1b[1;7m${text}\x1b[22;27m`);
+         this.openUrl = options.openUrl;
+@@ -423,7 +425,7 @@ export class TuiAltScreen extends TuiBase {
+             return { consume: true };
+         const keybindings = getKeybindings();
+         const isRelease = isKeyRelease(data);
+-        if (keybindings.matches(data, "tui.altScreen.search")) {
++        if (this.transcriptSearchEnabled && keybindings.matches(data, "tui.altScreen.search")) {
+             if (!isRelease)
+                 this.openSearch();
+             return { consume: true };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@earendil-works/pi-tui@0.84.2': f33849d493f144b07d5be1bd0d81adc4cb6017e215e6877e82ed331eb6fe7024
+  '@earendil-works/pi-tui@0.84.2': 18a5c3b8651757b10d3ad14bbe6db95f4506c3974331a7543d4340af77d48999
 
 importers:
 
@@ -52,7 +52,7 @@ importers:
         version: link:../../packages/presentation
       '@earendil-works/pi-tui':
         specifier: 0.84.2
-        version: 0.84.2(patch_hash=f33849d493f144b07d5be1bd0d81adc4cb6017e215e6877e82ed331eb6fe7024)
+        version: 0.84.2(patch_hash=18a5c3b8651757b10d3ad14bbe6db95f4506c3974331a7543d4340af77d48999)
       highlight.js:
         specifier: 11.11.1
         version: 11.11.1
@@ -1338,7 +1338,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.8':
     optional: true
 
-  '@earendil-works/pi-tui@0.84.2(patch_hash=f33849d493f144b07d5be1bd0d81adc4cb6017e215e6877e82ed331eb6fe7024)':
+  '@earendil-works/pi-tui@0.84.2(patch_hash=18a5c3b8651757b10d3ad14bbe6db95f4506c3974331a7543d4340af77d48999)':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5


### PR DESCRIPTION
## Summary

- disable the inherited Pi transcript-search chord only for Adam while preserving dependency defaults and Help behavior
- stop the TUI with explicit screen preservation so Ctrl+Q, /exit, confirmed idle Ctrl+C, SIGHUP, and SIGTERM do not repaint private Adam content after alternate-screen exit
- add caller-visible virtual-terminal and real-PTY regression contracts

## Verification

- pnpm test:tui:behavior (193 passed)
- pnpm test:tui:os under real host authority (28 passed)
- pnpm quality:check (51 files passed, 2 opt-in skipped; 1347 tests passed, 13 opt-in skipped)
- independent Standards review: no hard violations; duplicated assertion helper finding fixed
- independent Spec review: transcript-row existence assertion finding fixed