### PR TITLE
test(tui): recover exact-main causal checks

### DIFF
--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -4960,23 +4960,32 @@ test("the production editor clears a manual session name through canonical Prese
 
   try {
     const fixture = startFixture({ controlRoot, stateRoot, workspaceRoot });
+    console.error("[DEBUG-s3r0-clear-name] fixture-started");
     await fixture.waitFor("Adam · New session");
+    console.error("[DEBUG-s3r0-clear-name] initial-frame");
     fixture.write("/name Temporary name\r");
     await fixture.waitFor("Adam · Temporary name");
+    console.error("[DEBUG-s3r0-clear-name] temporary-name-frame");
     const beforeClear = fixture.output().length;
     fixture.write("/name --");
     await fixture.waitForCompleteFrameAfter("--generate", beforeClear);
+    console.error("[DEBUG-s3r0-clear-name] completion-frame");
     fixture.write("\t");
     await fixture.resize(81, 24);
+    console.error("[DEBUG-s3r0-clear-name] resized-frame");
     await fixture.waitForCompleteFrameAfter("/name --clear", beforeClear);
+    console.error("[DEBUG-s3r0-clear-name] clear-draft-frame");
     const beforeSubmit = fixture.output().length;
     fixture.write("\r");
     await expect(
       waitForFileContents(join(controlRoot, "clear-session-name-dispatch-settled"), "admitted\n"),
     ).resolves.toBe("admitted\n");
+    console.error("[DEBUG-s3r0-clear-name] dispatch-settled");
     await fixture.waitForCompleteFrameAfter("Adam · New session", beforeSubmit);
+    console.error("[DEBUG-s3r0-clear-name] cleared-frame");
     fixture.write("\u0011");
     await fixture.closed;
+    console.error("[DEBUG-s3r0-clear-name] fixture-closed");
     expect(fixture.screen()?.join("\n") ?? "").not.toContain("Adam · --clear");
   } finally {
     await rm(testRoot, { recursive: true, force: true });

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -4960,32 +4960,27 @@ test("the production editor clears a manual session name through canonical Prese
 
   try {
     const fixture = startFixture({ controlRoot, stateRoot, workspaceRoot });
-    console.error("[DEBUG-s3r0-clear-name] fixture-started");
     await fixture.waitFor("Adam · New session");
-    console.error("[DEBUG-s3r0-clear-name] initial-frame");
+    const beforeRename = fixture.output().length;
     fixture.write("/name Temporary name\r");
-    await fixture.waitFor("Adam · Temporary name");
-    console.error("[DEBUG-s3r0-clear-name] temporary-name-frame");
+    await expect(
+      waitForFileContents(join(controlRoot, "session-name-dispatch-settled"), "admitted\n"),
+    ).resolves.toBe("admitted\n");
+    await fixture.waitForCompleteFrameAfter("Adam · Temporary name", beforeRename);
     const beforeClear = fixture.output().length;
     fixture.write("/name --");
     await fixture.waitForCompleteFrameAfter("--generate", beforeClear);
-    console.error("[DEBUG-s3r0-clear-name] completion-frame");
     fixture.write("\t");
     await fixture.resize(81, 24);
-    console.error("[DEBUG-s3r0-clear-name] resized-frame");
     await fixture.waitForCompleteFrameAfter("/name --clear", beforeClear);
-    console.error("[DEBUG-s3r0-clear-name] clear-draft-frame");
     const beforeSubmit = fixture.output().length;
     fixture.write("\r");
     await expect(
       waitForFileContents(join(controlRoot, "clear-session-name-dispatch-settled"), "admitted\n"),
     ).resolves.toBe("admitted\n");
-    console.error("[DEBUG-s3r0-clear-name] dispatch-settled");
     await fixture.waitForCompleteFrameAfter("Adam · New session", beforeSubmit);
-    console.error("[DEBUG-s3r0-clear-name] cleared-frame");
     fixture.write("\u0011");
     await fixture.closed;
-    console.error("[DEBUG-s3r0-clear-name] fixture-closed");
     expect(fixture.screen()?.join("\n") ?? "").not.toContain("Adam · --clear");
   } finally {
     await rm(testRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Recovery context
- S3-R0 merge commit 2d5266182f30531f981f945b409ecc84b1067766 passed PR Quality but its exact-main push run exposed a clear-name TUI timeout
- the test previously observed the renamed title before its existing dispatch receipt settled, so autocomplete could race the editor cleanup owned by the rename command
- wait for the exact admitted receipt, then require a complete renamed frame before typing the clear command; no sleeps, polling, timeout increase, worker tuning, product behavior change, or debug logs remain

## Verification
- focused test: four independent invocations passed
- pnpm quality:check: 52 files passed, 2 skipped; 1376 tests passed, 13 skipped