### PR TITLE
feat(agent): add bounded repository search

### DIFF
--- a/apps/tui/src/fixture-scenario.ts
+++ b/apps/tui/src/fixture-scenario.ts
@@ -37,6 +37,7 @@ export const fixtureScenarios = [
   "review-operation-long-provenance",
   "review-recovery",
   "review-unavailable",
+  "search",
   "resume",
   "session-selection-history",
   "shell",

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -313,22 +313,32 @@ test("real PTY streams Ctrl+T reasoning and restores application mouse modes on 
       stateRoot,
       workspaceRoot,
     });
+    console.error("[DEBUG-s3r0-pty] fixture-started");
     await fixture.waitFor("Adam · New session");
+    console.error("[DEBUG-s3r0-pty] initial-frame");
     fixture.write("Exercise PTY reasoning\r");
     await waitForPath(join(controlRoot, "model-started"));
+    console.error("[DEBUG-s3r0-pty] model-started");
     await fixture.waitFor("Thinking · provider reasoning · adam");
+    console.error("[DEBUG-s3r0-pty] reasoning-card");
     fixture.write("\u0014");
     await fixture.waitFor("Inspect ");
+    console.error("[DEBUG-s3r0-pty] first-reasoning-delta");
     await writeFile(join(controlRoot, "release-reasoning"), "release\n", "utf8");
     await fixture.waitFor("Inspect the evidence.");
+    console.error("[DEBUG-s3r0-pty] full-reasoning-delta");
     const beforeAnswer = fixture.output().length;
     await writeFile(join(controlRoot, "release-model"), "release\n", "utf8");
     await waitForPath(join(controlRoot, "reasoning-session-settled"));
+    console.error("[DEBUG-s3r0-pty] session-settled");
     await fixture.waitForCompleteFrameAfter(" · idle", beforeAnswer);
+    console.error("[DEBUG-s3r0-pty] idle-frame");
     fixture.write("\u001b[F");
     await fixture.waitForCompleteFrameAfter("Reasoning answer.", beforeAnswer);
+    console.error("[DEBUG-s3r0-pty] answer-frame");
     fixture.write("\u0011");
     const result = await fixture.closed;
+    console.error("[DEBUG-s3r0-pty] child-closed");
 
     expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
     expect(result.stdout).toContain("\u001b[?2004h");

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -313,32 +313,22 @@ test("real PTY streams Ctrl+T reasoning and restores application mouse modes on 
       stateRoot,
       workspaceRoot,
     });
-    console.error("[DEBUG-s3r0-pty] fixture-started");
     await fixture.waitFor("Adam · New session");
-    console.error("[DEBUG-s3r0-pty] initial-frame");
     fixture.write("Exercise PTY reasoning\r");
     await waitForPath(join(controlRoot, "model-started"));
-    console.error("[DEBUG-s3r0-pty] model-started");
     await fixture.waitFor("Thinking · provider reasoning · adam");
-    console.error("[DEBUG-s3r0-pty] reasoning-card");
     fixture.write("\u0014");
     await fixture.waitFor("Inspect ");
-    console.error("[DEBUG-s3r0-pty] first-reasoning-delta");
     await writeFile(join(controlRoot, "release-reasoning"), "release\n", "utf8");
     await fixture.waitFor("Inspect the evidence.");
-    console.error("[DEBUG-s3r0-pty] full-reasoning-delta");
     const beforeAnswer = fixture.output().length;
     await writeFile(join(controlRoot, "release-model"), "release\n", "utf8");
     await waitForPath(join(controlRoot, "reasoning-session-settled"));
-    console.error("[DEBUG-s3r0-pty] session-settled");
     await fixture.waitForCompleteFrameAfter(" · idle", beforeAnswer);
-    console.error("[DEBUG-s3r0-pty] idle-frame");
     fixture.write("\u001b[F");
     await fixture.waitForCompleteFrameAfter("Reasoning answer.", beforeAnswer);
-    console.error("[DEBUG-s3r0-pty] answer-frame");
     fixture.write("\u0011");
     const result = await fixture.closed;
-    console.error("[DEBUG-s3r0-pty] child-closed");
 
     expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
     expect(result.stdout).toContain("\u001b[?2004h");

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -5534,6 +5534,29 @@ test("a real read tool is rendered as a bounded Pi-style tool card", async () =>
   }
 });
 
