### PR TITLE
feat(agent): add durable read-only Plan exploration

### DIFF
--- a/apps/tui/src/command-registry.ts
+++ b/apps/tui/src/command-registry.ts
@@ -27,6 +27,7 @@ export type AdamCommandDefinition = {
     | "model"
     | "name"
     | "new"
+    | "plan"
     | "reload"
     | "resume"
     | "session"
@@ -335,6 +336,14 @@ const builtInCommands: readonly AdamCommandDefinition[] = [
     name: "new",
     summary: "Choose an exact target and create a new session.",
     usage: "/new",
+  },
+  {
+    aliases: [],
+    availability: "idle",
+    id: "plan",
+    name: "plan",
+    summary: "Enter or exit the authoritative read-only Plan cycle.",
+    usage: "/plan",
   },
   {
     aliases: [],

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -2695,6 +2695,35 @@ test("the idle footer exposes Registry-driven interaction hints", async () => {
   }
 });
 
+test("the production TUI toggles and displays authoritative read-only Plan status", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-plan-status-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    await fixture.resize(120, 40);
+
+    fixture.write("/plan\r");
+    await fixture.waitFor("Plan exploring · read-only");
+    let frame = latestSynchronizedFrame(fixture.output()).join("\n");
+    expect(frame).toContain("Plan exploring · read-only");
+
+    const beforeExit = fixture.output().length;
+    fixture.write("/plan\r");
+    await fixture.waitForAfter("Exited read-only Plan.", beforeExit);
+    frame = latestSynchronizedFrame(fixture.output().slice(beforeExit)).join("\n");
+    expect(frame).not.toContain("Plan exploring · read-only");
+
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("the footer exposes authoritative project context and run facts", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-footer-facts-"));
   const workspaceRoot = join(testRoot, "workspace");

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -4242,6 +4242,7 @@ test("continued scrolling loads only the adjacent oversized reasoning range", as
     terminal.input("Traverse provider reasoning ranges\r");
     await waitForPath(join(controlRoot, "reasoning-session-settled"));
     await waitForPhysicalText(terminal, "Thinking done · adam");
+    await waitForPhysicalText(terminal, "Adam · Streaming session");
     const durableStateBeforeNavigation = await readFilesRecursively(stateRoot);
     await inputAndWaitForPhysicalFrame(terminal, "\u0014");
     await waitForPath(join(controlRoot, "artifact-read-1-settled"));

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -4168,6 +4168,7 @@ test("Ctrl+T reads artifact-backed provider reasoning without placing it in the 
     fixture.write("Store provider reasoning out of line\r");
     await fixture.waitForCompleteFrameAfter("Thinking done · adam", beforePrompt);
     await waitForPath(join(controlRoot, "reasoning-session-settled"));
+    await fixture.waitFor("Adam · Streaming session");
     let frame = latestSynchronizedFrame(fixture.output().slice(beforePrompt)).join("\n");
     expect(frame).not.toContain("Artifact reasoning evidence");
     const durableStateBeforeExpand = await readFilesRecursively(stateRoot);
@@ -4312,6 +4313,7 @@ test("oversized reasoning evicts offscreen ranges by bytes and reloads them on u
     terminal.input("Exercise bounded reasoning range eviction\r");
     await waitForPath(join(controlRoot, "reasoning-session-settled"));
     await waitForPhysicalText(terminal, "Thinking done · adam");
+    await waitForPhysicalText(terminal, "Adam · Streaming session");
     const durableStateBeforeNavigation = await readFilesRecursively(stateRoot);
     await inputAndWaitForPhysicalFrame(terminal, "\u0014");
     await waitForPath(join(controlRoot, "artifact-read-1-settled"));
@@ -4368,6 +4370,7 @@ test("a late downward reasoning range cannot replace the page selected while it 
     terminal.input("Keep a reordered reasoning range out of the viewport\r");
     await waitForPath(join(controlRoot, "reasoning-session-settled"));
     await waitForPhysicalText(terminal, "Thinking done · adam");
+    await waitForPhysicalText(terminal, "Adam · Streaming session");
     await inputAndWaitForPhysicalFrame(terminal, "\u0014");
     await waitForPath(join(controlRoot, "artifact-read-1-settled"));
     await waitForPhysicalText(terminal, "Large reasoning · plain view · 1-16384 of 270028 bytes");
@@ -4521,6 +4524,7 @@ test("folding oversized reasoning rejects a late range before a clean retry", as
     terminal.input("Hold one provider reasoning range\r");
     await waitForPath(join(controlRoot, "reasoning-session-settled"));
     await waitForPhysicalText(terminal, "Thinking done · adam");
+    await waitForPhysicalText(terminal, "Adam · Streaming session");
     await inputAndWaitForPhysicalFrame(terminal, "\u0014");
     await waitForPath(join(controlRoot, "reasoning-page-read-pending"));
 
@@ -4655,7 +4659,9 @@ test.each(["missing", "truncated", "same-size corrupt"] as const)(
         await writeFile(artifactPath, artifactBytes);
       }
       await chmod(artifactPath, 0o400);
+      const beforeRetryClose = fixture.output().length;
       fixture.write("\u0014");
+      await fixture.waitForCompleteFrameAfter("Thinking done · adam", beforeRetryClose);
       const beforeRetry = fixture.output().length;
       fixture.write("\u0014");
       await expect(

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -1478,15 +1478,17 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           : ` · ${selectedSkills.size} Skill${selectedSkills.size === 1 ? "" : "s"} selected`;
       const olderHistorySummary =
         active.transcript.olderCursor === null ? "" : " · older history available";
+      const planSummary = active.plan === undefined ? "" : " · Plan exploring · read-only";
+      const compactPlanSummary = active.plan === undefined ? "" : " · plan read-only";
       footer.setText({
         wide: theme.muted(
-          `${safeTerminalText(state.authoritative.project.label)} · ${footerContextText(active)} · ${runStatus}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}${upstreamSummary}${connectionSummary}${thinkingSummary}${selectedSkillSummary}${olderHistorySummary} · ${commandRegistry.footerHint()}`,
+          `${safeTerminalText(state.authoritative.project.label)} · ${footerContextText(active)}${planSummary} · ${runStatus}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}${upstreamSummary}${connectionSummary}${thinkingSummary}${selectedSkillSummary}${olderHistorySummary} · ${commandRegistry.footerHint()}`,
         ),
         standard: theme.muted(
-          `${safeTerminalText(state.authoritative.project.label)} · ${footerContextText(active)} · ${runStatus}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}${upstreamSummary}${connectionSummary}${thinkingSummary}${selectedSkillSummary}${olderHistorySummary} · /help · Tab complete`,
+          `${safeTerminalText(state.authoritative.project.label)} · ${footerContextText(active)}${planSummary} · ${runStatus}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}${upstreamSummary}${connectionSummary}${thinkingSummary}${selectedSkillSummary}${olderHistorySummary} · /help · Tab complete`,
         ),
         narrow: theme.muted(
-          `${runStatus} · ${footerContextCompactText(active)}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}${upstreamSummary}\n/help · Tab complete`,
+          `${runStatus}${compactPlanSummary} · ${footerContextCompactText(active)}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}${upstreamSummary}\n/help · Tab complete`,
         ),
       });
     }
@@ -2632,6 +2634,63 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         active.session.targetId,
         active.session.id,
       );
+      return;
+    }
+    if (parsedCommand.kind === "known" && parsedCommand.command.id === "plan") {
+      if (parsedCommand.argumentsText.length > 0) {
+        showNotice("warning", "Usage: /plan", "until_edit", active.session.id);
+        editor.disableSubmit = false;
+        renderState();
+        return;
+      }
+      const plan = active.plan;
+      const entering = plan === undefined;
+      const planActionId = showNotice(
+        "progress",
+        entering ? "Entering read-only Plan…" : "Exiting read-only Plan…",
+        "until_replaced",
+        active.session.id,
+      );
+      void options.presentation
+        .dispatch(
+          entering
+            ? { type: "enter_plan", sessionId: active.session.id }
+            : {
+                type: "exit_plan",
+                sessionId: active.session.id,
+                cycleId: plan.cycleId,
+                revision: plan.revision,
+              },
+        )
+        .then((receipt) => {
+          if (receipt.status === "admitted") {
+            editor.setText("");
+            settleNotice(
+              planActionId,
+              "success",
+              entering ? "Entered read-only Plan." : "Exited read-only Plan.",
+              "until_next_action",
+              active.session.id,
+            );
+          } else {
+            settleNotice(planActionId, "error", receipt.message, "until_edit", active.session.id);
+          }
+        })
+        .catch(() => {
+          settleNotice(
+            planActionId,
+            "error",
+            entering
+              ? "Read-only Plan could not be entered."
+              : "Read-only Plan could not be exited.",
+            "until_edit",
+            active.session.id,
+          );
+        })
+        .finally(() => {
+          editor.disableSubmit = false;
+          renderState();
+        });
       return;
     }
     if (parsedCommand.kind === "not_command" && runActive) {

--- a/packages/agent/src/agent-session.ts
+++ b/packages/agent/src/agent-session.ts
@@ -60,6 +60,7 @@ import {
   prepareExplicitUserImageMessagesV1,
   projectedContentUsageV1,
 } from "./model-user-content.js";
+import type { PlanCycleSnapshot } from "./plan-mode.js";
 import {
   assemblePromptMessagesV1,
   createPromptContextV1,
@@ -153,6 +154,8 @@ export class AgentSession {
   readonly #model: ModelDriver;
   readonly #modalityProfile: ModelModalityProfile | undefined;
   readonly #tools: ToolRegistry | undefined;
+  readonly #fixedRequestTools: readonly ModelToolDefinition[] | undefined;
+  readonly #plan: PlanCycleSnapshot | undefined;
   readonly #permissions: PermissionPolicy | undefined;
   #promptContext: PromptContextRecord | undefined;
   #skillContext: SkillContextRecordV1 | undefined;
@@ -244,6 +247,13 @@ export class AgentSession {
             "run_shell",
           ])
         : captureToolRegistry(dependencies.tools, selectedToolNames);
+    this.#plan = this.#durableContext?.plan;
+    this.#fixedRequestTools =
+      this.#durableContext !== undefined && durablePromptContext === undefined
+        ? undefined
+        : this.#plan === undefined
+          ? (this.#tools?.definitions() ?? [])
+          : planRequestToolDefinitions(this.#tools, this.#plan);
     this.#permissions = dependencies.permissions;
     this.#promptContext =
       this.#durableContext === undefined
@@ -551,7 +561,7 @@ export class AgentSession {
         return this.#settleTurnLimitExceeded();
       }
       let requestMessages = this.#assemblePromptMessages(messages);
-      const requestTools = this.#tools?.definitions() ?? [];
+      const requestTools = this.#fixedRequestTools ?? this.#tools?.definitions() ?? [];
       let activeEstimate =
         this.#contextProfile === undefined
           ? undefined
@@ -1449,7 +1459,7 @@ export class AgentSession {
       const replacementTooLarge =
         this.#estimatePromptTokens(
           this.#assemblePromptMessages(replacementMessages),
-          this.#tools?.definitions() ?? [],
+          this.#fixedRequestTools ?? this.#tools?.definitions() ?? [],
         ) >= contextProfile.postCompactTargetTokens;
       if (replacementTooLarge) {
         const smallerRetryMessages = shrinkContextMessagesForRetry(replacementMessages);
@@ -1949,9 +1959,11 @@ export class AgentSession {
         error: {
           code: "unknown_tool",
           message:
-            call.name === "search_repository"
-              ? "Repository search is unavailable in this historical Tool Profile. Start a new session to use search_repository."
-              : `Unknown tool: ${call.name}`,
+            this.#plan !== undefined
+              ? "Plan denies tools outside its exact eligible Tool Profile."
+              : call.name === "search_repository"
+                ? "Repository search is unavailable in this historical Tool Profile. Start a new session to use search_repository."
+                : `Unknown tool: ${call.name}`,
         },
       };
       toolResultsById.set(call.id, { call, result });
@@ -1965,6 +1977,13 @@ export class AgentSession {
       return undefined;
     }
     const preparedPermissionSubject = preparedCall.permissionSubject;
+    const permissionInput: PermissionPolicyInput = {
+      callId: call.id,
+      name: call.name,
+      effect: adapter.effect,
+      scope: "call",
+      subject: preparedPermissionSubject,
+    };
     const visibleModelSkillSelection =
       preparedPermissionSubject.type === "skill" &&
       preparedPermissionSubject.operation === "activate" &&
@@ -1977,6 +1996,32 @@ export class AgentSession {
         error: {
           code: "skill_unavailable",
           message: "The requested Agent Skill is unavailable in the visible catalog.",
+        },
+      };
+      toolResultsById.set(call.id, { call, result });
+      await this.#appendToolResult(messages, call, result);
+      return undefined;
+    }
+    const eligiblePlanDefinition = this.#plan?.eligibleToolProfile.definitions.find(
+      (definition) => definition.name === call.name,
+    );
+    if (
+      this.#plan !== undefined &&
+      (eligiblePlanDefinition === undefined ||
+        eligiblePlanDefinition.definitionDigest !== adapter.definitionDigest ||
+        eligiblePlanDefinition.effect !== adapter.effect ||
+        adapter.effect !== "read")
+    ) {
+      await this.#emit({
+        type: "tool_permission_decided",
+        decision: "deny",
+        ...permissionInput,
+      });
+      const result: ToolResult = {
+        status: "failed",
+        error: {
+          code: "permission_denied",
+          message: `Permission denied for tool in Plan: ${call.name}`,
         },
       };
       toolResultsById.set(call.id, { call, result });
@@ -2050,15 +2095,8 @@ export class AgentSession {
         }
       }
     }
-    const permissionInput: PermissionPolicyInput = {
-      callId: call.id,
-      name: call.name,
-      effect: adapter.effect,
-      scope: "call",
-      subject: preparedCall.permissionSubject,
-    };
     const policyDecision =
-      preparedPermissionSubject.type === "input_resource"
+      this.#plan !== undefined || preparedPermissionSubject.type === "input_resource"
         ? "allow"
         : (this.#permissions?.decide(permissionInput) ?? "deny");
     if (signal.aborted) {
@@ -3723,6 +3761,38 @@ function filterLiveToolRegistry(
     definitions: () => tools.definitions().filter((definition) => selected.has(definition.name)),
     resolve: (name) => (selected.has(name) ? tools.resolve(name) : undefined),
   };
+}
+
+function planRequestToolDefinitions(
+  tools: ToolRegistry | undefined,
+  plan: PlanCycleSnapshot | undefined,
+): readonly ModelToolDefinition[] {
+  if (tools === undefined) {
+    if (plan !== undefined) {
+      throw new TypeError("The exact Plan Tool Profile is not supported.");
+    }
+    return [];
+  }
+  if (plan === undefined) {
+    return tools.definitions();
+  }
+  const visibleDefinitions = new Map(
+    tools.definitions().map((definition) => [definition.name, definition] as const),
+  );
+  return plan.eligibleToolProfile.definitions.map((definition) => {
+    const modelDefinition = visibleDefinitions.get(definition.name);
+    const adapter = tools.resolve(definition.name);
+    if (
+      modelDefinition === undefined ||
+      adapter === undefined ||
+      adapter.definitionDigest !== definition.definitionDigest ||
+      adapter.effect !== definition.effect ||
+      definition.effect !== "read"
+    ) {
+      throw new TypeError("The exact Plan Tool Profile is not supported.");
+    }
+    return modelDefinition;
+  });
 }
 
 function areOptionalUsageDetailsValid(

--- a/packages/agent/src/image-input.ts
+++ b/packages/agent/src/image-input.ts
@@ -1,3 +1,4 @@
+import { inflateSync } from "node:zlib";
 import { decode as decodeJpeg } from "jpeg-js";
 import { PNG } from "pngjs";
 
@@ -49,14 +50,22 @@ export function sniffExplicitUserImageMediaTypeV1(
 }
 
 function inspectPng(bytes: Uint8Array): ImageInspection {
-  const dimensions = inspectPngContainer(bytes);
-  if (dimensions === undefined) {
+  const container = inspectPngContainer(bytes);
+  if (container === undefined) {
     return { status: "invalid" };
   }
+  const dimensions = { width: container.width, height: container.height };
   if (exceedsDimensionLimits(dimensions)) {
     return { status: "limit_exceeded", mediaType: "image/png", ...dimensions };
   }
   try {
+    const inflatedByteLength = expectedPngInflatedByteLength(container);
+    if (inflatedByteLength === undefined) {
+      return { status: "invalid" };
+    }
+    inflateSync(container.imageData, {
+      maxOutputLength: inflatedByteLength,
+    });
     const decoded = PNG.sync.read(Buffer.from(bytes), { checkCRC: true });
     if (
       decoded.width !== dimensions.width ||
@@ -100,13 +109,24 @@ function inspectJpeg(bytes: Uint8Array): ImageInspection {
   return { status: "valid", mediaType: "image/jpeg", ...dimensions };
 }
 
-function inspectPngContainer(
-  bytes: Uint8Array,
-): { readonly width: number; readonly height: number } | undefined {
+function inspectPngContainer(bytes: Uint8Array):
+  | {
+      readonly width: number;
+      readonly height: number;
+      readonly bitDepth: number;
+      readonly colorType: number;
+      readonly interlace: number;
+      readonly imageData: Buffer;
+    }
+  | undefined {
   let offset = pngSignature.byteLength;
   let width: number | undefined;
   let height: number | undefined;
+  let bitDepth: number | undefined;
+  let colorType: number | undefined;
+  let interlace: number | undefined;
   let sawImageData = false;
+  const imageDataChunks: Buffer[] = [];
   let chunkIndex = 0;
   while (offset < bytes.byteLength) {
     if (bytes.byteLength - offset < 12) {
@@ -134,7 +154,18 @@ function inspectPngContainer(
       }
       width = readUint32(bytes, dataStart);
       height = readUint32(bytes, dataStart + 4);
-      if (width === 0 || height === 0) {
+      bitDepth = bytes[dataStart + 8];
+      colorType = bytes[dataStart + 9];
+      const compression = bytes[dataStart + 10];
+      const filter = bytes[dataStart + 11];
+      interlace = bytes[dataStart + 12];
+      if (
+        width === 0 ||
+        height === 0 ||
+        compression !== 0 ||
+        filter !== 0 ||
+        (interlace !== 0 && interlace !== 1)
+      ) {
         return undefined;
       }
     } else if (type === "IHDR") {
@@ -142,6 +173,7 @@ function inspectPngContainer(
     }
     if (type === "IDAT") {
       sawImageData = true;
+      imageDataChunks.push(Buffer.from(bytes.subarray(dataStart, dataEnd)));
     }
     if (type === "IEND") {
       if (
@@ -149,16 +181,76 @@ function inspectPngContainer(
         !sawImageData ||
         width === undefined ||
         height === undefined ||
+        bitDepth === undefined ||
+        colorType === undefined ||
+        interlace === undefined ||
         chunkEnd !== bytes.byteLength
       ) {
         return undefined;
       }
-      return { width, height };
+      return {
+        width,
+        height,
+        bitDepth,
+        colorType,
+        interlace,
+        imageData: Buffer.concat(imageDataChunks),
+      };
     }
     offset = chunkEnd;
     chunkIndex += 1;
   }
   return undefined;
+}
+
+function expectedPngInflatedByteLength(input: {
+  readonly width: number;
+  readonly height: number;
+  readonly bitDepth: number;
+  readonly colorType: number;
+  readonly interlace: number;
+}): number | undefined {
+  const channels =
+    input.colorType === 0
+      ? 1
+      : input.colorType === 2
+        ? 3
+        : input.colorType === 3
+          ? 1
+          : input.colorType === 4
+            ? 2
+            : input.colorType === 6
+              ? 4
+              : undefined;
+  const validBitDepth =
+    (input.colorType === 0 && [1, 2, 4, 8, 16].includes(input.bitDepth)) ||
+    ((input.colorType === 2 || input.colorType === 4 || input.colorType === 6) &&
+      (input.bitDepth === 8 || input.bitDepth === 16)) ||
+    (input.colorType === 3 && [1, 2, 4, 8].includes(input.bitDepth));
+  if (channels === undefined || !validBitDepth) {
+    return undefined;
+  }
+  const bitsPerPixel = channels * input.bitDepth;
+  const passes =
+    input.interlace === 0
+      ? ([[0, 0, 1, 1]] as const)
+      : ([
+          [0, 0, 8, 8],
+          [4, 0, 8, 8],
+          [0, 4, 4, 8],
+          [2, 0, 4, 4],
+          [0, 2, 2, 4],
+          [1, 0, 2, 2],
+          [0, 1, 1, 2],
+        ] as const);
+  return passes.reduce((total, [xStart, yStart, xStep, yStep]) => {
+    const passWidth = Math.ceil(Math.max(0, input.width - xStart) / xStep);
+    const passHeight = Math.ceil(Math.max(0, input.height - yStart) / yStep);
+    if (passWidth === 0 || passHeight === 0) {
+      return total;
+    }
+    return total + passHeight * (Math.ceil((passWidth * bitsPerPixel) / 8) + 1);
+  }, 0);
 }
 
 function inspectJpegContainer(

--- a/packages/agent/src/plan-mode.ts
+++ b/packages/agent/src/plan-mode.ts
@@ -1,0 +1,80 @@
+import { createHash } from "node:crypto";
+
+import type { ToolEffect } from "./tool-runtime.js";
+
+export const planPolicyVersions = ["plan-policy.read-v1"] as const;
+
+export type PlanPolicyVersion = (typeof planPolicyVersions)[number];
+
+export type PlanEligibleToolProfileV1 = {
+  readonly version: 1;
+  readonly source: {
+    readonly version: 1;
+    readonly digest: `sha256:${string}`;
+  };
+  readonly definitions: readonly {
+    readonly name: string;
+    readonly definitionDigest: `sha256:${string}`;
+    readonly effect: ToolEffect;
+    readonly source: "builtin" | "mcp";
+  }[];
+  readonly digest: `sha256:${string}`;
+};
+
+export type PlanCycleSnapshot = {
+  readonly state: "exploring";
+  readonly cycleId: string;
+  readonly revision: number;
+  readonly policyVersion: PlanPolicyVersion;
+  readonly eligibleToolProfile: PlanEligibleToolProfileV1;
+};
+
+export function createReadOnlyPlanToolProfileV1(
+  input: Omit<PlanEligibleToolProfileV1, "digest" | "version">,
+): PlanEligibleToolProfileV1 {
+  const profile = {
+    version: 1 as const,
+    source: input.source,
+    definitions: input.definitions,
+  };
+  return { ...profile, digest: digestPlanProfile(profile) };
+}
+
+export function isReadOnlyPlanToolProfileV1Valid(profile: PlanEligibleToolProfileV1): boolean {
+  const { digest, ...withoutDigest } = profile;
+  return (
+    profile.version === 1 &&
+    /^sha256:[0-9a-f]{64}$/u.test(profile.source.digest) &&
+    profile.definitions.length > 0 &&
+    profile.definitions.length <= 64 &&
+    new Set(profile.definitions.map((definition) => definition.name)).size ===
+      profile.definitions.length &&
+    profile.definitions.every(
+      (definition) =>
+        definition.name.length > 0 &&
+        definition.name.length <= 256 &&
+        /^sha256:[0-9a-f]{64}$/u.test(definition.definitionDigest) &&
+        definition.effect === "read" &&
+        (definition.source === "builtin" || definition.source === "mcp"),
+    ) &&
+    digest === digestPlanProfile(withoutDigest)
+  );
+}
+
+function digestPlanProfile(input: Omit<PlanEligibleToolProfileV1, "digest">): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(canonicalJson(input)).digest("hex")}`;
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+  }
+  return `{${Object.entries(value)
+    .filter(([, entry]) => entry !== undefined)
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`)
+    .join(",")}}`;
+}

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -500,6 +500,7 @@ export async function createPresentationSession(
               skills: projectSkills(created),
               projectPaths,
               mcp: projectMcp(created),
+              ...(created.plan === undefined ? {} : { plan: created.plan }),
             },
     };
     let attachmentAvailable = initialDraft !== null || sessionSupportsInputResources(created);
@@ -1080,6 +1081,7 @@ export async function createPresentationSession(
             skills: projectSkills(snapshot),
             projectPaths,
             mcp: projectMcp(snapshot),
+            ...(snapshot.plan === undefined ? {} : { plan: snapshot.plan }),
           },
         },
         draft: null,
@@ -2763,6 +2765,58 @@ export async function createPresentationSession(
             status: "rejected",
             code: "authority_rejected",
             message: "The session name was not accepted.",
+          };
+        }
+      }
+      if (command.type === "enter_plan") {
+        if (command.sessionId !== state.authoritative.active?.session.id) {
+          return {
+            status: "rejected",
+            code: "stale_interaction",
+            message: "The selected session is no longer active.",
+          };
+        }
+        try {
+          const snapshot = await options.lifecycle.enterPlan(command);
+          await activateSnapshot(snapshot);
+          return { status: "admitted", commandId: randomUUID(), resource: null };
+        } catch (error) {
+          if (error instanceof SessionLifecycleError && error.code === "session_plan_unavailable") {
+            return {
+              status: "rejected",
+              code: "not_available",
+              message: error.message,
+            };
+          }
+          return {
+            status: "rejected",
+            code: "authority_rejected",
+            message: "Plan could not be entered from the current session state.",
+          };
+        }
+      }
+      if (command.type === "exit_plan") {
+        const plan = state.authoritative.active?.plan;
+        if (
+          command.sessionId !== state.authoritative.active?.session.id ||
+          command.cycleId !== plan?.cycleId ||
+          command.revision !== plan.revision
+        ) {
+          return {
+            status: "rejected",
+            code: "stale_interaction",
+            message: "The selected Plan cycle is no longer current.",
+          };
+        }
+        try {
+          const snapshot = await options.lifecycle.exitPlan(command);
+          await activateSnapshot(snapshot);
+          return { status: "admitted", commandId: randomUUID(), resource: null };
+        } catch {
+          return {
+            status: "rejected",
+            code: "authority_rejected",
+            message: "The current Plan cycle could not be exited.",
           };
         }
       }

--- a/packages/agent/src/session-durable-context.ts
+++ b/packages/agent/src/session-durable-context.ts
@@ -2,6 +2,7 @@ import type { ModelMessage } from "./agent-session-contracts.js";
 import type { ContextEvidenceV1 } from "./durable-context.js";
 import type { InputResourceOccurrenceV1 } from "./input-resources.js";
 import type { ModelTargetIdentity } from "./model-targets.js";
+import type { PlanCycleSnapshot } from "./plan-mode.js";
 import type { PromptContextRecord } from "./prompt-assembly.js";
 import type {
   ExtensionSkillSourceV1,
@@ -28,6 +29,7 @@ export type AgentSessionDurableContext = {
   readonly inputResourceRunBytes?: number;
   readonly initialMessages?: readonly ModelMessage[];
   readonly nextSequence: number;
+  readonly plan?: PlanCycleSnapshot;
   readonly newRunId?: string;
   readonly projectId?: string;
   readonly promptContext?: PromptContextRecord | undefined;

--- a/packages/agent/src/session-history-folds.ts
+++ b/packages/agent/src/session-history-folds.ts
@@ -2,6 +2,7 @@ import type { ContextUsageTotals } from "./agent-session-contracts.js";
 import { createContextProjectionMessage, estimateActiveContextTokens } from "./durable-context.js";
 import { createInputResourceProjectionMessageV1 } from "./input-resources.js";
 import type { ModelTargetIdentity } from "./model-targets.js";
+import type { PlanCycleSnapshot } from "./plan-mode.js";
 import {
   commitMcpToolProfileV3,
   hasSkillPromptContext,
@@ -374,7 +375,10 @@ export function isCompleteBranchBoundary(records: readonly SessionRecord[]): boo
             entry.record.type === "mcp_server_definition_approved" ||
             entry.record.type === "mcp_activation_started" ||
             entry.record.type === "mcp_activation_settled" ||
-            entry.record.type === "mcp_tool_profile_committed",
+            entry.record.type === "mcp_tool_profile_committed" ||
+            entry.record.type === "plan_cycle_entered" ||
+            entry.record.type === "plan_cycle_exited" ||
+            entry.record.type === "plan_cycle_inherited",
         )
     );
   }
@@ -898,6 +902,7 @@ export function snapshotFromRecords(
   }
   const currentRecords = records.filter((record) => record.schemaVersion === 3);
   const context = contextSnapshotFromRecords(records);
+  const plan = planCycleSnapshotFromRecords(records);
   const latestRun = currentRecords.findLast(
     (record) => record.record.type === "logical_run_started",
   );
@@ -909,6 +914,7 @@ export function snapshotFromRecords(
       ...(promptContext === undefined ? {} : { promptContext }),
       ...(skillContext === undefined ? {} : { skillContext: skillContextSnapshot(skillContext) }),
       ...(context === undefined ? {} : { context }),
+      ...(plan === undefined ? {} : { plan }),
       ...(artifactInspection?.degradation === undefined
         ? {}
         : { degradation: artifactInspection.degradation }),
@@ -966,6 +972,7 @@ export function snapshotFromRecords(
     ...(promptContext === undefined ? {} : { promptContext }),
     ...(skillContext === undefined ? {} : { skillContext: skillContextSnapshot(skillContext) }),
     ...(context === undefined ? {} : { context }),
+    ...(plan === undefined ? {} : { plan }),
     ...(artifactInspection?.degradation === undefined
       ? {}
       : { degradation: artifactInspection.degradation }),
@@ -986,4 +993,34 @@ export function snapshotFromRecords(
           }),
     },
   };
+}
+
+export function planCycleSnapshotFromRecords(
+  records: readonly SessionRecord[],
+): PlanCycleSnapshot | undefined {
+  let active: PlanCycleSnapshot | undefined;
+  for (const entry of records) {
+    if (entry.schemaVersion !== 3) {
+      continue;
+    }
+    if (
+      entry.record.type === "plan_cycle_entered" ||
+      entry.record.type === "plan_cycle_inherited"
+    ) {
+      active = {
+        state: "exploring",
+        cycleId: entry.record.cycleId,
+        revision: entry.record.revision,
+        policyVersion: entry.record.policyVersion,
+        eligibleToolProfile: entry.record.eligibleToolProfile,
+      };
+    } else if (
+      entry.record.type === "plan_cycle_exited" &&
+      entry.record.cycleId === active?.cycleId &&
+      entry.record.revision === active.revision + 1
+    ) {
+      active = undefined;
+    }
+  }
+  return active;
 }

--- a/packages/agent/src/session-history-validation.ts
+++ b/packages/agent/src/session-history-validation.ts
@@ -20,6 +20,7 @@ import {
 } from "./input-resources.js";
 import { isMcpToolProfileV1Valid } from "./mcp-profile-contracts.js";
 import { sameModelTargetIdentity } from "./model-targets.js";
+import { isReadOnlyPlanToolProfileV1Valid } from "./plan-mode.js";
 import {
   commitMcpToolProfileV3,
   hasSkillPromptContext,
@@ -159,6 +160,8 @@ export function validateCurrentSessionHistory(
       }
     | undefined;
   const titleGenerationIds = new Set<string>();
+  let activePlanCycleId: string | undefined;
+  let activePlanRevision: number | undefined;
   const activatableRepositoryRevisions = new Map<number, ValidatedToolState>();
   const publishedRepositoryRevisions = new Set<number>();
   let mcpWorkspaceConfirmation: SessionMcpWorkspaceConfirmedRecord["record"] | undefined;
@@ -178,6 +181,58 @@ export function validateCurrentSessionHistory(
     const record = entry.record;
     if (record.type === "session_genesis") {
       throw new SessionLifecycleError("session_invalid");
+    }
+    if (record.type === "plan_cycle_entered") {
+      if (
+        run !== undefined ||
+        activePlanCycleId !== undefined ||
+        !isReadOnlyPlanToolProfileV1Valid(record.eligibleToolProfile) ||
+        record.eligibleToolProfile.source.version !== activePromptContext?.toolProfile.version ||
+        record.eligibleToolProfile.source.digest !== activePromptContext.toolProfile.digest
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      activePlanCycleId = record.cycleId;
+      activePlanRevision = record.revision;
+      continue;
+    }
+    if (record.type === "plan_cycle_inherited") {
+      const lineage = genesis.record.lineage;
+      const sourceSessionId =
+        lineage !== undefined && "sourceSessionId" in lineage
+          ? lineage.sourceSessionId
+          : lineage?.parentSessionId;
+      const sourceSequence =
+        lineage !== undefined && "sourceEventPosition" in lineage
+          ? lineage.sourceEventPosition
+          : lineage?.parentEventPosition;
+      if (
+        run !== undefined ||
+        activePlanCycleId !== undefined ||
+        lineage === undefined ||
+        record.source.sessionId !== sourceSessionId ||
+        record.source.throughSequence !== sourceSequence ||
+        !isReadOnlyPlanToolProfileV1Valid(record.eligibleToolProfile) ||
+        record.eligibleToolProfile.source.version !== activePromptContext?.toolProfile.version ||
+        record.eligibleToolProfile.source.digest !== activePromptContext.toolProfile.digest
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      activePlanCycleId = record.cycleId;
+      activePlanRevision = record.revision;
+      continue;
+    }
+    if (record.type === "plan_cycle_exited") {
+      if (
+        run !== undefined ||
+        record.cycleId !== activePlanCycleId ||
+        record.revision !== (activePlanRevision ?? 0) + 1
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      activePlanCycleId = undefined;
+      activePlanRevision = undefined;
+      continue;
     }
     if (record.type === "mcp_workspace_confirmed") {
       if (run !== undefined || mcpWorkspaceConfirmation !== undefined) {

--- a/packages/agent/src/session-lifecycle-error.ts
+++ b/packages/agent/src/session-lifecycle-error.ts
@@ -8,6 +8,7 @@ export class SessionLifecycleError extends Error {
     | "session_workspace_untrusted"
     | "session_thinking_policy_unsupported"
     | "session_persistence_failed"
+    | "session_plan_unavailable"
     | "session_skill_confirmation_required"
     | "session_skill_policy_rejected"
     | "session_skill_unavailable"
@@ -80,6 +81,8 @@ function sessionLifecycleErrorMessage(code: SessionLifecycleError["code"]): stri
       return "The requested thinking level is unavailable for this exact model target.";
     case "session_persistence_failed":
       return "The new session could not be persisted.";
+    case "session_plan_unavailable":
+      return "Plan is unavailable in this historical Tool Profile. Start a new session to use Plan.";
     case "session_skill_unavailable":
       return "One selected Agent Skill is unavailable for draft admission.";
     case "session_skill_confirmation_required":

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -69,6 +69,7 @@ import {
   modelTargetUsesContextProfile,
   sameModelTargetIdentity,
 } from "./model-targets.js";
+import { createReadOnlyPlanToolProfileV1, type PlanEligibleToolProfileV1 } from "./plan-mode.js";
 import {
   createProjectLifecycleOwner,
   type ProjectLifecycleOwner,
@@ -116,6 +117,7 @@ import {
   isGenesisRecord,
   type ModelResponseArtifactDegradation,
   type ModelResponseArtifactInspection,
+  planCycleSnapshotFromRecords,
   promptContextRecordFromRecords,
   sessionNamingStateFromRecords,
   skillContextRecordFromRecords,
@@ -488,6 +490,13 @@ export type SessionCommand =
     } & SessionBranchInput)
   | { readonly type: "reload_repository_instructions"; readonly sessionId: string }
   | { readonly type: "reload_skills"; readonly sessionId: string }
+  | { readonly type: "enter_plan"; readonly sessionId: string }
+  | {
+      readonly type: "exit_plan";
+      readonly sessionId: string;
+      readonly cycleId: string;
+      readonly revision: number;
+    }
   | McpConfigurationCommand;
 
 export interface SessionLifecycle {
@@ -520,6 +529,12 @@ export interface SessionLifecycle {
   decidePermission(command: PermissionDecisionCommand): PermissionDecisionCommandResult;
   enableAutomaticTitles(): void;
   ensureAutomaticTitle(input: { readonly sessionId: string }): Promise<SessionNamingResult>;
+  enterPlan(input: { readonly sessionId: string }): Promise<CurrentSessionSnapshot>;
+  exitPlan(input: {
+    readonly sessionId: string;
+    readonly cycleId: string;
+    readonly revision: number;
+  }): Promise<CurrentSessionSnapshot>;
   inspect(input: { readonly sessionId: string }): Promise<SessionSnapshot>;
   inspectWorkspaceTrust(): Promise<WorkspaceTrustSnapshot>;
   inspectContextUsage(input: {
@@ -1435,6 +1450,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     validateCurrentSessionHistory(first, records, options.workspaceRoot);
     await lineage.validateSessionLineage(first, records);
     await validateMcpAuthorityFromLineage(lineage, first, records);
+    await validatePlanToolProfilesFromLineage(options, lineage, first, records);
     await skillResourceBytesFromLineage(lineage, first, records);
     const artifactInspection = await inspectModelResponseArtifactLineage(
       options,
@@ -2213,6 +2229,24 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           },
         };
         await store.append(genesis);
+        let nextSequence = 2;
+        const parentPlan = planCycleSnapshotFromRecords(parentPrefix);
+        if (parentPlan !== undefined) {
+          await store.append({
+            schemaVersion: 3,
+            sequence: nextSequence,
+            record: {
+              type: "plan_cycle_inherited",
+              recordVersion: 1,
+              cycleId: parentPlan.cycleId,
+              revision: parentPlan.revision,
+              policyVersion: parentPlan.policyVersion,
+              eligibleToolProfile: parentPlan.eligibleToolProfile,
+              source: { sessionId: sourceSessionId, throughSequence: sourceEventPosition },
+            },
+          });
+          nextSequence += 1;
+        }
         const extensionSources = await resolveExtensionSkillSources(options);
         if (hasSkillPromptContext(parentPromptContext) && parentSkillContext !== undefined) {
           const reconciled = reconcileExtensionSkillContextV1({
@@ -2224,7 +2258,6 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
               parentPromptContext,
               reconciled.context,
             );
-            let nextSequence = 2;
             await store.append({
               schemaVersion: 3,
               sequence: nextSequence,
@@ -2824,6 +2857,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
               ? {}
               : { inputResources: runtimeInputResources }),
             projectId: resumed.snapshot.projectId,
+            ...(resumed.snapshot.plan === undefined ? {} : { plan: resumed.snapshot.plan }),
             referencedModelResponseArtifactBytes,
             skillResourceLineageBytes,
             inputResourceLineageBytes,
@@ -4177,6 +4211,82 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         return { status: "updated", snapshot };
       });
     },
+    async enterPlan(input) {
+      if (activeSession !== undefined) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      return withOwner(async () => {
+        const inspected = await inspectSession({ sessionId: input.sessionId });
+        if (
+          inspected.schemaVersion !== 3 ||
+          (inspected.status !== "idle" && inspected.status !== "settled") ||
+          inspected.plan !== undefined
+        ) {
+          throw new SessionLifecycleError("session_invalid");
+        }
+        if (
+          inspected.promptContext?.toolProfile.definitions.some(
+            (definition) => definition.name === "search_repository",
+          ) !== true
+        ) {
+          throw new SessionLifecycleError("session_plan_unavailable");
+        }
+        const records = await readSessionRecords(options, input.sessionId);
+        const eligibleToolProfile = readOnlyPlanToolProfile(inspected, options.tools);
+        const store = await openSessionStore(options, input.sessionId);
+        await store.append({
+          schemaVersion: 3,
+          sequence: (records.at(-1)?.sequence ?? 0) + 1,
+          record: {
+            type: "plan_cycle_entered",
+            recordVersion: 1,
+            cycleId: randomUUID(),
+            revision: 1,
+            policyVersion: "plan-policy.read-v1",
+            eligibleToolProfile,
+          },
+        });
+        const snapshot = await inspectSession({ sessionId: input.sessionId });
+        if (snapshot.schemaVersion !== 3) {
+          throw new SessionLifecycleError("session_invalid");
+        }
+        return snapshot;
+      });
+    },
+    async exitPlan(input) {
+      if (activeSession !== undefined) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      return withOwner(async () => {
+        const inspected = await inspectSession({ sessionId: input.sessionId });
+        if (
+          inspected.schemaVersion !== 3 ||
+          (inspected.status !== "idle" && inspected.status !== "settled") ||
+          inspected.plan?.cycleId !== input.cycleId ||
+          inspected.plan.revision !== input.revision
+        ) {
+          throw new SessionLifecycleError("session_invalid");
+        }
+        const records = await readSessionRecords(options, input.sessionId);
+        const store = await openSessionStore(options, input.sessionId);
+        await store.append({
+          schemaVersion: 3,
+          sequence: (records.at(-1)?.sequence ?? 0) + 1,
+          record: {
+            type: "plan_cycle_exited",
+            recordVersion: 1,
+            cycleId: input.cycleId,
+            revision: input.revision + 1,
+            reason: "user_cancelled",
+          },
+        });
+        const snapshot = await inspectSession({ sessionId: input.sessionId });
+        if (snapshot.schemaVersion !== 3) {
+          throw new SessionLifecycleError("session_invalid");
+        }
+        return snapshot;
+      });
+    },
     async setSessionManualName(input) {
       if (activeSession !== undefined) {
         throw new SessionLifecycleError("session_invalid");
@@ -4784,7 +4894,23 @@ async function validatePromptProjectionDigests(
       skillContext,
       activeSkillContents,
     );
-    const tools = context.toolProfile.definitions.map(({ definition }) => definition);
+    const plan = planCycleSnapshotFromRecords(prefix);
+    const tools =
+      plan === undefined
+        ? context.toolProfile.definitions.map(({ definition }) => definition)
+        : plan.eligibleToolProfile.definitions.map((eligible) => {
+            const definition = context.toolProfile.definitions.find(
+              (candidate) => candidate.name === eligible.name,
+            )?.definition;
+            if (
+              definition === undefined ||
+              plan.eligibleToolProfile.source.version !== context.toolProfile.version ||
+              plan.eligibleToolProfile.source.digest !== context.toolProfile.digest
+            ) {
+              throw new SessionLifecycleError("session_invalid");
+            }
+            return definition;
+          });
     if (
       digestPromptRequestV1(messages, tools) !==
       entry.record.promptProjection.requestProjectionDigest
@@ -6481,6 +6607,113 @@ async function openSessionStore(
     throw new SessionLifecycleError("session_not_found");
   }
   return store;
+}
+
+function readOnlyPlanToolProfile(
+  snapshot: CurrentSessionSnapshot,
+  tools: ToolRegistry | undefined,
+): PlanEligibleToolProfileV1 {
+  const source = snapshot.promptContext?.toolProfile;
+  if (source === undefined || tools === undefined) {
+    throw new SessionLifecycleError("session_invalid");
+  }
+  return readOnlyPlanToolProfileFromAuthority(
+    source,
+    tools,
+    snapshot.mcp?.workspaceConfirmed === true ? snapshot.mcp.profile : undefined,
+  );
+}
+
+function readOnlyPlanToolProfileFromAuthority(
+  source: NonNullable<CurrentSessionSnapshot["promptContext"]>["toolProfile"],
+  tools: ToolRegistry,
+  mcpProfile:
+    | {
+        readonly digest: `sha256:${string}`;
+        readonly tools: readonly {
+          readonly qualifiedName: string;
+          readonly definitionDigest: `sha256:${string}`;
+          readonly effect: ToolEffect;
+        }[];
+      }
+    | undefined,
+): PlanEligibleToolProfileV1 {
+  const mcpTools = new Map(
+    mcpProfile?.tools.map((tool) => [tool.qualifiedName, tool] as const) ?? [],
+  );
+  const definitions: PlanEligibleToolProfileV1["definitions"][number][] = [];
+  for (const definition of source.definitions) {
+    const mcp = mcpTools.get(definition.name);
+    if (mcp !== undefined) {
+      if (mcp.effect === "read") {
+        definitions.push({
+          name: definition.name,
+          definitionDigest: mcp.definitionDigest,
+          effect: mcp.effect,
+          source: "mcp",
+        });
+      }
+      continue;
+    }
+    const adapter = tools.resolve(definition.name);
+    if (adapter === undefined || !/^sha256:[0-9a-f]{64}$/u.test(adapter.definitionDigest)) {
+      throw new SessionLifecycleError("session_invalid");
+    }
+    if (adapter.effect === "read") {
+      definitions.push({
+        name: definition.name,
+        definitionDigest: adapter.definitionDigest as `sha256:${string}`,
+        effect: adapter.effect,
+        source: "builtin",
+      });
+    }
+  }
+  return createReadOnlyPlanToolProfileV1({
+    source: { version: source.version, digest: source.digest },
+    definitions,
+  });
+}
+
+async function validatePlanToolProfilesFromLineage(
+  options: SessionLifecycleOptions,
+  lineage: SessionLineageTraversal,
+  genesis: SessionGenesisRecord,
+  records: readonly SessionRecord[],
+): Promise<void> {
+  if (options.tools === undefined) {
+    throw new SessionLifecycleError("session_invalid");
+  }
+  for (const entry of records) {
+    if (
+      entry.schemaVersion !== 3 ||
+      (entry.record.type !== "plan_cycle_entered" && entry.record.type !== "plan_cycle_inherited")
+    ) {
+      continue;
+    }
+    const prefix = records.filter((candidate) => candidate.sequence < entry.sequence);
+    const promptContext = promptContextRecordFromRecords(genesis, prefix);
+    if (promptContext === undefined) {
+      throw new SessionLifecycleError("session_invalid");
+    }
+    const mcpProfile = await mcpCommittedProfileFromLineage(lineage, genesis, prefix);
+    if (
+      (promptContext.recordVersion === 3 && promptContext.mcp !== undefined) !==
+        (mcpProfile !== undefined) ||
+      (promptContext.recordVersion === 3 &&
+        promptContext.mcp !== undefined &&
+        promptContext.mcp.profileDigest !== mcpProfile?.digest)
+    ) {
+      throw new SessionLifecycleError("session_invalid");
+    }
+    const expected = readOnlyPlanToolProfileFromAuthority(
+      promptContext.toolProfile,
+      options.tools,
+      mcpProfile,
+    );
+    if (!isDeepStrictEqual(entry.record.eligibleToolProfile, expected)) {
+      throw new SessionLifecycleError("session_invalid");
+    }
+  }
 }
 
 function draftSkillSelectionsAreValid(selections: readonly string[]): boolean {

--- a/packages/agent/src/session-lineage.ts
+++ b/packages/agent/src/session-lineage.ts
@@ -8,6 +8,7 @@ import {
 import {
   isCompleteBranchBoundary,
   isGenesisRecord,
+  planCycleSnapshotFromRecords,
   promptContextRecordFromRecords,
 } from "./session-history-folds.js";
 import { validateCurrentSessionHistory } from "./session-history-validation.js";
@@ -47,12 +48,13 @@ export function createSessionLineageTraversal(input: {
     genesis: SessionGenesisRecord,
     records: readonly SessionRecord[],
   ): Promise<void> {
-    await validateSessionLineageAncestors(genesis, new Set([genesis.record.sessionId]));
+    await validateSessionLineageAncestors(genesis, records, new Set([genesis.record.sessionId]));
     await validateInheritedContextEvidence(genesis, records);
   }
 
   async function validateSessionLineageAncestors(
     genesis: SessionGenesisRecord,
+    records: readonly SessionRecord[],
     visited: ReadonlySet<string>,
   ): Promise<void> {
     const lineage = genesis.record.lineage;
@@ -63,6 +65,7 @@ export function createSessionLineageTraversal(input: {
       throw new SessionLifecycleError("session_invalid");
     }
     const { parentGenesis, prefixRecords } = await readValidatedLineagePrefix(genesis);
+    validateInheritedPlanCycle(genesis, records, prefixRecords);
     const expectedPromptContext = promptContextRecordFromRecords(parentGenesis, prefixRecords);
     if (!isDeepStrictEqual(genesis.record.promptContext, expectedPromptContext)) {
       throw new SessionLifecycleError("session_invalid");
@@ -76,14 +79,62 @@ export function createSessionLineageTraversal(input: {
       }
       await validateSessionLineageAncestors(
         declaredParentGenesis,
+        declaredParentRecords,
         new Set([...visited, lineage.parentSessionId]),
       );
       return;
     }
     await validateSessionLineageAncestors(
       parentGenesis,
+      await input.readRecords(parentGenesis.record.sessionId),
       new Set([...visited, lineage.parentSessionId]),
     );
+  }
+
+  function validateInheritedPlanCycle(
+    genesis: SessionGenesisRecord,
+    records: readonly SessionRecord[],
+    prefixRecords: readonly SessionRecord[],
+  ): void {
+    const lineage = genesis.record.lineage;
+    if (lineage === undefined) {
+      return;
+    }
+    const inherited = records.filter(
+      (entry) => entry.schemaVersion === 3 && entry.record.type === "plan_cycle_inherited",
+    );
+    const expected = planCycleSnapshotFromRecords(prefixRecords);
+    if (expected === undefined) {
+      if (inherited.length > 0) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      return;
+    }
+    const actual = inherited[0];
+    const sourceSessionId =
+      "recordVersion" in lineage ? lineage.sourceSessionId : lineage.parentSessionId;
+    const sourceEventPosition =
+      "recordVersion" in lineage ? lineage.sourceEventPosition : lineage.parentEventPosition;
+    if (
+      inherited.length !== 1 ||
+      actual?.schemaVersion !== 3 ||
+      actual.sequence !== 2 ||
+      actual.record.type !== "plan_cycle_inherited" ||
+      actual.record.source.sessionId !== sourceSessionId ||
+      actual.record.source.throughSequence !== sourceEventPosition ||
+      !isDeepStrictEqual(
+        {
+          state: "exploring",
+          cycleId: actual.record.cycleId,
+          revision: actual.record.revision,
+          policyVersion: actual.record.policyVersion,
+          eligibleToolProfile: actual.record.eligibleToolProfile,
+        },
+        expected,
+      )
+    ) {
+      throw new SessionLifecycleError("session_invalid");
+    }
   }
 
   async function sessionInheritsSourceBoundary(

--- a/packages/agent/src/session-snapshot-contracts.ts
+++ b/packages/agent/src/session-snapshot-contracts.ts
@@ -2,6 +2,7 @@ import type { ContextUsageTotals, RunResult } from "./agent-session-contracts.js
 import type { ContextProfile } from "./context-profile.js";
 import type { McpSessionSnapshot } from "./mcp-host.js";
 import type { ModelTargetIdentity } from "./model-targets.js";
+import type { PlanCycleSnapshot } from "./plan-mode.js";
 import type { PromptContextSnapshot } from "./prompt-assembly.js";
 import type { SessionGenesisRecord } from "./session-store.js";
 import type { SkillContextSnapshot } from "./skills.js";
@@ -13,6 +14,7 @@ export type CurrentSessionSnapshot = {
   readonly targetIdentity: ModelTargetIdentity;
   readonly status: "idle" | "interrupted" | "settled";
   readonly lastSequence: number;
+  readonly plan?: PlanCycleSnapshot;
   readonly mcp?: McpSessionSnapshot;
   readonly promptContext?: PromptContextSnapshot;
   readonly skillContext?: SkillContextSnapshot;

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -19,6 +19,7 @@ import type { McpToolProfileV1 } from "./mcp-profile-contracts.js";
 import { modelDriverErrorCategories } from "./model-driver-error.js";
 import type { ModelTargetIdentity } from "./model-targets.js";
 import { imageInputLimitsV1, type ProjectedContentUsageV1 } from "./model-user-content.js";
+import type { PlanEligibleToolProfileV1, PlanPolicyVersion } from "./plan-mode.js";
 import {
   type PromptContextRecord,
   type PromptContextRecordV1,
@@ -291,6 +292,48 @@ export type SessionManualNameSetRecord = {
     readonly type: "session_manual_name_set";
     readonly recordVersion: 1;
     readonly name: string;
+  };
+};
+
+export type SessionPlanCycleEnteredRecord = {
+  readonly schemaVersion: 3;
+  readonly sequence: number;
+  readonly record: {
+    readonly type: "plan_cycle_entered";
+    readonly recordVersion: 1;
+    readonly cycleId: string;
+    readonly revision: 1;
+    readonly policyVersion: PlanPolicyVersion;
+    readonly eligibleToolProfile: PlanEligibleToolProfileV1;
+  };
+};
+
+export type SessionPlanCycleExitedRecord = {
+  readonly schemaVersion: 3;
+  readonly sequence: number;
+  readonly record: {
+    readonly type: "plan_cycle_exited";
+    readonly recordVersion: 1;
+    readonly cycleId: string;
+    readonly revision: number;
+    readonly reason: "user_cancelled";
+  };
+};
+
+export type SessionPlanCycleInheritedRecord = {
+  readonly schemaVersion: 3;
+  readonly sequence: number;
+  readonly record: {
+    readonly type: "plan_cycle_inherited";
+    readonly recordVersion: 1;
+    readonly cycleId: string;
+    readonly revision: number;
+    readonly policyVersion: PlanPolicyVersion;
+    readonly eligibleToolProfile: PlanEligibleToolProfileV1;
+    readonly source: {
+      readonly sessionId: string;
+      readonly throughSequence: number;
+    };
   };
 };
 
@@ -801,6 +844,9 @@ export type SessionV3Record =
   | SessionMcpToolProfileCommittedRecord
   | SessionMcpCatalogStateChangedRecord
   | SessionLogicalRunStartedRecord
+  | SessionPlanCycleEnteredRecord
+  | SessionPlanCycleExitedRecord
+  | SessionPlanCycleInheritedRecord
   | SessionManualNameSetRecord
   | SessionManualNameClearedRecord
   | SessionTitleGenerationStartedRecord
@@ -1598,6 +1644,26 @@ const sessionGenesisV2RecordSchema = sessionGenesisV1RecordSchema.extend({
   recordVersion: z.literal(2),
   contextProfile: contextProfileSchema,
 });
+const sha256DigestSchema = z.string().regex(/^sha256:[0-9a-f]{64}$/u) as z.ZodType<Sha256Digest>;
+const planEligibleToolProfileV1Schema: z.ZodType<PlanEligibleToolProfileV1> = z.strictObject({
+  version: z.literal(1),
+  source: z.strictObject({
+    version: z.literal(1),
+    digest: sha256DigestSchema,
+  }),
+  definitions: z
+    .array(
+      z.strictObject({
+        name: z.string().min(1).max(256),
+        definitionDigest: sha256DigestSchema,
+        effect: z.enum(["read", "write", "execute", "network", "delegate", "administrative"]),
+        source: z.enum(["builtin", "mcp"]),
+      }),
+    )
+    .min(1)
+    .max(64),
+  digest: sha256DigestSchema,
+});
 const sessionV3RecordSchema = z.union([
   sessionGenesisV1RecordSchema,
   sessionGenesisV2RecordSchema,
@@ -1802,6 +1868,33 @@ const sessionV3RecordSchema = z.union([
       .min(1)
       .max(inputResourceLimitsV1.maximumOccurrencesPerRun)
       .optional(),
+  }),
+  z.strictObject({
+    type: z.literal("plan_cycle_entered"),
+    recordVersion: z.literal(1),
+    cycleId: z.uuid(),
+    revision: z.literal(1),
+    policyVersion: z.literal("plan-policy.read-v1"),
+    eligibleToolProfile: planEligibleToolProfileV1Schema,
+  }),
+  z.strictObject({
+    type: z.literal("plan_cycle_exited"),
+    recordVersion: z.literal(1),
+    cycleId: z.uuid(),
+    revision: z.number().int().positive(),
+    reason: z.literal("user_cancelled"),
+  }),
+  z.strictObject({
+    type: z.literal("plan_cycle_inherited"),
+    recordVersion: z.literal(1),
+    cycleId: z.uuid(),
+    revision: z.number().int().positive(),
+    policyVersion: z.literal("plan-policy.read-v1"),
+    eligibleToolProfile: planEligibleToolProfileV1Schema,
+    source: z.strictObject({
+      sessionId: z.uuid(),
+      throughSequence: z.number().int().positive(),
+    }),
   }),
   z.strictObject({
     type: z.literal("session_manual_name_set"),

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -373,6 +373,23 @@ export type ActiveSessionDisplay = {
   readonly skills: SkillCatalogDisplay | null;
   readonly projectPaths: ProjectPathCatalogDisplay;
   readonly mcp: McpDisplay | null;
+  readonly plan?: {
+    readonly state: "exploring";
+    readonly cycleId: string;
+    readonly revision: number;
+    readonly policyVersion: "plan-policy.read-v1";
+    readonly eligibleToolProfile: {
+      readonly version: 1;
+      readonly source: { readonly version: 1; readonly digest: `sha256:${string}` };
+      readonly definitions: readonly {
+        readonly name: string;
+        readonly definitionDigest: `sha256:${string}`;
+        readonly effect: "read" | "write" | "execute" | "network" | "delegate" | "administrative";
+        readonly source: "builtin" | "mcp";
+      }[];
+      readonly digest: `sha256:${string}`;
+    };
+  };
 };
 
 export type OperationCursor = {
@@ -767,6 +784,16 @@ export type PresentationCommand =
   | {
       readonly type: "create_session";
       readonly targetId: string;
+    }
+  | {
+      readonly type: "enter_plan";
+      readonly sessionId: string;
+    }
+  | {
+      readonly type: "exit_plan";
+      readonly sessionId: string;
+      readonly cycleId: string;
+      readonly revision: number;
     }
   | {
       readonly type: "set_default_target";

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -828,6 +828,257 @@ test("PresentationSession opens an empty project catalog without creating a sess
   }
 });
 
+test("PresentationSession durably enters a read-only Plan cycle and rehydrates its exact identity", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-plan-enter-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  let lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+  let presentation: Awaited<ReturnType<typeof createPresentationSession>> | undefined;
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    presentation = await createPresentationSession({
+      lifecycle,
+      projectLabel: "workspace",
+      sessionId: created.sessionId,
+      stateRoot,
+      workspaceRoot,
+    });
+
+    await expect(
+      presentation.dispatch({ type: "enter_plan", sessionId: created.sessionId }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    const entered = presentation.getState().authoritative.active?.plan;
+    expect(entered).toMatchObject({
+      state: "exploring",
+      cycleId: expect.stringMatching(/^[0-9a-f-]{36}$/u),
+      revision: 1,
+      policyVersion: "plan-policy.read-v1",
+    });
+
+    await presentation.close();
+    presentation = undefined;
+    await lifecycle.close();
+    lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+    presentation = await createPresentationSession({
+      lifecycle,
+      projectLabel: "workspace",
+      sessionId: created.sessionId,
+      stateRoot,
+      workspaceRoot,
+    });
+
+    expect(presentation.getState().authoritative.active?.plan).toEqual(entered);
+  } finally {
+    await presentation?.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession freezes the exact eligible read-only Tool Profile for a Plan cycle", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-plan-profile-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    const presentation = await createPresentationSession({
+      lifecycle,
+      projectLabel: "workspace",
+      sessionId: created.sessionId,
+      stateRoot,
+      workspaceRoot,
+    });
+
+    await expect(
+      presentation.dispatch({ type: "enter_plan", sessionId: created.sessionId }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    const profile = presentation.getState().authoritative.active?.plan?.eligibleToolProfile;
+    expect(profile).toMatchObject({
+      version: 1,
+      source: {
+        version: created.promptContext?.toolProfile.version,
+        digest: created.promptContext?.toolProfile.digest,
+      },
+      digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+    });
+    expect(profile?.definitions).toEqual(
+      [
+        "read_file",
+        "search_repository",
+        "activate_skill",
+        "read_skill_resource",
+        "read_input_resource",
+      ].map((name) => ({
+        name,
+        definitionDigest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+        effect: "read",
+        source: "builtin",
+      })),
+    );
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession exits one Plan cycle and enters a distinct later cycle", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-plan-repeat-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    const presentation = await createPresentationSession({
+      lifecycle,
+      projectLabel: "workspace",
+      sessionId: created.sessionId,
+      stateRoot,
+      workspaceRoot,
+    });
+    await presentation.dispatch({ type: "enter_plan", sessionId: created.sessionId });
+    const first = presentation.getState().authoritative.active?.plan;
+    if (first === undefined) {
+      throw new Error("Expected the first Plan cycle.");
+    }
+
+    await expect(
+      presentation.dispatch({
+        type: "exit_plan",
+        sessionId: created.sessionId,
+        cycleId: first.cycleId,
+        revision: first.revision,
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    expect(presentation.getState().authoritative.active?.plan).toBeUndefined();
+
+    await expect(
+      presentation.dispatch({ type: "enter_plan", sessionId: created.sessionId }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    const second = presentation.getState().authoritative.active?.plan;
+    expect(second).toMatchObject({
+      state: "exploring",
+      revision: 1,
+      policyVersion: "plan-policy.read-v1",
+      eligibleToolProfile: first.eligibleToolProfile,
+    });
+    expect(second?.cycleId).not.toBe(first.cycleId);
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession gives new-session guidance when a historical profile cannot enter Plan", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-plan-historical-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const currentTools = createCodingToolRegistry({ stateRoot, workspaceRoot });
+  const historicalTools: ToolRegistry = {
+    definitions: () =>
+      currentTools.definitions().filter((definition) => definition.name !== "search_repository"),
+    resolve(name) {
+      return name === "search_repository" ? undefined : currentTools.resolve(name);
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const historicalLifecycle = harness.createLifecycle({
+    stateRoot,
+    tools: historicalTools,
+    workspaceRoot,
+  });
+  const created = await historicalLifecycle.create({ targetIdentity });
+  await historicalLifecycle.close();
+  const lifecycle = harness.createLifecycle({ stateRoot, workspaceRoot });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      projectLabel: "workspace",
+      sessionId: created.sessionId,
+      stateRoot,
+      workspaceRoot,
+    });
+    await expect(
+      presentation.dispatch({ type: "enter_plan", sessionId: created.sessionId }),
+    ).resolves.toEqual({
+      status: "rejected",
+      code: "not_available",
+      message:
+        "Plan is unavailable in this historical Tool Profile. Start a new session to use Plan.",
+    });
+    expect(presentation.getState().authoritative.active?.plan).toBeUndefined();
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession rejects a stale Plan-cycle command without changing durable state", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-plan-stale-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    const presentation = await createPresentationSession({
+      lifecycle,
+      projectLabel: "workspace",
+      sessionId: created.sessionId,
+      stateRoot,
+      workspaceRoot,
+    });
+    await presentation.dispatch({ type: "enter_plan", sessionId: created.sessionId });
+    const current = presentation.getState().authoritative.active?.plan;
+    if (current === undefined) {
+      throw new Error("Expected an active Plan cycle.");
+    }
+
+    await expect(
+      presentation.dispatch({
+        type: "exit_plan",
+        sessionId: created.sessionId,
+        cycleId: current.cycleId,
+        revision: current.revision + 1,
+      }),
+    ).resolves.toEqual({
+      status: "rejected",
+      code: "stale_interaction",
+      message: "The selected Plan cycle is no longer current.",
+    });
+    expect(presentation.getState().authoritative.active?.plan).toEqual(current);
+    await expect(lifecycle.inspect({ sessionId: created.sessionId })).resolves.toMatchObject({
+      lastSequence: current.revision + 1,
+      plan: current,
+    });
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("PresentationSession projects exact target identity and readiness for project launch", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-targets-"));
   const stateRoot = join(testRoot, "state");

--- a/packages/testkit/src/session-lifecycle-test-topology.test.ts
+++ b/packages/testkit/src/session-lifecycle-test-topology.test.ts
@@ -54,6 +54,7 @@ test("SessionLifecycle behavior and OS contracts keep separate environment owner
       "node:fs/promises",
       "node:os",
       "node:path",
+      "node:zlib",
       "vitest",
     ]);
   expect
@@ -151,7 +152,7 @@ test("SessionLifecycle behavior and OS contracts keep separate environment owner
 
   const behaviorNames = declaredTestNames(behaviorSource);
   const operatingSystemNames = declaredTestNames(operatingSystemSource);
-  expect.soft(behaviorNames).toHaveLength(77);
+  expect.soft(behaviorNames).toHaveLength(89);
   expect.soft(operatingSystemNames).toEqual([...operatingSystemTestNames].sort());
   expect.soft(operatingSystemNames).toHaveLength(19);
   expect.soft(operatingSystemTestNames.filter((name) => behaviorNames.includes(name))).toEqual([]);

--- a/packages/testkit/src/session-lifecycle.test.ts
+++ b/packages/testkit/src/session-lifecycle.test.ts
@@ -12,6 +12,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { deflateSync } from "node:zlib";
 
 import {
   type ContextProfile,
@@ -94,6 +95,777 @@ function thinkingSelection(
 const codingToolDefinitions = createCodingToolRegistry({
   workspaceRoot: "/tmp/adam-agent-session-lifecycle-tool-definitions",
 }).definitions();
+
+test("SessionLifecycle Plan exposes only its exact read profile and denies a forged write call", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-write-deny-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  let requestCount = 0;
+  const driver = new FakeModelDriver((request) => {
+    requestCount += 1;
+    if (requestCount === 1) {
+      expect(request.tools.map((tool) => tool.name)).toEqual([
+        "read_file",
+        "search_repository",
+        "activate_skill",
+        "read_skill_resource",
+        "read_input_resource",
+      ]);
+      return [
+        { type: "tool_call_start", id: "plan-write", name: "write_file" },
+        {
+          type: "tool_call_delta",
+          id: "plan-write",
+          json: '{"path":"forbidden.txt","content":"must not exist"}',
+        },
+        { type: "tool_call_end", id: "plan-write" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    expect(request.messages.at(-1)).toMatchObject({
+      role: "tool",
+      name: "write_file",
+      result: { status: "failed", error: { code: "permission_denied" } },
+    });
+    return [
+      { type: "text_delta", text: "The mutation was denied by Plan." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({
+      allowedEffects: ["read", "write", "execute", "network", "delegate", "administrative"],
+    }),
+    stateRoot,
+    tools: createCodingToolRegistry({ workspaceRoot }),
+    workspaceRoot,
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.enterPlan({ sessionId: created.sessionId });
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: "Inspect the change without modifying the repository." },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "The mutation was denied by Plan." },
+      snapshot: { plan: { state: "exploring", policyVersion: "plan-policy.read-v1" } },
+    });
+    await expect(readFile(join(workspaceRoot, "forbidden.txt"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle Plan fails closed for an unknown MCP tool outside the exact profile", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-unknown-mcp-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  let requestCount = 0;
+  const driver = new FakeModelDriver((request) => {
+    requestCount += 1;
+    if (requestCount === 1) {
+      return [
+        { type: "tool_call_start", id: "unknown-mcp", name: "mcp__ghost__inspect" },
+        { type: "tool_call_delta", id: "unknown-mcp", json: "{}" },
+        { type: "tool_call_end", id: "unknown-mcp" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    expect(request.messages.at(-1)).toEqual({
+      role: "tool",
+      callId: "unknown-mcp",
+      name: "mcp__ghost__inspect",
+      result: {
+        status: "failed",
+        error: {
+          code: "unknown_tool",
+          message: "Plan denies tools outside its exact eligible Tool Profile.",
+        },
+      },
+    });
+    return [
+      { type: "text_delta", text: "The unknown MCP tool was denied." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.enterPlan({ sessionId: created.sessionId });
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: "Try an unregistered MCP inspection." },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "The unknown MCP tool was denied." },
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects Plan entry while an ordinary run owns the session", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-running-entry-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const providerStarted = Promise.withResolvers<void>();
+  const releaseProvider = Promise.withResolvers<void>();
+  const driver: ModelDriver = {
+    async *stream() {
+      providerStarted.resolve();
+      await releaseProvider.promise;
+      yield { type: "text_delta", text: "The ordinary run completed." };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    const running = lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Complete one ordinary run." },
+    });
+    await providerStarted.promise;
+
+    await expect(lifecycle.enterPlan({ sessionId: created.sessionId })).rejects.toMatchObject({
+      code: "session_invalid",
+    });
+    await expect(lifecycle.inspect({ sessionId: created.sessionId })).resolves.not.toHaveProperty(
+      "plan",
+    );
+
+    releaseProvider.resolve();
+    const completed = await running;
+    expect(completed).toMatchObject({
+      result: { status: "completed", answer: "The ordinary run completed." },
+    });
+    expect(completed.snapshot).not.toHaveProperty("plan");
+  } finally {
+    releaseProvider.resolve();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects Plan entry from interrupted history without appending", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-interrupted-entry-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const driver = new FakeModelDriver([
+    { type: "text_delta", text: "First answer." },
+    { type: "finish", reason: "stop" },
+  ]);
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    const completed = await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "First prompt" },
+    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created session store.");
+    }
+    const interruptedRunId = "123e4567-e89b-42d3-a456-426614174011";
+    const interruptedRecords: readonly Omit<
+      Extract<SessionRecord, { readonly schemaVersion: 3 }>,
+      "sequence"
+    >[] = [
+      {
+        schemaVersion: 3,
+        record: {
+          type: "logical_run_started",
+          runId: interruptedRunId,
+          userMessage: "Interrupted prompt",
+        },
+      },
+      {
+        schemaVersion: 3,
+        record: {
+          type: "runtime_event",
+          runId: interruptedRunId,
+          event: { type: "user_message", text: "Interrupted prompt" },
+        },
+      },
+      {
+        schemaVersion: 3,
+        record: {
+          type: "provider_attempt_started",
+          runId: interruptedRunId,
+          turn: 1,
+          attempt: 1,
+          targetIdentity,
+          promptProjection: promptProjectionFor(created, [
+            { role: "user", content: "First prompt" },
+            { role: "assistant", content: "First answer.", toolCalls: [] },
+            { role: "user", content: "Interrupted prompt" },
+          ]),
+        },
+      },
+      {
+        schemaVersion: 3,
+        record: {
+          type: "runtime_event",
+          runId: interruptedRunId,
+          event: { type: "model_message_started" },
+        },
+      },
+      {
+        schemaVersion: 3,
+        record: {
+          type: "runtime_event",
+          runId: interruptedRunId,
+          event: { type: "session_interrupted", reason: "cancelled" },
+        },
+      },
+    ];
+    for (const [index, record] of interruptedRecords.entries()) {
+      await store.append({
+        ...record,
+        sequence: completed.snapshot.lastSequence + index + 1,
+      } as SessionRecord);
+    }
+    const beforeEntry = await store.read();
+    await expect(lifecycle.inspect({ sessionId: created.sessionId })).resolves.toMatchObject({
+      status: "interrupted",
+    });
+
+    await expect(lifecycle.enterPlan({ sessionId: created.sessionId })).rejects.toMatchObject({
+      code: "session_invalid",
+    });
+    await expect(store.read()).resolves.toEqual(beforeEntry);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle never exposes Plan entry as a model tool", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-model-entry-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  let requestCount = 0;
+  const driver = new FakeModelDriver((request) => {
+    requestCount += 1;
+    if (requestCount === 1) {
+      expect(request.tools.some((tool) => tool.name === "enter_plan")).toBe(false);
+      return [
+        { type: "tool_call_start", id: "model-enter-plan", name: "enter_plan" },
+        { type: "tool_call_delta", id: "model-enter-plan", json: "{}" },
+        { type: "tool_call_end", id: "model-enter-plan" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    expect(request.messages.at(-1)).toEqual({
+      role: "tool",
+      callId: "model-enter-plan",
+      name: "enter_plan",
+      result: {
+        status: "failed",
+        error: { code: "unknown_tool", message: "Unknown tool: enter_plan" },
+      },
+    });
+    return [
+      { type: "text_delta", text: "Only an external user command can enter Plan." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    const continued = await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Try to enter Plan yourself." },
+      limits: { maxTurns: 2 },
+    });
+
+    expect(continued).toMatchObject({
+      result: { status: "completed", answer: "Only an external user command can enter Plan." },
+    });
+    expect(continued.snapshot).not.toHaveProperty("plan");
+    expect(requestCount).toBe(2);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects an unsupported durable Plan policy before model use", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-policy-history-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const initial = createSessionLifecycle({ stateRoot, workspaceRoot });
+  let cold: ReturnType<typeof createSessionLifecycle> | undefined;
+  let resolveCalls = 0;
+
+  try {
+    const created = await initial.create({ targetIdentity });
+    await initial.enterPlan({ sessionId: created.sessionId });
+    await expect(initial.close()).resolves.toEqual({ status: "closed" });
+    const sessionPath = join(
+      stateRoot,
+      "projects",
+      created.projectId.replace(/^sha256:/u, ""),
+      "sessions",
+      `${created.sessionId}.jsonl`,
+    );
+    const durableHistory = await readFile(sessionPath, "utf8");
+    expect(durableHistory.match(/plan-policy\.read-v1/gu)).toHaveLength(1);
+    await writeFile(
+      sessionPath,
+      durableHistory.replace("plan-policy.read-v1", "plan-policy.future-v99"),
+      "utf8",
+    );
+    const modelTargets: ModelTargets = {
+      async resolve() {
+        resolveCalls += 1;
+        throw new Error("An unsupported durable Plan policy must fail before model resolution.");
+      },
+      async snapshot() {
+        return {
+          targets: [
+            {
+              identity: targetIdentity,
+              readiness: { status: "available", credentialSource: "deterministic test adapter" },
+              contextProfile: testContextProfile,
+            },
+          ],
+        };
+      },
+    };
+    cold = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+    await expect(
+      cold.continue({
+        sessionId: created.sessionId,
+        input: { text: "Do not silently upgrade this Plan cycle." },
+      }),
+    ).rejects.toMatchObject({ code: "session_log_invalid" });
+    expect(resolveCalls).toBe(0);
+  } finally {
+    await initial.close();
+    await cold?.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects a self-consistent forged Plan profile before model resolution", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-profile-tamper-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const initial = createSessionLifecycle({ stateRoot, workspaceRoot });
+  let cold: ReturnType<typeof createSessionLifecycle> | undefined;
+  let resolveCalls = 0;
+
+  try {
+    const created = await initial.create({ targetIdentity });
+    await initial.enterPlan({ sessionId: created.sessionId });
+    await expect(initial.close()).resolves.toEqual({ status: "closed" });
+    const sessionPath = join(
+      stateRoot,
+      "projects",
+      created.projectId.replace(/^sha256:/u, ""),
+      "sessions",
+      `${created.sessionId}.jsonl`,
+    );
+    const records = (await readFile(sessionPath, "utf8"))
+      .trimEnd()
+      .split("\n")
+      .map((line) => JSON.parse(line) as SessionRecord);
+    const entered = records.find(
+      (entry) => entry.schemaVersion === 3 && entry.record.type === "plan_cycle_entered",
+    );
+    if (entered?.schemaVersion !== 3 || entered.record.type !== "plan_cycle_entered") {
+      throw new Error("Expected the durable Plan entry.");
+    }
+    const forgedWithoutDigest = {
+      version: 1 as const,
+      source: entered.record.eligibleToolProfile.source,
+      definitions: entered.record.eligibleToolProfile.definitions.slice(1),
+    };
+    Object.assign(entered.record, {
+      eligibleToolProfile: {
+        ...forgedWithoutDigest,
+        digest: `sha256:${createHash("sha256")
+          .update(canonicalFixtureJson(forgedWithoutDigest))
+          .digest("hex")}`,
+      },
+    });
+    await writeFile(
+      sessionPath,
+      `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+      "utf8",
+    );
+    const modelTargets: ModelTargets = {
+      async resolve() {
+        resolveCalls += 1;
+        return {
+          identity: targetIdentity,
+          driver: new FakeModelDriver([
+            { type: "text_delta", text: "must not run" },
+            { type: "finish", reason: "stop" },
+          ]),
+          contextProfile: testContextProfile,
+        };
+      },
+      async snapshot() {
+        return {
+          targets: [
+            {
+              identity: targetIdentity,
+              readiness: { status: "available", credentialSource: "deterministic test adapter" },
+              contextProfile: testContextProfile,
+            },
+          ],
+        };
+      },
+    };
+    cold = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+
+    await expect(
+      cold.continue({
+        sessionId: created.sessionId,
+        input: { text: "Do not accept a forged eligible profile." },
+      }),
+    ).rejects.toMatchObject({ code: "session_invalid" });
+    expect(resolveCalls).toBe(0);
+  } finally {
+    await initial.close();
+    await cold?.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle preserves the exact Plan cycle identity through context compaction", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-compaction-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "README.md"), "# Plan compaction\n", "utf8");
+  const compactProfile: ContextProfile = {
+    version: 1,
+    contextWindowTokens: 10_000,
+    maximumOutputTokens: 1_000,
+    compactAtTokens: 5_000,
+    postCompactTargetTokens: 3_000,
+    retainedTargetTokens: 200,
+    estimatorVersion: 1,
+  };
+  let ordinaryCalls = 0;
+  let compactionCalls = 0;
+  const driver = new FakeModelDriver((request) => {
+    if (request.tools.length === 0) {
+      compactionCalls += 1;
+      return [
+        {
+          type: "text_delta",
+          text: JSON.stringify({
+            schemaVersion: 1,
+            objective: "Preserve the exact active Plan cycle.",
+            constraints: [],
+            progress: [],
+            unresolvedQuestions: [],
+            failures: [],
+            remainingVerification: ["Complete the read-only inspection."],
+            nextSafeAction: "Read the requested file.",
+          }),
+        },
+        { type: "usage", inputTokens: 120, outputTokens: 30 },
+        { type: "finish", reason: "stop" },
+      ];
+    }
+    ordinaryCalls += 1;
+    return ordinaryCalls === 1
+      ? [
+          { type: "tool_call_start", id: "plan-read", name: "read_file" },
+          { type: "tool_call_delta", id: "plan-read", json: '{"path":"README.md"}' },
+          { type: "tool_call_end", id: "plan-read" },
+          { type: "usage", inputTokens: 7_000, outputTokens: 10 },
+          { type: "finish", reason: "tool_calls" },
+        ]
+      : [
+          { type: "text_delta", text: "The read-only inspection survived compaction." },
+          { type: "usage", inputTokens: 80, outputTokens: 12 },
+          { type: "finish", reason: "stop" },
+        ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: compactProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: compactProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    const entered = await lifecycle.enterPlan({ sessionId: created.sessionId });
+    const plan = entered.plan;
+    const continued = await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Inspect README without changing the repository." },
+    });
+    expect(continued.result).toEqual({
+      status: "completed",
+      answer: "The read-only inspection survived compaction.",
+    });
+    expect(continued.snapshot).toMatchObject({ plan });
+    expect(compactionCalls).toBe(1);
+    await expect(lifecycle.inspect({ sessionId: created.sessionId })).resolves.toMatchObject({
+      plan,
+      context: { checkpoint: { status: "committed" } },
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle prefix branch inherits the exact selected exploring Plan state", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-branch-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    const parent = await lifecycle.create({ targetIdentity });
+    const entered = await lifecycle.enterPlan({ sessionId: parent.sessionId });
+    const child = await lifecycle.branch({
+      parentSessionId: parent.sessionId,
+      atSequence: entered.lastSequence,
+    });
+
+    expect(child).toMatchObject({
+      lineage: {
+        parentSessionId: parent.sessionId,
+        parentEventPosition: entered.lastSequence,
+      },
+      plan: entered.plan,
+    });
+    await expect(lifecycle.inspect({ sessionId: child.sessionId })).resolves.toMatchObject({
+      plan: entered.plan,
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects a branch whose inherited Plan identity diverges from its source prefix", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-branch-tamper-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ stateRoot, workspaceRoot });
+
+  try {
+    const parent = await lifecycle.create({ targetIdentity });
+    const entered = await lifecycle.enterPlan({ sessionId: parent.sessionId });
+    const child = await lifecycle.branch({
+      parentSessionId: parent.sessionId,
+      atSequence: entered.lastSequence,
+    });
+    const childStore = await harness.sessions.open(child.sessionId);
+    if (childStore === undefined) {
+      throw new Error("Expected the child session store.");
+    }
+    const inherited = (await childStore.read()).find(
+      (entry) => entry.schemaVersion === 3 && entry.record.type === "plan_cycle_inherited",
+    );
+    if (inherited?.schemaVersion !== 3 || inherited.record.type !== "plan_cycle_inherited") {
+      throw new Error("Expected the inherited Plan record.");
+    }
+    Object.assign(inherited.record, { cycleId: "123e4567-e89b-42d3-a456-426614174099" });
+
+    await expect(lifecycle.inspect({ sessionId: child.sessionId })).rejects.toMatchObject({
+      code: "session_invalid",
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects forged Plan inheritance from an inactive source prefix", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-branch-inactive-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ stateRoot, workspaceRoot });
+
+  try {
+    const inactiveParent = await lifecycle.create({ targetIdentity });
+    const donor = await lifecycle.create({ targetIdentity });
+    const donorPlan = (await lifecycle.enterPlan({ sessionId: donor.sessionId })).plan;
+    if (donorPlan === undefined) {
+      throw new Error("Expected the donor Plan cycle.");
+    }
+    const child = await lifecycle.branch({
+      parentSessionId: inactiveParent.sessionId,
+      atSequence: inactiveParent.lastSequence,
+    });
+    const childStore = await harness.sessions.open(child.sessionId);
+    if (childStore === undefined) {
+      throw new Error("Expected the child session store.");
+    }
+    await childStore.append({
+      schemaVersion: 3,
+      sequence: 2,
+      record: {
+        type: "plan_cycle_inherited",
+        recordVersion: 1,
+        cycleId: donorPlan.cycleId,
+        revision: donorPlan.revision,
+        policyVersion: donorPlan.policyVersion,
+        eligibleToolProfile: donorPlan.eligibleToolProfile,
+        source: {
+          sessionId: inactiveParent.sessionId,
+          throughSequence: inactiveParent.lastSequence,
+        },
+      },
+    });
+
+    await expect(lifecycle.inspect({ sessionId: child.sessionId })).rejects.toMatchObject({
+      code: "session_invalid",
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
 
 function promptProjectionFor(
   snapshot: {
@@ -432,6 +1204,56 @@ function canonicalFixtureJson(value: unknown): string {
       .join(",")}}`;
   }
   throw new TypeError("Fixture canonical JSON requires a JSON value.");
+}
+
+function createAdam7BoundaryPng(): Buffer {
+  const width = 4_096;
+  const height = 4_096;
+  const passes = [
+    [0, 0, 8, 8],
+    [4, 0, 8, 8],
+    [0, 4, 4, 8],
+    [2, 0, 4, 4],
+    [0, 2, 2, 4],
+    [1, 0, 2, 2],
+    [0, 1, 1, 2],
+  ] as const;
+  const rawByteLength = passes.reduce((total, [xStart, yStart, xStep, yStep]) => {
+    const passWidth = Math.ceil(Math.max(0, width - xStart) / xStep);
+    const passHeight = Math.ceil(Math.max(0, height - yStart) / yStep);
+    return total + passHeight * (passWidth * 8 + 1);
+  }, 0);
+  const header = Buffer.alloc(13);
+  header.writeUInt32BE(width, 0);
+  header.writeUInt32BE(height, 4);
+  header.set([16, 6, 0, 0, 1], 8);
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    createPngChunk("IHDR", header),
+    createPngChunk("IDAT", deflateSync(Buffer.alloc(rawByteLength))),
+    createPngChunk("IEND", Buffer.alloc(0)),
+  ]);
+}
+
+function createPngChunk(type: "IDAT" | "IEND" | "IHDR", data: Buffer): Buffer {
+  const typeBytes = Buffer.from(type, "ascii");
+  const chunk = Buffer.alloc(12 + data.byteLength);
+  chunk.writeUInt32BE(data.byteLength, 0);
+  typeBytes.copy(chunk, 4);
+  data.copy(chunk, 8);
+  chunk.writeUInt32BE(pngFixtureCrc32(Buffer.concat([typeBytes, data])), 8 + data.byteLength);
+  return chunk;
+}
+
+function pngFixtureCrc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
 }
 
 function snapshotWithLastPromptProjection<Snapshot extends { readonly promptContext?: object }>(
@@ -2998,6 +3820,77 @@ test("SessionLifecycle trusts validated image bytes over names and rejects image
           message: "The selected image is corrupt or has an unsupported image format.",
         },
       },
+    });
+    expect(driverCalls).toBe(1);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle admits a compressed 16-bit RGBA Adam7 PNG at the exact image boundary", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-vision-adam7-boundary-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "boundary.png");
+  const pngBytes = createAdam7BoundaryPng();
+  const visionIdentity: ModelTargetIdentity = {
+    targetId: "deepseek-v4-flash-vision-exp.direct",
+    vendor: "deepseek",
+    modelId: "deepseek-v4-flash-vision-exp",
+    route: "direct",
+    profileVersion: 1,
+    certification: "certified",
+  };
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, pngBytes);
+  let driverCalls = 0;
+  const driver = new FakeModelDriver(() => {
+    driverCalls += 1;
+    return [
+      { type: "text_delta", text: "The boundary image was admitted." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return {
+        identity: visionIdentity,
+        driver,
+        contextProfile: preparedDirectDeepSeekV2ContextProfile,
+        modalityProfile: {
+          profileVersion: 1,
+          explicitUserImages: "supported",
+          imageToolResults: "unsupported",
+        },
+      };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: visionIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: preparedDirectDeepSeekV2ContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    stateRoot: join(testRoot, "state"),
+    workspaceRoot,
+  });
+
+  try {
+    await expect(
+      lifecycle.admit({
+        targetIdentity: visionIdentity,
+        input: { text: "Inspect the exact boundary image." },
+        resourceSelections: [{ type: "local_file", path: selectedPath }],
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "The boundary image was admitted." },
     });
     expect(driverCalls).toBe(1);
   } finally {

--- a/packages/testkit/src/trusted-mcp-host-test-topology.test.ts
+++ b/packages/testkit/src/trusted-mcp-host-test-topology.test.ts
@@ -108,7 +108,7 @@ test("MCP deterministic and operating-system contracts keep separate harness own
 
   const behaviorNames = declaredTestNames(behaviorSource);
   const operatingSystemNames = declaredTestNames(operatingSystemSource);
-  expect.soft(behaviorNames).toHaveLength(79);
+  expect.soft(behaviorNames).toHaveLength(81);
   expect.soft(operatingSystemNames).toHaveLength(19);
   expect.soft(operatingSystemNames).toEqual([...operatingSystemTestNames].sort());
   expect.soft(operatingSystemTestNames.filter((name) => behaviorNames.includes(name))).toEqual([]);

--- a/packages/testkit/src/trusted-mcp-host.test.ts
+++ b/packages/testkit/src/trusted-mcp-host.test.ts
@@ -5119,6 +5119,206 @@ test("SessionLifecycle rejects a core and MCP qualified-name collision before mo
   }
 });
 
+test("SessionLifecycle Plan auto-allows an exact committed read-only MCP tool", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-mcp-plan-read-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeScriptedMcpConfiguration(testRoot, workspaceRoot);
+
+  let qualifiedName: string | undefined;
+  const requests: ModelRequest[] = [];
+  const driver = new FakeModelDriver((request) => {
+    requests.push(request);
+    if (requests.length === 1) {
+      expect(request.tools.map((tool) => tool.name)).toEqual([
+        "read_file",
+        "search_repository",
+        "activate_skill",
+        "read_skill_resource",
+        "read_input_resource",
+        qualifiedName,
+      ]);
+      return [
+        { type: "tool_call_start", id: "plan-mcp-read", name: qualifiedName as string },
+        { type: "tool_call_delta", id: "plan-mcp-read", json: '{"value":"plan"}' },
+        { type: "tool_call_end", id: "plan-mcp-read" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    expect(request.messages.at(-1)).toMatchObject({
+      role: "tool",
+      callId: "plan-mcp-read",
+      name: qualifiedName,
+      result: {
+        status: "completed",
+        output: { structuredContent: { echoed: "plan" } },
+      },
+    });
+    return [
+      { type: "text_delta", text: "Plan used the exact read-only MCP tool." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "test" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const { lifecycle, peer } = createScriptedMcpLifecycle(
+    {
+      modelTargets,
+      permissions: createPermissionPolicy({ allowedEffects: [] }),
+      stateRoot,
+      workspaceRoot,
+    },
+    { fixture: ordinaryScriptedMcpServer() },
+  );
+  const permissionEvents: RuntimeEvent[] = [];
+  lifecycle.subscribe((event) => {
+    if (event.type === "tool_permission_requested") {
+      permissionEvents.push(event);
+    }
+  });
+
+  try {
+    const committed = await commitFixtureEchoTool(lifecycle, "read");
+    qualifiedName = committed.qualifiedName;
+    const entered = await lifecycle.enterPlan({ sessionId: committed.sessionId });
+    expect(entered.plan?.eligibleToolProfile.definitions.at(-1)).toEqual({
+      name: qualifiedName,
+      definitionDigest: committed.definitionDigest,
+      effect: "read",
+      source: "mcp",
+    });
+
+    await expect(
+      lifecycle.continue({
+        sessionId: committed.sessionId,
+        input: { text: "Inspect through the committed MCP read tool." },
+        limits: { maxTurns: 2 },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "Plan used the exact read-only MCP tool." },
+    });
+    expect(permissionEvents).toEqual([]);
+    expect(peer.requests("fixture").filter((request) => request.method === "tools/call")).toEqual([
+      { method: "tools/call", params: { name: "echo", arguments: { value: "plan" } } },
+    ]);
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle Plan denies every committed non-read MCP effect before dispatch", async () => {
+  const deniedEffects = ["execute", "network", "delegate", "administrative"] as const;
+
+  for (const effect of deniedEffects) {
+    const testRoot = await mkdtemp(join(tmpdir(), `adam-agent-mcp-plan-${effect}-deny-`));
+    const stateRoot = join(testRoot, "state");
+    const workspaceRoot = join(testRoot, "workspace");
+    await mkdir(workspaceRoot);
+    await writeScriptedMcpConfiguration(testRoot, workspaceRoot);
+
+    let qualifiedName: string | undefined;
+    let requestCount = 0;
+    const driver = new FakeModelDriver((request) => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        expect(request.tools.some((tool) => tool.name === qualifiedName)).toBe(false);
+        return [
+          { type: "tool_call_start", id: `plan-mcp-${effect}`, name: qualifiedName as string },
+          { type: "tool_call_delta", id: `plan-mcp-${effect}`, json: '{"value":"forbidden"}' },
+          { type: "tool_call_end", id: `plan-mcp-${effect}` },
+          { type: "finish", reason: "tool_calls" },
+        ];
+      }
+      expect(request.messages.at(-1)).toMatchObject({
+        role: "tool",
+        name: qualifiedName,
+        result: { status: "failed", error: { code: "permission_denied" } },
+      });
+      return [
+        { type: "text_delta", text: `Plan denied the ${effect} MCP effect.` },
+        { type: "finish", reason: "stop" },
+      ];
+    });
+    const modelTargets: ModelTargets = {
+      async resolve() {
+        return { identity: targetIdentity, driver, contextProfile };
+      },
+      async snapshot() {
+        return {
+          targets: [
+            {
+              identity: targetIdentity,
+              readiness: { status: "available", credentialSource: "test" },
+              contextProfile,
+            },
+          ],
+        };
+      },
+    };
+    const { lifecycle, peer } = createScriptedMcpLifecycle(
+      {
+        modelTargets,
+        permissions: createPermissionPolicy({
+          allowedEffects: ["read", "write", "execute", "network", "delegate", "administrative"],
+        }),
+        stateRoot,
+        workspaceRoot,
+      },
+      { fixture: ordinaryScriptedMcpServer() },
+    );
+    const permissionEvents: RuntimeEvent[] = [];
+    lifecycle.subscribe((event) => {
+      if (event.type === "tool_permission_requested") {
+        permissionEvents.push(event);
+      }
+    });
+
+    try {
+      const committed = await commitFixtureEchoTool(lifecycle, effect);
+      qualifiedName = committed.qualifiedName;
+      const entered = await lifecycle.enterPlan({ sessionId: committed.sessionId });
+      expect(
+        entered.plan?.eligibleToolProfile.definitions.some(
+          (definition) => definition.name === committed.qualifiedName,
+        ),
+      ).toBe(false);
+
+      await expect(
+        lifecycle.continue({
+          sessionId: committed.sessionId,
+          input: { text: `Try the committed ${effect} MCP tool in Plan.` },
+          limits: { maxTurns: 2 },
+        }),
+      ).resolves.toMatchObject({
+        result: { status: "completed", answer: `Plan denied the ${effect} MCP effect.` },
+      });
+      expect(permissionEvents).toEqual([]);
+      expect(peer.requests("fixture").filter((request) => request.method === "tools/call")).toEqual(
+        [],
+      );
+    } finally {
+      await lifecycle.close();
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  }
+});
+
 test("SessionLifecycle completes an MCP tool-level error response without treating it as transport failure", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-mcp-tool-error-result-"));
   const stateRoot = join(testRoot, "state");


### PR DESCRIPTION
## Summary
- add durable exploring Plan cycles with exact frozen read-v1 tool profiles
- enforce fail-closed read-only execution across built-in and MCP tools, resume, compaction, and prefix branches
- expose authoritative Plan commands and status through Presentation and TUI
- harden restored profile/lineage validation and bounded PNG decoding discovered during review

## Verification
- local pnpm quality:check: 52 passed, 2 skipped; 1396 tests passed, 13 skipped
- independent specification review: 0 remaining findings
- independent standards review: 0 remaining findings