+test("a real repository search is rendered as one bounded read-like tool card", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-search-tool-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "alpha.ts"), "export const orchard = 1;\n", "utf8");
+  await writeFile(join(workspaceRoot, "beta.ts"), "export const orchard = 2;\n", "utf8");
+
+  try {
+    const fixture = startFixture({ noColor: true, scenario: "search", stateRoot, workspaceRoot });
+    await fixture.waitForCompleteFrameAfter("Adam · New session", 0);
+    await fixture.waitForCompleteFrameAfter(" · idle", 0);
+    fixture.write("Search orchard\r");
+    await fixture.waitFor("Search complete.");
+    expect(fixture.output()).toContain("search .");
+    expect(fixture.output()).toContain("2 results");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("Kitty Ctrl+O repeat and release phases toggle bounded tool details only once", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-tool-details-"));
   const workspaceRoot = join(testRoot, "workspace");

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -4587,6 +4587,7 @@ test.each(["missing", "truncated", "same-size corrupt"] as const)(
       fixture.write("Recover one unavailable reasoning range\r");
       await fixture.waitForCompleteFrameAfter("Thinking done · adam", beforePrompt);
       await waitForPath(join(controlRoot, "reasoning-session-settled"));
+      await fixture.waitFor("Adam · Streaming session");
       const artifactRoot = join(stateRoot, "artifacts");
       const artifactRelativePaths = (await readdir(artifactRoot, { recursive: true })).filter(
         (path): path is string => typeof path === "string" && !path.endsWith(".tmp"),

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -1041,6 +1041,20 @@ function createFixtureModelTargets(options: {
           return;
         }
         yield { type: "text_delta", text: "Read complete." };
+      } else if (options.scenario === "search") {
+        const latest = request.messages.at(-1);
+        if (latest?.role === "user") {
+          yield { type: "tool_call_start", id: "search-repository", name: "search_repository" };
+          yield {
+            type: "tool_call_delta",
+            id: "search-repository",
+            json: '{"kind":"content","query":"orchard"}',
+          };
+          yield { type: "tool_call_end", id: "search-repository" };
+          yield { type: "finish", reason: "tool_calls" };
+          return;
+        }
+        yield { type: "text_delta", text: "Search complete." };
       } else if (options.scenario === "tool-multiple") {
         const latest = request.messages.at(-1);
         if (latest?.role === "user") {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -21,6 +21,7 @@
     "@ai-sdk/provider": "4.0.7",
     "@biomejs/biome": "2.5.8",
     "@modelcontextprotocol/client": "2.0.0",
+    "@vscode/ripgrep": "1.18.0",
     "jpeg-js": "0.4.4",
     "npm": "11.6.2",
     "openai": "7.4.0",

--- a/packages/agent/src/agent-session.ts
+++ b/packages/agent/src/agent-session.ts
@@ -145,6 +145,7 @@ export type AgentSessionDependencies = AgentSessionBaseDependencies &
   );
 
 export class AgentSession {
+  readonly #runtimeSessionId = randomUUID();
   readonly #listeners = new Set<RuntimeEventListener>();
   readonly #notificationListeners = new Set<RuntimeEventNotificationListener>();
   #nextNotification = 1;
@@ -232,7 +233,7 @@ export class AgentSession {
     const durablePromptContext = this.#durableContext?.promptContext;
     const selectedToolNames =
       durablePromptContext === undefined
-        ? ["read_file", "write_file", "edit_file", "run_shell"]
+        ? ["read_file", "search_repository", "write_file", "edit_file", "run_shell"]
         : durablePromptContext.toolProfile.definitions.map((definition) => definition.name);
     this.#tools =
       this.#durableContext !== undefined && durablePromptContext === undefined
@@ -1945,7 +1946,13 @@ export class AgentSession {
     if (adapter === undefined) {
       const result: ToolResult = {
         status: "failed",
-        error: { code: "unknown_tool", message: `Unknown tool: ${call.name}` },
+        error: {
+          code: "unknown_tool",
+          message:
+            call.name === "search_repository"
+              ? "Repository search is unavailable in this historical Tool Profile. Start a new session to use search_repository."
+              : `Unknown tool: ${call.name}`,
+        },
       };
       toolResultsById.set(call.id, { call, result });
       await this.#appendToolResult(messages, call, result);
@@ -2129,16 +2136,21 @@ export class AgentSession {
     if (signal.aborted) {
       return this.#settleCancelled();
     }
+    const executionContext = {
+      signal,
+      callId: call.id,
+      toolName: call.name,
+      sessionId: this.#durableContext?.sessionId ?? this.#runtimeSessionId,
+      toolProfileDigest: this.#promptContext?.toolProfile.digest ?? "prompt-profile-v0",
+    } as const;
     const result =
       call.name === "activate_skill"
         ? await this.#activateModelSelectedSkill(call)
         : call.name === "read_skill_resource"
           ? await this.#readSkillResource(call)
           : call.name === "read_input_resource"
-            ? await this.#readInputResource(call, () =>
-                preparedCall.execute({ signal, callId: call.id, toolName: call.name }),
-              )
-            : await preparedCall.execute({ signal, callId: call.id, toolName: call.name });
+            ? await this.#readInputResource(call, () => preparedCall.execute(executionContext))
+            : await preparedCall.execute(executionContext);
     toolResultsById.set(call.id, { call, result });
     await this.#appendToolResult(messages, call, result);
     if (result.status === "failed" && result.error.code === "tool_effect_indeterminate") {
@@ -2621,7 +2633,10 @@ export class AgentSession {
     if (
       context === undefined ||
       workspaceRoot === undefined ||
-      (call.name !== "read_file" && call.name !== "write_file" && call.name !== "edit_file")
+      (call.name !== "read_file" &&
+        call.name !== "search_repository" &&
+        call.name !== "write_file" &&
+        call.name !== "edit_file")
     ) {
       return undefined;
     }
@@ -2694,7 +2709,7 @@ export class AgentSession {
     if (runId === undefined) {
       throw new TypeError("Repository activation requires one active run.");
     }
-    const mutation = call.name !== "read_file";
+    const mutation = call.name !== "read_file" && call.name !== "search_repository";
     await this.#appendRecord({
       schemaVersion: 3,
       sequence: this.#nextSequence,
@@ -2797,7 +2812,7 @@ export class AgentSession {
           trigger: {
             runId,
             callId: call.id,
-            name: call.name as "read_file" | "write_file" | "edit_file",
+            name: call.name as "read_file" | "search_repository" | "write_file" | "edit_file",
             argumentsDigest: `sha256:${createHash("sha256")
               .update(call.argumentsJson, "utf8")
               .digest("hex")}`,
@@ -2814,7 +2829,7 @@ export class AgentSession {
       | PromptContextRecordV2
       | PromptContextRecordV3;
     nextPromptContext = replacePromptSkillsV2(nextPromptContext, nextSkillContext);
-    const mutation = call.name !== "read_file";
+    const mutation = call.name !== "read_file" && call.name !== "search_repository";
     await this.#appendRecord({
       schemaVersion: 3,
       sequence: this.#nextSequence,
@@ -2831,7 +2846,7 @@ export class AgentSession {
         trigger: {
           runId,
           callId: call.id,
-          name: call.name as "read_file" | "write_file" | "edit_file",
+          name: call.name as "read_file" | "search_repository" | "write_file" | "edit_file",
           argumentsDigest: `sha256:${createHash("sha256")
             .update(call.argumentsJson, "utf8")
             .digest("hex")}`,

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -60,6 +60,13 @@ export {
   digestPromptRequestV1,
 } from "./prompt-assembly.js";
 export {
+  createRepositorySearchToolAdapter as createRepositorySearchToolAdapterForTesting,
+  type RepositorySearchBackend,
+  type RepositorySearchBackendBudget,
+  type RepositorySearchProcessObserver,
+  repositorySearchBackendForTesting,
+} from "./repository-search.js";
+export {
   createPresentationPreferencesWithStorageForTesting,
   createTrustedWorkspaceTrustForTesting,
   createWorkspaceTrustWithStorageForTesting,

--- a/packages/agent/src/presentation-tool-projection.ts
+++ b/packages/agent/src/presentation-tool-projection.ts
@@ -357,7 +357,7 @@ function presentationChangePreviewRef(
 }
 
 function toolKind(name: string): ToolCallDisplay["kind"] {
-  if (name === "read_file") {
+  if (name === "read_file" || name === "search_repository") {
     return "read";
   }
   if (name === "run_shell") {
@@ -372,13 +372,15 @@ function toolKind(name: string): ToolCallDisplay["kind"] {
 function toolLabel(name: string): string {
   return name === "read_file"
     ? "read"
-    : name === "run_shell"
-      ? "shell"
-      : name === "write_file"
-        ? "write"
-        : name === "edit_file"
-          ? "edit"
-          : name;
+    : name === "search_repository"
+      ? "search"
+      : name === "run_shell"
+        ? "shell"
+        : name === "write_file"
+          ? "write"
+          : name === "edit_file"
+            ? "edit"
+            : name;
 }
 
 function safeToolSubject(
@@ -401,6 +403,7 @@ function safeToolSubject(
 
 function toolResultSummary(name: string, output: JsonValue | undefined): string | null {
   const outputRecord = jsonRecord(output);
+  const { resultCount } = outputRecord ?? {};
   if (name === "read_file" && typeof outputRecord?.content === "string") {
     return `${Buffer.byteLength(outputRecord.content, "utf8")} bytes${
       outputRecord.truncated === true ? " · output truncated" : ""
@@ -429,6 +432,9 @@ function toolResultSummary(name: string, output: JsonValue | undefined): string 
         outputTruncated ? " · output truncated" : ""
       }`;
     }
+  }
+  if (name === "search_repository" && typeof resultCount === "number") {
+    return `${resultCount} ${resultCount === 1 ? "result" : "results"}`;
   }
   if (name.startsWith("mcp__")) {
     const content = outputRecord?.content;

--- a/packages/agent/src/repository-search.ts
+++ b/packages/agent/src/repository-search.ts
@@ -852,6 +852,8 @@ async function runContentSearch(options: {
   readonly omissions: readonly z.infer<typeof omissionSchema>[];
 }> {
   const args = [
+    "--no-config",
+    "--no-require-git",
     "--json",
     ...(options.mode === "literal" ? ["--fixed-strings"] : []),
     ...(options.case === "smart"
@@ -951,6 +953,8 @@ async function runPathSearch(options: {
   });
   await options.backend.runRecords({
     args: [
+      "--no-config",
+      "--no-require-git",
       "--files",
       "--null",
       ...(options.mode === "glob" ? ["--glob", options.query] : []),

--- a/packages/agent/src/repository-search.ts
+++ b/packages/agent/src/repository-search.ts
@@ -1,0 +1,1836 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { constants, lstatSync, realpathSync } from "node:fs";
+import { lstat, open } from "node:fs/promises";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import { StringDecoder } from "node:string_decoder";
+
+import { rgPath } from "@vscode/ripgrep";
+import { z } from "zod";
+
+import type { ToolAdapter } from "./tool-runtime.js";
+
+const searchPolicyVersion = "search-repository.v1" as const;
+const maximumPageBytes = 16 * 1024;
+const maximumContentResults = 50;
+const defaultContentResults = 20;
+const defaultPathResults = 30;
+const maximumMatchesPerFilePerPage = 5;
+const maximumSnippetCharacters = 500;
+const binaryProbeBytes = 8 * 1_024;
+const maximumSnapshots = 8;
+const maximumAggregateSnapshotBytes = 16 * 1024 * 1024;
+const maximumSnapshotBytes = 4 * 1024 * 1024;
+const maximumSnapshotResults = 4_096;
+const maximumRankedCandidates = 16_384;
+const maximumRawParsedBytes = 64 * 1_024 * 1_024;
+const maximumRawRecords = 100_000;
+const maximumWorkRecords = 200_000;
+const snapshotIdleMilliseconds = 10 * 60 * 1_000;
+const searchProcessTerminationGraceMilliseconds = 100;
+const searchGlobSchema = z
+  .string()
+  .min(1)
+  .max(512)
+  .refine((value) => !value.includes("\0") && !value.startsWith("!"));
+
+const searchRepositoryInputSchema = z.discriminatedUnion("kind", [
+  z.strictObject({
+    kind: z.literal("content"),
+    query: z.string().min(1).max(4_096),
+    mode: z.enum(["literal", "regex"]).optional(),
+    case: z.enum(["smart", "sensitive", "insensitive"]).optional(),
+    include: z.array(searchGlobSchema).max(16).optional(),
+    exclude: z.array(searchGlobSchema).max(16).optional(),
+    context: z.number().int().min(0).max(3).optional(),
+    path: z.string().min(1).max(4_096).optional(),
+    limit: z.number().int().min(1).max(maximumContentResults).optional(),
+    cursor: z.string().min(1).max(1_024).optional(),
+  }),
+  z.strictObject({
+    kind: z.literal("path"),
+    query: z.string().min(1).max(4_096),
+    mode: z.enum(["fuzzy", "glob"]).optional(),
+    path: z.string().min(1).max(4_096).optional(),
+    limit: z.number().int().min(1).max(maximumContentResults).optional(),
+    cursor: z.string().min(1).max(1_024).optional(),
+  }),
+]);
+
+const contextLineSchema = z.strictObject({
+  line: z.number().int().positive(),
+  snippet: z.string().max(maximumSnippetCharacters),
+});
+const contentMatchSchema = z.strictObject({
+  line: z.number().int().positive(),
+  column: z.number().int().positive(),
+  snippet: z.string().max(maximumSnippetCharacters),
+  rankReason: z.enum(["literal", "regex"]),
+  contextBefore: z.array(contextLineSchema).max(3),
+  contextAfter: z.array(contextLineSchema).max(3),
+});
+const contentGroupSchema = z.strictObject({
+  path: z.string(),
+  matches: z.array(contentMatchSchema).max(maximumMatchesPerFilePerPage),
+});
+const pathEntrySchema = z.strictObject({
+  path: z.string(),
+  rankReason: z.enum([
+    "exact_basename",
+    "prefix_basename",
+    "literal_substring",
+    "all_tokens",
+    "fuzzy_subsequence",
+    "glob",
+  ]),
+});
+const omissionSchema = z.strictObject({
+  reason: z.enum([
+    "page_limit",
+    "page_byte_limit",
+    "per_file_page_limit",
+    "snapshot_result_limit",
+    "ranked_candidate_limit",
+    "binary",
+    "non_ordinary",
+    "unreadable",
+    "changed",
+  ]),
+  path: z.string(),
+  count: z.number().int().positive(),
+});
+const contentSearchOutputShape = {
+  schemaVersion: z.literal(1),
+  policyVersion: z.literal(searchPolicyVersion),
+  kind: z.literal("content"),
+  mode: z.enum(["literal", "regex"]),
+  case: z.enum(["smart", "sensitive", "insensitive"]),
+  context: z.number().int().min(0).max(3),
+  query: z.string(),
+  path: z.string(),
+  resultCount: z.number().int().nonnegative().max(maximumContentResults),
+  snapshotResultCount: z.number().int().nonnegative().max(maximumSnapshotResults),
+  pageIndex: z.number().int().nonnegative(),
+  remainingResultCount: z.number().int().nonnegative().max(maximumSnapshotResults),
+  currentContentMustBeReread: z.literal(true),
+  groups: z.array(contentGroupSchema),
+  omissions: z.array(omissionSchema),
+} as const;
+const pathSearchOutputShape = {
+  schemaVersion: z.literal(1),
+  policyVersion: z.literal(searchPolicyVersion),
+  kind: z.literal("path"),
+  mode: z.enum(["fuzzy", "glob"]),
+  query: z.string(),
+  path: z.string(),
+  resultCount: z.number().int().nonnegative().max(maximumContentResults),
+  snapshotResultCount: z.number().int().nonnegative().max(maximumSnapshotResults),
+  pageIndex: z.number().int().nonnegative(),
+  remainingResultCount: z.number().int().nonnegative().max(maximumSnapshotResults),
+  currentContentMustBeReread: z.literal(true),
+  entries: z.array(pathEntrySchema),
+  omissions: z.array(omissionSchema),
+} as const;
+const repositorySearchOutputSchema = z.union([
+  z.strictObject(contentSearchOutputShape),
+  z.strictObject({ ...contentSearchOutputShape, nextCursor: z.string().max(1_024) }),
+  z.strictObject(pathSearchOutputShape),
+  z.strictObject({ ...pathSearchOutputShape, nextCursor: z.string().max(1_024) }),
+]);
+
+type ContentMatch = z.infer<typeof contentMatchSchema>;
+type RankedContentMatch = ContentMatch & { readonly path: string };
+type ContentPage = {
+  readonly matches: readonly RankedContentMatch[];
+  readonly omissions: readonly z.infer<typeof omissionSchema>[];
+};
+type PathEntry = z.infer<typeof pathEntrySchema>;
+type PathPage = {
+  readonly entries: readonly PathEntry[];
+  readonly omissions: readonly z.infer<typeof omissionSchema>[];
+};
+type SearchSnapshotBase = {
+  readonly id: string;
+  readonly sessionId: string;
+  readonly toolProfileDigest: string;
+  readonly requestKey: string;
+  readonly query: string;
+  readonly path: string;
+  readonly resultCount: number;
+  readonly byteCount: number;
+  lastAccessedAt: number;
+  lastAccessOrder: number;
+};
+type ContentSearchSnapshot = SearchSnapshotBase & {
+  readonly kind: "content";
+  readonly mode: "literal" | "regex";
+  readonly case: "smart" | "sensitive" | "insensitive";
+  readonly context: number;
+  readonly pages: readonly ContentPage[];
+};
+type PathSearchSnapshot = SearchSnapshotBase & {
+  readonly kind: "path";
+  readonly mode: "fuzzy" | "glob";
+  readonly pages: readonly PathPage[];
+};
+type SearchSnapshot = ContentSearchSnapshot | PathSearchSnapshot;
+
+class BoundedBestCandidates<T> {
+  readonly #values: T[] = [];
+
+  constructor(
+    readonly limit: number,
+    readonly compare: (left: T, right: T) => number,
+  ) {}
+
+  add(value: T) {
+    if (this.#values.length < this.limit) {
+      this.#values.push(value);
+      this.#bubbleUp(this.#values.length - 1);
+      return;
+    }
+    const worst = this.#values[0];
+    if (worst === undefined || this.compare(value, worst) >= 0) {
+      return;
+    }
+    this.#values[0] = value;
+    this.#bubbleDown(0);
+  }
+
+  sorted(): readonly T[] {
+    return [...this.#values].sort(this.compare);
+  }
+
+  #bubbleUp(start: number) {
+    let index = start;
+    while (index > 0) {
+      const parent = Math.floor((index - 1) / 2);
+      const value = this.#values[index];
+      const parentValue = this.#values[parent];
+      if (
+        value === undefined ||
+        parentValue === undefined ||
+        this.compare(value, parentValue) <= 0
+      ) {
+        return;
+      }
+      this.#values[index] = parentValue;
+      this.#values[parent] = value;
+      index = parent;
+    }
+  }
+
+  #bubbleDown(start: number) {
+    let index = start;
+    while (true) {
+      const left = index * 2 + 1;
+      const right = left + 1;
+      let worst = index;
+      if (
+        left < this.#values.length &&
+        this.compare(this.#values[left] as T, this.#values[worst] as T) > 0
+      ) {
+        worst = left;
+      }
+      if (
+        right < this.#values.length &&
+        this.compare(this.#values[right] as T, this.#values[worst] as T) > 0
+      ) {
+        worst = right;
+      }
+      if (worst === index) {
+        return;
+      }
+      const value = this.#values[index] as T;
+      this.#values[index] = this.#values[worst] as T;
+      this.#values[worst] = value;
+      index = worst;
+    }
+  }
+}
+
+class SearchCursorError extends Error {
+  constructor(
+    readonly code: "search_cursor_invalid" | "search_cursor_stale" | "search_quota_exceeded",
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+class SearchRequestBudget {
+  #rawBytes = 0;
+  #workRecords = 0;
+
+  consumeRawBytes(byteCount: number) {
+    this.#rawBytes += byteCount;
+    if (this.#rawBytes > maximumRawParsedBytes) {
+      throw new SearchCursorError(
+        "search_quota_exceeded",
+        "Repository search exceeded the aggregate raw parsed byte limit.",
+      );
+    }
+  }
+
+  consumeWorkRecord() {
+    this.#workRecords += 1;
+    if (this.#workRecords > maximumWorkRecords) {
+      throw new SearchCursorError(
+        "search_quota_exceeded",
+        "Repository search exceeded the aggregate parser work limit.",
+      );
+    }
+  }
+}
+
+class SearchSnapshotRegistry {
+  readonly #snapshots = new Map<string, SearchSnapshot>();
+  #aggregateBytes = 0;
+  #accessSequence = 0;
+
+  createContent(input: {
+    readonly sessionId: string;
+    readonly toolProfileDigest: string;
+    readonly requestKey: string;
+    readonly query: string;
+    readonly path: string;
+    readonly mode: "literal" | "regex";
+    readonly case: "smart" | "sensitive" | "insensitive";
+    readonly context: number;
+    readonly matches: readonly RankedContentMatch[];
+    readonly omissions: readonly z.infer<typeof omissionSchema>[];
+    readonly limit: number;
+  }) {
+    const boundedMatches = input.matches.slice(0, maximumSnapshotResults);
+    const pages = createContentPages(
+      boundedMatches,
+      input.limit,
+      input.matches.length,
+      input.omissions,
+    );
+    const byteCount = Buffer.byteLength(JSON.stringify(pages), "utf8");
+    if (byteCount > maximumSnapshotBytes) {
+      throw new SearchCursorError(
+        "search_quota_exceeded",
+        "The normalized repository search snapshot exceeded its byte limit.",
+      );
+    }
+    const now = Date.now();
+    this.#pruneExpired(now);
+    const snapshot: SearchSnapshot = {
+      id: randomUUID(),
+      sessionId: input.sessionId,
+      toolProfileDigest: input.toolProfileDigest,
+      requestKey: input.requestKey,
+      kind: "content",
+      query: input.query,
+      path: input.path,
+      mode: input.mode,
+      case: input.case,
+      context: input.context,
+      pages,
+      resultCount: boundedMatches.length,
+      byteCount,
+      lastAccessedAt: now,
+      lastAccessOrder: ++this.#accessSequence,
+    };
+    return this.#admit(snapshot);
+  }
+
+  createPath(input: {
+    readonly sessionId: string;
+    readonly toolProfileDigest: string;
+    readonly requestKey: string;
+    readonly query: string;
+    readonly path: string;
+    readonly mode: "fuzzy" | "glob";
+    readonly entries: readonly PathEntry[];
+    readonly omissions: readonly z.infer<typeof omissionSchema>[];
+    readonly limit: number;
+  }) {
+    const boundedEntries = input.entries.slice(0, maximumSnapshotResults);
+    const pages = createPathPages(
+      boundedEntries,
+      input.limit,
+      input.entries.length,
+      input.omissions,
+    );
+    const byteCount = Buffer.byteLength(JSON.stringify(pages), "utf8");
+    if (byteCount > maximumSnapshotBytes) {
+      throw new SearchCursorError(
+        "search_quota_exceeded",
+        "The normalized repository search snapshot exceeded its byte limit.",
+      );
+    }
+    const now = Date.now();
+    this.#pruneExpired(now);
+    const snapshot: PathSearchSnapshot = {
+      id: randomUUID(),
+      sessionId: input.sessionId,
+      toolProfileDigest: input.toolProfileDigest,
+      requestKey: input.requestKey,
+      kind: "path",
+      query: input.query,
+      path: input.path,
+      mode: input.mode,
+      pages,
+      resultCount: boundedEntries.length,
+      byteCount,
+      lastAccessedAt: now,
+      lastAccessOrder: ++this.#accessSequence,
+    };
+    return this.#admit(snapshot);
+  }
+
+  page(input: {
+    readonly cursor: string;
+    readonly sessionId: string;
+    readonly toolProfileDigest: string;
+    readonly requestKey: string;
+  }) {
+    const decoded = decodeCursor(input.cursor);
+    if (decoded === undefined) {
+      throw new SearchCursorError(
+        "search_cursor_invalid",
+        "The repository search cursor is malformed.",
+      );
+    }
+    const now = Date.now();
+    this.#pruneExpired(now);
+    const snapshot = this.#snapshots.get(decoded.snapshotId);
+    if (snapshot === undefined) {
+      throw new SearchCursorError(
+        "search_cursor_stale",
+        "The repository search snapshot is no longer available; start a new search.",
+      );
+    }
+    if (
+      snapshot.sessionId !== input.sessionId ||
+      snapshot.toolProfileDigest !== input.toolProfileDigest ||
+      snapshot.requestKey !== input.requestKey
+    ) {
+      throw new SearchCursorError(
+        "search_cursor_invalid",
+        "The repository search cursor does not match this session, Tool Profile, or request.",
+      );
+    }
+    if (decoded.pageIndex <= 0 || decoded.pageIndex >= snapshot.pages.length) {
+      throw new SearchCursorError(
+        "search_cursor_invalid",
+        "The repository search cursor page is invalid.",
+      );
+    }
+    snapshot.lastAccessedAt = now;
+    snapshot.lastAccessOrder = ++this.#accessSequence;
+    return this.#output(snapshot, decoded.pageIndex);
+  }
+
+  #output(snapshot: SearchSnapshot, pageIndex: number) {
+    const nextPageIndex = pageIndex + 1;
+    if (snapshot.kind === "path") {
+      const page = snapshot.pages[pageIndex] ?? { entries: [], omissions: [] };
+      const consumed = snapshot.pages
+        .slice(0, nextPageIndex)
+        .reduce((total, candidate) => total + candidate.entries.length, 0);
+      return {
+        schemaVersion: 1 as const,
+        policyVersion: searchPolicyVersion,
+        kind: "path" as const,
+        mode: snapshot.mode,
+        query: snapshot.query,
+        path: snapshot.path,
+        resultCount: page.entries.length,
+        snapshotResultCount: snapshot.resultCount,
+        pageIndex,
+        remainingResultCount: snapshot.resultCount - consumed,
+        ...(nextPageIndex < snapshot.pages.length
+          ? { nextCursor: encodeCursor(snapshot.id, nextPageIndex) }
+          : {}),
+        currentContentMustBeReread: true as const,
+        entries: page.entries,
+        omissions: page.omissions,
+      };
+    }
+    const page = snapshot.pages[pageIndex] ?? { matches: [], omissions: [] };
+    const consumed = snapshot.pages
+      .slice(0, nextPageIndex)
+      .reduce((total, candidate) => total + candidate.matches.length, 0);
+    const groups = new Map<string, ContentMatch[]>();
+    for (const { path, ...match } of page.matches) {
+      const grouped = groups.get(path) ?? [];
+      grouped.push(match);
+      groups.set(path, grouped);
+    }
+    return {
+      schemaVersion: 1 as const,
+      policyVersion: searchPolicyVersion,
+      kind: "content" as const,
+      mode: snapshot.mode,
+      case: snapshot.case,
+      context: snapshot.context,
+      query: snapshot.query,
+      path: snapshot.path,
+      resultCount: page.matches.length,
+      snapshotResultCount: snapshot.resultCount,
+      pageIndex,
+      remainingResultCount: snapshot.resultCount - consumed,
+      ...(nextPageIndex < snapshot.pages.length
+        ? { nextCursor: encodeCursor(snapshot.id, nextPageIndex) }
+        : {}),
+      currentContentMustBeReread: true as const,
+      groups: [...groups].map(([path, matches]) => ({ path, matches })),
+      omissions: page.omissions,
+    };
+  }
+
+  #admit(snapshot: SearchSnapshot) {
+    while (
+      this.#snapshots.size >= maximumSnapshots ||
+      this.#aggregateBytes + snapshot.byteCount > maximumAggregateSnapshotBytes
+    ) {
+      if (!this.#evictLeastRecentlyUsed()) {
+        break;
+      }
+    }
+    if (this.#aggregateBytes + snapshot.byteCount > maximumAggregateSnapshotBytes) {
+      throw new SearchCursorError(
+        "search_quota_exceeded",
+        "The repository search snapshot registry is full.",
+      );
+    }
+    for (let pageIndex = 0; pageIndex < snapshot.pages.length; pageIndex += 1) {
+      if (
+        Buffer.byteLength(JSON.stringify(this.#output(snapshot, pageIndex)), "utf8") >
+        maximumPageBytes
+      ) {
+        throw new SearchCursorError(
+          "search_quota_exceeded",
+          "The repository search page metadata exceeded its UTF-8 byte limit.",
+        );
+      }
+    }
+    this.#snapshots.set(snapshot.id, snapshot);
+    this.#aggregateBytes += snapshot.byteCount;
+    return this.#output(snapshot, 0);
+  }
+
+  #pruneExpired(now: number) {
+    for (const snapshot of this.#snapshots.values()) {
+      if (now - snapshot.lastAccessedAt >= snapshotIdleMilliseconds) {
+        this.#delete(snapshot.id);
+      }
+    }
+  }
+
+  #evictLeastRecentlyUsed(): boolean {
+    const oldest = [...this.#snapshots.values()].sort(
+      (left, right) =>
+        left.lastAccessOrder - right.lastAccessOrder ||
+        (left.id < right.id ? -1 : left.id > right.id ? 1 : 0),
+    )[0];
+    if (oldest === undefined) {
+      return false;
+    }
+    this.#delete(oldest.id);
+    return true;
+  }
+
+  #delete(snapshotId: string) {
+    const snapshot = this.#snapshots.get(snapshotId);
+    if (snapshot === undefined) {
+      return;
+    }
+    this.#snapshots.delete(snapshotId);
+    this.#aggregateBytes -= snapshot.byteCount;
+  }
+}
+
+export function createRepositorySearchToolAdapter(options: {
+  readonly workspaceRoot: string;
+  readonly processObserver?: RepositorySearchProcessObserver;
+  readonly rgPathOverrideForTesting?: string;
+  readonly backendForTesting?: RepositorySearchBackend;
+}): Omit<ToolAdapter, "definitionDigest" | "replay"> {
+  const workspaceRoot = resolve(options.workspaceRoot);
+  const snapshots = new SearchSnapshotRegistry();
+  const backend =
+    options.backendForTesting ??
+    createProcessRepositorySearchBackend({
+      rgExecutablePath: options.rgPathOverrideForTesting ?? rgPath,
+      ...(options.processObserver === undefined
+        ? {}
+        : { processObserver: options.processObserver }),
+    });
+  return {
+    definition: {
+      name: "search_repository",
+      description:
+        "Search repository content or paths with search-repository.v1. Results use ignore/hidden/symlink and 8 KiB binary rules, deterministic relevance plus same-tier Git ranking, at most 50 results per 16 KiB page, and runtime-local immutable cursors bounded to 8 live snapshots, 16 MiB aggregate, 4,096 results and 4 MiB each, 16,384 ranked candidates, 64 MiB raw bytes, 100,000 raw records, 200,000 work records, and 10 minutes idle. Results are discovery evidence; reread current content with read_file before relying on it.",
+      inputSchema: z.toJSONSchema(searchRepositoryInputSchema),
+    },
+    outputSchema: repositorySearchOutputSchema,
+    effect: "read",
+    cancellation: "abort_signal",
+    maximumResult: { maximumBytes: maximumPageBytes },
+    prepare(argumentsJson) {
+      const parsedArguments = searchRepositoryInputSchema.safeParse(parseJson(argumentsJson));
+      if (!parsedArguments.success) {
+        return invalidInput();
+      }
+      const requestedPath = parsedArguments.data.path ?? ".";
+      if (isAbsolute(requestedPath)) {
+        return outsideWorkspace();
+      }
+      let canonicalWorkspaceRoot: string;
+      try {
+        canonicalWorkspaceRoot = realpathSync(workspaceRoot);
+      } catch {
+        return {
+          status: "failed",
+          error: {
+            code: "tool_io_failed",
+            message: "The canonical workspace root is unavailable.",
+          },
+        };
+      }
+      const absolutePath = resolve(canonicalWorkspaceRoot, requestedPath);
+      if (
+        absolutePath !== canonicalWorkspaceRoot &&
+        !absolutePath.startsWith(`${canonicalWorkspaceRoot}${sep}`)
+      ) {
+        return outsideWorkspace();
+      }
+      const normalizedPath =
+        relative(canonicalWorkspaceRoot, absolutePath).split(sep).join("/") || ".";
+      if (hasHiddenPathComponent(normalizedPath)) {
+        return outsideWorkspace();
+      }
+      let instructionScopePath = ".";
+      try {
+        const requestedStat = lstatSync(absolutePath);
+        if (
+          requestedStat.isSymbolicLink() ||
+          (!requestedStat.isDirectory() && !requestedStat.isFile()) ||
+          realpathSync(absolutePath) !== absolutePath
+        ) {
+          return outsideWorkspace();
+        }
+        instructionScopePath = requestedStat.isDirectory()
+          ? normalizedPath === "."
+            ? "."
+            : `${normalizedPath}/.`
+          : normalizedPath;
+      } catch {
+        // An absent explicit path activates only the already eager root scope.
+      }
+      return {
+        status: "ready",
+        permissionSubject: { type: "workspace_path", path: instructionScopePath },
+        async execute(context) {
+          context.signal.throwIfAborted();
+          try {
+            const requestKey = JSON.stringify({
+              kind: parsedArguments.data.kind,
+              query: parsedArguments.data.query,
+              mode:
+                parsedArguments.data.mode ??
+                (parsedArguments.data.kind === "content" ? "literal" : "fuzzy"),
+              ...(parsedArguments.data.kind === "content"
+                ? {
+                    case: parsedArguments.data.case ?? "smart",
+                    include: parsedArguments.data.include ?? [],
+                    exclude: parsedArguments.data.exclude ?? [],
+                    context: parsedArguments.data.context ?? 0,
+                  }
+                : {}),
+              path: normalizedPath,
+              limit:
+                parsedArguments.data.limit ??
+                (parsedArguments.data.kind === "content"
+                  ? defaultContentResults
+                  : defaultPathResults),
+            });
+            if (parsedArguments.data.kind === "path") {
+              if (parsedArguments.data.cursor !== undefined) {
+                return {
+                  status: "completed",
+                  output: snapshots.page({
+                    cursor: parsedArguments.data.cursor,
+                    sessionId: context.sessionId,
+                    toolProfileDigest: context.toolProfileDigest,
+                    requestKey,
+                  }),
+                };
+              }
+              const budget = new SearchRequestBudget();
+              const mode = parsedArguments.data.mode ?? "fuzzy";
+              const searchResult = await runPathSearch({
+                workspaceRoot: canonicalWorkspaceRoot,
+                path: normalizedPath,
+                query: parsedArguments.data.query,
+                mode,
+                signal: context.signal,
+                budget,
+                backend,
+              });
+              const limit = parsedArguments.data.limit ?? defaultPathResults;
+              return {
+                status: "completed",
+                output: snapshots.createPath({
+                  sessionId: context.sessionId,
+                  toolProfileDigest: context.toolProfileDigest,
+                  requestKey,
+                  query: parsedArguments.data.query,
+                  path: normalizedPath,
+                  mode,
+                  entries: searchResult.entries,
+                  omissions: searchResult.omissions,
+                  limit,
+                }),
+              };
+            }
+            const budget = new SearchRequestBudget();
+            if (parsedArguments.data.cursor !== undefined) {
+              return {
+                status: "completed",
+                output: snapshots.page({
+                  cursor: parsedArguments.data.cursor,
+                  sessionId: context.sessionId,
+                  toolProfileDigest: context.toolProfileDigest,
+                  requestKey,
+                }),
+              };
+            }
+            const searchResult = await runContentSearch({
+              workspaceRoot: canonicalWorkspaceRoot,
+              path: normalizedPath,
+              query: parsedArguments.data.query,
+              mode: parsedArguments.data.mode ?? "literal",
+              case: parsedArguments.data.case ?? "smart",
+              include: parsedArguments.data.include ?? [],
+              exclude: parsedArguments.data.exclude ?? [],
+              context: parsedArguments.data.context ?? 0,
+              signal: context.signal,
+              budget,
+              backend,
+            });
+            context.signal.throwIfAborted();
+            return {
+              status: "completed",
+              output: snapshots.createContent({
+                sessionId: context.sessionId,
+                toolProfileDigest: context.toolProfileDigest,
+                requestKey,
+                matches: searchResult.matches,
+                omissions: searchResult.omissions,
+                path: normalizedPath,
+                query: parsedArguments.data.query,
+                mode: parsedArguments.data.mode ?? "literal",
+                case: parsedArguments.data.case ?? "smart",
+                context: parsedArguments.data.context ?? 0,
+                limit: parsedArguments.data.limit ?? defaultContentResults,
+              }),
+            };
+          } catch (error) {
+            if (context.signal.aborted) {
+              throw context.signal.reason;
+            }
+            return error instanceof SearchCursorError
+              ? {
+                  status: "failed",
+                  error: { code: error.code, message: error.message },
+                }
+              : {
+                  status: "failed",
+                  error: {
+                    code: "tool_io_failed",
+                    message: error instanceof Error ? error.message : "Repository search failed.",
+                  },
+                };
+          }
+        },
+      };
+    },
+  };
+}
+
+export type RepositorySearchProcessObserver = {
+  spawned(): void;
+  recorded?(): void;
+  signalled?(signal: NodeJS.Signals): void;
+  closed(): void;
+};
+
+export type RepositorySearchBackend = {
+  readChangedPaths(input: {
+    readonly workspaceRoot: string;
+    readonly path: string;
+    readonly signal: AbortSignal;
+    readonly budget: RepositorySearchBackendBudget;
+  }): Promise<ReadonlySet<string>>;
+  runRecords(input: {
+    readonly args: readonly string[];
+    readonly workspaceRoot: string;
+    readonly signal: AbortSignal;
+    readonly separator: "\n" | "\0";
+    readonly budget: RepositorySearchBackendBudget;
+    accept(record: string): void;
+  }): Promise<void>;
+};
+
+export type RepositorySearchBackendBudget = {
+  consumeRawBytes(byteCount: number): void;
+  consumeWorkRecord(): void;
+};
+
+function createProcessRepositorySearchBackend(options: {
+  readonly rgExecutablePath: string;
+  readonly processObserver?: RepositorySearchProcessObserver;
+}): RepositorySearchBackend {
+  return {
+    readChangedPaths(input) {
+      return readGitChangedPaths(input.workspaceRoot, input.path, input.signal, input.budget);
+    },
+    runRecords(input) {
+      return runRipgrepRecords({
+        ...input,
+        executablePath: options.rgExecutablePath,
+        ...(options.processObserver === undefined
+          ? {}
+          : { processObserver: options.processObserver }),
+      });
+    },
+  };
+}
+
+function outsideWorkspace() {
+  return {
+    status: "failed" as const,
+    error: {
+      code: "outside_workspace" as const,
+      message: "The requested path is outside the canonical workspace or crosses a symlink.",
+    },
+  };
+}
+
+function hasHiddenPathComponent(path: string): boolean {
+  return path !== "." && path.split("/").some((component) => component.startsWith("."));
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function invalidInput() {
+  return {
+    status: "failed" as const,
+    error: {
+      code: "invalid_tool_input" as const,
+      message: "The tool input did not match its schema.",
+    },
+  };
+}
+
+async function runContentSearch(options: {
+  readonly workspaceRoot: string;
+  readonly path: string;
+  readonly query: string;
+  readonly mode: "literal" | "regex";
+  readonly case: "smart" | "sensitive" | "insensitive";
+  readonly include: readonly string[];
+  readonly exclude: readonly string[];
+  readonly context: number;
+  readonly signal: AbortSignal;
+  readonly budget: SearchRequestBudget;
+  readonly backend: RepositorySearchBackend;
+}): Promise<{
+  readonly matches: readonly RankedContentMatch[];
+  readonly omissions: readonly z.infer<typeof omissionSchema>[];
+}> {
+  const args = [
+    "--json",
+    ...(options.mode === "literal" ? ["--fixed-strings"] : []),
+    ...(options.case === "smart"
+      ? ["--smart-case"]
+      : options.case === "sensitive"
+        ? ["--case-sensitive"]
+        : ["--ignore-case"]),
+    "--color",
+    "never",
+    ...options.include.flatMap((glob) => ["--glob", glob]),
+    ...options.exclude.flatMap((glob) => ["--glob", `!${glob}`]),
+    ...(options.context === 0 ? [] : ["--context", String(options.context)]),
+    "--",
+    options.query,
+    options.path,
+  ];
+  const changedPaths = await options.backend.readChangedPaths({
+    workspaceRoot: options.workspaceRoot,
+    path: options.path,
+    signal: options.signal,
+    budget: options.budget,
+  });
+  try {
+    const collector = new ContentMatchCollector(
+      options.mode,
+      options.context,
+      changedPaths,
+      options.budget,
+      options.workspaceRoot,
+    );
+    await options.backend.runRecords({
+      args,
+      workspaceRoot: options.workspaceRoot,
+      signal: options.signal,
+      separator: "\n",
+      accept: (record) => collector.accept(record),
+      budget: options.budget,
+    });
+    const parsed = collector.finish();
+    const probed = await probeCandidatePaths(
+      options.workspaceRoot,
+      [...new Set(parsed.matches.map((match) => match.path))],
+      options.budget,
+      parsed.initialFileIdentities,
+    );
+    const accepted = new Set(probed.paths);
+    return {
+      matches: parsed.matches.filter((match) => accepted.has(match.path)),
+      omissions: [
+        ...probed.omissions,
+        ...(parsed.omittedCandidateCount > 0
+          ? [
+              {
+                reason: "ranked_candidate_limit" as const,
+                path: ".",
+                count: parsed.omittedCandidateCount,
+              },
+            ]
+          : []),
+      ],
+    };
+  } catch (error) {
+    if (error instanceof SearchCursorError) {
+      throw error;
+    }
+    throw new Error("The repository search backend returned invalid output.");
+  }
+}
+
+async function runPathSearch(options: {
+  readonly workspaceRoot: string;
+  readonly path: string;
+  readonly query: string;
+  readonly mode: "fuzzy" | "glob";
+  readonly signal: AbortSignal;
+  readonly budget: SearchRequestBudget;
+  readonly backend: RepositorySearchBackend;
+}): Promise<{
+  readonly entries: readonly { readonly path: string; readonly rankReason: PathRankReason }[];
+  readonly omissions: readonly z.infer<typeof omissionSchema>[];
+}> {
+  const changedPaths = await options.backend.readChangedPaths({
+    workspaceRoot: options.workspaceRoot,
+    path: options.path,
+    signal: options.signal,
+    budget: options.budget,
+  });
+  let rawRecordCount = 0;
+  let rankedCandidateCount = 0;
+  const initialFileIdentities = new Map<string, FileIdentity | undefined>();
+  const candidates = new BoundedBestCandidates<{
+    readonly path: string;
+    readonly tier: number;
+    readonly rankReason: PathRankReason;
+  }>(maximumRankedCandidates, (left, right) => {
+    return left.tier - right.tier || compareChangedThenPath(left.path, right.path, changedPaths);
+  });
+  await options.backend.runRecords({
+    args: [
+      "--files",
+      "--null",
+      ...(options.mode === "glob" ? ["--glob", options.query] : []),
+      "--",
+      options.path,
+    ],
+    workspaceRoot: options.workspaceRoot,
+    signal: options.signal,
+    separator: "\0",
+    budget: options.budget,
+    accept(record) {
+      options.budget.consumeWorkRecord();
+      rawRecordCount += 1;
+      if (rawRecordCount > maximumRawRecords || rawRecordCount > maximumWorkRecords) {
+        throw new SearchCursorError(
+          "search_quota_exceeded",
+          "Repository path search exceeded its record limit.",
+        );
+      }
+      const path = record.split(sep).join("/").replace(/^\.\//u, "");
+      initialFileIdentities.set(path, captureFileIdentity(options.workspaceRoot, path));
+      const rank =
+        options.mode === "glob"
+          ? { tier: 0, rankReason: "glob" as const }
+          : fuzzyPathRank(options.query, path);
+      if (rank !== undefined) {
+        rankedCandidateCount += 1;
+        candidates.add({ path, ...rank });
+      }
+    },
+  });
+  const ranked = candidates.sorted();
+  const probed = await probeCandidatePaths(
+    options.workspaceRoot,
+    ranked.map((candidate) => candidate.path),
+    options.budget,
+    initialFileIdentities,
+  );
+  const accepted = new Set(probed.paths);
+  const candidateOmissions =
+    rankedCandidateCount > ranked.length
+      ? [
+          {
+            reason: "ranked_candidate_limit" as const,
+            path: ".",
+            count: rankedCandidateCount - ranked.length,
+          },
+        ]
+      : [];
+  const entries = ranked
+    .filter((candidate) => accepted.has(candidate.path))
+    .map(({ path, rankReason }) => ({ path, rankReason }));
+  return { entries, omissions: [...probed.omissions, ...candidateOmissions] };
+}
+
+function compareChangedThenPath(left: string, right: string, changedPaths: ReadonlySet<string>) {
+  const changedDifference = Number(changedPaths.has(right)) - Number(changedPaths.has(left));
+  return changedDifference || (left < right ? -1 : left > right ? 1 : 0);
+}
+
+function readGitChangedPaths(
+  workspaceRoot: string,
+  path: string,
+  signal: AbortSignal,
+  budget: RepositorySearchBackendBudget,
+): Promise<ReadonlySet<string>> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawn(
+        "git",
+        [
+          "-c",
+          "core.fsmonitor=false",
+          "-c",
+          "core.untrackedCache=false",
+          "-c",
+          "core.hooksPath=/dev/null",
+          "-c",
+          "submodule.recurse=false",
+          "status",
+          "--porcelain=v1",
+          "-z",
+          "--untracked-files=all",
+          "--ignore-submodules=all",
+          "--",
+          path,
+        ],
+        {
+          cwd: workspaceRoot,
+          env: frozenGitEnvironment(),
+          shell: false,
+          stdio: ["pipe", "pipe", "pipe"],
+        },
+      );
+      child.stdin.end();
+    } catch {
+      resolvePromise(new Set());
+      return;
+    }
+    const chunks: Buffer[] = [];
+    let byteCount = 0;
+    let settled = false;
+    let terminalError = false;
+    const termination = createBoundedChildTermination(child);
+    const abort = () => termination.start();
+    if (signal.aborted) {
+      abort();
+    } else {
+      signal.addEventListener("abort", abort, { once: true });
+    }
+    child.stdout.on("data", (chunk: Buffer) => {
+      try {
+        budget.consumeRawBytes(chunk.length);
+      } catch {
+        byteCount = maximumRawParsedBytes + 1;
+        termination.start();
+        return;
+      }
+      byteCount += chunk.length;
+      chunks.push(chunk);
+    });
+    child.stderr.resume();
+    child.once("error", () => {
+      if (settled) {
+        return;
+      }
+      terminalError = true;
+      termination.start();
+    });
+    child.once("close", (exitCode) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      termination.closed();
+      signal.removeEventListener("abort", abort);
+      if (signal.aborted) {
+        rejectPromise(signal.reason);
+        return;
+      }
+      if (byteCount > maximumRawParsedBytes) {
+        rejectPromise(
+          new SearchCursorError(
+            "search_quota_exceeded",
+            "Repository Git status exceeded the raw byte limit.",
+          ),
+        );
+        return;
+      }
+      if (terminalError || exitCode !== 0) {
+        resolvePromise(new Set());
+        return;
+      }
+      const fields = Buffer.concat(chunks).toString("utf8").split("\0");
+      const paths = new Set<string>();
+      for (let index = 0; index < fields.length; index += 1) {
+        const field = fields[index];
+        if (field === undefined || field.length < 4) {
+          continue;
+        }
+        budget.consumeWorkRecord();
+        paths.add(field.slice(3).split(sep).join("/"));
+        if (field[0] === "R" || field[1] === "R" || field[0] === "C" || field[1] === "C") {
+          const source = fields[index + 1];
+          if (source !== undefined) {
+            paths.add(source.split(sep).join("/"));
+            index += 1;
+          }
+        }
+      }
+      resolvePromise(paths);
+    });
+  });
+}
+
+function frozenGitEnvironment(): NodeJS.ProcessEnv {
+  const { PATH: inheritedPath } = process.env;
+  return {
+    ...(inheritedPath === undefined ? {} : { PATH: inheritedPath }),
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_OPTIONAL_LOCKS: "0",
+    GIT_TERMINAL_PROMPT: "0",
+    LC_ALL: "C",
+  };
+}
+
+async function probeCandidatePaths(
+  workspaceRoot: string,
+  paths: readonly string[],
+  budget: SearchRequestBudget,
+  initialFileIdentities?: ReadonlyMap<string, FileIdentity | undefined>,
+): Promise<{
+  readonly paths: string[];
+  readonly omissions: z.infer<typeof omissionSchema>[];
+}> {
+  const accepted: string[] = [];
+  const omissions: z.infer<typeof omissionSchema>[] = [];
+  for (const path of paths) {
+    budget.consumeWorkRecord();
+    const omission = await probeCandidatePath(
+      workspaceRoot,
+      path,
+      initialFileIdentities === undefined
+        ? undefined
+        : {
+            observed: initialFileIdentities.has(path),
+            identity: initialFileIdentities.get(path),
+          },
+    );
+    if (omission === undefined) {
+      accepted.push(path);
+    } else {
+      omissions.push({ reason: omission, path, count: 1 });
+    }
+  }
+  return { paths: accepted, omissions };
+}
+
+async function probeCandidatePath(
+  workspaceRoot: string,
+  path: string,
+  initial?: { readonly observed: boolean; readonly identity: FileIdentity | undefined },
+): Promise<"binary" | "non_ordinary" | "unreadable" | "changed" | undefined> {
+  const absolutePath = resolve(workspaceRoot, path);
+  if (absolutePath !== workspaceRoot && !absolutePath.startsWith(`${workspaceRoot}${sep}`)) {
+    return "non_ordinary";
+  }
+  try {
+    const before = await lstat(absolutePath);
+    if (!before.isFile() || before.isSymbolicLink()) {
+      return "non_ordinary";
+    }
+    if (
+      initial !== undefined &&
+      (!initial.observed ||
+        initial.identity === undefined ||
+        !sameFileIdentity(initial.identity, before))
+    ) {
+      return "changed";
+    }
+    const handle = await open(absolutePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+    try {
+      const opened = await handle.stat();
+      if (
+        opened.dev !== before.dev ||
+        opened.ino !== before.ino ||
+        opened.size !== before.size ||
+        opened.mtimeMs !== before.mtimeMs
+      ) {
+        return "changed";
+      }
+      const prefix = Buffer.allocUnsafe(Math.min(binaryProbeBytes, opened.size));
+      const { bytesRead } = await handle.read(prefix, 0, prefix.length, 0);
+      const after = await handle.stat();
+      if (
+        after.dev !== opened.dev ||
+        after.ino !== opened.ino ||
+        after.size !== opened.size ||
+        after.mtimeMs !== opened.mtimeMs
+      ) {
+        return "changed";
+      }
+      return prefix.subarray(0, bytesRead).includes(0) ? "binary" : undefined;
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return "unreadable";
+  }
+}
+
+type FileIdentity = {
+  readonly dev: number;
+  readonly ino: number;
+  readonly mode: number;
+  readonly size: number;
+  readonly mtimeMs: number;
+  readonly ctimeMs: number;
+};
+
+function captureFileIdentity(workspaceRoot: string, path: string): FileIdentity | undefined {
+  const absolutePath = resolve(workspaceRoot, path);
+  if (absolutePath !== workspaceRoot && !absolutePath.startsWith(`${workspaceRoot}${sep}`)) {
+    return undefined;
+  }
+  try {
+    const current = lstatSync(absolutePath);
+    return {
+      dev: current.dev,
+      ino: current.ino,
+      mode: current.mode,
+      size: current.size,
+      mtimeMs: current.mtimeMs,
+      ctimeMs: current.ctimeMs,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function sameFileIdentity(identity: FileIdentity, current: FileIdentity): boolean {
+  return (
+    identity.dev === current.dev &&
+    identity.ino === current.ino &&
+    identity.mode === current.mode &&
+    identity.size === current.size &&
+    identity.mtimeMs === current.mtimeMs &&
+    identity.ctimeMs === current.ctimeMs
+  );
+}
+
+type PathRankReason =
+  | "exact_basename"
+  | "prefix_basename"
+  | "literal_substring"
+  | "all_tokens"
+  | "fuzzy_subsequence"
+  | "glob";
+
+function fuzzyPathRank(
+  query: string,
+  path: string,
+): { readonly tier: number; readonly rankReason: Exclude<PathRankReason, "glob"> } | undefined {
+  const normalizedQuery = query.toLocaleLowerCase("en-US");
+  const normalizedPath = path.toLocaleLowerCase("en-US");
+  const basename = normalizedPath.split("/").at(-1) ?? normalizedPath;
+  if (basename === normalizedQuery) {
+    return { tier: 0, rankReason: "exact_basename" };
+  }
+  if (basename.startsWith(normalizedQuery)) {
+    return { tier: 1, rankReason: "prefix_basename" };
+  }
+  if (normalizedPath.includes(normalizedQuery)) {
+    return { tier: 2, rankReason: "literal_substring" };
+  }
+  const tokens = normalizedQuery.split(/\s+/u).filter((token) => token.length > 0);
+  if (tokens.length > 0 && tokens.every((token) => normalizedPath.includes(token))) {
+    return { tier: 3, rankReason: "all_tokens" };
+  }
+  if (tokens.length > 0 && tokens.every((token) => isSubsequence(token, normalizedPath))) {
+    return { tier: 4, rankReason: "fuzzy_subsequence" };
+  }
+  return undefined;
+}
+
+function isSubsequence(needle: string, haystack: string): boolean {
+  let needleIndex = 0;
+  for (const character of haystack) {
+    if (character === needle[needleIndex]) {
+      needleIndex += 1;
+      if (needleIndex === needle.length) {
+        return true;
+      }
+    }
+  }
+  return needle.length === 0;
+}
+
+function runRipgrepRecords(options: {
+  readonly args: readonly string[];
+  readonly executablePath: string;
+  readonly workspaceRoot: string;
+  readonly signal: AbortSignal;
+  readonly separator: "\n" | "\0";
+  readonly budget: RepositorySearchBackendBudget;
+  readonly processObserver?: RepositorySearchProcessObserver;
+  accept(record: string): void;
+}): Promise<void> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawn(options.executablePath, options.args, {
+        cwd: options.workspaceRoot,
+        shell: false,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      child.stdin.end();
+    } catch {
+      rejectPromise(new Error("The application-local repository search process could not start."));
+      return;
+    }
+    const decoder = new StringDecoder("utf8");
+    let remainder = "";
+    let stderrByteCount = 0;
+    let terminalError: unknown;
+    let settled = false;
+    const termination = createBoundedChildTermination(child, options.processObserver);
+    const abort = () => termination.start();
+    if (options.signal.aborted) {
+      abort();
+    } else {
+      options.signal.addEventListener("abort", abort, { once: true });
+    }
+    options.processObserver?.spawned();
+    const acceptText = (text: string) => {
+      remainder += text;
+      while (terminalError === undefined) {
+        const boundary = remainder.indexOf(options.separator);
+        if (boundary < 0) {
+          return;
+        }
+        const record = remainder.slice(0, boundary);
+        remainder = remainder.slice(boundary + 1);
+        if (record.length > 0) {
+          options.accept(record);
+          options.processObserver?.recorded?.();
+        }
+      }
+    };
+    child.stdout.on("data", (chunk: Buffer) => {
+      if (terminalError !== undefined) {
+        return;
+      }
+      try {
+        options.budget.consumeRawBytes(chunk.length);
+      } catch (error) {
+        terminalError = error;
+        termination.start();
+        return;
+      }
+      try {
+        acceptText(decoder.write(chunk));
+      } catch (error) {
+        terminalError = error;
+        termination.start();
+      }
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderrByteCount += chunk.length;
+    });
+    child.once("error", () => {
+      if (settled) {
+        return;
+      }
+      terminalError = new Error("The application-local repository search process could not start.");
+      termination.start();
+    });
+    child.once("close", (exitCode) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      termination.closed();
+      options.signal.removeEventListener("abort", abort);
+      options.processObserver?.closed();
+      if (options.signal.aborted) {
+        rejectPromise(options.signal.reason);
+        return;
+      }
+      if (terminalError !== undefined) {
+        rejectPromise(terminalError);
+        return;
+      }
+      try {
+        acceptText(decoder.end());
+        if (remainder.length > 0) {
+          options.accept(remainder);
+          remainder = "";
+        }
+      } catch (error) {
+        rejectPromise(error);
+        return;
+      }
+      if (exitCode !== 0 && exitCode !== 1) {
+        rejectPromise(
+          new Error(
+            stderrByteCount === 0
+              ? "Repository search failed."
+              : "The repository search backend rejected the request.",
+          ),
+        );
+        return;
+      }
+      resolvePromise();
+    });
+  });
+}
+
+function createBoundedChildTermination(
+  child: ChildProcessWithoutNullStreams,
+  observer?: RepositorySearchProcessObserver,
+): { readonly start: () => void; readonly closed: () => void } {
+  let started = false;
+  let closed = false;
+  let killTimer: ReturnType<typeof setTimeout> | undefined;
+  return {
+    start() {
+      if (started || closed) {
+        return;
+      }
+      started = true;
+      observer?.signalled?.("SIGTERM");
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => {
+        if (closed) {
+          return;
+        }
+        observer?.signalled?.("SIGKILL");
+        child.kill("SIGKILL");
+      }, searchProcessTerminationGraceMilliseconds);
+      killTimer.unref();
+    },
+    closed() {
+      closed = true;
+      if (killTimer !== undefined) {
+        clearTimeout(killTimer);
+      }
+    },
+  };
+}
+
+class ContentMatchCollector {
+  readonly #candidates: BoundedBestCandidates<
+    Omit<RankedContentMatch, "contextBefore" | "contextAfter">
+  >;
+  readonly #contextLines = new Map<string, { readonly line: number; readonly snippet: string }>();
+  readonly #initialFileIdentities = new Map<string, FileIdentity | undefined>();
+  #rawMatchCount = 0;
+  #workRecordCount = 0;
+
+  constructor(
+    readonly mode: "literal" | "regex",
+    readonly context: number,
+    readonly changedPaths: ReadonlySet<string>,
+    readonly budget: SearchRequestBudget,
+    readonly workspaceRoot: string,
+  ) {
+    this.#candidates = new BoundedBestCandidates(maximumRankedCandidates, (left, right) => {
+      return (
+        compareChangedThenPath(left.path, right.path, changedPaths) ||
+        left.line - right.line ||
+        left.column - right.column
+      );
+    });
+  }
+
+  accept(line: string) {
+    this.budget.consumeWorkRecord();
+    this.#workRecordCount += 1;
+    if (this.#workRecordCount > maximumWorkRecords) {
+      throw new SearchCursorError(
+        "search_quota_exceeded",
+        "Repository content search exceeded the parser work limit.",
+      );
+    }
+    const event = ripgrepEventSchema.parse(JSON.parse(line));
+    if (event.type === "begin") {
+      const path = event.data.path.text.split(sep).join("/").replace(/^\.\//u, "");
+      this.#initialFileIdentities.set(path, captureFileIdentity(this.workspaceRoot, path));
+      return;
+    }
+    if (event.type !== "match" && event.type !== "context") {
+      return;
+    }
+    const path = event.data.path.text.split(sep).join("/").replace(/^\.\//u, "");
+    const snippet = truncateDisplayedCharacters(event.data.lines.text.replace(/[\r\n]+$/u, ""));
+    if (event.type === "context") {
+      this.#contextLines.set(`${path}\0${event.data.line_number}`, {
+        line: event.data.line_number,
+        snippet,
+      });
+      return;
+    }
+    this.#rawMatchCount += event.data.submatches.length;
+    if (this.#rawMatchCount > maximumRawRecords) {
+      throw new SearchCursorError(
+        "search_quota_exceeded",
+        "Repository content search exceeded the raw match limit.",
+      );
+    }
+    if (event.data.submatches.length === 0) {
+      throw new Error("The repository search backend returned an invalid match boundary.");
+    }
+    for (const submatch of event.data.submatches) {
+      const column = characterColumnFromUtf8Boundary(
+        event.data.lines.text,
+        submatch.start,
+        submatch.end,
+        submatch.match.text,
+      );
+      this.#candidates.add({
+        path,
+        line: event.data.line_number,
+        column,
+        snippet,
+        rankReason: this.mode,
+      });
+    }
+  }
+
+  finish(): {
+    readonly matches: readonly RankedContentMatch[];
+    readonly omittedCandidateCount: number;
+    readonly initialFileIdentities: ReadonlyMap<string, FileIdentity | undefined>;
+  } {
+    const matches = this.#candidates.sorted().map((match) => ({
+      ...match,
+      contextBefore: Array.from({ length: this.context }, (_unused, offset) =>
+        this.#contextLines.get(`${match.path}\0${match.line - this.context + offset}`),
+      ).filter(
+        (line): line is { readonly line: number; readonly snippet: string } => line !== undefined,
+      ),
+      contextAfter: Array.from({ length: this.context }, (_unused, offset) =>
+        this.#contextLines.get(`${match.path}\0${match.line + offset + 1}`),
+      ).filter(
+        (line): line is { readonly line: number; readonly snippet: string } => line !== undefined,
+      ),
+    }));
+    return {
+      matches,
+      omittedCandidateCount: Math.max(0, this.#rawMatchCount - matches.length),
+      initialFileIdentities: this.#initialFileIdentities,
+    };
+  }
+}
+
+function characterColumnFromUtf8Boundary(
+  line: string,
+  start: number,
+  end: number,
+  match: string,
+): number {
+  const bytes = Buffer.from(line, "utf8");
+  if (start > end || end > bytes.length) {
+    throw new Error("The repository search backend returned an invalid match boundary.");
+  }
+  const prefix = bytes.subarray(0, start).toString("utf8");
+  const matched = bytes.subarray(start, end).toString("utf8");
+  if (
+    Buffer.byteLength(prefix, "utf8") !== start ||
+    Buffer.byteLength(matched, "utf8") !== end - start ||
+    matched !== match
+  ) {
+    throw new Error("The repository search backend returned an invalid UTF-8 match boundary.");
+  }
+  return Array.from(prefix).length + 1;
+}
+
+const ripgrepEventSchema = z.union([
+  z.strictObject({
+    type: z.literal("begin"),
+    data: z.strictObject({ path: z.strictObject({ text: z.string() }) }),
+  }),
+  z.strictObject({ type: z.enum(["end", "summary"]), data: z.unknown() }),
+  z.strictObject({
+    type: z.enum(["match", "context"]),
+    data: z.strictObject({
+      path: z.strictObject({ text: z.string() }),
+      lines: z.strictObject({ text: z.string() }),
+      line_number: z.number().int().positive(),
+      absolute_offset: z.number().int().nonnegative(),
+      submatches: z.array(
+        z.strictObject({
+          match: z.strictObject({ text: z.string() }),
+          start: z.number().int().nonnegative(),
+          end: z.number().int().nonnegative(),
+        }),
+      ),
+    }),
+  }),
+]);
+
+function truncateDisplayedCharacters(value: string): string {
+  return Array.from(value).slice(0, maximumSnippetCharacters).join("");
+}
+
+function createPathPages(
+  entries: readonly PathEntry[],
+  limit: number,
+  unboundedResultCount: number,
+  initialOmissions: readonly z.infer<typeof omissionSchema>[],
+): readonly PathPage[] {
+  const pages: PathPage[] = [];
+  let offset = 0;
+  while (offset < entries.length) {
+    const accepted: PathEntry[] = [];
+    const omissions = pages.length === 0 ? [...initialOmissions] : [];
+    while (accepted.length < limit && offset + accepted.length < entries.length) {
+      const entry = entries[offset + accepted.length];
+      if (entry === undefined) {
+        break;
+      }
+      const remaining = entries.length - offset - accepted.length - 1;
+      const candidateOmissions =
+        remaining > 0
+          ? [...omissions, { reason: "page_byte_limit" as const, path: ".", count: remaining }]
+          : omissions;
+      if (
+        Buffer.byteLength(
+          JSON.stringify({ entries: [...accepted, entry], omissions: candidateOmissions }),
+          "utf8",
+        ) >
+        12 * 1_024
+      ) {
+        break;
+      }
+      accepted.push(entry);
+    }
+    if (accepted.length === 0) {
+      throw new SearchCursorError(
+        "search_quota_exceeded",
+        "One normalized repository path result exceeded the page byte limit.",
+      );
+    }
+    offset += accepted.length;
+    if (offset < entries.length) {
+      omissions.push({
+        reason: accepted.length === limit ? "page_limit" : "page_byte_limit",
+        path: ".",
+        count: entries.length - offset,
+      });
+    }
+    if (pages.length === 0 && unboundedResultCount > entries.length) {
+      omissions.push({
+        reason: "snapshot_result_limit",
+        path: ".",
+        count: unboundedResultCount - entries.length,
+      });
+    }
+    pages.push({ entries: accepted, omissions });
+  }
+  return pages.length === 0 ? [{ entries: [], omissions: [...initialOmissions] }] : pages;
+}
+
+function createContentPages(
+  matches: readonly RankedContentMatch[],
+  limit: number,
+  unboundedResultCount: number,
+  initialOmissions: readonly z.infer<typeof omissionSchema>[],
+): readonly ContentPage[] {
+  let remaining = [...groupMatches(matches).entries()].map(([path, grouped]) => ({
+    path,
+    matches: grouped,
+  }));
+  const pages: ContentPage[] = [];
+  while (remaining.length > 0) {
+    const accepted: RankedContentMatch[] = [];
+    const next: typeof remaining = [];
+    const omissions: z.infer<typeof omissionSchema>[] =
+      pages.length === 0 ? [...initialOmissions] : [];
+    let byteLimited = false;
+    for (let groupIndex = 0; groupIndex < remaining.length; groupIndex += 1) {
+      const group = remaining[groupIndex] as (typeof remaining)[number];
+      const available = limit - accepted.length;
+      const maximumAcceptedCount = Math.min(
+        group.matches.length,
+        maximumMatchesPerFilePerPage,
+        Math.max(0, available),
+      );
+      let acceptedCount = 0;
+      while (acceptedCount < maximumAcceptedCount) {
+        const match = group.matches[acceptedCount];
+        if (match === undefined) {
+          break;
+        }
+        const candidateMatches = [...accepted, match];
+        const remainingCount =
+          remaining
+            .slice(groupIndex)
+            .reduce((total, candidate) => total + candidate.matches.length, 0) -
+          acceptedCount -
+          1;
+        const candidateOmissions =
+          remainingCount > 0
+            ? [
+                ...omissions,
+                {
+                  reason: "page_byte_limit" as const,
+                  path: ".",
+                  count: remainingCount,
+                },
+              ]
+            : omissions;
+        if (contentPagePayloadBytes(candidateMatches, candidateOmissions) > 12 * 1_024) {
+          byteLimited = true;
+          break;
+        }
+        accepted.push(match);
+        acceptedCount += 1;
+      }
+      const rest = group.matches.slice(acceptedCount);
+      if (rest.length > 0) {
+        next.push({ path: group.path, matches: rest });
+        omissions.push({
+          reason: byteLimited
+            ? "page_byte_limit"
+            : acceptedCount >= maximumMatchesPerFilePerPage
+              ? "per_file_page_limit"
+              : "page_limit",
+          path: group.path,
+          count: rest.length,
+        });
+      }
+      if (byteLimited) {
+        next.push(...remaining.slice(groupIndex + 1));
+        break;
+      }
+    }
+    if (accepted.length === 0) {
+      throw new SearchCursorError(
+        "search_quota_exceeded",
+        "The repository search page could not make bounded progress.",
+      );
+    }
+    if (pages.length === 0 && unboundedResultCount > matches.length) {
+      omissions.push({
+        reason: "snapshot_result_limit",
+        path: ".",
+        count: unboundedResultCount - matches.length,
+      });
+    }
+    pages.push({ matches: accepted, omissions });
+    remaining = next;
+  }
+  return pages.length === 0 ? [{ matches: [], omissions: [...initialOmissions] }] : pages;
+}
+
+function contentPagePayloadBytes(
+  matches: readonly RankedContentMatch[],
+  omissions: readonly z.infer<typeof omissionSchema>[],
+): number {
+  return Buffer.byteLength(
+    JSON.stringify({
+      groups: [...groupMatches(matches)].map(([path, grouped]) => ({
+        path,
+        matches: grouped.map(({ path: _path, ...match }) => match),
+      })),
+      omissions,
+    }),
+    "utf8",
+  );
+}
+
+function groupMatches(
+  matches: readonly RankedContentMatch[],
+): ReadonlyMap<string, readonly RankedContentMatch[]> {
+  const groups = new Map<string, RankedContentMatch[]>();
+  for (const match of matches) {
+    const grouped = groups.get(match.path) ?? [];
+    grouped.push(match);
+    groups.set(match.path, grouped);
+  }
+  return groups;
+}
+
+function encodeCursor(snapshotId: string, pageIndex: number): string {
+  return `search-repository:v1:${Buffer.from(
+    JSON.stringify({ snapshotId, pageIndex }),
+    "utf8",
+  ).toString("base64url")}`;
+}
+
+function decodeCursor(
+  cursor: string,
+): { readonly snapshotId: string; readonly pageIndex: number } | undefined {
+  const prefix = "search-repository:v1:";
+  if (!cursor.startsWith(prefix)) {
+    return undefined;
+  }
+  try {
+    const value = JSON.parse(
+      Buffer.from(cursor.slice(prefix.length), "base64url").toString("utf8"),
+    );
+    return typeof value === "object" &&
+      value !== null &&
+      "snapshotId" in value &&
+      typeof value.snapshotId === "string" &&
+      /^[0-9a-f-]{36}$/u.test(value.snapshotId) &&
+      "pageIndex" in value &&
+      Number.isSafeInteger(value.pageIndex) &&
+      (value.pageIndex as number) > 0
+      ? { snapshotId: value.snapshotId, pageIndex: value.pageIndex as number }
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function repositorySearchBackendForTesting() {
+  return { rgPath } as const;
+}

--- a/packages/agent/src/session-history-validation.ts
+++ b/packages/agent/src/session-history-validation.ts
@@ -491,7 +491,8 @@ export function validateCurrentSessionHistory(
           toolState.decision !== undefined ||
           toolState.permissionRequestId !== undefined ||
           toolState.repositoryDisposition !== undefined ||
-          (record.trigger.name === "read_file") !== (record.trigger.disposition === "read_continue")
+          (record.trigger.name === "read_file" || record.trigger.name === "search_repository") !==
+            (record.trigger.disposition === "read_continue")
         ) {
           throw new SessionLifecycleError("session_invalid");
         }

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -444,7 +444,7 @@ export type SessionPathContextCommittedRecord = {
     readonly trigger: {
       readonly runId: string;
       readonly callId: string;
-      readonly name: "read_file" | "write_file" | "edit_file";
+      readonly name: "read_file" | "search_repository" | "write_file" | "edit_file";
       readonly argumentsDigest: Sha256Digest;
       readonly disposition: "read_continue" | "mutation_retry_required";
     };
@@ -465,7 +465,7 @@ export type SessionPathContextFailedRecord = {
     readonly trigger: {
       readonly runId: string;
       readonly callId: string;
-      readonly name: "read_file" | "write_file" | "edit_file";
+      readonly name: "read_file" | "search_repository" | "write_file" | "edit_file";
       readonly argumentsDigest: Sha256Digest;
       readonly disposition: "unavailable";
     };
@@ -765,7 +765,7 @@ export type SessionRepositoryInstructionsCommittedRecord = {
     readonly trigger?: {
       readonly runId: string;
       readonly callId: string;
-      readonly name: "read_file" | "write_file" | "edit_file";
+      readonly name: "read_file" | "search_repository" | "write_file" | "edit_file";
       readonly argumentsDigest: Sha256Digest;
       readonly disposition: "read_continue" | "mutation_retry_required";
     };
@@ -784,7 +784,7 @@ export type SessionRepositoryInstructionsFailedRecord = {
     readonly trigger?: {
       readonly runId: string;
       readonly callId: string;
-      readonly name: "read_file" | "write_file" | "edit_file";
+      readonly name: "read_file" | "search_repository" | "write_file" | "edit_file";
       readonly argumentsDigest: Sha256Digest;
       readonly disposition: "unavailable";
     };
@@ -1927,7 +1927,7 @@ const sessionV3RecordSchema = z.union([
     trigger: z.strictObject({
       runId: z.uuid(),
       callId: z.string().min(1).max(256),
-      name: z.enum(["read_file", "write_file", "edit_file"]),
+      name: z.enum(["read_file", "search_repository", "write_file", "edit_file"]),
       argumentsDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
       disposition: z.enum(["read_continue", "mutation_retry_required"]),
     }),
@@ -1943,7 +1943,7 @@ const sessionV3RecordSchema = z.union([
     trigger: z.strictObject({
       runId: z.uuid(),
       callId: z.string().min(1).max(256),
-      name: z.enum(["read_file", "write_file", "edit_file"]),
+      name: z.enum(["read_file", "search_repository", "write_file", "edit_file"]),
       argumentsDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
       disposition: z.literal("unavailable"),
     }),
@@ -2035,7 +2035,7 @@ const sessionV3RecordSchema = z.union([
       .strictObject({
         runId: z.uuid(),
         callId: z.string().min(1).max(256),
-        name: z.enum(["read_file", "write_file", "edit_file"]),
+        name: z.enum(["read_file", "search_repository", "write_file", "edit_file"]),
         argumentsDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
         disposition: z.enum(["read_continue", "mutation_retry_required"]),
       })
@@ -2051,7 +2051,7 @@ const sessionV3RecordSchema = z.union([
       .strictObject({
         runId: z.uuid(),
         callId: z.string().min(1).max(256),
-        name: z.enum(["read_file", "write_file", "edit_file"]),
+        name: z.enum(["read_file", "search_repository", "write_file", "edit_file"]),
         argumentsDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
         disposition: z.literal("unavailable"),
       })

--- a/packages/agent/src/tool-runtime.ts
+++ b/packages/agent/src/tool-runtime.ts
@@ -23,6 +23,10 @@ import {
   type PatchFileSystem,
   PatchTransactionError,
 } from "./patch-transaction.js";
+import {
+  createRepositorySearchToolAdapter,
+  type RepositorySearchBackend,
+} from "./repository-search.js";
 
 export type ToolEffect = "read" | "write" | "execute" | "network" | "delegate" | "administrative";
 
@@ -89,6 +93,9 @@ export type ToolResult =
               | "input_resource_not_visible"
               | "input_resource_quota_exceeded"
               | "input_resource_unsupported"
+              | "search_cursor_invalid"
+              | "search_cursor_stale"
+              | "search_quota_exceeded"
               | "artifact_store_failed"
               | "mcp_protocol_error"
               | "mcp_output_invalid"
@@ -196,6 +203,8 @@ type ToolExecutionContext = {
   readonly signal: AbortSignal;
   readonly callId: string;
   readonly toolName: string;
+  readonly sessionId: string;
+  readonly toolProfileDigest: string;
 };
 
 class ToolExecutionError extends Error {
@@ -417,6 +426,13 @@ const runShellOutputSchema = z.strictObject({
 });
 
 export function createReadToolRegistry(options: { readonly workspaceRoot: string }): ToolRegistry {
+  return createReadToolRegistryInternal(options);
+}
+
+function createReadToolRegistryInternal(options: {
+  readonly workspaceRoot: string;
+  readonly repositorySearchBackend?: RepositorySearchBackend;
+}): ToolRegistry {
   const workspaceRoot = resolve(options.workspaceRoot);
   const readFileAdapter = identifyToolAdapter(
     {
@@ -463,7 +479,18 @@ export function createReadToolRegistry(options: { readonly workspaceRoot: string
     },
     "safe",
   );
-  const adapters = new Map([[readFileAdapter.definition.name, readFileAdapter]]);
+  const repositorySearchAdapter = identifyToolAdapter(
+    createRepositorySearchToolAdapter({
+      workspaceRoot,
+      ...(options.repositorySearchBackend === undefined
+        ? {}
+        : { backendForTesting: options.repositorySearchBackend }),
+    }),
+    "safe",
+  );
+  const adapters = new Map(
+    [readFileAdapter, repositorySearchAdapter].map((adapter) => [adapter.definition.name, adapter]),
+  );
 
   return {
     definitions() {
@@ -720,7 +747,8 @@ export function createCodingToolRegistryForTesting(options: {
   readonly stateRoot?: string;
   readonly artifactStore?: ArtifactStore;
   readonly shellLimits?: ShellRuntimeLimits;
-  readonly patchFileSystem: PatchFileSystem;
+  readonly patchFileSystem?: PatchFileSystem;
+  readonly repositorySearchBackend?: RepositorySearchBackend;
 }): ToolRegistry {
   return createCodingToolRegistryInternal(options);
 }
@@ -731,6 +759,7 @@ function createCodingToolRegistryInternal(options: {
   readonly artifactStore?: ArtifactStore;
   readonly shellLimits?: ShellRuntimeLimits;
   readonly patchFileSystem?: PatchFileSystem;
+  readonly repositorySearchBackend?: RepositorySearchBackend;
 }): ToolRegistry {
   const workspaceRoot = resolve(options.workspaceRoot);
   const shellLimits = options.shellLimits ?? defaultShellRuntimeLimits;
@@ -739,7 +768,12 @@ function createCodingToolRegistryInternal(options: {
     command: z.string().min(1),
     timeoutMs: z.number().int().positive().max(shellLimits.timeoutMs).optional(),
   });
-  const readTools = createReadToolRegistry({ workspaceRoot });
+  const readTools = createReadToolRegistryInternal({
+    workspaceRoot,
+    ...(options.repositorySearchBackend === undefined
+      ? {}
+      : { repositorySearchBackend: options.repositorySearchBackend }),
+  });
   const mutationTools = createMutationToolRegistryInternal({
     workspaceRoot,
     ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
@@ -926,6 +960,7 @@ function createCodingToolRegistryInternal(options: {
   });
   const adapters = [
     requireAdapter(readTools, "read_file"),
+    requireAdapter(readTools, "search_repository"),
     requireAdapter(mutationTools, "write_file"),
     requireAdapter(mutationTools, "edit_file"),
     shellAdapter,

--- a/packages/testkit/src/agent-session.test.ts
+++ b/packages/testkit/src/agent-session.test.ts
@@ -1621,6 +1621,8 @@ describe("AgentSession", () => {
       });
       expect(searchResult).toEqual({ status: "completed", output: expect.anything() });
       expect(observedArguments).toEqual([
+        "--no-config",
+        "--no-require-git",
         "--json",
         "--case-sensitive",
         "--color",
@@ -2080,6 +2082,8 @@ describe("AgentSession", () => {
         ],
       });
       expect(observedArguments).toEqual([
+        "--no-config",
+        "--no-require-git",
         "--files",
         "--null",
         "--glob",

--- a/packages/testkit/src/agent-session.test.ts
+++ b/packages/testkit/src/agent-session.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
 import {
   chmod,
   lstat,
@@ -29,18 +30,22 @@ import {
   createReadToolRegistry,
   type ModelDriver,
   ModelDriverError,
+  type ModelEvent,
   type ModelRequest,
   type RuntimeEvent,
   type SessionEventRecord,
   type SessionStore,
+  type ToolRegistry,
+  type ToolResult,
 } from "@adam-agent/agent";
 import {
   createCodingToolRegistryForTesting,
   createPromptContextV1,
+  type RepositorySearchBackend,
   type SessionRecord,
   sessionDurableContext,
 } from "@adam-agent/agent/internal-testing";
-import { describe, expect, expectTypeOf, test } from "vitest";
+import { describe, expect, expectTypeOf, test, vi } from "vitest";
 
 import { FakeModelDriver } from "./index.js";
 
@@ -1449,6 +1454,822 @@ describe("AgentSession", () => {
       },
     });
     expect(events.at(-1)).toEqual({ type: "session_settled", result });
+  });
+
+  test("repository search cursor pages one immutable session and policy-bound snapshot", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-cursor-"));
+    const sourceRoot = join(workspaceRoot, "src");
+
+    try {
+      await mkdir(sourceRoot);
+      for (const name of ["10-first.ts", "20-second.ts", "30-third.ts", "40-fourth.ts"]) {
+        await writeFile(
+          join(sourceRoot, name),
+          `export const marker = "snapshot needle";\n`,
+          "utf8",
+        );
+      }
+      const pages: unknown[] = [];
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return searchRepositoryEvents({ query: "snapshot needle", limit: 2 });
+        }
+        if (
+          latestMessage?.role === "tool" &&
+          latestMessage.name === "search_repository" &&
+          latestMessage.result.status === "completed"
+        ) {
+          const page = latestMessage.result.output as {
+            readonly nextCursor?: string;
+          };
+          pages.push(page);
+          if (pages.length === 1) {
+            expect(page.nextCursor).toEqual(expect.any(String));
+            if (page.nextCursor === undefined) {
+              throw new Error("Expected the first immutable search page to have a cursor.");
+            }
+            writeFileSync(
+              join(sourceRoot, "00-new.ts"),
+              'export const marker = "snapshot needle";\n',
+            );
+            writeFileSync(join(sourceRoot, "30-third.ts"), "export const marker = 'changed';\n");
+            return searchRepositoryEvents({
+              query: "snapshot needle",
+              limit: 2,
+              cursor: page.nextCursor,
+            });
+          }
+        }
+        return [
+          { type: "text_delta", text: "The cursor retained one immutable snapshot." },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createCodingToolRegistryForTesting({
+          workspaceRoot,
+          repositorySearchBackend: createScriptedRepositorySearchBackend([
+            {
+              records: scriptedContentRecords([
+                { path: "src/10-first.ts" },
+                { path: "src/20-second.ts" },
+                { path: "src/30-third.ts" },
+                { path: "src/40-fourth.ts" },
+              ]),
+            },
+          ]),
+        }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      await expect(session.run({ text: "Page the repository snapshot." })).resolves.toEqual({
+        status: "completed",
+        answer: "The cursor retained one immutable snapshot.",
+      });
+      expect(pages).toHaveLength(2);
+      expect(pages[0]).toMatchObject({
+        snapshotResultCount: 4,
+        pageIndex: 0,
+        resultCount: 2,
+        remainingResultCount: 2,
+        groups: [{ path: "src/10-first.ts" }, { path: "src/20-second.ts" }],
+      });
+      expect(pages[1]).toMatchObject({
+        snapshotResultCount: 4,
+        pageIndex: 1,
+        resultCount: 2,
+        remainingResultCount: 0,
+        currentContentMustBeReread: true,
+        groups: [{ path: "src/30-third.ts" }, { path: "src/40-fourth.ts" }],
+      });
+      expect(pages[1]).not.toEqual(
+        expect.objectContaining({ groups: expect.arrayContaining([{ path: "src/00-new.ts" }]) }),
+      );
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("content search applies explicit regex, case, and include-exclude glob semantics", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-regex-"));
+    const sourceRoot = join(workspaceRoot, "src");
+    const testSourceRoot = join(workspaceRoot, "tests");
+
+    try {
+      await mkdir(sourceRoot);
+      await mkdir(testSourceRoot);
+      await writeFile(join(sourceRoot, "selected.ts"), "const value = NeedleAlpha;\n", "utf8");
+      await writeFile(join(sourceRoot, "wrong-case.ts"), "const value = needleAlpha;\n", "utf8");
+      await writeFile(
+        join(testSourceRoot, "excluded.test.ts"),
+        "const value = NeedleBeta;\n",
+        "utf8",
+      );
+      let searchOutput: unknown;
+      let searchResult: ToolResult | undefined;
+      let observedArguments: readonly string[] | undefined;
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return toolCallEvents("search-regex", "search_repository", {
+            kind: "content",
+            query: "Needle[A-Z][a-z]+",
+            mode: "regex",
+            case: "sensitive",
+            include: ["**/*.ts"],
+            exclude: ["tests/**"],
+          });
+        }
+        if (latestMessage?.role === "tool" && latestMessage.name === "search_repository") {
+          searchResult = latestMessage.result;
+          if (latestMessage.result.status === "completed") {
+            searchOutput = latestMessage.result.output;
+          }
+        }
+        return [
+          { type: "text_delta", text: "The exact regex result was selected." },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createCodingToolRegistryForTesting({
+          workspaceRoot,
+          repositorySearchBackend: createScriptedRepositorySearchBackend([
+            {
+              records: scriptedContentRecords([
+                {
+                  path: "src/selected.ts",
+                  text: "const value = NeedleAlpha;\n",
+                  submatches: [{ text: "NeedleAlpha", start: 14, end: 25 }],
+                },
+              ]),
+              assertArguments(arguments_) {
+                observedArguments = arguments_;
+              },
+            },
+          ]),
+        }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      await expect(session.run({ text: "Find the selected symbol." })).resolves.toEqual({
+        status: "completed",
+        answer: "The exact regex result was selected.",
+      });
+      expect(searchResult).toEqual({ status: "completed", output: expect.anything() });
+      expect(observedArguments).toEqual([
+        "--json",
+        "--case-sensitive",
+        "--color",
+        "never",
+        "--glob",
+        "**/*.ts",
+        "--glob",
+        "!tests/**",
+        "--",
+        "Needle[A-Z][a-z]+",
+        ".",
+      ]);
+      expect(searchOutput).toMatchObject({
+        kind: "content",
+        mode: "regex",
+        case: "sensitive",
+        groups: [{ path: "src/selected.ts", matches: [{ line: 1, rankReason: "regex" }] }],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("path search ranks an all-token typo-tolerant repository filename first", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-path-"));
+    const sourceRoot = join(workspaceRoot, "src");
+
+    try {
+      await mkdir(sourceRoot);
+      await writeFile(join(sourceRoot, "search_repository_adapter.ts"), "export {};\n", "utf8");
+      await writeFile(join(sourceRoot, "repository_search_notes.ts"), "export {};\n", "utf8");
+      await writeFile(join(sourceRoot, "unrelated.ts"), "export {};\n", "utf8");
+      let searchOutput: unknown;
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return toolCallEvents("search-path", "search_repository", {
+            kind: "path",
+            query: "serch repos adapter",
+          });
+        }
+        if (
+          latestMessage?.role === "tool" &&
+          latestMessage.name === "search_repository" &&
+          latestMessage.result.status === "completed"
+        ) {
+          searchOutput = latestMessage.result.output;
+        }
+        return [
+          { type: "text_delta", text: "The intended repository path ranked first." },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createCodingToolRegistryForTesting({
+          workspaceRoot,
+          repositorySearchBackend: createScriptedRepositorySearchBackend([
+            {
+              records: [
+                "src/search_repository_adapter.ts",
+                "src/repository_search_notes.ts",
+                "src/unrelated.ts",
+              ],
+            },
+          ]),
+        }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      await expect(
+        session.run({ text: "Find the repository search adapter path." }),
+      ).resolves.toEqual({
+        status: "completed",
+        answer: "The intended repository path ranked first.",
+      });
+      expect(searchOutput).toMatchObject({
+        kind: "path",
+        mode: "fuzzy",
+        resultCount: 1,
+        entries: [
+          {
+            path: "src/search_repository_adapter.ts",
+            rankReason: "fuzzy_subsequence",
+          },
+        ],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("path search cursor pages one immutable result snapshot after filesystem mutation", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-path-cursor-"));
+
+    try {
+      for (const path of ["10-needle.ts", "20-needle.ts", "30-needle.ts", "40-needle.ts"]) {
+        await writeFile(join(workspaceRoot, path), "export {};\n", "utf8");
+      }
+      const pages: Array<{
+        entries: Array<{ path: string }>;
+        nextCursor?: string;
+      }> = [];
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return toolCallEvents("search-path-cursor-1", "search_repository", {
+            kind: "path",
+            query: "needle",
+            limit: 2,
+          });
+        }
+        if (
+          latestMessage?.role === "tool" &&
+          latestMessage.name === "search_repository" &&
+          latestMessage.result.status === "completed"
+        ) {
+          const page = latestMessage.result.output as (typeof pages)[number];
+          pages.push(page);
+          if (pages.length === 1 && page.nextCursor !== undefined) {
+            writeFileSync(join(workspaceRoot, "00-needle-new.ts"), "export {};\n");
+            writeFileSync(join(workspaceRoot, "30-needle.ts"), "renamed content\n");
+            return toolCallEvents("search-path-cursor-2", "search_repository", {
+              kind: "path",
+              query: "needle",
+              limit: 2,
+              cursor: page.nextCursor,
+            });
+          }
+        }
+        return [
+          { type: "text_delta", text: "The path cursor retained one immutable snapshot." },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createCodingToolRegistryForTesting({
+          workspaceRoot,
+          repositorySearchBackend: createScriptedRepositorySearchBackend([
+            {
+              records: ["10-needle.ts", "20-needle.ts", "30-needle.ts", "40-needle.ts"],
+            },
+          ]),
+        }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      await expect(session.run({ text: "Page the repository paths." })).resolves.toEqual({
+        status: "completed",
+        answer: "The path cursor retained one immutable snapshot.",
+      });
+      expect(pages).toHaveLength(2);
+      expect(pages[0]).toMatchObject({
+        pageIndex: 0,
+        remainingResultCount: 2,
+        entries: [{ path: "10-needle.ts" }, { path: "20-needle.ts" }],
+      });
+      expect(pages[1]).toMatchObject({
+        pageIndex: 1,
+        remainingResultCount: 0,
+        entries: [{ path: "30-needle.ts" }, { path: "40-needle.ts" }],
+      });
+      expect(JSON.stringify(pages[1])).not.toContain("00-needle-new.ts");
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("repository search rejects a cursor whose normalized request changed", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-cursor-request-"));
+
+    try {
+      await writeFile(join(workspaceRoot, "one.ts"), "first needle\nsecond needle\n");
+      const registry = createCodingToolRegistryForTesting({
+        workspaceRoot,
+        repositorySearchBackend: createScriptedRepositorySearchBackend([
+          {
+            records: scriptedContentRecords([
+              { path: "one.ts", line: 1 },
+              { path: "one.ts", line: 2 },
+            ]),
+          },
+        ]),
+      });
+      const first = await executeRepositorySearchForTesting(registry, {
+        kind: "content",
+        query: "needle",
+        limit: 1,
+      });
+      expect(first).toMatchObject({ status: "completed" });
+      const cursor = repositorySearchCursor(first);
+
+      await expect(
+        executeRepositorySearchForTesting(registry, {
+          kind: "content",
+          query: "different",
+          limit: 1,
+          cursor,
+        }),
+      ).resolves.toMatchObject({
+        status: "failed",
+        error: { code: "search_cursor_invalid" },
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("repository search reports a runtime-restart cursor as stale", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-cursor-restart-"));
+
+    try {
+      await writeFile(join(workspaceRoot, "one.ts"), "first needle\nsecond needle\n");
+      const first = await executeRepositorySearchForTesting(
+        createCodingToolRegistryForTesting({
+          workspaceRoot,
+          repositorySearchBackend: createScriptedRepositorySearchBackend([
+            {
+              records: scriptedContentRecords([
+                { path: "one.ts", line: 1 },
+                { path: "one.ts", line: 2 },
+              ]),
+            },
+          ]),
+        }),
+        { kind: "content", query: "needle", limit: 1 },
+      );
+      const cursor = repositorySearchCursor(first);
+
+      await expect(
+        executeRepositorySearchForTesting(
+          createCodingToolRegistryForTesting({
+            workspaceRoot,
+            repositorySearchBackend: createScriptedRepositorySearchBackend([]),
+          }),
+          {
+            kind: "content",
+            query: "needle",
+            limit: 1,
+            cursor,
+          },
+        ),
+      ).resolves.toMatchObject({
+        status: "failed",
+        error: { code: "search_cursor_stale" },
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("repository search evicts the least-recently-used snapshot after eight live snapshots", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-cursor-lru-"));
+
+    try {
+      await writeFile(join(workspaceRoot, "one.ts"), "first needle\nsecond needle\n");
+      const registry = createCodingToolRegistryForTesting({
+        workspaceRoot,
+        repositorySearchBackend: createScriptedRepositorySearchBackend(
+          Array.from({ length: 9 }, () => ({
+            records: scriptedContentRecords([
+              { path: "one.ts", line: 1 },
+              { path: "one.ts", line: 2 },
+            ]),
+          })),
+        ),
+      });
+      let firstCursor = "";
+      for (let index = 0; index < 9; index += 1) {
+        const result = await executeRepositorySearchForTesting(registry, {
+          kind: "content",
+          query: "needle",
+          limit: 1,
+        });
+        expect(result).toMatchObject({ status: "completed" });
+        if (index === 0) {
+          firstCursor = repositorySearchCursor(result);
+        }
+      }
+
+      await expect(
+        executeRepositorySearchForTesting(registry, {
+          kind: "content",
+          query: "needle",
+          limit: 1,
+          cursor: firstCursor,
+        }),
+      ).resolves.toMatchObject({
+        status: "failed",
+        error: { code: "search_cursor_stale" },
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("repository search expires one cursor after exactly ten idle minutes without polling", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-cursor-expiry-"));
+    const actualNow = Date.now();
+    let now = actualNow;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+
+    try {
+      await writeFile(join(workspaceRoot, "one.ts"), "first needle\nsecond needle\n");
+      const registry = createCodingToolRegistryForTesting({
+        workspaceRoot,
+        repositorySearchBackend: createScriptedRepositorySearchBackend([
+          {
+            records: scriptedContentRecords([
+              { path: "one.ts", line: 1 },
+              { path: "one.ts", line: 2 },
+            ]),
+          },
+        ]),
+      });
+      const first = await executeRepositorySearchForTesting(registry, {
+        kind: "content",
+        query: "needle",
+        limit: 1,
+      });
+      const cursor = repositorySearchCursor(first);
+      now += 10 * 60 * 1_000;
+
+      await expect(
+        executeRepositorySearchForTesting(registry, {
+          kind: "content",
+          query: "needle",
+          limit: 1,
+          cursor,
+        }),
+      ).resolves.toMatchObject({
+        status: "failed",
+        error: { code: "search_cursor_stale" },
+      });
+    } finally {
+      nowSpy.mockRestore();
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("path search boosts current Git changes only within one equal match-quality tier", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-git-rank-"));
+
+    try {
+      await mkdir(join(workspaceRoot, "src"));
+      await writeFile(join(workspaceRoot, "src", "a-needle-clean.ts"), "export const a = 1;\n");
+      await writeFile(join(workspaceRoot, "src", "z-needle-modified.ts"), "export const z = 2;\n");
+      let searchOutput: unknown;
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return toolCallEvents("search-git-rank", "search_repository", {
+            kind: "path",
+            query: "needle",
+          });
+        }
+        if (
+          latestMessage?.role === "tool" &&
+          latestMessage.name === "search_repository" &&
+          latestMessage.result.status === "completed"
+        ) {
+          searchOutput = latestMessage.result.output;
+        }
+        return [
+          { type: "text_delta", text: "The current Git change ranked first." },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createCodingToolRegistryForTesting({
+          workspaceRoot,
+          repositorySearchBackend: createScriptedRepositorySearchBackend([
+            {
+              records: ["src/a-needle-clean.ts", "src/z-needle-modified.ts"],
+              changedPaths: ["src/z-needle-modified.ts"],
+            },
+          ]),
+        }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      await expect(session.run({ text: "Rank the matching repository paths." })).resolves.toEqual({
+        status: "completed",
+        answer: "The current Git change ranked first.",
+      });
+      expect(searchOutput).toMatchObject({
+        entries: [
+          { path: "src/z-needle-modified.ts", rankReason: "literal_substring" },
+          { path: "src/a-needle-clean.ts", rankReason: "literal_substring" },
+        ],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("path search applies one explicit ripgrep glob without fuzzy fallback", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-path-glob-"));
+
+    try {
+      await mkdir(join(workspaceRoot, "src"), { recursive: true });
+      await mkdir(join(workspaceRoot, "tests"), { recursive: true });
+      await writeFile(join(workspaceRoot, "src", "alpha.test.ts"), "export {};\n", "utf8");
+      await writeFile(join(workspaceRoot, "tests", "beta.test.ts"), "export {};\n", "utf8");
+      await writeFile(join(workspaceRoot, "src", "alpha.ts"), "export {};\n", "utf8");
+      let searchOutput: unknown;
+      let observedArguments: readonly string[] | undefined;
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return toolCallEvents("search-path-glob", "search_repository", {
+            kind: "path",
+            query: "{src,tests}/**/*.test.ts",
+            mode: "glob",
+          });
+        }
+        if (
+          latestMessage?.role === "tool" &&
+          latestMessage.name === "search_repository" &&
+          latestMessage.result.status === "completed"
+        ) {
+          searchOutput = latestMessage.result.output;
+        }
+        return [
+          { type: "text_delta", text: "Only the explicit glob paths were returned." },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createCodingToolRegistryForTesting({
+          workspaceRoot,
+          repositorySearchBackend: createScriptedRepositorySearchBackend([
+            {
+              records: ["src/alpha.test.ts", "tests/beta.test.ts"],
+              assertArguments(arguments_) {
+                observedArguments = arguments_;
+              },
+            },
+          ]),
+        }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      await expect(session.run({ text: "Find the exact test-file glob." })).resolves.toEqual({
+        status: "completed",
+        answer: "Only the explicit glob paths were returned.",
+      });
+      expect(searchOutput).toMatchObject({
+        kind: "path",
+        mode: "glob",
+        entries: [
+          { path: "src/alpha.test.ts", rankReason: "glob" },
+          { path: "tests/beta.test.ts", rankReason: "glob" },
+        ],
+      });
+      expect(observedArguments).toEqual([
+        "--files",
+        "--null",
+        "--glob",
+        "{src,tests}/**/*.test.ts",
+        "--",
+        ".",
+      ]);
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("content search returns the requested bounded context around one match", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-context-"));
+
+    try {
+      await writeFile(
+        join(workspaceRoot, "context.ts"),
+        ["line one", "line two", "needle line", "line four", "line five", ""].join("\n"),
+        "utf8",
+      );
+      let searchOutput: unknown;
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return toolCallEvents("search-context", "search_repository", {
+            kind: "content",
+            query: "needle",
+            context: 1,
+          });
+        }
+        if (
+          latestMessage?.role === "tool" &&
+          latestMessage.name === "search_repository" &&
+          latestMessage.result.status === "completed"
+        ) {
+          searchOutput = latestMessage.result.output;
+        }
+        return [
+          { type: "text_delta", text: "The bounded surrounding lines were returned." },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createCodingToolRegistryForTesting({
+          workspaceRoot,
+          repositorySearchBackend: createScriptedRepositorySearchBackend([
+            {
+              records: [
+                JSON.stringify({
+                  type: "begin",
+                  data: { path: { text: "context.ts" } },
+                }),
+                scriptedRipgrepLine("context", "context.ts", 2, "line two\n", []),
+                scriptedRipgrepLine("match", "context.ts", 3, "needle line\n", [
+                  { text: "needle", start: 0, end: 6 },
+                ]),
+                scriptedRipgrepLine("context", "context.ts", 4, "line four\n", []),
+              ],
+            },
+          ]),
+        }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      await expect(session.run({ text: "Inspect one line of context." })).resolves.toEqual({
+        status: "completed",
+        answer: "The bounded surrounding lines were returned.",
+      });
+      expect(searchOutput).toMatchObject({
+        kind: "content",
+        context: 1,
+        groups: [
+          {
+            path: "context.ts",
+            matches: [
+              {
+                line: 3,
+                snippet: "needle line",
+                contextBefore: [{ line: 2, snippet: "line two" }],
+                contextAfter: [{ line: 4, snippet: "line four" }],
+              },
+            ],
+          },
+        ],
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("content search shapes complete normalized results into a 16 KiB UTF-8 page", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-page-bytes-"));
+
+    try {
+      for (let index = 0; index < 20; index += 1) {
+        await writeFile(
+          join(workspaceRoot, `${String(index).padStart(2, "0")}.ts`),
+          `needle ${"界".repeat(500)}\n`,
+          "utf8",
+        );
+      }
+      let searchOutput: unknown;
+      const model = new FakeModelDriver((request) => {
+        const latestMessage = request.messages.at(-1);
+        if (latestMessage?.role === "user") {
+          return toolCallEvents("search-page-bytes", "search_repository", {
+            kind: "content",
+            query: "needle",
+          });
+        }
+        if (
+          latestMessage?.role === "tool" &&
+          latestMessage.name === "search_repository" &&
+          latestMessage.result.status === "completed"
+        ) {
+          searchOutput = latestMessage.result.output;
+        }
+        return [
+          { type: "text_delta", text: "The first UTF-8 page remained bounded." },
+          { type: "finish", reason: "stop" },
+        ];
+      });
+      const session = createTestSession({
+        model,
+        tools: createCodingToolRegistryForTesting({
+          workspaceRoot,
+          repositorySearchBackend: createScriptedRepositorySearchBackend([
+            {
+              records: scriptedContentRecords(
+                Array.from({ length: 20 }, (_unused, index) => ({
+                  path: `${String(index).padStart(2, "0")}.ts`,
+                  text: `needle ${"界".repeat(500)}\n`,
+                })),
+              ),
+            },
+          ]),
+        }),
+        permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      });
+
+      await expect(session.run({ text: "Return one bounded search page." })).resolves.toEqual({
+        status: "completed",
+        answer: "The first UTF-8 page remained bounded.",
+      });
+      expect(searchOutput).toMatchObject({
+        resultCount: expect.any(Number),
+        nextCursor: expect.any(String),
+        omissions: expect.arrayContaining([expect.objectContaining({ reason: "page_byte_limit" })]),
+      });
+      expect(Buffer.byteLength(JSON.stringify(searchOutput), "utf8")).toBeLessThanOrEqual(
+        16 * 1_024,
+      );
+      expect((searchOutput as { resultCount: number }).resultCount).toBeLessThan(20);
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("repository search rejects more than 100000 raw content matches without a partial snapshot", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-raw-cap-"));
+
+    try {
+      await writeFile(join(workspaceRoot, "overflow.txt"), "needle\n", "utf8");
+      const records = scriptedContentRecords(
+        Array.from({ length: 100_001 }, (_unused, index) => ({
+          path: "overflow.txt",
+          line: index + 1,
+        })),
+      );
+
+      await expect(
+        executeRepositorySearchForTesting(
+          createCodingToolRegistryForTesting({
+            workspaceRoot,
+            repositorySearchBackend: createScriptedRepositorySearchBackend([{ records }]),
+          }),
+          {
+            kind: "content",
+            query: "needle",
+          },
+        ),
+      ).resolves.toMatchObject({
+        status: "failed",
+        error: { code: "search_quota_exceeded" },
+      });
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
   });
 
   test("answers from one read_file result without changing the repository", async () => {
@@ -3732,6 +4553,7 @@ describe("AgentSession", () => {
       }).toEqual({
         definitions: [
           "read_file",
+          "search_repository",
           "write_file",
           "edit_file",
           "run_shell",
@@ -4789,6 +5611,51 @@ describe("AgentSession", () => {
     }
   });
 
+  test("an unavailable historical repository search gives actionable new-session guidance", async () => {
+    let observedMessage: string | undefined;
+    const model = new FakeModelDriver((request) => {
+      const latestMessage = request.messages.at(-1);
+      if (latestMessage?.role === "user") {
+        return toolCallEvents("historical-search", "search_repository", {
+          kind: "content",
+          query: "needle",
+        });
+      }
+      if (
+        latestMessage?.role === "tool" &&
+        latestMessage.name === "search_repository" &&
+        latestMessage.result.status === "failed"
+      ) {
+        observedMessage = latestMessage.result.error.message;
+      }
+      return [
+        { type: "text_delta", text: "The historical profile remained unchanged." },
+        { type: "finish", reason: "stop" },
+      ];
+    });
+    const historicalTools: ToolRegistry = {
+      definitions() {
+        return [];
+      },
+      resolve() {
+        return undefined;
+      },
+    };
+    const session = createTestSession({
+      model,
+      tools: historicalTools,
+      permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    });
+
+    await expect(session.run({ text: "Search from the historical session." })).resolves.toEqual({
+      status: "completed",
+      answer: "The historical profile remained unchanged.",
+    });
+    expect(observedMessage).toBe(
+      "Repository search is unavailable in this historical Tool Profile. Start a new session to use search_repository.",
+    );
+  });
+
   test("feeds one permission denial back without executing the tool", async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-denied-"));
 
@@ -5482,6 +6349,159 @@ function createTestSession(
     maximumOutputTokens: 4_096,
     store: dependencies.store ?? createInMemorySessionStore(),
   });
+}
+
+function searchRepositoryEvents(input: {
+  readonly query: string;
+  readonly limit: number;
+  readonly cursor?: string;
+}): readonly ModelEvent[] {
+  return toolCallEvents(`search-page-${input.cursor === undefined ? 1 : 2}`, "search_repository", {
+    kind: "content",
+    ...input,
+  });
+}
+
+async function executeRepositorySearchForTesting(
+  registry: ToolRegistry,
+  input: Record<string, unknown>,
+) {
+  const adapter = registry.resolve("search_repository");
+  if (adapter === undefined) {
+    throw new TypeError("The repository search tool is unavailable.");
+  }
+  const prepared = adapter.prepare(JSON.stringify(input));
+  if (prepared.status !== "ready") {
+    return prepared;
+  }
+  return prepared.execute({
+    signal: new AbortController().signal,
+    callId: "search-contract",
+    toolName: "search_repository",
+    sessionId: "search-contract-session",
+    toolProfileDigest: "sha256:search-contract-profile",
+  });
+}
+
+type ScriptedRepositorySearch = {
+  readonly records: readonly string[];
+  readonly changedPaths?: readonly string[];
+  readonly assertArguments?: (arguments_: readonly string[]) => void;
+};
+
+function createScriptedRepositorySearchBackend(
+  scripts: readonly ScriptedRepositorySearch[],
+): RepositorySearchBackend {
+  let nextScript = 0;
+  return {
+    async readChangedPaths() {
+      return new Set(scripts[nextScript]?.changedPaths ?? []);
+    },
+    async runRecords(input) {
+      const script = scripts[nextScript];
+      nextScript += 1;
+      if (script === undefined) {
+        throw new TypeError("The deterministic repository search script was exhausted.");
+      }
+      script.assertArguments?.(input.args);
+      for (const record of script.records) {
+        input.signal.throwIfAborted();
+        input.budget.consumeRawBytes(Buffer.byteLength(record, "utf8") + 1);
+        input.accept(record);
+      }
+    },
+  };
+}
+
+function scriptedContentRecords(
+  matches: readonly {
+    readonly path: string;
+    readonly line?: number;
+    readonly text?: string;
+    readonly submatches?: readonly {
+      readonly text: string;
+      readonly start: number;
+      readonly end: number;
+    }[];
+  }[],
+): readonly string[] {
+  const records: string[] = [];
+  for (const path of new Set(matches.map((match) => match.path))) {
+    records.push(JSON.stringify({ type: "begin", data: { path: { text: path } } }));
+  }
+  for (const match of matches) {
+    const text = match.text ?? "needle\n";
+    records.push(
+      JSON.stringify({
+        type: "match",
+        data: {
+          path: { text: match.path },
+          lines: { text },
+          line_number: match.line ?? 1,
+          absolute_offset: 0,
+          submatches: match.submatches?.map((submatch) => ({
+            match: { text: submatch.text },
+            start: submatch.start,
+            end: submatch.end,
+          })) ?? [{ match: { text: "needle" }, start: 0, end: 6 }],
+        },
+      }),
+    );
+  }
+  return records;
+}
+
+function scriptedRipgrepLine(
+  type: "match" | "context",
+  path: string,
+  line: number,
+  text: string,
+  submatches: readonly { readonly text: string; readonly start: number; readonly end: number }[],
+): string {
+  return JSON.stringify({
+    type,
+    data: {
+      path: { text: path },
+      lines: { text },
+      line_number: line,
+      absolute_offset: 0,
+      submatches: submatches.map((submatch) => ({
+        match: { text: submatch.text },
+        start: submatch.start,
+        end: submatch.end,
+      })),
+    },
+  });
+}
+
+function repositorySearchCursor(result: ToolResult): string {
+  const output = result.status === "completed" ? result.output : undefined;
+  if (
+    typeof output !== "object" ||
+    output === null ||
+    !("nextCursor" in output) ||
+    typeof (output as { readonly nextCursor?: unknown }).nextCursor !== "string"
+  ) {
+    throw new TypeError("The repository search result has no next cursor.");
+  }
+  return (output as { readonly nextCursor: string }).nextCursor;
+}
+
+function toolCallEvents(
+  id: string,
+  name: string,
+  input: Readonly<Record<string, unknown>>,
+): readonly ModelEvent[] {
+  return [
+    { type: "tool_call_start", id, name },
+    {
+      type: "tool_call_delta",
+      id,
+      json: JSON.stringify(input),
+    },
+    { type: "tool_call_end", id },
+    { type: "finish", reason: "tool_calls" },
+  ];
 }
 
 function imageOccurrence(artifactId: `sha256:${string}`, byteCount: number, occurrenceId: string) {

--- a/packages/testkit/src/context-compaction-process.test.ts
+++ b/packages/testkit/src/context-compaction-process.test.ts
@@ -543,7 +543,7 @@ async function createProcessHarness(prefix: string): Promise<{
   await mkdir(workspaceRoot);
   await writeFile(
     join(workspaceRoot, "context.txt"),
-    `${"process context line\n".repeat(500)}PROCESS_RAW_CONTEXT_TAIL`,
+    `${"process context line\n".repeat(1_200)}PROCESS_RAW_CONTEXT_TAIL`,
     "utf8",
   );
   const created = await createSessionLifecycle({

--- a/packages/testkit/src/context-compaction.fixture.ts
+++ b/packages/testkit/src/context-compaction.fixture.ts
@@ -31,8 +31,8 @@ const contextProfile: ContextProfile = {
   version: 1,
   contextWindowTokens: 20_000,
   maximumOutputTokens: 100,
-  compactAtTokens: 2_000,
-  postCompactTargetTokens: 1_600,
+  compactAtTokens: 4_000,
+  postCompactTargetTokens: 3_000,
   retainedTargetTokens: 100,
   estimatorVersion: 1,
 };

--- a/packages/testkit/src/context-compaction.test.ts
+++ b/packages/testkit/src/context-compaction.test.ts
@@ -4090,11 +4090,11 @@ test("SessionLifecycle restarts and branches from one committed context checkpoi
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
   await mkdir(workspaceRoot);
-  await writeFile(join(workspaceRoot, "context.txt"), "lifecycle context ".repeat(220), "utf8");
+  await writeFile(join(workspaceRoot, "context.txt"), "lifecycle context ".repeat(600), "utf8");
   const lifecycleContextProfile: ContextProfile = {
     ...contextProfile,
-    compactAtTokens: 900,
-    postCompactTargetTokens: 700,
+    compactAtTokens: 1_500,
+    postCompactTargetTokens: 1_200,
   };
 
   let ordinaryCall = 0;
@@ -4373,14 +4373,14 @@ test("SessionLifecycle reports then normalizes a dangling compaction attempt aft
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
   await mkdir(workspaceRoot);
-  await writeFile(join(workspaceRoot, "context.txt"), "dangling context ".repeat(220), "utf8");
+  await writeFile(join(workspaceRoot, "context.txt"), "dangling context ".repeat(600), "utf8");
 
   let ordinaryCall = 0;
   let compactionCall = 0;
   const danglingContextProfile = {
     ...contextProfile,
-    compactAtTokens: 900,
-    postCompactTargetTokens: 700,
+    compactAtTokens: 1_500,
+    postCompactTargetTokens: 1_200,
   };
   const model: ModelDriver = {
     async *stream(request) {

--- a/packages/testkit/src/prompt-assembly.test.ts
+++ b/packages/testkit/src/prompt-assembly.test.ts
@@ -49,6 +49,55 @@ const contextProfile: ContextProfile = {
   estimatorVersion: 1,
 };
 
+const expectedSearchRepositoryTool = {
+  name: "search_repository",
+  description:
+    "Search repository content or paths with search-repository.v1. Results use ignore/hidden/symlink and 8 KiB binary rules, deterministic relevance plus same-tier Git ranking, at most 50 results per 16 KiB page, and runtime-local immutable cursors bounded to 8 live snapshots, 16 MiB aggregate, 4,096 results and 4 MiB each, 16,384 ranked candidates, 64 MiB raw bytes, 100,000 raw records, 200,000 work records, and 10 minutes idle. Results are discovery evidence; reread current content with read_file before relying on it.",
+  inputSchema: {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    oneOf: [
+      {
+        type: "object",
+        properties: {
+          kind: { type: "string", const: "content" },
+          query: { type: "string", minLength: 1, maxLength: 4_096 },
+          mode: { type: "string", enum: ["literal", "regex"] },
+          case: { type: "string", enum: ["smart", "sensitive", "insensitive"] },
+          include: {
+            maxItems: 16,
+            type: "array",
+            items: { type: "string", minLength: 1, maxLength: 512 },
+          },
+          exclude: {
+            maxItems: 16,
+            type: "array",
+            items: { type: "string", minLength: 1, maxLength: 512 },
+          },
+          context: { type: "integer", minimum: 0, maximum: 3 },
+          path: { type: "string", minLength: 1, maxLength: 4_096 },
+          limit: { type: "integer", minimum: 1, maximum: 50 },
+          cursor: { type: "string", minLength: 1, maxLength: 1_024 },
+        },
+        required: ["kind", "query"],
+        additionalProperties: false,
+      },
+      {
+        type: "object",
+        properties: {
+          kind: { type: "string", const: "path" },
+          query: { type: "string", minLength: 1, maxLength: 4_096 },
+          mode: { type: "string", enum: ["fuzzy", "glob"] },
+          path: { type: "string", minLength: 1, maxLength: 4_096 },
+          limit: { type: "integer", minimum: 1, maximum: 50 },
+          cursor: { type: "string", minLength: 1, maxLength: 1_024 },
+        },
+        required: ["kind", "query"],
+        additionalProperties: false,
+      },
+    ],
+  },
+} as const;
+
 const expectedCodingTools = [
   {
     name: "read_file",
@@ -61,6 +110,7 @@ const expectedCodingTools = [
       additionalProperties: false,
     },
   },
+  expectedSearchRepositoryTool,
   {
     name: "write_file",
     description:
@@ -224,9 +274,9 @@ const expectedCodingTools = [
     },
   },
 ] as const;
-const expectedHistoricalCodingTools = expectedCodingTools.slice(0, 4);
+const expectedTransientCodingTools = expectedCodingTools.slice(0, 5);
 
-test("a newly created v3 session sends code-owned prompts before the current user request with the exact seven-tool profile", async () => {
+test("a newly created v3 session sends code-owned prompts before the current user request with the exact eight-tool profile", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-prompt-assembly-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
@@ -367,8 +417,8 @@ test.each([
       answer: "Permission observed.",
     });
     expect(requests.map((request) => request.tools)).toEqual([
-      [expectedCodingTools[0]],
-      [expectedCodingTools[0]],
+      [expectedCodingTools[0], expectedCodingTools[1]],
+      [expectedCodingTools[0], expectedCodingTools[1]],
     ]);
   } finally {
     await rm(workspaceRoot, { recursive: true, force: true });
@@ -400,6 +450,10 @@ test("a new v3 session persists bounded prompt and Skill identity without exposi
           digest: "sha256:84c7b9fde73815162c795cd0a12361061332b903018efe55266598639014cff3",
         },
         {
+          name: "search_repository",
+          digest: "sha256:d55a2ababa77640301923a1867f8d0c457e012ef1f7ab50e6bfd6ac697e07812",
+        },
+        {
           name: "write_file",
           digest: "sha256:5ed8fbf39d91e2b6a3fd9a10454b80cdef473d2d98d61d90d776a73c3356e939",
         },
@@ -424,7 +478,7 @@ test("a new v3 session persists bounded prompt and Skill identity without exposi
           digest: "sha256:682b2ff206b5456ecaa4fc96384c3a9531475cca89b70776f13619ee80492d52",
         },
       ],
-      digest: "sha256:b25da1fc060ca3e6f923e946f0f54bdfd7e7c7732ef9703d23da468ef95fb194",
+      digest: "sha256:373ca18a3d00a82eacf0168e76848a6eae7e002b074f97c254981595608d4d1b",
     },
     repository: {
       version: 1,
@@ -498,10 +552,10 @@ test("v3 accounting compacts for the assembled messages and tools while keeping 
   });
   const accountingProfile: ContextProfile = {
     ...contextProfile,
-    contextWindowTokens: 4_000,
+    contextWindowTokens: 5_000,
     maximumOutputTokens: 100,
-    compactAtTokens: 2_000,
-    postCompactTargetTokens: 1_800,
+    compactAtTokens: 3_000,
+    postCompactTargetTokens: 2_500,
     retainedTargetTokens: 0,
   };
   const accountingInput = `Account for the assembled request. ${"context ".repeat(800)}`;
@@ -543,6 +597,7 @@ test("v3 accounting compacts for the assembled messages and tools while keeping 
       [],
       [
         "read_file",
+        "search_repository",
         "write_file",
         "edit_file",
         "run_shell",
@@ -558,7 +613,7 @@ test("v3 accounting compacts for the assembled messages and tools while keeping 
   }
 });
 
-test("transient v1 base and four coding tools reduce the profile-v2 ordinary output clamp", async () => {
+test("transient v1 base and five coding tools reduce the profile-v2 ordinary output clamp", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-prompt-output-clamp-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
@@ -598,8 +653,8 @@ test("transient v1 base and four coding tools reduce the profile-v2 ordinary out
         { role: "system", content: basePrompt },
         { role: "user", content: "Clamp v1." },
       ],
-      tools: expectedHistoricalCodingTools,
-      maximumOutputTokens: 7_007,
+      tools: expectedTransientCodingTools,
+      maximumOutputTokens: 6_563,
     });
   } finally {
     await rm(testRoot, { recursive: true, force: true });
@@ -778,11 +833,9 @@ test("a pre-B6 schema-v3 session keeps historical prompt profile v0", async () =
     expect(observedRequests[1]?.messages).toEqual([
       { role: "user", content: "Continue the historical branch." },
     ]);
-    expect(observedRequests[0]?.tools.map((tool) => tool.name)).toEqual([
-      "read_file",
-      "write_file",
-      "edit_file",
-      "run_shell",
+    expect(observedRequests.map((request) => request.tools.map((tool) => tool.name))).toEqual([
+      ["read_file", "write_file", "edit_file", "run_shell"],
+      ["read_file", "write_file", "edit_file", "run_shell"],
     ]);
   } finally {
     await rm(testRoot, { recursive: true, force: true });
@@ -1385,11 +1438,11 @@ test("a v3 provider attempt persists only the safe exact request projection dige
     expect({ continuedPromptContext, inspectedPromptContext }).toMatchObject({
       continuedPromptContext: {
         lastRequestProjectionDigest:
-          "sha256:9e981d5b1658c5ab788d702d2ac4c8c76d018ac4ea1a299e06ca3992360cd8f3",
+          "sha256:89ecb6411851333748a10d0c28842015beb46d0ba5ce03f864533401f38a633d",
       },
       inspectedPromptContext: {
         lastRequestProjectionDigest:
-          "sha256:9e981d5b1658c5ab788d702d2ac4c8c76d018ac4ea1a299e06ca3992360cd8f3",
+          "sha256:89ecb6411851333748a10d0c28842015beb46d0ba5ce03f864533401f38a633d",
       },
     });
     expect(JSON.stringify({ continued, inspected })).not.toContain("Inspect the project.");

--- a/packages/testkit/src/repository-instructions.test.ts
+++ b/packages/testkit/src/repository-instructions.test.ts
@@ -195,6 +195,10 @@ test("root AGENTS.md is frozen in revision 1 and projected as untrusted user con
             digest: "sha256:84c7b9fde73815162c795cd0a12361061332b903018efe55266598639014cff3",
           },
           {
+            name: "search_repository",
+            digest: "sha256:d55a2ababa77640301923a1867f8d0c457e012ef1f7ab50e6bfd6ac697e07812",
+          },
+          {
             name: "write_file",
             digest: "sha256:5ed8fbf39d91e2b6a3fd9a10454b80cdef473d2d98d61d90d776a73c3356e939",
           },
@@ -219,7 +223,7 @@ test("root AGENTS.md is frozen in revision 1 and projected as untrusted user con
             digest: "sha256:682b2ff206b5456ecaa4fc96384c3a9531475cca89b70776f13619ee80492d52",
           },
         ],
-        digest: "sha256:b25da1fc060ca3e6f923e946f0f54bdfd7e7c7732ef9703d23da468ef95fb194",
+        digest: "sha256:373ca18a3d00a82eacf0168e76848a6eae7e002b074f97c254981595608d4d1b",
       },
       repository: {
         version: 1,
@@ -651,6 +655,159 @@ test.each([
     }
   },
 );
+
+test("repository search hits do not activate their nested instruction scopes", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-repository-search-hit-scope-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(join(workspaceRoot, "nested"), { recursive: true });
+  await writeFile(join(workspaceRoot, "AGENTS.md"), rootInstruction);
+  await writeFile(join(workspaceRoot, "nested", "AGENTS.md"), "Never reveal nested search hits.\n");
+  await writeFile(join(workspaceRoot, "nested", "fact.txt"), "search-scope-needle\n");
+  const requests: ModelRequest[] = [];
+  const driver = new FakeModelDriver((request) => {
+    requests.push(request);
+    return request.messages.at(-1)?.role === "user"
+      ? [
+          { type: "tool_call_start" as const, id: "search-root", name: "search_repository" },
+          {
+            type: "tool_call_delta" as const,
+            id: "search-root",
+            json: '{"kind":"content","query":"search-scope-needle"}',
+          },
+          { type: "tool_call_end" as const, id: "search-root" },
+          { type: "finish" as const, reason: "tool_calls" as const },
+        ]
+      : [
+          { type: "text_delta" as const, text: "Search completed." },
+          { type: "finish" as const, reason: "stop" as const },
+        ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+
+  try {
+    const lifecycle = createSessionLifecycle({
+      modelTargets,
+      permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      stateRoot,
+      tools: createCodingToolRegistry({ stateRoot, workspaceRoot }),
+      workspaceRoot,
+    });
+    const created = await lifecycle.create({ targetIdentity });
+    const continued = await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Search for the repository fact." },
+    });
+
+    expect(continued).toMatchObject({
+      result: { status: "completed", answer: "Search completed." },
+      snapshot: {
+        promptContext: { repository: { revision: 1, activeScopes: ["."] } },
+      },
+    });
+    expect(JSON.stringify(requests[1]?.messages)).not.toContain("Never reveal nested search hits.");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("an explicit repository search directory activates its instructions before the read effect", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-repository-search-path-scope-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(join(workspaceRoot, "nested"), { recursive: true });
+  await writeFile(join(workspaceRoot, "AGENTS.md"), rootInstruction);
+  await writeFile(join(workspaceRoot, "nested", "AGENTS.md"), "Search nested files carefully.\n");
+  await writeFile(join(workspaceRoot, "nested", "fact.txt"), "explicit-scope-needle\n");
+  const requests: ModelRequest[] = [];
+  const driver = new FakeModelDriver((request) => {
+    requests.push(request);
+    return request.messages.at(-1)?.role === "user"
+      ? [
+          { type: "tool_call_start" as const, id: "search-nested", name: "search_repository" },
+          {
+            type: "tool_call_delta" as const,
+            id: "search-nested",
+            json: '{"kind":"content","query":"explicit-scope-needle","path":"nested"}',
+          },
+          { type: "tool_call_end" as const, id: "search-nested" },
+          { type: "finish" as const, reason: "tool_calls" as const },
+        ]
+      : [
+          { type: "text_delta" as const, text: "Nested search completed." },
+          { type: "finish" as const, reason: "stop" as const },
+        ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+
+  try {
+    const lifecycle = createSessionLifecycle({
+      modelTargets,
+      permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      stateRoot,
+      tools: createCodingToolRegistry({ stateRoot, workspaceRoot }),
+      workspaceRoot,
+    });
+    const created = await lifecycle.create({ targetIdentity });
+    const events: RuntimeEvent[] = [];
+    lifecycle.subscribe((event) => events.push(event));
+    const continued = await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Search the explicit nested directory." },
+    });
+
+    expect(continued).toMatchObject({
+      result: { status: "completed", answer: "Nested search completed." },
+      snapshot: {
+        promptContext: { repository: { revision: 2, activeScopes: [".", "nested"] } },
+      },
+    });
+    expect(
+      events.filter((event) =>
+        ["tool_requested", "repository_instructions_activated", "tool_started"].includes(
+          event.type,
+        ),
+      ),
+    ).toEqual([
+      { type: "tool_requested", callId: "search-nested", name: "search_repository" },
+      expect.objectContaining({ type: "repository_instructions_activated", revision: 2 }),
+      { type: "tool_started", callId: "search-nested", name: "search_repository" },
+    ]);
+    expect(JSON.stringify(requests[1]?.messages)).toContain("Search nested files carefully.");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
 
 test("the first nested read commits and publishes revision 2 before permission and read effect", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-repository-read-activation-"));

--- a/packages/testkit/src/repository-search.os.test.ts
+++ b/packages/testkit/src/repository-search.os.test.ts
@@ -1,0 +1,561 @@
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join } from "node:path";
+
+import {
+  AgentSession,
+  createCodingToolRegistry,
+  createInMemorySessionStore,
+  createPermissionPolicy,
+} from "@adam-agent/agent";
+import {
+  createRepositorySearchToolAdapterForTesting,
+  repositorySearchBackendForTesting,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+
+import { FakeModelDriver } from "./index.js";
+
+test("literal repository search keeps relevant files on the first grouped bounded page", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-repository-"));
+  const sourceRoot = join(workspaceRoot, "src");
+
+  try {
+    await mkdir(sourceRoot);
+    await writeFile(
+      join(sourceRoot, "00-noise.ts"),
+      Array.from({ length: 25 }, (_unused, index) => `// needle noise ${index + 1}`).join("\n"),
+      "utf8",
+    );
+    await writeFile(
+      join(sourceRoot, "10-relevant.ts"),
+      'export const relevantNeedle = "needle";\n',
+      "utf8",
+    );
+    await writeFile(
+      join(sourceRoot, "20-also-relevant.ts"),
+      'export function findNeedle() { return "needle"; }\n',
+      "utf8",
+    );
+    let searchOutput: unknown;
+    const model = new FakeModelDriver((request) => {
+      const latestMessage = request.messages.at(-1);
+      if (latestMessage?.role === "user") {
+        expect(request.tools.find((tool) => tool.name === "search_repository")).toMatchObject({
+          name: "search_repository",
+        });
+        return [
+          { type: "tool_call_start", id: "search-literal", name: "search_repository" },
+          {
+            type: "tool_call_delta",
+            id: "search-literal",
+            json: JSON.stringify({ kind: "content", query: "needle" }),
+          },
+          { type: "tool_call_end", id: "search-literal" },
+          { type: "finish", reason: "tool_calls" },
+        ];
+      }
+      if (
+        latestMessage?.role === "tool" &&
+        latestMessage.name === "search_repository" &&
+        latestMessage.result.status === "completed"
+      ) {
+        searchOutput = latestMessage.result.output;
+      }
+      return [
+        { type: "text_delta", text: "The relevant repository files remain visible." },
+        { type: "finish", reason: "stop" },
+      ];
+    });
+    const session = new AgentSession({
+      model,
+      tools: createCodingToolRegistry({ workspaceRoot }),
+      permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      maximumOutputTokens: 4_096,
+      store: createInMemorySessionStore(),
+    });
+
+    await expect(session.run({ text: "Find the relevant needle locations." })).resolves.toEqual({
+      status: "completed",
+      answer: "The relevant repository files remain visible.",
+    });
+    expect(searchOutput).toMatchObject({
+      schemaVersion: 1,
+      policyVersion: "search-repository.v1",
+      kind: "content",
+      query: "needle",
+      currentContentMustBeReread: true,
+      groups: expect.arrayContaining([
+        expect.objectContaining({ path: "src/10-relevant.ts" }),
+        expect.objectContaining({ path: "src/20-also-relevant.ts" }),
+      ]),
+    });
+    const output = searchOutput as {
+      readonly groups: readonly {
+        readonly path: string;
+        readonly matches: readonly unknown[];
+      }[];
+    };
+    expect(output.groups.flatMap((group) => group.matches)).toHaveLength(9);
+    expect(output.groups.find((group) => group.path === "src/00-noise.ts")?.matches).toHaveLength(
+      5,
+    );
+    expect(Buffer.byteLength(JSON.stringify(searchOutput), "utf8")).toBeLessThanOrEqual(16 * 1024);
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("repository search rejects an explicit hidden path before starting a child process", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-hidden-root-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(join(workspaceRoot, ".github"), { recursive: true });
+  await writeFile(join(workspaceRoot, ".github", "private.txt"), "needle\n", "utf8");
+  let spawned = 0;
+  const adapter = createRepositorySearchToolAdapterForTesting({
+    workspaceRoot,
+    processObserver: {
+      spawned() {
+        spawned += 1;
+      },
+      closed() {},
+    },
+  });
+
+  try {
+    for (const input of [
+      { kind: "content", query: "needle", path: ".github" },
+      { kind: "path", query: "private", path: ".github" },
+    ]) {
+      const prepared = adapter.prepare(JSON.stringify(input));
+      expect(prepared).toMatchObject({
+        status: "failed",
+        error: { code: "outside_workspace" },
+      });
+    }
+    expect(spawned).toBe(0);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("repository search normalizes every same-line ripgrep submatch to character columns", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-columns-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "unicode.txt"), "界needle + needle\n", "utf8");
+  const adapter = createRepositorySearchToolAdapterForTesting({ workspaceRoot });
+
+  try {
+    const prepared = adapter.prepare(
+      JSON.stringify({ kind: "content", query: "needle", case: "sensitive" }),
+    );
+    if (prepared.status !== "ready") {
+      throw new TypeError("The repository search call was not prepared.");
+    }
+    const result = await prepared.execute({
+      signal: new AbortController().signal,
+      callId: "search-unicode-columns",
+      toolName: "search_repository",
+      sessionId: "search-unicode-columns-session",
+      toolProfileDigest: "sha256:search-unicode-columns-profile",
+    });
+
+    expect(result).toMatchObject({
+      status: "completed",
+      output: {
+        snapshotResultCount: 2,
+        groups: [
+          {
+            path: "unicode.txt",
+            matches: [{ column: 2 }, { column: 11 }],
+          },
+        ],
+      },
+    });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("repository search Git ranking never invokes repository-configured fsmonitor code", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-git-config-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const markerPath = join(testRoot, "fsmonitor-invoked");
+  const monitorPath = join(testRoot, "fsmonitor.sh");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "candidate.txt"), "needle\n", "utf8");
+  await writeFile(monitorPath, `#!/bin/sh\nprintf invoked > "${markerPath}"\n`, "utf8");
+  await chmod(monitorPath, 0o700);
+  execFileSync("git", ["init", "--quiet"], { cwd: workspaceRoot });
+  execFileSync("git", ["config", "core.fsmonitor", monitorPath], { cwd: workspaceRoot });
+  const adapter = createRepositorySearchToolAdapterForTesting({ workspaceRoot });
+
+  try {
+    const prepared = adapter.prepare(JSON.stringify({ kind: "path", query: "candidate" }));
+    if (prepared.status !== "ready") {
+      throw new TypeError("The repository search call was not prepared.");
+    }
+    await prepared.execute({
+      signal: new AbortController().signal,
+      callId: "search-frozen-git-config",
+      toolName: "search_repository",
+      sessionId: "search-frozen-git-config-session",
+      toolProfileDigest: "sha256:search-frozen-git-config-profile",
+    });
+
+    await expect(
+      import("node:fs/promises").then(({ readFile }) => readFile(markerPath, "utf8")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("repository search cancellation escalates TERM to KILL and settles only after child close", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-kill-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const backendPath = join(testRoot, "ignore-term-rg.sh");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "candidate.txt"), "needle\n", "utf8");
+  await writeFile(
+    backendPath,
+    "#!/bin/sh\ntrap '' TERM\nprintf 'candidate.txt\\000'\nwhile :; do :; done\n",
+    "utf8",
+  );
+  await chmod(backendPath, 0o700);
+  const controller = new AbortController();
+  const cancellation = new Error("cancel repository search after one record");
+  const signals: string[] = [];
+  let closed = false;
+  let settled = false;
+  let settledAtClose: boolean | undefined;
+  const adapterOptions = {
+    workspaceRoot,
+    rgPathOverrideForTesting: backendPath,
+    processObserver: {
+      spawned() {},
+      recorded() {
+        controller.abort(cancellation);
+      },
+      signalled(signal: string) {
+        signals.push(signal);
+      },
+      closed() {
+        settledAtClose = settled;
+        closed = true;
+      },
+    },
+  };
+  const adapter = createRepositorySearchToolAdapterForTesting(adapterOptions);
+
+  try {
+    const prepared = adapter.prepare(JSON.stringify({ kind: "path", query: "candidate" }));
+    if (prepared.status !== "ready") {
+      throw new TypeError("The repository search call was not prepared.");
+    }
+    const execution = prepared.execute({
+      signal: controller.signal,
+      callId: "search-kill-after-term",
+      toolName: "search_repository",
+      sessionId: "search-kill-after-term-session",
+      toolProfileDigest: "sha256:search-kill-after-term-profile",
+    });
+    void execution.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    await expect(execution).rejects.toBe(cancellation);
+    expect({ signals, closed, settledAtClose }).toEqual({
+      signals: ["SIGTERM", "SIGKILL"],
+      closed: true,
+      settledAtClose: false,
+    });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("repository search parser failure escalates through the same TERM to KILL owner", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-parser-kill-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const backendPath = join(testRoot, "invalid-rg");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "candidate.txt"), "needle\n", "utf8");
+  await writeFile(
+    backendPath,
+    "#!/usr/bin/env node\nconst { writeSync } = require('node:fs');\nprocess.on('SIGTERM', () => {});\nwriteSync(1, '{\\\"type\\\":\\\"match\\\"}\\n');\nsetInterval(() => {}, 1_000);\n",
+    "utf8",
+  );
+  await chmod(backendPath, 0o700);
+  const signals: string[] = [];
+  let closed = false;
+  const adapter = createRepositorySearchToolAdapterForTesting({
+    workspaceRoot,
+    rgPathOverrideForTesting: backendPath,
+    processObserver: {
+      spawned() {},
+      signalled(signal) {
+        signals.push(signal);
+      },
+      closed() {
+        closed = true;
+      },
+    },
+  });
+
+  try {
+    const result = await executeSearch(adapter, { kind: "content", query: "needle" });
+    expect(result).toMatchObject({
+      status: "failed",
+      error: {
+        code: "tool_io_failed",
+        message: "The repository search backend returned invalid output.",
+      },
+    });
+    expect({ signals, closed }).toEqual({ signals: ["SIGTERM", "SIGKILL"], closed: true });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("repository search omits a content candidate changed after the backend begins reading it", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-changed-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const candidatePath = join(workspaceRoot, "candidate.txt");
+  const backendPath = join(testRoot, "scripted-rg.sh");
+  await mkdir(workspaceRoot);
+  await writeFile(candidatePath, "needle before\n", "utf8");
+  const records = [
+    { type: "begin", data: { path: { text: "candidate.txt" } } },
+    {
+      type: "match",
+      data: {
+        path: { text: "candidate.txt" },
+        lines: { text: "needle before\n" },
+        line_number: 1,
+        absolute_offset: 0,
+        submatches: [{ match: { text: "needle" }, start: 0, end: 6 }],
+      },
+    },
+    { type: "end", data: {} },
+    { type: "summary", data: {} },
+  ];
+  await writeFile(
+    backendPath,
+    `#!/bin/sh\nprintf '%s\\n' ${records.map((record) => `'${JSON.stringify(record)}'`).join(" ")}\n`,
+    "utf8",
+  );
+  await chmod(backendPath, 0o700);
+  let recordCount = 0;
+  const adapter = createRepositorySearchToolAdapterForTesting({
+    workspaceRoot,
+    rgPathOverrideForTesting: backendPath,
+    processObserver: {
+      spawned() {},
+      recorded() {
+        recordCount += 1;
+        if (recordCount === 1) {
+          writeFileSync(candidatePath, "replacement after begin\n", "utf8");
+        }
+      },
+      closed() {},
+    },
+  });
+
+  try {
+    const prepared = adapter.prepare(JSON.stringify({ kind: "content", query: "needle" }));
+    if (prepared.status !== "ready") {
+      throw new TypeError("The repository search call was not prepared.");
+    }
+    const result = await prepared.execute({
+      signal: new AbortController().signal,
+      callId: "search-changed-after-begin",
+      toolName: "search_repository",
+      sessionId: "search-changed-after-begin-session",
+      toolProfileDigest: "sha256:search-changed-after-begin-profile",
+    });
+
+    expect(result).toMatchObject({
+      status: "completed",
+      output: {
+        groups: [],
+        omissions: [{ reason: "changed", path: "candidate.txt", count: 1 }],
+      },
+    });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("repository path search omits a candidate changed after its backend record", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-path-changed-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const candidatePath = join(workspaceRoot, "candidate.txt");
+  const backendPath = join(testRoot, "scripted-path-rg.sh");
+  await mkdir(workspaceRoot);
+  await writeFile(candidatePath, "before\n", "utf8");
+  await writeFile(backendPath, "#!/bin/sh\nprintf 'candidate.txt\\000'\n", "utf8");
+  await chmod(backendPath, 0o700);
+  const adapter = createRepositorySearchToolAdapterForTesting({
+    workspaceRoot,
+    rgPathOverrideForTesting: backendPath,
+    processObserver: {
+      spawned() {},
+      recorded() {
+        writeFileSync(candidatePath, "after backend record\n", "utf8");
+      },
+      closed() {},
+    },
+  });
+
+  try {
+    const result = await executeSearch(adapter, { kind: "path", query: "candidate" });
+    expect(result).toMatchObject({
+      status: "completed",
+      output: {
+        entries: [],
+        omissions: [{ reason: "changed", path: "candidate.txt", count: 1 }],
+      },
+    });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("repository search excludes ignored, hidden, binary, and symlink candidates", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-exclusions-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const sourceRoot = join(workspaceRoot, "src");
+
+  try {
+    await mkdir(sourceRoot, { recursive: true });
+    await mkdir(join(workspaceRoot, "generated"));
+    await mkdir(join(workspaceRoot, ".hidden"));
+    await writeFile(join(workspaceRoot, ".gitignore"), "generated/\n", "utf8");
+    await writeFile(join(sourceRoot, "visible-needle.ts"), "const value = 'needle';\n", "utf8");
+    await writeFile(
+      join(workspaceRoot, "generated", "ignored-needle.ts"),
+      "const value = 'needle';\n",
+      "utf8",
+    );
+    await writeFile(
+      join(workspaceRoot, ".hidden", "secret-needle.ts"),
+      "const value = 'needle';\n",
+      "utf8",
+    );
+    await writeFile(join(sourceRoot, "binary-needle.bin"), Buffer.from("needle\0private"));
+    const externalPath = join(testRoot, "external-needle.ts");
+    await writeFile(externalPath, "const value = 'needle';\n", "utf8");
+    await symlink(externalPath, join(sourceRoot, "external-needle.ts"));
+    const adapter = createRepositorySearchToolAdapterForTesting({ workspaceRoot });
+
+    const pathResult = await executeSearch(adapter, { kind: "path", query: "needle" });
+    const contentResult = await executeSearch(adapter, { kind: "content", query: "needle" });
+
+    expect(pathResult).toMatchObject({
+      status: "completed",
+      output: {
+        entries: [{ path: "src/visible-needle.ts" }],
+        omissions: [{ reason: "binary", path: "src/binary-needle.bin", count: 1 }],
+      },
+    });
+    expect(contentResult).toMatchObject({
+      status: "completed",
+      output: { groups: [{ path: "src/visible-needle.ts" }] },
+    });
+    expect(JSON.stringify([pathResult, contentResult])).not.toMatch(
+      /ignored-needle|secret-needle|external-needle/u,
+    );
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("repository search rejects an explicit symlink path before execution", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-explicit-symlink-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const externalPath = join(testRoot, "external.txt");
+  await writeFile(externalPath, "private needle\n", "utf8");
+  await symlink(externalPath, join(workspaceRoot, "linked.txt"));
+
+  try {
+    await expect(
+      executeSearch(createRepositorySearchToolAdapterForTesting({ workspaceRoot }), {
+        kind: "content",
+        query: "needle",
+        path: "linked.txt",
+      }),
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "outside_workspace" },
+    });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("repository search resolves the pinned absolute application-local Linux backend", () => {
+  const backend = repositorySearchBackendForTesting();
+  const version = execFileSync(backend.rgPath, ["--version"], { encoding: "utf8" });
+
+  expect({ absolute: isAbsolute(backend.rgPath), version: version.split("\n")[0] }).toEqual({
+    absolute: true,
+    version: "ripgrep 15.0.0 (rev 3a612f88b8)",
+  });
+});
+
+test("repository search cancellation settles only after the owned ripgrep child closes", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-search-cancel-close-"));
+  const controller = new AbortController();
+  const cancellation = new Error("cancel repository search");
+  let childClosed = false;
+
+  try {
+    await writeFile(join(workspaceRoot, "search.txt"), "needle\n".repeat(10_000), "utf8");
+    const adapter = createRepositorySearchToolAdapterForTesting({
+      workspaceRoot,
+      processObserver: {
+        spawned() {
+          controller.abort(cancellation);
+        },
+        closed() {
+          childClosed = true;
+        },
+      },
+    });
+
+    await expect(
+      executeSearch(adapter, { kind: "content", query: "needle" }, controller.signal),
+    ).rejects.toBe(cancellation);
+    expect(childClosed).toBe(true);
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+async function executeSearch(
+  adapter: ReturnType<typeof createRepositorySearchToolAdapterForTesting>,
+  input: Readonly<Record<string, unknown>>,
+  signal: AbortSignal = new AbortController().signal,
+) {
+  const prepared = adapter.prepare(JSON.stringify(input));
+  if (prepared.status !== "ready") {
+    return prepared;
+  }
+  return prepared.execute({
+    signal,
+    callId: "repository-search-os-contract",
+    toolName: "search_repository",
+    sessionId: "repository-search-os-contract-session",
+    toolProfileDigest: "sha256:repository-search-os-contract-profile",
+  });
+}

--- a/packages/testkit/src/session-lifecycle.test.ts
+++ b/packages/testkit/src/session-lifecycle.test.ts
@@ -448,9 +448,9 @@ function snapshotWithLastPromptProjection<Snapshot extends { readonly promptCont
 }
 
 const introductionRequestDigest =
-  "sha256:0782707796dafcb2988d1eadadddc3de09e48ef4a1760ab57a4be9a983b9a181" as const;
+  "sha256:261865cb0025860d34717e6bc56716925fbdaf70a4757f6b4826af1417305fc7" as const;
 const permissionRequestDigest =
-  "sha256:341baabb2a66d516430fc49f39c3c408a15dae8a47608ad543a3bb888431b01c" as const;
+  "sha256:c82b39aa784fec5a2d91bfc5f2471cde20a55ff8f618747023c3efc21ee16f8f" as const;
 
 test("SessionLifecycle rejects a deterministic competing owner and proceeds after release", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-lifecycle-memory-owner-"));
@@ -3485,6 +3485,7 @@ test("SessionLifecycle creates a prompt-v3 genesis with an empty bounded Skill s
           toolProfile: {
             definitions: [
               { name: "read_file" },
+              { name: "search_repository" },
               { name: "write_file" },
               { name: "edit_file" },
               { name: "run_shell" },

--- a/packages/testkit/src/shell-session.test.ts
+++ b/packages/testkit/src/shell-session.test.ts
@@ -16,7 +16,7 @@ import { expect, test } from "vitest";
 
 import { FakeModelDriver } from "./index.js";
 
-test("the default coding registry exposes the seven current prompt tools", async () => {
+test("the default coding registry exposes the eight current prompt tools", async () => {
   const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-coding-registry-"));
 
   try {
@@ -45,6 +45,7 @@ test("the default coding registry exposes the seven current prompt tools", async
     }).toEqual({
       definitions: [
         "read_file",
+        "search_repository",
         "write_file",
         "edit_file",
         "run_shell",

--- a/packages/testkit/src/skills.test.ts
+++ b/packages/testkit/src/skills.test.ts
@@ -618,6 +618,7 @@ test("SessionLifecycle bounds unknown frontmatter fields and reports allowed-too
       created.promptContext?.toolProfile.definitions.map((definition) => definition.name),
     ).toEqual([
       "read_file",
+      "search_repository",
       "write_file",
       "edit_file",
       "run_shell",
@@ -676,6 +677,7 @@ test("SessionLifecycle admits audited Skill metadata arrays without granting lis
       created.promptContext?.toolProfile.definitions.map((definition) => definition.name),
     ).toEqual([
       "read_file",
+      "search_repository",
       "write_file",
       "edit_file",
       "run_shell",

--- a/packages/testkit/src/trusted-mcp-host.test.ts
+++ b/packages/testkit/src/trusted-mcp-host.test.ts
@@ -5002,6 +5002,7 @@ test("SessionLifecycle keeps user-assigned MCP effect authority over server anno
     });
     expect(requests[0]?.tools.map((tool) => tool.name)).toEqual([
       "read_file",
+      "search_repository",
       "write_file",
       "edit_file",
       "run_shell",

--- a/packages/testkit/src/user-configuration.test.ts
+++ b/packages/testkit/src/user-configuration.test.ts
@@ -1145,7 +1145,7 @@ test("a legacy compacted session reuses the selected-prefix profile instead of c
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-legacy-compacted-profile-"));
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot, { mode: 0o700 });
-  await writeFile(join(workspaceRoot, "context.txt"), "legacy context ".repeat(220), "utf8");
+  await writeFile(join(workspaceRoot, "context.txt"), "legacy context ".repeat(600), "utf8");
   const configuration = createInMemoryUserConfiguration(
     `${JSON.stringify({
       schemaVersion: 2,
@@ -1162,8 +1162,8 @@ test("a legacy compacted session reuses the selected-prefix profile instead of c
     version: 1,
     contextWindowTokens: 20_000,
     maximumOutputTokens: 100,
-    compactAtTokens: 900,
-    postCompactTargetTokens: 700,
+    compactAtTokens: 1_500,
+    postCompactTargetTokens: 1_200,
     retainedTargetTokens: 100,
     estimatorVersion: 1,
   };
@@ -1171,7 +1171,7 @@ test("a legacy compacted session reuses the selected-prefix profile instead of c
     ...historicalOfficialProfile,
     contextWindowTokens: 30_000,
     maximumOutputTokens: 200,
-    compactAtTokens: 1_500,
+    compactAtTokens: 2_200,
   };
   const summary = JSON.stringify({
     schemaVersion: 1,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@modelcontextprotocol/client':
         specifier: 2.0.0
         version: 2.0.0
+      '@vscode/ripgrep':
+        specifier: 1.18.0
+        version: 1.18.0
       jpeg-js:
         specifier: 0.4.4
         version: 0.4.4
@@ -539,6 +542,69 @@ packages:
 
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  '@vscode/ripgrep-darwin-arm64@1.18.0':
+    resolution: {integrity: sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@vscode/ripgrep-darwin-x64@1.18.0':
+    resolution: {integrity: sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@vscode/ripgrep-linux-arm64@1.18.0':
+    resolution: {integrity: sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-arm@1.18.0':
+    resolution: {integrity: sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-ia32@1.18.0':
+    resolution: {integrity: sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-ppc64@1.18.0':
+    resolution: {integrity: sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-riscv64@1.18.0':
+    resolution: {integrity: sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-s390x@1.18.0':
+    resolution: {integrity: sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-x64@1.18.0':
+    resolution: {integrity: sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@vscode/ripgrep-win32-arm64@1.18.0':
+    resolution: {integrity: sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@vscode/ripgrep-win32-ia32@1.18.0':
+    resolution: {integrity: sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@vscode/ripgrep-win32-x64@1.18.0':
+    resolution: {integrity: sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@vscode/ripgrep@1.18.0':
+    resolution: {integrity: sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==}
 
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
@@ -1562,6 +1628,57 @@ snapshots:
       '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
+
+  '@vscode/ripgrep-darwin-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-darwin-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-arm@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-ia32@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-ppc64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-riscv64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-s390x@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-ia32@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep@1.18.0':
+    optionalDependencies:
+      '@vscode/ripgrep-darwin-arm64': 1.18.0
+      '@vscode/ripgrep-darwin-x64': 1.18.0
+      '@vscode/ripgrep-linux-arm': 1.18.0
+      '@vscode/ripgrep-linux-arm64': 1.18.0
+      '@vscode/ripgrep-linux-ia32': 1.18.0
+      '@vscode/ripgrep-linux-ppc64': 1.18.0
+      '@vscode/ripgrep-linux-riscv64': 1.18.0
+      '@vscode/ripgrep-linux-s390x': 1.18.0
+      '@vscode/ripgrep-linux-x64': 1.18.0
+      '@vscode/ripgrep-win32-arm64': 1.18.0
+      '@vscode/ripgrep-win32-ia32': 1.18.0
+      '@vscode/ripgrep-win32-x64': 1.18.0
 
   '@workflow/serde@4.1.0': {}
 


### PR DESCRIPTION
## Summary
- add the single read-only search_repository tool with frozen content/path modes, deterministic ranking, bounded immutable paging, and historical-profile behavior
- pin and invoke the application-local ripgrep backend while enforcing ignore, hidden, binary, symlink, mutation, Git-config, quota, and process-lifecycle boundaries
- add renderer-neutral/TUI search presentation plus deterministic semantic tests and explicit OS-contract coverage

## Verification
- pnpm quality:check
- 52 test files passed, 2 skipped; 1376 tests passed, 13 skipped
- repository-search OS matrix: 12 passed
- independent specification review: 0 actionable findings
- independent standards/test-architecture review: 0 actionable findings