### PR TITLE
feat(agent): add hybrid Plan shell policy

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -65,3 +65,283 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## `@narumitw/pi-plan-mode` 0.56.0 selected parser mechanisms
+
+Adam Agent selectively adapts quote/escape-aware command splitting, tokenization, unsupported-syntax rejection, first-blocked-segment reporting, and adversarial flag-validation mechanisms from [`@narumitw/pi-plan-mode@0.56.0`](https://github.com/narumiruna/pi-extensions/tree/9b4cab310013a71d7990e7736452c3c1aebfd148/packages/pi-plan-mode) at gitHead `9b4cab310013a71d7990e7736452c3c1aebfd148`, specifically `src/tool-policy.ts` lines 314-840 and selected derived fixtures from `test/tool-policy.test.ts` lines 30-468. Adam does not include the package, its whole-command trust configuration, or its command policy. The selected source is licensed under the MIT License.
+
+Copyright (c) 2026 narumiruna
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## npm CLI 11.6.2, `@npmcli/config` 10.4.2, and `nopt` 8.1.0 selected grammar data and parser semantics
+
+Adam Agent freezes npm CLI 11.6.2's public commands, aliases, and abbreviation behavior from [`lib/utils/cmd-list.js` lines 3-177](https://github.com/npm/cli/blob/v11.6.2/lib/utils/cmd-list.js); freezes `@npmcli/config` 10.4.2's public option names, shorthands, and type arity from [`workspaces/config/lib/definitions/index.js` lines 24-60](https://github.com/npm/cli/blob/v11.6.2/workspaces/config/lib/definitions/index.js) and [`workspaces/config/lib/definitions/definitions.js` lines 87-2316](https://github.com/npm/cli/blob/v11.6.2/workspaces/config/lib/definitions/definitions.js); and independently reimplements the relevant equals, shorthand, single-character cluster, definition-vs-shorthand precedence, unique-prefix, negation, Boolean-secondary-type, and value-consumption semantics of [`nopt` 8.1.0 `lib/nopt-lib.js` lines 249-504](https://github.com/npm/nopt/blob/v8.1.0/lib/nopt-lib.js). Adam does not include or execute npm, `@npmcli/config`, or `nopt` in Plan command assessment; Adam adds its own bounded command-position resolver, mutation classification, resource limits, and fail-closed result. npm CLI is licensed under the Artistic License 2.0; `@npmcli/config` and `nopt` are licensed under the ISC License.
+
+### npm CLI 11.6.2 original notices and Artistic License 2.0
+
+```text
+The npm application
+Copyright (c) npm, Inc. and Contributors
+Licensed on the terms of The Artistic License 2.0
+
+Node package dependencies of the npm application
+Copyright (c) their respective copyright owners
+Licensed on their respective license terms
+
+The npm public registry at https://registry.npmjs.org
+and the npm website at https://www.npmjs.com
+Operated by npm, Inc.
+Use governed by terms published on https://www.npmjs.com
+
+"Node.js"
+Trademark Joyent, Inc., https://joyent.com
+Neither npm nor npm, Inc. are affiliated with Joyent, Inc.
+
+The Node.js application
+Project of Node Foundation, https://nodejs.org
+
+The npm Logo
+Copyright (c) Mathias Pettersson and Brian Hammond
+
+"Gubblebum Blocky" typeface
+Copyright (c) Tjarda Koster, https://jelloween.deviantart.com
+Used with permission
+
+
+--------
+
+
+The Artistic License 2.0
+
+Copyright (c) 2000-2006, The Perl Foundation.
+
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+Preamble
+
+This license establishes the terms under which a given free software
+Package may be copied, modified, distributed, and/or redistributed.
+The intent is that the Copyright Holder maintains some artistic
+control over the development of that Package while still keeping the
+Package available as open source and free software.
+
+You are always permitted to make arrangements wholly outside of this
+license directly with the Copyright Holder of a given Package.  If the
+terms of this license do not permit the full use that you propose to
+make of the Package, you should contact the Copyright Holder and seek
+a different licensing arrangement.
+
+Definitions
+
+    "Copyright Holder" means the individual(s) or organization(s)
+    named in the copyright notice for the entire Package.
+
+    "Contributor" means any party that has contributed code or other
+    material to the Package, in accordance with the Copyright Holder's
+    procedures.
+
+    "You" and "your" means any person who would like to copy,
+    distribute, or modify the Package.
+
+    "Package" means the collection of files distributed by the
+    Copyright Holder, and derivatives of that collection and/or of
+    those files. A given Package may consist of either the Standard
+    Version, or a Modified Version.
+
+    "Distribute" means providing a copy of the Package or making it
+    accessible to anyone else, or in the case of a company or
+    organization, to others outside of your company or organization.
+
+    "Distributor Fee" means any fee that you charge for Distributing
+    this Package or providing support for this Package to another
+    party.  It does not mean licensing fees.
+
+    "Standard Version" refers to the Package if it has not been
+    modified, or has been modified only in ways explicitly requested
+    by the Copyright Holder.
+
+    "Modified Version" means the Package, if it has been changed, and
+    such changes were not explicitly requested by the Copyright
+    Holder.
+
+    "Original License" means this Artistic License as Distributed with
+    the Standard Version of the Package, in its current version or as
+    it may be modified by The Perl Foundation in the future.
+
+    "Source" form means the source code, documentation source, and
+    configuration files for the Package.
+
+    "Compiled" form means the compiled bytecode, object code, binary,
+    or any other form resulting from mechanical transformation or
+    translation of the Source form.
+
+
+Permission for Use and Modification Without Distribution
+
+(1)  You are permitted to use the Standard Version and create and use
+Modified Versions for any purpose without restriction, provided that
+you do not Distribute the Modified Version.
+
+
+Permissions for Redistribution of the Standard Version
+
+(2)  You may Distribute verbatim copies of the Source form of the
+Standard Version of this Package in any medium without restriction,
+either gratis or for a Distributor Fee, provided that you duplicate
+all of the original copyright notices and associated disclaimers.  At
+your discretion, such verbatim copies may or may not include a
+Compiled form of the Package.
+
+(3)  You may apply any bug fixes, portability changes, and other
+modifications made available from the Copyright Holder.  The resulting
+Package will still be considered the Standard Version, and as such
+will be subject to the Original License.
+
+
+Distribution of Modified Versions of the Package as Source
+
+(4)  You may Distribute your Modified Version as Source (either gratis
+or for a Distributor Fee, and with or without a Compiled form of the
+Modified Version) provided that you clearly document how it differs
+from the Standard Version, including, but not limited to, documenting
+any non-standard features, executables, or modules, and provided that
+you do at least ONE of the following:
+
+    (a)  make the Modified Version available to the Copyright Holder
+    of the Standard Version, under the Original License, so that the
+    Copyright Holder may include your modifications in the Standard
+    Version.
+
+    (b)  ensure that installation of your Modified Version does not
+    prevent the user installing or running the Standard Version. In
+    addition, the Modified Version must bear a name that is different
+    from the name of the Standard Version.
+
+    (c)  allow anyone who receives a copy of the Modified Version to
+    make the Source form of the Modified Version available to others
+    under
+
+        (i)  the Original License or
+
+        (ii)  a license that permits the licensee to freely copy,
+        modify and redistribute the Modified Version using the same
+        licensing terms that apply to the copy that the licensee
+        received, and requires that the Source form of the Modified
+        Version, and of any works derived from it, be made freely
+        available in that license fees are prohibited but Distributor
+        Fees are allowed.
+
+
+Distribution of Compiled Forms of the Standard Version
+or Modified Versions without the Source
+
+(5)  You may Distribute Compiled forms of the Standard Version without
+the Source, provided that you include complete instructions on how to
+get the Source of the Standard Version.  Such instructions must be
+valid at the time of your distribution.  If these instructions, at any
+time while you are carrying out such distribution, become invalid, you
+must provide new instructions on demand or cease further distribution.
+If you provide valid instructions or cease distribution within thirty
+days after you become aware that the instructions are invalid, then
+you do not forfeit any of your rights under this license.
+
+(6)  You may Distribute a Modified Version in Compiled form without
+the Source, provided that you comply with Section 4 with respect to
+the Source of the Modified Version.
+
+
+Aggregating or Linking the Package
+
+(7)  You may aggregate the Package (either the Standard Version or
+Modified Version) with other packages and Distribute the resulting
+aggregation provided that you do not charge a licensing fee for the
+Package.  Distributor Fees are permitted, and licensing fees for other
+components in the aggregation are permitted. The terms of this license
+apply to the use and Distribution of the Standard or Modified Versions
+as included in the aggregation.
+
+(8) You are permitted to link Modified and Standard Versions with
+other works, to embed the Package in a larger work of your own, or to
+build stand-alone binary or bytecode versions of applications that
+include the Package, and Distribute the result without restriction,
+provided the result does not expose a direct interface to the Package.
+
+
+Items That are Not Considered Part of a Modified Version
+
+(9) Works (including, but not limited to, modules and scripts) that
+merely extend or make use of the Package, do not, by themselves, cause
+the Package to be a Modified Version.  In addition, such works are not
+considered parts of the Package itself, and are not subject to the
+terms of this license.
+
+
+General Provisions
+
+(10)  Any use, modification, and distribution of the Standard or
+Modified Versions is governed by this Artistic License. By using,
+modifying or distributing the Package, you accept this license. Do not
+use, modify, or distribute the Package, if you do not accept this
+license.
+
+(11)  If your Modified Version has been derived from a Modified
+Version made by someone other than you, you are nevertheless required
+to ensure that your Modified Version complies with the requirements of
+this license.
+
+(12)  This license does not grant you the right to use any trademark,
+service mark, tradename, or logo of the Copyright Holder.
+
+(13)  This license includes the non-exclusive, worldwide,
+free-of-charge patent license to make, have made, use, offer to sell,
+sell, import and otherwise transfer the Package with respect to any
+patent claims licensable by the Copyright Holder that are necessarily
+infringed by the Package. If you institute patent litigation
+(including a cross-claim or counterclaim) against any party alleging
+that the Package constitutes direct or contributory patent
+infringement, then this Artistic License to you shall terminate on the
+date that such litigation is filed.
+
+(14)  Disclaimer of Warranty:
+THE PACKAGE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS "AS
+IS' AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES. THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR
+NON-INFRINGEMENT ARE DISCLAIMED TO THE EXTENT PERMITTED BY YOUR LOCAL
+LAW. UNLESS REQUIRED BY LAW, NO COPYRIGHT HOLDER OR CONTRIBUTOR WILL
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THE PACKAGE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+--------
+```
+
+### `@npmcli/config` 10.4.2 ISC License
+
+```text
+The ISC License
+
+Copyright (c) npm, Inc.
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+```
+
+### `nopt` 8.1.0 ISC License
+
+```text
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+```

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -285,6 +285,9 @@ function formatPermissionPrompt(
   if (event.subject.type === "command") {
     return `Allow ${event.name} at "${event.subject.cwd}": ${quoteForTerminal(event.subject.command)} [y/N] `;
   }
+  if (event.subject.type === "plan_command") {
+    return `Allow ${event.name} Plan execute at "${event.subject.cwd}": ${quoteForTerminal(event.subject.command)}. Plan parsing is not a sandbox; approval may run project code, write cache or artifacts, read accessible data, or use network. [y/N] `;
+  }
   if (event.subject.type === "patch") {
     const operations = event.subject.operations
       .map((operation) =>

--- a/apps/tui/src/permission-overlay.test.ts
+++ b/apps/tui/src/permission-overlay.test.ts
@@ -1,0 +1,88 @@
+import type { PendingInteraction } from "@adam-agent/presentation";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { expect, test } from "vitest";
+import { PermissionOverlay } from "./permission-overlay.js";
+import { createAdamTuiTheme } from "./theme.js";
+
+test("Plan shell permission renders the exact command and truthful execution warning", () => {
+  const interaction: PendingInteraction = {
+    type: "permission",
+    requestId: "run:plan-shell",
+    callId: "plan-shell",
+    effect: "execute",
+    subject: { type: "command", value: "unknown --diagnose" },
+    warning:
+      "Plan parsing is not a sandbox. Approval may run project code, write cache or artifacts, read accessible data, or use network.",
+    canAllow: true,
+    changePreviewRef: null,
+  };
+  const overlay = new PermissionOverlay({
+    interaction,
+    onDecision() {},
+    theme: createAdamTuiTheme(true),
+  });
+  overlay.setPreview({ readable: true, text: "No preview available." });
+
+  const rendered = overlay.render(200).join("\n");
+
+  expect(rendered).toContain("Action execute · Subject unknown --diagnose");
+  expect(rendered).toContain("Plan parsing is not a sandbox.");
+  expect(rendered).toContain(
+    "Approval may run project code, write cache or artifacts, read accessible data, or use network.",
+  );
+  expect(rendered).toContain("Allow");
+  expect(rendered).toContain("Deny");
+});
+
+test("Plan shell permission preserves the exact command and complete warning at 80 columns", () => {
+  const command = `unknown --diagnose ${"x".repeat(100)}`;
+  const warning =
+    "Plan parsing is not a sandbox. Approval may run project code, write cache or artifacts, read accessible data, or use network.";
+  const overlay = new PermissionOverlay({
+    interaction: {
+      type: "permission",
+      requestId: "run:plan-shell-narrow",
+      callId: "plan-shell-narrow",
+      effect: "execute",
+      subject: { type: "command", value: command },
+      warning,
+      canAllow: true,
+      changePreviewRef: null,
+    },
+    onDecision() {},
+    theme: createAdamTuiTheme(true),
+  });
+  overlay.setPreview({ readable: true, text: "No preview available." });
+
+  const lines = overlay.render(80);
+  const withoutVisualLineBreaks = lines.join("");
+
+  expect(lines.every((line) => visibleWidth(line) <= 80)).toBe(true);
+  expect(withoutVisualLineBreaks).toContain(`Action execute · Subject ${command}`);
+  expect(withoutVisualLineBreaks).toContain(warning);
+});
+
+test("Plan shell permission renders a reversible exact representation of unsafe raw text", () => {
+  const command = "unknown\t--diagnose\u202e";
+  const overlay = new PermissionOverlay({
+    interaction: {
+      type: "permission",
+      requestId: "run:plan-shell-unsafe",
+      callId: "plan-shell-unsafe",
+      effect: "execute",
+      subject: { type: "command", value: command },
+      canAllow: true,
+      changePreviewRef: null,
+    },
+    onDecision() {},
+    theme: createAdamTuiTheme(true),
+  });
+  overlay.setPreview({ readable: true, text: "No preview available." });
+
+  const withoutVisualLineBreaks = overlay.render(80).join("");
+
+  expect(withoutVisualLineBreaks).toContain(
+    'Action execute · Subject "unknown\\t--diagnose\\u202e"',
+  );
+  expect(withoutVisualLineBreaks).not.toContain("unknown  --diagnose");
+});

--- a/apps/tui/src/permission-overlay.ts
+++ b/apps/tui/src/permission-overlay.ts
@@ -5,6 +5,7 @@ import {
   Key,
   matchesKey,
   truncateToWidth,
+  visibleWidth,
 } from "@earendil-works/pi-tui";
 import { safeTerminalText } from "./safe-terminal-text.js";
 import type { AdamTuiTheme } from "./theme.js";
@@ -69,14 +70,33 @@ export class PermissionOverlay implements Component, Focusable {
   invalidate(): void {}
 
   render(width: number): string[] {
-    const subject = truncateToWidth(safeTerminalText(this.#interaction.subject.value), width);
+    const subject = exactTerminalSubject(this.#interaction.subject.value);
     const effect =
       this.#interaction.effect === "read"
         ? this.#theme.keyword(this.#interaction.effect)
         : this.#theme.danger(this.#interaction.effect);
-    const actionLine = `${this.#theme.keyword("Action")} ${effect} · ${this.#theme.keyword(
+    const actionPrefix = `${this.#theme.keyword("Action")} ${effect} · ${this.#theme.keyword(
       "Subject",
-    )} ${this.#theme.subject(subject)}`;
+    )} `;
+    const actionPrefixWidth = visibleWidth(actionPrefix);
+    const actionLines =
+      width > actionPrefixWidth
+        ? wrapExactText(subject, width - actionPrefixWidth).map((line, index) =>
+            index === 0 ? `${actionPrefix}${this.#theme.subject(line)}` : this.#theme.subject(line),
+          )
+        : [
+            ...wrapExactText(
+              `Action ${this.#interaction.effect} · Subject `,
+              Math.max(1, width),
+            ).map((line) => this.#theme.keyword(line)),
+            ...wrapExactText(subject, Math.max(1, width)).map((line) => this.#theme.subject(line)),
+          ];
+    const warningLine =
+      this.#interaction.warning === undefined
+        ? []
+        : wrapExactText(safeTerminalText(this.#interaction.warning), Math.max(1, width)).map(
+            (line) => this.#theme.danger(line),
+          );
     const options = this.#allowEnabled
       ? `${this.#selection === "allow" ? ">" : " "} ${this.#theme.allow("Allow")}    ${
           this.#selection === "deny" ? ">" : " "
@@ -100,7 +120,8 @@ export class PermissionOverlay implements Component, Focusable {
       width < 60
         ? [
             this.#theme.toolTitle("Permission required"),
-            actionLine,
+            ...actionLines,
+            ...warningLine,
             options,
             "Enter · Esc deny · Ctrl+C abort",
             previewPosition,
@@ -108,7 +129,8 @@ export class PermissionOverlay implements Component, Focusable {
           ]
         : [
             this.#theme.toolTitle("Permission required"),
-            actionLine,
+            ...actionLines,
+            ...warningLine,
             "",
             ...preview,
             "",
@@ -123,4 +145,44 @@ export class PermissionOverlay implements Component, Focusable {
     const maximum = Math.max(0, this.#preview.split("\n").length - this.#previewPageSize);
     this.#previewOffset = Math.max(0, Math.min(maximum, this.#previewOffset + lines));
   }
+}
+
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+function wrapExactText(value: string, maximumWidth: number): string[] {
+  if (value.length === 0) {
+    return [""];
+  }
+  const lines: string[] = [];
+  let line = "";
+  let lineWidth = 0;
+  for (const { segment } of graphemeSegmenter.segment(value)) {
+    const segmentWidth = visibleWidth(segment);
+    if (line.length > 0 && lineWidth + segmentWidth > maximumWidth) {
+      lines.push(line);
+      line = "";
+      lineWidth = 0;
+    }
+    line += segment;
+    lineWidth += segmentWidth;
+  }
+  if (line.length > 0) {
+    lines.push(line);
+  }
+  return lines;
+}
+
+function exactTerminalSubject(value: string): string {
+  const safe = safeTerminalText(value);
+  if (safe === value) {
+    return value;
+  }
+  return [...JSON.stringify(value)]
+    .map((character) => {
+      if (safeTerminalText(character) === character) {
+        return character;
+      }
+      return `\\u${(character.codePointAt(0) as number).toString(16).padStart(4, "0")}`;
+    })
+    .join("");
 }

--- a/packages/agent/src/agent-session.ts
+++ b/packages/agent/src/agent-session.ts
@@ -60,6 +60,15 @@ import {
   prepareExplicitUserImageMessagesV1,
   projectedContentUsageV1,
 } from "./model-user-content.js";
+import {
+  downgradePlanCommandAssessmentV1,
+  type PlanCommandAssessment,
+} from "./plan-command-assessment.js";
+import {
+  assessPlanCommandExecutionV1,
+  resolvePlanTrustedExecutableV1,
+} from "./plan-executable-policy.js";
+import { createPlanGitAttestationV1, type PlanGitAttestationV1 } from "./plan-git-policy.js";
 import type { PlanCycleSnapshot } from "./plan-mode.js";
 import {
   assemblePromptMessagesV1,
@@ -156,6 +165,7 @@ export class AgentSession {
   readonly #tools: ToolRegistry | undefined;
   readonly #fixedRequestTools: readonly ModelToolDefinition[] | undefined;
   readonly #plan: PlanCycleSnapshot | undefined;
+  #planGitAttestation: PlanGitAttestationV1 | undefined;
   readonly #permissions: PermissionPolicy | undefined;
   #promptContext: PromptContextRecord | undefined;
   #skillContext: SkillContextRecordV1 | undefined;
@@ -248,6 +258,7 @@ export class AgentSession {
           ])
         : captureToolRegistry(dependencies.tools, selectedToolNames);
     this.#plan = this.#durableContext?.plan;
+    this.#planGitAttestation = this.#plan?.gitAttestation;
     this.#fixedRequestTools =
       this.#durableContext !== undefined && durablePromptContext === undefined
         ? undefined
@@ -1977,12 +1988,47 @@ export class AgentSession {
       return undefined;
     }
     const preparedPermissionSubject = preparedCall.permissionSubject;
+    const planCommandAssessment =
+      this.#plan?.policyVersion === "plan-policy.hybrid-v1" &&
+      call.name === "run_shell" &&
+      preparedPermissionSubject.type === "command"
+        ? this.#plan.shellEnvironment !== undefined && this.#repositoryWorkspaceRoot !== undefined
+          ? await assessPlanCommandExecutionV1({
+              rawCommand: preparedPermissionSubject.command,
+              shellEnvironment: this.#plan.shellEnvironment,
+              workspaceRoot: this.#repositoryWorkspaceRoot,
+              ...(this.#planGitAttestation === undefined
+                ? {}
+                : { gitAttestation: this.#planGitAttestation }),
+            })
+          : downgradePlanCommandAssessmentV1(
+              preparedPermissionSubject.command,
+              "environment_untrusted",
+            )
+        : undefined;
+    if (planCommandAssessment?.status === "invalid") {
+      const result: ToolResult = {
+        status: "failed",
+        error: {
+          code: "invalid_tool_input",
+          message: "The Plan shell command does not satisfy the bounded command grammar.",
+        },
+      };
+      toolResultsById.set(call.id, { call, result });
+      await this.#appendToolResult(messages, call, result);
+      return undefined;
+    }
+    const permissionSubject = planPermissionSubject(
+      this.#plan,
+      preparedPermissionSubject,
+      planCommandAssessment,
+    );
     const permissionInput: PermissionPolicyInput = {
       callId: call.id,
       name: call.name,
       effect: adapter.effect,
       scope: "call",
-      subject: preparedPermissionSubject,
+      subject: permissionSubject,
     };
     const visibleModelSkillSelection =
       preparedPermissionSubject.type === "skill" &&
@@ -2005,13 +2051,14 @@ export class AgentSession {
     const eligiblePlanDefinition = this.#plan?.eligibleToolProfile.definitions.find(
       (definition) => definition.name === call.name,
     );
-    if (
-      this.#plan !== undefined &&
-      (eligiblePlanDefinition === undefined ||
-        eligiblePlanDefinition.definitionDigest !== adapter.definitionDigest ||
-        eligiblePlanDefinition.effect !== adapter.effect ||
-        adapter.effect !== "read")
-    ) {
+    const planDisposition = planToolDisposition(
+      this.#plan,
+      eligiblePlanDefinition,
+      adapter,
+      preparedPermissionSubject,
+      planCommandAssessment,
+    );
+    if (this.#plan !== undefined && planDisposition === "deny") {
       await this.#emit({
         type: "tool_permission_decided",
         decision: "deny",
@@ -2096,9 +2143,13 @@ export class AgentSession {
       }
     }
     const policyDecision =
-      this.#plan !== undefined || preparedPermissionSubject.type === "input_resource"
-        ? "allow"
-        : (this.#permissions?.decide(permissionInput) ?? "deny");
+      this.#plan !== undefined
+        ? planDisposition === "ask"
+          ? "ask"
+          : "allow"
+        : preparedPermissionSubject.type === "input_resource"
+          ? "allow"
+          : (this.#permissions?.decide(permissionInput) ?? "deny");
     if (signal.aborted) {
       return this.#settleCancelled();
     }
@@ -2180,6 +2231,15 @@ export class AgentSession {
       toolName: call.name,
       sessionId: this.#durableContext?.sessionId ?? this.#runtimeSessionId,
       toolProfileDigest: this.#promptContext?.toolProfile.digest ?? "prompt-profile-v0",
+      ...(call.name === "run_shell" && this.#plan?.shellEnvironment !== undefined
+        ? { planShellEnvironment: this.#plan.shellEnvironment }
+        : {}),
+      ...(call.name === "run_shell" && planCommandAssessment !== undefined
+        ? { planCommandAssessment }
+        : {}),
+      ...(call.name === "run_shell" && this.#planGitAttestation !== undefined
+        ? { planGitAttestation: this.#planGitAttestation }
+        : {}),
     } as const;
     const result =
       call.name === "activate_skill"
@@ -2191,6 +2251,7 @@ export class AgentSession {
             : await preparedCall.execute(executionContext);
     toolResultsById.set(call.id, { call, result });
     await this.#appendToolResult(messages, call, result);
+    await this.#commitPlanGitAttestation(call, result);
     if (result.status === "failed" && result.error.code === "tool_effect_indeterminate") {
       return this.#settle({
         status: "failed",
@@ -2198,6 +2259,50 @@ export class AgentSession {
       });
     }
     return undefined;
+  }
+
+  async #commitPlanGitAttestation(call: ToolCall, result: ToolResult): Promise<void> {
+    const runId = this.#activeRunId;
+    const plan = this.#plan;
+    const shellEnvironment = plan?.shellEnvironment;
+    const workspaceRoot = this.#repositoryWorkspaceRoot;
+    if (
+      this.#planGitAttestation !== undefined ||
+      runId === undefined ||
+      plan?.policyVersion !== "plan-policy.hybrid-v1" ||
+      shellEnvironment === undefined ||
+      workspaceRoot === undefined ||
+      call.name !== "run_shell" ||
+      !isExactGitVersionToolCall(call) ||
+      !isExactGitVersionToolResult(result)
+    ) {
+      return;
+    }
+    const executable = await resolvePlanTrustedExecutableV1({
+      commandName: "git",
+      shellEnvironment,
+      workspaceRoot,
+    });
+    if (executable === undefined) {
+      return;
+    }
+    const attestation = createPlanGitAttestationV1({
+      executable,
+      shellEnvironmentDigest: shellEnvironment.digest,
+    });
+    await this.#appendRecord({
+      schemaVersion: 3,
+      sequence: this.#nextSequence,
+      record: {
+        type: "plan_git_attested",
+        recordVersion: 1,
+        cycleId: plan.cycleId,
+        runId,
+        callId: call.id,
+        attestation,
+      },
+    });
+    this.#planGitAttestation = attestation;
   }
 
   async #activateModelSelectedSkill(call: ToolCall): Promise<ToolResult> {
@@ -3787,7 +3892,7 @@ function planRequestToolDefinitions(
       adapter === undefined ||
       adapter.definitionDigest !== definition.definitionDigest ||
       adapter.effect !== definition.effect ||
-      definition.effect !== "read"
+      !planProfileAllowsDefinition(plan, definition)
     ) {
       throw new TypeError("The exact Plan Tool Profile is not supported.");
     }
@@ -3795,11 +3900,139 @@ function planRequestToolDefinitions(
   });
 }
 
+function planProfileAllowsDefinition(
+  plan: PlanCycleSnapshot,
+  definition: PlanCycleSnapshot["eligibleToolProfile"]["definitions"][number],
+): boolean {
+  if (definition.effect === "read") {
+    return true;
+  }
+  if (
+    plan.policyVersion !== "plan-policy.hybrid-v1" ||
+    plan.shellPolicyVersion !== "plan-shell-policy.v1"
+  ) {
+    return false;
+  }
+  return (
+    (definition.source === "builtin" &&
+      definition.name === "run_shell" &&
+      definition.effect === "execute") ||
+    (definition.source === "mcp" &&
+      (definition.effect === "execute" || definition.effect === "network"))
+  );
+}
+
+function planToolDisposition(
+  plan: PlanCycleSnapshot | undefined,
+  definition: PlanCycleSnapshot["eligibleToolProfile"]["definitions"][number] | undefined,
+  adapter: NonNullable<ReturnType<ToolRegistry["resolve"]>>,
+  subject: PermissionSubject,
+  commandAssessment: PlanCommandAssessment | undefined,
+): "allow" | "ask" | "deny" | undefined {
+  if (plan === undefined) {
+    return undefined;
+  }
+  if (
+    definition === undefined ||
+    definition.definitionDigest !== adapter.definitionDigest ||
+    definition.effect !== adapter.effect ||
+    !planProfileAllowsDefinition(plan, definition)
+  ) {
+    return "deny";
+  }
+  if (definition.effect === "read") {
+    return "allow";
+  }
+  if (
+    definition.source === "builtin" &&
+    definition.name === "run_shell" &&
+    definition.effect === "execute" &&
+    subject.type === "command" &&
+    commandAssessment !== undefined
+  ) {
+    return commandAssessment.disposition === "allow_inspection"
+      ? "allow"
+      : commandAssessment.disposition === "ask_ambiguous"
+        ? "ask"
+        : "deny";
+  }
+  if (
+    definition.source === "mcp" &&
+    (definition.effect === "execute" || definition.effect === "network")
+  ) {
+    return "ask";
+  }
+  return "deny";
+}
+
+function planPermissionSubject(
+  plan: PlanCycleSnapshot | undefined,
+  subject: PermissionSubject,
+  assessment: PlanCommandAssessment | undefined,
+): PermissionSubject {
+  if (
+    plan?.policyVersion !== "plan-policy.hybrid-v1" ||
+    plan.shellPolicyVersion !== "plan-shell-policy.v1" ||
+    plan.shellEnvironment === undefined ||
+    plan.gitPolicyVersion !== "git-auto-policy.v1" ||
+    plan.gitPolicyDigest === undefined ||
+    subject.type !== "command" ||
+    assessment === undefined ||
+    assessment.status !== "assessed"
+  ) {
+    return subject;
+  }
+  return {
+    type: "plan_command",
+    command: subject.command,
+    cwd: subject.cwd,
+    planCycleId: plan.cycleId,
+    planPolicyVersion: plan.policyVersion,
+    shellPolicyVersion: plan.shellPolicyVersion,
+    shellEnvironmentVersion: plan.shellEnvironment.version,
+    shellEnvironmentDigest: plan.shellEnvironment.digest,
+    toolProfileDigest: plan.eligibleToolProfile.digest,
+    gitPolicyVersion: plan.gitPolicyVersion,
+    gitPolicyDigest: plan.gitPolicyDigest,
+    assessment: {
+      version: assessment.version,
+      disposition: assessment.disposition,
+      reasons: assessment.reasons,
+      digest: assessment.digest,
+    },
+  };
+}
+
 function areOptionalUsageDetailsValid(
   usage: Extract<ModelEvent, { readonly type: "usage" }>,
 ): boolean {
   return [usage.reasoningTokens, usage.cachedInputTokens, usage.cacheMissInputTokens].every(
     (value) => value === undefined || isNonnegativeSafeInteger(value),
+  );
+}
+
+function isExactGitVersionToolCall(call: ToolCall): boolean {
+  try {
+    const parsed = JSON.parse(call.argumentsJson) as unknown;
+    return (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      !Array.isArray(parsed) &&
+      (parsed as { readonly command?: unknown }).command === "git --version"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isExactGitVersionToolResult(result: ToolResult): boolean {
+  return (
+    result.status === "completed" &&
+    isDeepStrictEqual(result.output, {
+      termination: { type: "exited", exitCode: 0 },
+      stdout: { tail: "git version 2.43.0\n", totalBytes: 19, omittedBytes: 0 },
+      stderr: { tail: "", totalBytes: 0, omittedBytes: 0 },
+    })
   );
 }
 

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -33,6 +33,22 @@ export {
 } from "./mcp-host.js";
 export { preparedDirectDeepSeekV2ContextProfile } from "./model-targets.js";
 export type { PatchFileSystem } from "./patch-transaction.js";
+export { assessPlanCommandV1 } from "./plan-command-assessment.js";
+export {
+  assessPlanCommandExecutionV1,
+  resolvePlanTrustedExecutableV1,
+} from "./plan-executable-policy.js";
+export {
+  createPlanGitAttestationV1,
+  planGitAutomaticPolicyV1,
+  planGitEnvironmentV1,
+} from "./plan-git-policy.js";
+export { isExactPlanMcpPermissionEventV1 } from "./plan-mcp-permission-validation.js";
+export { createPlanToolProfileV1 } from "./plan-mode.js";
+export {
+  createPlanShellEnvironmentV1,
+  createUnavailablePlanShellEnvironmentV1,
+} from "./plan-shell-environment.js";
 export {
   type PresentationArtifactReadBarrier,
   type PresentationHydrationBarrier,
@@ -84,6 +100,8 @@ export {
   mcpActivationSettlementBarrier,
   mcpCatalogStaleDurableBarrier,
   mcpCatalogStaleObservationBarrier,
+  type PlanShellEnvironmentFactory,
+  planShellEnvironmentFactory,
   type SessionCloseDrainBarrier,
   type SessionLogicalRunStartedBarrier,
   type SessionRuntimeNotificationTransform,

--- a/packages/agent/src/plan-command-assessment.ts
+++ b/packages/agent/src/plan-command-assessment.ts
@@ -1,0 +1,2033 @@
+import { createHash } from "node:crypto";
+
+// Parser and validator mechanisms are selectively adapted from
+// @narumitw/pi-plan-mode@0.56.0, src/tool-policy.ts lines 314-840,
+// gitHead 9b4cab310013a71d7990e7736452c3c1aebfd148, under the MIT License.
+export const planShellPolicyVersions = ["plan-shell-policy.v1"] as const;
+export const planGitAutomaticCommandCorpusVersion = "plan-git-corpus.v1" as const;
+
+export type PlanShellPolicyVersion = (typeof planShellPolicyVersions)[number];
+
+export type PlanCommandAssessment = {
+  readonly status: "assessed" | "invalid";
+  readonly version: 1;
+  readonly policyVersion: "plan-shell-policy.v1";
+  readonly disposition: "allow_inspection" | "ask_ambiguous" | "deny_mutation";
+  readonly reasons: readonly (
+    | "automatic_system_inspection"
+    | "automatic_git_inspection"
+    | "automatic_workspace_inspection"
+    | "command_too_large"
+    | "environment_untrusted"
+    | "executable_untrusted"
+    | "git_attestation_required"
+    | "git_repository_untrusted"
+    | "in_place_mutation"
+    | "invalid_unicode"
+    | "malformed_command"
+    | "output_redirection"
+    | "path_untrusted"
+    | "recognized_mutation"
+    | "shell_builtin_or_indirection"
+    | "token_too_large"
+    | "too_many_arguments"
+    | "too_many_paths"
+    | "too_many_segments"
+    | "unclassified_command"
+    | "unsupported_control"
+    | "unsupported_syntax"
+  )[];
+  readonly digest: `sha256:${string}`;
+};
+
+export function assessPlanCommandV1(rawCommand: string): PlanCommandAssessment {
+  if (!hasValidUnicode(rawCommand)) {
+    return assessment(rawCommand, "ask_ambiguous", ["invalid_unicode"], "invalid");
+  }
+  if (Buffer.byteLength(rawCommand, "utf8") > 16 * 1024) {
+    return assessment(rawCommand, "ask_ambiguous", ["command_too_large"], "invalid");
+  }
+  if (
+    [...rawCommand].some((character) => {
+      const code = character.codePointAt(0) as number;
+      return (code < 0x20 && code !== 0x09) || code === 0x7f;
+    })
+  ) {
+    return assessment(rawCommand, "ask_ambiguous", ["unsupported_control"], "invalid");
+  }
+  if (containsUnquotedOutputRedirect(rawCommand)) {
+    return assessment(rawCommand, "deny_mutation", ["output_redirection"]);
+  }
+  const unsupportedSyntax = containsUnsupportedShellSyntax(rawCommand);
+  const segments = splitCommandSegments(rawCommand);
+  if (segments === undefined) {
+    return unsupportedSyntax
+      ? assessment(rawCommand, "ask_ambiguous", ["unsupported_syntax"])
+      : assessment(rawCommand, "ask_ambiguous", ["malformed_command"], "invalid");
+  }
+  if (segments.length > 32) {
+    return assessment(rawCommand, "ask_ambiguous", ["too_many_segments"], "invalid");
+  }
+  const argumentsBySegment = segments.map((segment) => tokenizeSimpleCommand(segment));
+  if (
+    argumentsBySegment.some((argv) =>
+      argv?.some((token) => Buffer.byteLength(token, "utf8") > 4_096),
+    )
+  ) {
+    return assessment(rawCommand, "ask_ambiguous", ["token_too_large"], "invalid");
+  }
+  if (argumentsBySegment.some((argv) => argv !== undefined && argv.length > 128)) {
+    return assessment(rawCommand, "ask_ambiguous", ["too_many_arguments"], "invalid");
+  }
+  const operators = commandOperatorsV1(rawCommand);
+  const classifications = argumentsBySegment.map((argv, index) =>
+    classifySegment(argv, index > 0 && operators[index - 1] === "|"),
+  );
+  const pathOperands = classifications.flatMap((classification) => classification.pathOperands);
+  if (pathOperands.length > 32) {
+    return assessment(rawCommand, "ask_ambiguous", ["too_many_paths"], "invalid");
+  }
+  const denied = classifications.find(
+    (classification) => classification.disposition === "deny_mutation",
+  );
+  if (denied !== undefined) {
+    return assessment(rawCommand, "deny_mutation", [denied.reason]);
+  }
+  if (
+    classifications.some(
+      (classification) => classification.reason === "shell_builtin_or_indirection",
+    )
+  ) {
+    return assessment(rawCommand, "ask_ambiguous", ["shell_builtin_or_indirection"]);
+  }
+  if (unsupportedSyntax) {
+    return assessment(rawCommand, "ask_ambiguous", ["unsupported_syntax"]);
+  }
+  if (
+    classifications.every((classification) => classification.disposition === "allow_inspection")
+  ) {
+    return assessment(rawCommand, "allow_inspection", [
+      classifications.some((classification) => classification.reason === "automatic_git_inspection")
+        ? "automatic_git_inspection"
+        : classifications.some(
+              (classification) => classification.reason === "automatic_workspace_inspection",
+            )
+          ? "automatic_workspace_inspection"
+          : "automatic_system_inspection",
+    ]);
+  }
+  return assessment(rawCommand, "ask_ambiguous", ["unclassified_command"]);
+}
+
+function containsUnsupportedShellSyntax(rawCommand: string): boolean {
+  if (/^[\t ]*[A-Za-z_][A-Za-z0-9_]*=/u.test(rawCommand)) {
+    return true;
+  }
+  let quote: "single" | "double" | undefined;
+  let escaped = false;
+  for (let index = 0; index < rawCommand.length; index += 1) {
+    const character = rawCommand[index] as string;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quote !== "single") {
+      escaped = true;
+      continue;
+    }
+    if (character === "'" && quote !== "double") {
+      quote = quote === "single" ? undefined : "single";
+      continue;
+    }
+    if (character === '"' && quote !== "single") {
+      quote = quote === "double" ? undefined : "double";
+      continue;
+    }
+    if (quote === "single") {
+      continue;
+    }
+    if (character === "$" || character === "`") {
+      return true;
+    }
+    if (quote === "double") {
+      continue;
+    }
+    if ("<#(){}*?[~".includes(character)) {
+      return true;
+    }
+    if (character === "&" && rawCommand[index + 1] !== "&") {
+      return true;
+    }
+    if (character === "&") {
+      index += 1;
+    }
+  }
+  return false;
+}
+
+function hasValidUnicode(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return false;
+      }
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function planCommandArgumentsV1(
+  rawCommand: string,
+): readonly (readonly string[])[] | undefined {
+  const segments = splitCommandSegments(rawCommand);
+  if (segments === undefined) {
+    return undefined;
+  }
+  const argumentsBySegment = segments.map((segment) => tokenizeSimpleCommand(segment));
+  return argumentsBySegment.some((argv) => argv === undefined)
+    ? undefined
+    : (argumentsBySegment as readonly (readonly string[])[]);
+}
+
+export function planAutomaticPathOperandsV1(rawCommand: string): readonly string[] | undefined {
+  const argumentsBySegment = planCommandArgumentsV1(rawCommand);
+  if (argumentsBySegment === undefined) {
+    return undefined;
+  }
+  const operators = commandOperatorsV1(rawCommand);
+  const classifications = argumentsBySegment.map((argv, index) =>
+    classifySegment(argv, index > 0 && operators[index - 1] === "|"),
+  );
+  return classifications.every(
+    (classification) => classification.disposition === "allow_inspection",
+  )
+    ? classifications.flatMap((classification) => classification.pathOperands)
+    : undefined;
+}
+
+export function bindPlanCommandExecutionIdentityV1(
+  rawCommand: string,
+  current: PlanCommandAssessment,
+  executionIdentity: unknown,
+): PlanCommandAssessment {
+  return assessment(
+    rawCommand,
+    current.disposition,
+    current.reasons,
+    current.status,
+    executionIdentity,
+  );
+}
+
+export function downgradePlanCommandAssessmentV1(
+  rawCommand: string,
+  reason:
+    | "environment_untrusted"
+    | "executable_untrusted"
+    | "git_attestation_required"
+    | "git_repository_untrusted"
+    | "path_untrusted",
+  executionIdentity?: unknown,
+): PlanCommandAssessment {
+  return assessment(rawCommand, "ask_ambiguous", [reason], "assessed", executionIdentity);
+}
+
+function containsUnquotedOutputRedirect(rawCommand: string): boolean {
+  let quote: "single" | "double" | undefined;
+  let escaped = false;
+  for (const character of rawCommand) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quote !== "single") {
+      escaped = true;
+    } else if (character === "'" && quote !== "double") {
+      quote = quote === "single" ? undefined : "single";
+    } else if (character === '"' && quote !== "single") {
+      quote = quote === "double" ? undefined : "double";
+    } else if (character === ">" && quote === undefined) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function classifySegment(
+  argv: readonly string[] | undefined,
+  automaticPipelineInput = false,
+): {
+  readonly disposition: PlanCommandAssessment["disposition"];
+  readonly reason: PlanCommandAssessment["reasons"][number];
+  readonly pathOperands: readonly string[];
+} {
+  if (isDirectMutation(argv)) {
+    return { disposition: "deny_mutation", reason: "recognized_mutation", pathOperands: [] };
+  }
+  if (isInPlaceOrOutputMutation(argv)) {
+    return { disposition: "deny_mutation", reason: "in_place_mutation", pathOperands: [] };
+  }
+  if (argv?.[0] !== undefined && planShellBuiltinAndIndirectionV1.has(argv[0])) {
+    return {
+      disposition: "ask_ambiguous",
+      reason: "shell_builtin_or_indirection",
+      pathOperands: [],
+    };
+  }
+  if (isSystemObservation(argv) || isVersionObservation(argv)) {
+    return {
+      disposition: "allow_inspection",
+      reason: "automatic_system_inspection",
+      pathOperands: [],
+    };
+  }
+  const gitPaths = gitAutomaticInspectionPaths(argv);
+  if (gitPaths !== undefined) {
+    return {
+      disposition: "allow_inspection",
+      reason: "automatic_git_inspection",
+      pathOperands: gitPaths,
+    };
+  }
+  const workspacePaths = workspaceInspectionPaths(argv, automaticPipelineInput);
+  if (workspacePaths !== undefined) {
+    return {
+      disposition: "allow_inspection",
+      reason: "automatic_workspace_inspection",
+      pathOperands: workspacePaths,
+    };
+  }
+  return { disposition: "ask_ambiguous", reason: "unclassified_command", pathOperands: [] };
+}
+
+export function isPlanAutomaticGitCommandV1(argv: readonly string[]): boolean {
+  return argv.length === 2 && argv[0] === "git" && argv[1] === "--version"
+    ? true
+    : gitAutomaticInspectionPaths(argv) !== undefined;
+}
+
+export function isPlanAutomaticRepositoryGitCommandV1(argv: readonly string[]): boolean {
+  return gitAutomaticInspectionPaths(argv) !== undefined;
+}
+
+function gitAutomaticInspectionPaths(
+  argv: readonly string[] | undefined,
+): readonly string[] | undefined {
+  if (argv?.[0] !== "git" || argv[1] !== "--no-pager") {
+    return undefined;
+  }
+  if (
+    argv[2] === "status" &&
+    (argv.length === 6 || argv.length === 7) &&
+    argv[3] === "--porcelain=v1" &&
+    argv[4] === "--untracked-files=normal" &&
+    argv[5] === "--ignore-submodules=all" &&
+    (argv.length === 6 || argv[6] === "--branch")
+  ) {
+    return [];
+  }
+  if (
+    argv[2] === "rev-parse" &&
+    ((argv.length === 4 &&
+      ["--show-toplevel", "--is-inside-work-tree", "--show-prefix"].includes(argv[3] as string)) ||
+      (argv.length === 5 && argv[3] === "--verify" && argv[4] === "HEAD"))
+  ) {
+    return [];
+  }
+  if (
+    argv.length === 7 &&
+    argv[2] === "log" &&
+    argv[3] === "--oneline" &&
+    argv[4] === "--decorate=no" &&
+    argv[5] === "-n" &&
+    isBoundedPositiveDecimal(argv[6])
+  ) {
+    return [];
+  }
+  const gitReadPrefix = ["--no-ext-diff", "--no-textconv", "--ignore-submodules=all"];
+  if (
+    argv[2] === "diff" &&
+    argv.slice(3, 6).every((argument, index) => argument === gitReadPrefix[index])
+  ) {
+    let index = 6;
+    if (["--stat", "--name-only", "--name-status"].includes(argv[index] as string)) {
+      index += 1;
+    }
+    if (argv[index] === "--cached") {
+      index += 1;
+    }
+    if (index === argv.length) {
+      return [];
+    }
+    return argv[index] === "--" && index + 1 < argv.length ? argv.slice(index + 1) : undefined;
+  }
+  if (
+    argv[2] === "show" &&
+    argv.slice(3, 6).every((argument, index) => argument === gitReadPrefix[index]) &&
+    argv.length === 8 &&
+    ["--stat", "--name-only", "--name-status"].includes(argv[6] as string) &&
+    (argv[7] === "HEAD" || /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u.test(argv[7] as string))
+  ) {
+    return [];
+  }
+  return undefined;
+}
+
+function workspaceInspectionPaths(
+  argv: readonly string[] | undefined,
+  automaticPipelineInput = false,
+): readonly string[] | undefined {
+  if (argv === undefined) {
+    return undefined;
+  }
+  if (argv[0] === "ls") {
+    let index = 1;
+    if (["-1", "-a", "-A"].includes(argv[index] as string)) {
+      index += 1;
+    }
+    if (argv[index] === "--") {
+      index += 1;
+    }
+    const paths = argv.slice(index);
+    return paths.some((path) => path.startsWith("-")) ? undefined : paths;
+  }
+  if (
+    argv[0] === "stat" &&
+    argv.length >= 5 &&
+    argv[1] === "-c" &&
+    argv[2] === "%f %s %Y" &&
+    argv[3] === "--"
+  ) {
+    return argv.slice(4);
+  }
+  if (
+    (argv[0] === "head" || argv[0] === "tail") &&
+    argv.length >= 5 &&
+    argv[1] === "-n" &&
+    isBoundedPositiveDecimal(argv[2]) &&
+    argv[3] === "--"
+  ) {
+    return argv.slice(4);
+  }
+  if (
+    argv[0] === "wc" &&
+    argv.length >= 4 &&
+    ["-l", "-w", "-c"].includes(argv[1] as string) &&
+    argv[2] === "--"
+  ) {
+    return argv.slice(3);
+  }
+  if (argv[0] === "rg") {
+    const prefix = ["--no-config", "--no-follow", "--line-number", "--fixed-strings"];
+    if (argv.slice(1, 5).some((argument, index) => argument !== prefix[index])) {
+      return undefined;
+    }
+    let index = 5;
+    if (argv[index] === "--ignore-case" || argv[index] === "--case-sensitive") {
+      index += 1;
+    }
+    return argv[index] === "--" && argv.length >= index + 3 ? argv.slice(index + 2) : undefined;
+  }
+  if (argv[0] === "grep" && argv[1] === "-nF") {
+    let index = 2;
+    if (argv[index] === "-i") {
+      index += 1;
+    }
+    if (argv[index] !== "--") {
+      return undefined;
+    }
+    if (argv.length >= index + 3) {
+      return argv.slice(index + 2);
+    }
+    return automaticPipelineInput && argv.length === index + 2 ? [] : undefined;
+  }
+  if (
+    argv.length === 9 &&
+    argv[0] === "find" &&
+    argv[2] === "-maxdepth" &&
+    isBoundedNonnegativeDecimal(argv[3], 32) &&
+    argv[4] === "-type" &&
+    argv[5] === "f" &&
+    (argv[6] === "-name" || argv[6] === "-iname") &&
+    argv[8] === "-print"
+  ) {
+    return [argv[1] as string];
+  }
+  return undefined;
+}
+
+function commandOperatorsV1(rawCommand: string): readonly ("|" | "||" | "&&" | ";")[] {
+  const operators: Array<"|" | "||" | "&&" | ";"> = [];
+  let quote: "single" | "double" | undefined;
+  let escaped = false;
+  for (let index = 0; index < rawCommand.length; index += 1) {
+    const character = rawCommand[index] as string;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quote !== "single") {
+      escaped = true;
+    } else if (character === "'" && quote !== "double") {
+      quote = quote === "single" ? undefined : "single";
+    } else if (character === '"' && quote !== "single") {
+      quote = quote === "double" ? undefined : "double";
+    } else if (quote === undefined && character === ";") {
+      operators.push(";");
+    } else if (quote === undefined && character === "|") {
+      if (rawCommand[index + 1] === "|") {
+        operators.push("||");
+        index += 1;
+      } else {
+        operators.push("|");
+      }
+    } else if (quote === undefined && character === "&" && rawCommand[index + 1] === "&") {
+      operators.push("&&");
+      index += 1;
+    }
+  }
+  return operators;
+}
+
+function isBoundedPositiveDecimal(value: string | undefined): boolean {
+  return value !== undefined && /^(?:[1-9]|[1-9]\d|1\d\d|200)$/u.test(value);
+}
+
+function isBoundedNonnegativeDecimal(value: string | undefined, maximum: number): boolean {
+  return value !== undefined && /^(?:0|[1-9]\d*)$/u.test(value) && Number(value) <= maximum;
+}
+
+export const planShellBuiltinAndIndirectionV1: ReadonlySet<string> = new Set([
+  "!",
+  ".",
+  ":",
+  "[",
+  "alias",
+  "bg",
+  "break",
+  "builtin",
+  "case",
+  "cd",
+  "command",
+  "continue",
+  "do",
+  "done",
+  "echo",
+  "elif",
+  "else",
+  "env",
+  "esac",
+  "eval",
+  "exec",
+  "exit",
+  "export",
+  "false",
+  "fc",
+  "fg",
+  "fi",
+  "for",
+  "getopts",
+  "hash",
+  "if",
+  "in",
+  "jobs",
+  "kill",
+  "local",
+  "printf",
+  "pwd",
+  "read",
+  "readonly",
+  "return",
+  "set",
+  "shift",
+  "test",
+  "then",
+  "times",
+  "trap",
+  "true",
+  "type",
+  "ulimit",
+  "umask",
+  "unalias",
+  "unset",
+  "until",
+  "wait",
+  "while",
+  "xargs",
+  "{",
+  "}",
+]);
+
+function isDirectMutation(argv: readonly string[] | undefined): boolean {
+  const command = argv?.[0];
+  if (command === undefined || argv === undefined) {
+    return false;
+  }
+  if (
+    [
+      "chattr",
+      "chgrp",
+      "chmod",
+      "chown",
+      "cp",
+      "crontab",
+      "dd",
+      "doas",
+      "ed",
+      "emacs",
+      "ex",
+      "install",
+      "kill",
+      "killall",
+      "ln",
+      "mkdir",
+      "mkfifo",
+      "mknod",
+      "mount",
+      "mv",
+      "nano",
+      "patch",
+      "pkill",
+      "reboot",
+      "rm",
+      "rmdir",
+      "rsync",
+      "service",
+      "setfacl",
+      "shutdown",
+      "shred",
+      "su",
+      "sudo",
+      "systemctl",
+      "tee",
+      "touch",
+      "truncate",
+      "umount",
+      "unlink",
+      "vi",
+      "vim",
+    ].includes(command)
+  ) {
+    return true;
+  }
+  if (command === "git") {
+    const subcommandIndex = gitSubcommandIndex(argv);
+    if (subcommandIndex === undefined) {
+      return false;
+    }
+    const subcommand = argv[subcommandIndex];
+    const subcommandArguments = argv.slice(subcommandIndex + 1);
+    if (
+      subcommand !== undefined &&
+      [
+        "add",
+        "am",
+        "apply",
+        "bisect",
+        "branch",
+        "checkout",
+        "cherry-pick",
+        "clean",
+        "clone",
+        "commit",
+        "config",
+        "fetch",
+        "format-patch",
+        "gc",
+        "init",
+        "ls-remote",
+        "maintenance",
+        "merge",
+        "mergetool",
+        "mv",
+        "notes",
+        "pack-refs",
+        "prune",
+        "pull",
+        "push",
+        "rebase",
+        "reflog",
+        "remote",
+        "repack",
+        "replace",
+        "reset",
+        "restore",
+        "revert",
+        "rm",
+        "sparse-checkout",
+        "stage",
+        "stash",
+        "submodule",
+        "switch",
+        "tag",
+        "update-index",
+        "update-ref",
+        "worktree",
+        "write-tree",
+      ].includes(subcommand)
+    ) {
+      return true;
+    }
+    if (
+      subcommand === "hash-object" &&
+      subcommandArguments.some((argument) => argument === "-w" || argument === "--stdin-paths")
+    ) {
+      return true;
+    }
+  }
+  if (["npm", "pnpm", "yarn", "bun", "cargo"].includes(command)) {
+    if (hasPackageMutationSubcommand(command, argv)) {
+      return true;
+    }
+  }
+  if (command === "go") {
+    const subcommandIndex = commandIndexAfterLeadingOptions(argv, 1, {
+      valueOptions: ["-C"],
+      attachedValuePrefixes: ["-C="],
+    });
+    if (subcommandIndex === undefined) {
+      return false;
+    }
+    const subcommand = argv[subcommandIndex];
+    const subcommandArguments = argv.slice(subcommandIndex + 1);
+    if (["clean", "get", "install"].includes(subcommand as string)) {
+      return true;
+    }
+    if (
+      subcommand === "env" &&
+      subcommandArguments.some((argument) => argument === "-w" || argument === "-u")
+    ) {
+      return true;
+    }
+    return (
+      (subcommand === "mod" &&
+        ["download", "edit", "init", "tidy", "vendor"].includes(
+          subcommandArguments[0] as string,
+        )) ||
+      (subcommand === "work" &&
+        ["edit", "init", "sync", "use"].includes(subcommandArguments[0] as string))
+    );
+  }
+  return false;
+}
+
+function isInPlaceOrOutputMutation(argv: readonly string[] | undefined): boolean {
+  if (argv === undefined) {
+    return false;
+  }
+  const command = argv[0];
+  const arguments_ = argv.slice(1);
+  const optionArguments = argumentsBeforeOperandSeparator(arguments_);
+  if (command === "sed" && hasSedInPlaceOption(arguments_)) {
+    return true;
+  }
+  if (command === "perl" && hasPerlInPlaceOption(arguments_)) {
+    return true;
+  }
+  if (command === "find" && hasFindMutationPredicate(arguments_)) {
+    return true;
+  }
+  if (command === "sort" && hasSortOutputOption(arguments_)) {
+    return true;
+  }
+  if (
+    ["diff", "uniq"].includes(command as string) &&
+    optionArguments.some(
+      (argument) =>
+        argument === "-o" || argument === "--output" || argument.startsWith("--output="),
+    )
+  ) {
+    return true;
+  }
+  if (command === "git") {
+    const subcommandIndex = gitSubcommandIndex(argv);
+    if (subcommandIndex === undefined) {
+      return false;
+    }
+    const subcommand = argv[subcommandIndex];
+    return (
+      ["archive", "diff", "format-patch", "log", "show"].includes(subcommand as string) &&
+      argumentsBeforeOperandSeparator(argv.slice(subcommandIndex + 1)).some(
+        (argument) =>
+          argument === "--output" ||
+          argument.startsWith("--output=") ||
+          (subcommand === "archive" && argument.startsWith("-o")),
+      )
+    );
+  }
+  return false;
+}
+
+function gitSubcommandIndex(argv: readonly string[]): number | undefined {
+  return commandIndexAfterLeadingOptions(argv, 1, {
+    valueOptions: [
+      "-C",
+      "-c",
+      "--config-env",
+      "--exec-path",
+      "--git-dir",
+      "--namespace",
+      "--super-prefix",
+      "--work-tree",
+    ],
+    attachedValuePrefixes: [
+      "-C",
+      "-c",
+      "--config-env=",
+      "--exec-path=",
+      "--git-dir=",
+      "--namespace=",
+      "--super-prefix=",
+      "--work-tree=",
+    ],
+    flagOptions: [
+      "--bare",
+      "--glob-pathspecs",
+      "--help",
+      "--html-path",
+      "--icase-pathspecs",
+      "--info-path",
+      "--literal-pathspecs",
+      "--man-path",
+      "--no-advice",
+      "--no-lazy-fetch",
+      "--no-optional-locks",
+      "--no-pager",
+      "--no-replace-objects",
+      "--noglob-pathspecs",
+      "--paginate",
+      "--version",
+      "-h",
+      "-P",
+      "-p",
+    ],
+  });
+}
+
+// Provenance: these tables freeze npm CLI 11.6.2's public command and alias surface from
+// npm/cli lib/utils/cmd-list.js lines 3-177, plus @npmcli/config 10.4.2's option names,
+// shorthands, and type arity from lib/definitions/index.js lines 24-60 and
+// lib/definitions/definitions.js lines 87-2316. The bounded parser preserves the relevant
+// equals, shorthand, unique-prefix, negation, Boolean-secondary-type, and value-consumption
+// semantics of nopt 8.1.0 lib/nopt-lib.js lines 249-504 without executing npm or nopt code.
+// Adam owns the position resolver, mutation classification, bounds, and fail-closed result.
+// See THIRD_PARTY_NOTICES.md for exact upstream links, differences, and licenses.
+const frozenNpmCommandsV1 = [
+  "access",
+  "adduser",
+  "audit",
+  "bugs",
+  "cache",
+  "ci",
+  "completion",
+  "config",
+  "dedupe",
+  "deprecate",
+  "diff",
+  "dist-tag",
+  "docs",
+  "doctor",
+  "edit",
+  "exec",
+  "explain",
+  "explore",
+  "find-dupes",
+  "fund",
+  "get",
+  "help",
+  "help-search",
+  "init",
+  "install",
+  "install-ci-test",
+  "install-test",
+  "link",
+  "ll",
+  "login",
+  "logout",
+  "ls",
+  "org",
+  "outdated",
+  "owner",
+  "pack",
+  "ping",
+  "pkg",
+  "prefix",
+  "profile",
+  "prune",
+  "publish",
+  "query",
+  "rebuild",
+  "repo",
+  "restart",
+  "root",
+  "run",
+  "sbom",
+  "search",
+  "set",
+  "shrinkwrap",
+  "star",
+  "stars",
+  "start",
+  "stop",
+  "team",
+  "test",
+  "token",
+  "undeprecate",
+  "uninstall",
+  "unpublish",
+  "unstar",
+  "update",
+  "version",
+  "view",
+  "whoami",
+] as const;
+
+const frozenNpmAliasesV1: Readonly<Record<string, string>> = {
+  add: "install",
+  "add-user": "adduser",
+  author: "owner",
+  c: "config",
+  cit: "install-ci-test",
+  "clean-install": "ci",
+  "clean-install-test": "install-ci-test",
+  create: "init",
+  ddp: "dedupe",
+  "dist-tags": "dist-tag",
+  find: "search",
+  hlep: "help",
+  home: "docs",
+  i: "install",
+  ic: "ci",
+  in: "install",
+  info: "view",
+  innit: "init",
+  ins: "install",
+  inst: "install",
+  insta: "install",
+  instal: "install",
+  "install-clean": "ci",
+  isnt: "install",
+  isnta: "install",
+  isntal: "install",
+  isntall: "install",
+  "isntall-clean": "ci",
+  issues: "bugs",
+  it: "install-test",
+  la: "ll",
+  list: "ls",
+  ln: "link",
+  ogr: "org",
+  r: "uninstall",
+  rb: "rebuild",
+  remove: "uninstall",
+  rm: "uninstall",
+  rum: "run",
+  "run-script": "run",
+  s: "search",
+  se: "search",
+  show: "view",
+  sit: "install-ci-test",
+  t: "test",
+  tst: "test",
+  un: "uninstall",
+  unlink: "uninstall",
+  up: "update",
+  upgrade: "update",
+  udpate: "update",
+  urn: "run",
+  v: "view",
+  verison: "version",
+  why: "explain",
+  x: "exec",
+};
+
+const frozenNpmMutationCommandsV1 = new Set([
+  "ci",
+  "dedupe",
+  "init",
+  "install",
+  "install-ci-test",
+  "install-test",
+  "link",
+  "prune",
+  "publish",
+  "rebuild",
+  "uninstall",
+  "unpublish",
+  "update",
+]);
+
+const frozenNpmBooleanOptionsV1 = new Set([
+  "--all",
+  "--allow-same-version",
+  "--audit",
+  "--bin-links",
+  "--commit-hooks",
+  "--description",
+  "--dev",
+  "--diff-ignore-all-space",
+  "--diff-name-only",
+  "--diff-no-prefix",
+  "--diff-text",
+  "--dry-run",
+  "--engine-strict",
+  "--expect-results",
+  "--force",
+  "--foreground-scripts",
+  "--format-package-lock",
+  "--fund",
+  "--git-tag-version",
+  "--global",
+  "--global-style",
+  "--if-present",
+  "--ignore-scripts",
+  "--include-staged",
+  "--include-workspace-root",
+  "--init-private",
+  "--install-links",
+  "--json",
+  "--legacy-bundling",
+  "--legacy-peer-deps",
+  "--link",
+  "--long",
+  "--offline",
+  "--omit-lockfile-registry-resolved",
+  "--optional",
+  "--package-lock",
+  "--package-lock-only",
+  "--parseable",
+  "--prefer-dedupe",
+  "--prefer-offline",
+  "--prefer-online",
+  "--production",
+  "--progress",
+  "--provenance",
+  "--read-only",
+  "--rebuild-bundle",
+  "--save",
+  "--save-bundle",
+  "--save-dev",
+  "--save-exact",
+  "--save-optional",
+  "--save-peer",
+  "--save-prod",
+  "--shrinkwrap",
+  "--sign-git-commit",
+  "--sign-git-tag",
+  "--strict-peer-deps",
+  "--strict-ssl",
+  "--timing",
+  "--unicode",
+  "--update-notifier",
+  "--usage",
+  "--version",
+  "--versions",
+  "--workspaces",
+  "--workspaces-update",
+  "--yes",
+]);
+
+const frozenNpmValueOptionsV1 = new Set([
+  "--_auth",
+  "--access",
+  "--also",
+  "--audit-level",
+  "--auth-type",
+  "--before",
+  "--ca",
+  "--cache",
+  "--cache-max",
+  "--cache-min",
+  "--cafile",
+  "--call",
+  "--cert",
+  "--cidr",
+  "--cpu",
+  "--depth",
+  "--diff",
+  "--diff-dst-prefix",
+  "--diff-src-prefix",
+  "--diff-unified",
+  "--editor",
+  "--expect-result-count",
+  "--fetch-retries",
+  "--fetch-retry-factor",
+  "--fetch-retry-maxtimeout",
+  "--fetch-retry-mintimeout",
+  "--fetch-timeout",
+  "--git",
+  "--globalconfig",
+  "--heading",
+  "--https-proxy",
+  "--include",
+  "--init-author-email",
+  "--init-author-name",
+  "--init-author-url",
+  "--init-license",
+  "--init-module",
+  "--init-type",
+  "--init-version",
+  "--init.author.email",
+  "--init.author.name",
+  "--init.author.url",
+  "--init.license",
+  "--init.module",
+  "--init.version",
+  "--install-strategy",
+  "--key",
+  "--libc",
+  "--local-address",
+  "--location",
+  "--lockfile-version",
+  "--loglevel",
+  "--logs-dir",
+  "--logs-max",
+  "--maxsockets",
+  "--message",
+  "--node-gyp",
+  "--node-options",
+  "--noproxy",
+  "--omit",
+  "--only",
+  "--os",
+  "--otp",
+  "--package",
+  "--pack-destination",
+  "--prefix",
+  "--preid",
+  "--provenance-file",
+  "--proxy",
+  "--registry",
+  "--replace-registry-host",
+  "--save-prefix",
+  "--sbom-format",
+  "--sbom-type",
+  "--scope",
+  "--script-shell",
+  "--searchexclude",
+  "--searchlimit",
+  "--searchopts",
+  "--searchstaleness",
+  "--shell",
+  "--tag",
+  "--tag-version-prefix",
+  "--umask",
+  "--user-agent",
+  "--userconfig",
+  "--viewer",
+  "--which",
+  "--workspace",
+]);
+
+const frozenNpmMixedOptionsV1 = new Set(["--browser", "--color"]);
+const frozenNpmExactStringOptionsV1 = new Set([
+  "--call",
+  "--diff-dst-prefix",
+  "--diff-src-prefix",
+  "--editor",
+  "--git",
+  "--heading",
+  "--init-author-email",
+  "--init-author-name",
+  "--init-license",
+  "--init-type",
+  "--init.author.email",
+  "--init.author.name",
+  "--init.license",
+  "--message",
+  "--pack-destination",
+  "--preid",
+  "--save-prefix",
+  "--scope",
+  "--searchexclude",
+  "--searchopts",
+  "--shell",
+  "--tag",
+  "--tag-version-prefix",
+  "--user-agent",
+  "--viewer",
+]);
+const frozenNpmNullableValueOptionsV1 = new Set([
+  "--_auth",
+  "--access",
+  "--also",
+  "--audit-level",
+  "--before",
+  "--browser",
+  "--ca",
+  "--cert",
+  "--cidr",
+  "--cpu",
+  "--depth",
+  "--expect-result-count",
+  "--expect-results",
+  "--https-proxy",
+  "--key",
+  "--libc",
+  "--lockfile-version",
+  "--logs-dir",
+  "--node-options",
+  "--only",
+  "--optional",
+  "--os",
+  "--otp",
+  "--production",
+  "--proxy",
+  "--script-shell",
+  "--which",
+  "--workspaces",
+  "--yes",
+]);
+const frozenNpmArrayStringOptionsV1 = new Set([
+  "--_auth",
+  "--browser",
+  "--ca",
+  "--cert",
+  "--cidr",
+  "--cpu",
+  "--diff",
+  "--key",
+  "--libc",
+  "--node-options",
+  "--noproxy",
+  "--os",
+  "--otp",
+  "--package",
+  "--replace-registry-host",
+  "--script-shell",
+  "--workspace",
+]);
+const frozenNpmNumericArrayOptionsV1 = new Set(["--depth", "--expect-result-count", "--which"]);
+const frozenNpmExplicitOptionValuesV1: Readonly<Record<string, readonly string[]>> = {
+  "--access": ["public", "restricted"],
+  "--also": ["dev", "development"],
+  "--audit-level": ["critical", "high", "info", "low", "moderate", "none"],
+  "--auth-type": ["legacy", "web"],
+  "--color": ["always"],
+  "--include": ["dev", "optional", "peer", "prod"],
+  "--install-strategy": ["hoisted", "linked", "nested", "shallow"],
+  "--location": ["global", "project", "user"],
+  "--lockfile-version": ["1", "2", "3"],
+  "--loglevel": ["error", "http", "info", "notice", "silent", "silly", "verbose", "warn"],
+  "--omit": ["dev", "optional", "peer"],
+  "--only": ["prod", "production"],
+  "--replace-registry-host": ["always", "never", "npmjs"],
+  "--sbom-format": ["cyclonedx", "spdx"],
+  "--sbom-type": ["application", "framework", "library"],
+};
+const frozenNpmShorthandsV1 = {
+  "?": ["--usage"],
+  B: ["--save-bundle"],
+  C: ["--prefix"],
+  D: ["--save-dev"],
+  E: ["--save-exact"],
+  H: ["--usage"],
+  L: ["--location"],
+  O: ["--save-optional"],
+  P: ["--save-prod"],
+  S: ["--save"],
+  a: ["--all"],
+  c: ["--call"],
+  d: ["--loglevel", "info"],
+  dd: ["--loglevel", "verbose"],
+  ddd: ["--loglevel", "silly"],
+  desc: ["--description"],
+  "enjoy-by": ["--before"],
+  f: ["--force"],
+  g: ["--global"],
+  h: ["--usage"],
+  help: ["--usage"],
+  iwr: ["--include-workspace-root"],
+  l: ["--long"],
+  local: ["--no-global"],
+  m: ["--message"],
+  n: ["--no-yes"],
+  no: ["--no-yes"],
+  p: ["--parseable"],
+  porcelain: ["--parseable"],
+  q: ["--loglevel", "warn"],
+  quiet: ["--loglevel", "warn"],
+  readonly: ["--read-only"],
+  reg: ["--registry"],
+  s: ["--loglevel", "silent"],
+  silent: ["--loglevel", "silent"],
+  v: ["--version"],
+  verbose: ["--loglevel", "verbose"],
+  w: ["--workspace"],
+  ws: ["--workspaces"],
+  y: ["--yes"],
+} as const satisfies Readonly<Record<string, readonly string[]>>;
+const frozenNpmDefinitionOptionsV1 = new Set([
+  ...frozenNpmBooleanOptionsV1,
+  ...frozenNpmValueOptionsV1,
+  ...frozenNpmMixedOptionsV1,
+]);
+
+function hasNpmMutationCommand(argv: readonly string[]): boolean {
+  const positionalArguments = frozenNpmPositionalArgumentsV1(argv);
+  const command = resolveFrozenNpmCommandV1(positionalArguments[0] as string);
+  if (command === undefined) {
+    return false;
+  }
+  if (frozenNpmMutationCommandsV1.has(command)) {
+    return true;
+  }
+  return (
+    command === "version" &&
+    positionalArguments.slice(1).some((argument) => !argument.startsWith("-"))
+  );
+}
+
+type FrozenNpmTokenV1 = {
+  readonly hadEquals: boolean;
+  readonly value: string;
+};
+
+function frozenNpmPositionalArgumentsV1(argv: readonly string[]): readonly string[] {
+  const tokens: FrozenNpmTokenV1[] = argv.slice(1).map((value) => ({ hadEquals: false, value }));
+  const positionalArguments: string[] = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    let token = tokens[index] as FrozenNpmTokenV1;
+    if (/^-{2,}$/u.test(token.value)) {
+      positionalArguments.push(...tokens.slice(index + 1).map(({ value }) => value));
+      break;
+    }
+    if (!token.value.startsWith("-") || token.value === "-") {
+      positionalArguments.push(token.value);
+      continue;
+    }
+    const equalsIndex = token.value.indexOf("=");
+    if (equalsIndex !== -1) {
+      const option = token.value.slice(0, equalsIndex);
+      const value = token.value.slice(equalsIndex + 1);
+      token = { hadEquals: true, value: option };
+      tokens.splice(index, 1, token, { hadEquals: false, value });
+    }
+    const optionName = token.value.replace(/^-+/u, "");
+    const shorthand = resolveFrozenNpmShorthandV1(optionName);
+    if (shorthand !== undefined) {
+      tokens.splice(index, 1, ...shorthand.map((value) => ({ hadEquals: false, value })));
+      index -= 1;
+      continue;
+    }
+    let normalizedName = optionName;
+    let negated = false;
+    while (normalizedName.toLowerCase().startsWith("no-")) {
+      negated = true;
+      normalizedName = normalizedName.slice(3);
+    }
+    const option = resolveFrozenNpmDefinitionOptionV1(normalizedName);
+    const next = tokens[index + 1]?.value;
+    const isBoolean =
+      negated ||
+      (option !== undefined &&
+        (frozenNpmBooleanOptionsV1.has(option) || frozenNpmMixedOptionsV1.has(option))) ||
+      (option === undefined && !token.hadEquals);
+    if (isBoolean) {
+      if (next !== undefined && frozenNpmBooleanConsumesV1(option, next)) {
+        index += 1;
+      }
+      continue;
+    }
+    if (option === undefined) {
+      if (token.hadEquals && next !== undefined && !/^-{2,}$/u.test(next)) {
+        index += 1;
+      }
+      continue;
+    }
+    if (frozenNpmExactStringOptionsV1.has(option)) {
+      if (next !== undefined && !/^-{1,2}[^-]+/u.test(next) && !/^-{2,}$/u.test(next)) {
+        index += 1;
+      }
+      continue;
+    }
+    if (next !== undefined && !/^-{2,}$/u.test(next)) {
+      index += 1;
+    }
+  }
+  return positionalArguments;
+}
+
+function frozenNpmBooleanConsumesV1(option: string | undefined, next: string): boolean {
+  if (next === "false" || next === "true") {
+    return true;
+  }
+  if (option === undefined) {
+    return false;
+  }
+  if (next === "null" && frozenNpmNullableValueOptionsV1.has(option)) {
+    return true;
+  }
+  if (frozenNpmExplicitOptionValuesV1[option]?.includes(next) === true) {
+    return true;
+  }
+  if (
+    frozenNpmNumericArrayOptionsV1.has(option) &&
+    next.length > 0 &&
+    !Number.isNaN(Number(next)) &&
+    !/^-{2,}[^-]/u.test(next)
+  ) {
+    return true;
+  }
+  return frozenNpmArrayStringOptionsV1.has(option) && !/^-[^-]/u.test(next);
+}
+
+function resolveFrozenNpmDefinitionOptionV1(argument: string): string | undefined {
+  const exact = `--${argument}`;
+  if (frozenNpmDefinitionOptionsV1.has(exact)) {
+    return exact;
+  }
+  const matches = [...frozenNpmDefinitionOptionsV1].filter((option) =>
+    option.slice(2).startsWith(argument),
+  );
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+function resolveFrozenNpmShorthandV1(argument: string): readonly string[] | undefined {
+  if (frozenNpmDefinitionOptionsV1.has(`--${argument}`)) {
+    return undefined;
+  }
+  const exact = frozenNpmShorthandsV1[argument as keyof typeof frozenNpmShorthandsV1];
+  if (exact !== undefined) {
+    return exact;
+  }
+  const characters = [...argument];
+  const characterShorthands = characters.map(
+    (character) => frozenNpmShorthandsV1[character as keyof typeof frozenNpmShorthandsV1],
+  );
+  if (characterShorthands.every((shorthand) => shorthand !== undefined)) {
+    return characterShorthands.flatMap((shorthand) => shorthand as readonly string[]);
+  }
+  if (resolveFrozenNpmDefinitionOptionV1(argument) !== undefined) {
+    return undefined;
+  }
+  const matches = Object.keys(frozenNpmShorthandsV1).filter((shorthand) =>
+    shorthand.startsWith(argument),
+  );
+  return matches.length === 1
+    ? frozenNpmShorthandsV1[matches[0] as keyof typeof frozenNpmShorthandsV1]
+    : undefined;
+}
+
+function resolveFrozenNpmCommandV1(argument: string): string | undefined {
+  const normalized = /[A-Z]/u.test(argument)
+    ? argument.replace(/[A-Z]/gu, (character) => `-${character.toLowerCase()}`)
+    : argument;
+  if ((frozenNpmCommandsV1 as readonly string[]).includes(normalized)) {
+    return normalized;
+  }
+  const directAlias = frozenNpmAliasesV1[normalized];
+  if (directAlias !== undefined) {
+    return directAlias;
+  }
+  const matches = [
+    ...(frozenNpmCommandsV1 as readonly string[]),
+    ...Object.keys(frozenNpmAliasesV1),
+  ].filter((candidate) => candidate.startsWith(normalized));
+  if (matches.length !== 1) {
+    return undefined;
+  }
+  let resolved = matches[0] as string;
+  const seen = new Set<string>();
+  while (frozenNpmAliasesV1[resolved] !== undefined && !seen.has(resolved)) {
+    seen.add(resolved);
+    resolved = frozenNpmAliasesV1[resolved] as string;
+  }
+  return resolved;
+}
+
+function hasPackageMutationSubcommand(command: string, argv: readonly string[]): boolean {
+  if (command === "npm") {
+    return hasNpmMutationCommand(argv);
+  }
+  if (command === "yarn" && argv.length === 1) {
+    return true;
+  }
+  const mutationSubcommands = new Set(
+    command === "pnpm"
+      ? [
+          "add",
+          "dedupe",
+          "deploy",
+          "fetch",
+          "i",
+          "import",
+          "install",
+          "link",
+          "patch",
+          "patch-commit",
+          "prune",
+          "publish",
+          "rebuild",
+          "remove",
+          "rm",
+          "unlink",
+          "up",
+          "update",
+        ]
+      : command === "yarn"
+        ? ["add", "install", "link", "npm", "remove", "set", "unlink", "up", "upgrade"]
+        : command === "bun"
+          ? [
+              "add",
+              "i",
+              "install",
+              "link",
+              "patch",
+              "patch-commit",
+              "publish",
+              "remove",
+              "rm",
+              "unlink",
+              "update",
+            ]
+          : [
+              "add",
+              "install",
+              "login",
+              "owner",
+              "publish",
+              "remove",
+              "uninstall",
+              "update",
+              "yank",
+            ],
+  );
+  const valueOptions = [
+    "--cache",
+    "--color",
+    "--config",
+    "--dir",
+    "--filter",
+    "--globalconfig",
+    "--jobs",
+    "--location",
+    "--loglevel",
+    "--prefix",
+    "--registry",
+    "--scope",
+    "--tag",
+    "--userconfig",
+    "--workspace",
+    "-C",
+  ];
+  const flagOptions = [
+    "--audit",
+    "--force",
+    "--fund",
+    "--global",
+    "--help",
+    "--json",
+    "--long",
+    "--no-audit",
+    "--no-fund",
+    "--no-unicode",
+    "--offline",
+    "--parseable",
+    "--quiet",
+    "--silent",
+    "--unicode",
+    "--usage",
+    "--verbose",
+    "--version",
+    "--workspace-root",
+    ...(command === "pnpm" ? ["-w"] : []),
+    ...(command === "cargo" ? ["--frozen", "--locked"] : ["--ignore-scripts"]),
+    "-g",
+    "-h",
+    "-q",
+    "-s",
+    "-v",
+  ];
+  const attachedValuePrefixes = valueOptions.map((option) =>
+    option.startsWith("--") ? `${option}=` : option,
+  );
+  let uncertainOptionPosition = false;
+  for (let index = 1; index < argv.length; index += 1) {
+    const argument = argv[index] as string;
+    if (argument === "--") {
+      const subcommand = argv[index + 1];
+      return mutationSubcommands.has(subcommand as string);
+    }
+    if (command === "cargo" && index === 1 && /^\+[A-Za-z0-9._-]+$/u.test(argument)) {
+      continue;
+    }
+    if (valueOptions.includes(argument)) {
+      index += 1;
+      continue;
+    }
+    if (
+      attachedValuePrefixes.some(
+        (prefix) => argument.startsWith(prefix) && argument.length > prefix.length,
+      ) ||
+      flagOptions.includes(argument)
+    ) {
+      continue;
+    }
+    if (argument.startsWith("-") && argument !== "-") {
+      uncertainOptionPosition = true;
+      continue;
+    }
+    if (mutationSubcommands.has(argument)) {
+      return true;
+    }
+    if (!uncertainOptionPosition) {
+      return false;
+    }
+  }
+  return false;
+}
+
+function hasSedInPlaceOption(arguments_: readonly string[]): boolean {
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index] as string;
+    if (argument === "--") {
+      return false;
+    }
+    if (argument.startsWith("--")) {
+      const separatorIndex = argument.indexOf("=");
+      const option = separatorIndex === -1 ? argument : argument.slice(0, separatorIndex);
+      const resolved = resolveSedLongOption(option);
+      if (resolved === "--in-place") {
+        return true;
+      }
+      if (
+        separatorIndex === -1 &&
+        (resolved === "--expression" || resolved === "--file" || resolved === "--line-length")
+      ) {
+        index += 1;
+      }
+      continue;
+    }
+    if (!argument.startsWith("-")) {
+      continue;
+    }
+    for (let optionIndex = 1; optionIndex < argument.length; optionIndex += 1) {
+      const option = argument[optionIndex] as string;
+      if (option === "i") {
+        return true;
+      }
+      if (option === "e" || option === "f" || option === "l") {
+        if (optionIndex + 1 === argument.length) {
+          index += 1;
+        }
+        break;
+      }
+    }
+  }
+  return false;
+}
+
+function resolveSedLongOption(argument: string): string | undefined {
+  const options = [
+    "--debug",
+    "--expression",
+    "--file",
+    "--follow-symlinks",
+    "--help",
+    "--in-place",
+    "--line-length",
+    "--null-data",
+    "--posix",
+    "--quiet",
+    "--regexp-extended",
+    "--sandbox",
+    "--separate",
+    "--silent",
+    "--unbuffered",
+    "--version",
+  ];
+  const matches = options.filter((option) => option.startsWith(argument));
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+function hasSortOutputOption(arguments_: readonly string[]): boolean {
+  const longValueOptions = [
+    "--batch-size",
+    "--buffer-size",
+    "--compress-program",
+    "--field-separator",
+    "--files0-from",
+    "--key",
+    "--parallel",
+    "--random-source",
+    "--sort",
+    "--temporary-directory",
+  ];
+  const shortValueOptions = new Set(["k", "S", "t", "T"]);
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index] as string;
+    if (argument === "--") {
+      return false;
+    }
+    if (argument.startsWith("--")) {
+      const separatorIndex = argument.indexOf("=");
+      const option = separatorIndex === -1 ? argument : argument.slice(0, separatorIndex);
+      const resolved = resolveSortLongOption(option);
+      if (resolved === "--output") {
+        return true;
+      }
+      if (separatorIndex === -1 && resolved !== undefined && longValueOptions.includes(resolved)) {
+        index += 1;
+      }
+      continue;
+    }
+    if (!argument.startsWith("-") || argument === "-") {
+      continue;
+    }
+    for (let optionIndex = 1; optionIndex < argument.length; optionIndex += 1) {
+      const option = argument[optionIndex] as string;
+      if (option === "o") {
+        return true;
+      }
+      if (shortValueOptions.has(option)) {
+        if (optionIndex + 1 === argument.length) {
+          index += 1;
+        }
+        break;
+      }
+    }
+  }
+  return false;
+}
+
+function resolveSortLongOption(argument: string): string | undefined {
+  const options = [
+    "--batch-size",
+    "--buffer-size",
+    "--check",
+    "--compress-program",
+    "--debug",
+    "--dictionary-order",
+    "--field-separator",
+    "--files0-from",
+    "--general-numeric-sort",
+    "--help",
+    "--human-numeric-sort",
+    "--ignore-case",
+    "--ignore-leading-blanks",
+    "--ignore-nonprinting",
+    "--key",
+    "--merge",
+    "--month-sort",
+    "--numeric-sort",
+    "--output",
+    "--parallel",
+    "--random-sort",
+    "--random-source",
+    "--reverse",
+    "--sort",
+    "--stable",
+    "--temporary-directory",
+    "--unique",
+    "--version",
+    "--version-sort",
+    "--zero-terminated",
+  ];
+  const matches = options.filter((option) => option.startsWith(argument));
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+function hasPerlInPlaceOption(arguments_: readonly string[]): boolean {
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index] as string;
+    if (argument === "--") {
+      return false;
+    }
+    if (!argument.startsWith("-") || argument.startsWith("--")) {
+      continue;
+    }
+    for (let optionIndex = 1; optionIndex < argument.length; optionIndex += 1) {
+      const option = argument[optionIndex] as string;
+      if (option === "i") {
+        return true;
+      }
+      if (["e", "E", "F", "I", "m", "M"].includes(option)) {
+        if (optionIndex + 1 === argument.length) {
+          index += 1;
+        }
+        break;
+      }
+    }
+  }
+  return false;
+}
+
+function commandIndexAfterLeadingOptions(
+  argv: readonly string[],
+  start: number,
+  options: {
+    readonly valueOptions: readonly string[];
+    readonly attachedValuePrefixes: readonly string[];
+    readonly flagOptions?: readonly string[];
+  },
+): number | undefined {
+  let index = start;
+  while (index < argv.length) {
+    const argument = argv[index] as string;
+    if (argument === "--") {
+      return index + 1 < argv.length ? index + 1 : undefined;
+    }
+    if (!argument.startsWith("-") || argument === "-") {
+      return index;
+    }
+    if (options.valueOptions.includes(argument)) {
+      index += 2;
+      if (index > argv.length) {
+        return undefined;
+      }
+      continue;
+    }
+    if (
+      options.attachedValuePrefixes.some(
+        (prefix) => argument.startsWith(prefix) && argument.length > prefix.length,
+      ) ||
+      options.flagOptions?.includes(argument) === true
+    ) {
+      index += 1;
+      continue;
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+function argumentsBeforeOperandSeparator(arguments_: readonly string[]): readonly string[] {
+  const separator = arguments_.indexOf("--");
+  return separator === -1 ? arguments_ : arguments_.slice(0, separator);
+}
+
+function hasFindMutationPredicate(arguments_: readonly string[]): boolean {
+  const predicatesWithOneValue = new Set([
+    "-amin",
+    "-anewer",
+    "-atime",
+    "-cmin",
+    "-cnewer",
+    "-ctime",
+    "-fstype",
+    "-gid",
+    "-group",
+    "-iname",
+    "-inum",
+    "-links",
+    "-maxdepth",
+    "-mindepth",
+    "-mmin",
+    "-mtime",
+    "-name",
+    "-newer",
+    "-path",
+    "-perm",
+    "-regex",
+    "-regextype",
+    "-samefile",
+    "-size",
+    "-type",
+    "-uid",
+    "-user",
+    "-wholename",
+    "-xtype",
+  ]);
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const argument = arguments_[index] as string;
+    if (["-delete", "-exec", "-execdir", "-ok", "-okdir"].includes(argument)) {
+      return true;
+    }
+    if (predicatesWithOneValue.has(argument)) {
+      index += 1;
+    }
+  }
+  return false;
+}
+
+function isVersionObservation(argv: readonly string[] | undefined): boolean {
+  return (
+    argv?.length === 2 &&
+    argv[1] === "--version" &&
+    (argv[0] === "git" || argv[0] === "rg" || argv[0] === "node")
+  );
+}
+
+function isSystemObservation(argv: readonly string[] | undefined): boolean {
+  if (argv === undefined) {
+    return false;
+  }
+  if (argv.length === 1) {
+    return (
+      argv[0] === "uptime" || argv[0] === "hostname" || argv[0] === "uname" || argv[0] === "date"
+    );
+  }
+  if (argv.length !== 2) {
+    return false;
+  }
+  return (
+    (argv[0] === "uname" && ["-a", "-s", "-r", "-m"].includes(argv[1] as string)) ||
+    (argv[0] === "id" && ["-u", "-g", "-G"].includes(argv[1] as string)) ||
+    (argv[0] === "date" && argv[1] === "-u")
+  );
+}
+
+function splitCommandSegments(rawCommand: string): readonly string[] | undefined {
+  const segments: string[] = [];
+  let segment = "";
+  let quote: "single" | "double" | undefined;
+  let escaped = false;
+  const finishSegment = () => {
+    const normalized = segment.replace(/^[\t ]+|[\t ]+$/gu, "");
+    if (normalized.length === 0) {
+      return false;
+    }
+    segments.push(normalized);
+    segment = "";
+    return true;
+  };
+  for (let index = 0; index < rawCommand.length; index += 1) {
+    const character = rawCommand[index] as string;
+    if (escaped) {
+      segment += character;
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quote !== "single") {
+      segment += character;
+      escaped = true;
+      continue;
+    }
+    if (character === "'" && quote !== "double") {
+      quote = quote === "single" ? undefined : "single";
+      segment += character;
+      continue;
+    }
+    if (character === '"' && quote !== "single") {
+      quote = quote === "double" ? undefined : "double";
+      segment += character;
+      continue;
+    }
+    if (quote !== undefined) {
+      segment += character;
+      continue;
+    }
+    if (character === ";" || character === "|") {
+      if (!finishSegment()) {
+        return undefined;
+      }
+      if (character === "|" && rawCommand[index + 1] === "|") {
+        index += 1;
+      }
+      continue;
+    }
+    if (character === "&") {
+      if (rawCommand[index + 1] !== "&" || !finishSegment()) {
+        return undefined;
+      }
+      index += 1;
+      continue;
+    }
+    segment += character;
+  }
+  if (escaped || quote !== undefined || !finishSegment()) {
+    return undefined;
+  }
+  return segments;
+}
+
+function tokenizeSimpleCommand(rawCommand: string): readonly string[] | undefined {
+  const tokens: string[] = [];
+  let token = "";
+  let tokenStarted = false;
+  let quote: "single" | "double" | undefined;
+  let escaped = false;
+  const finishToken = () => {
+    if (tokenStarted) {
+      tokens.push(token);
+      token = "";
+      tokenStarted = false;
+    }
+  };
+  for (let index = 0; index < rawCommand.length; index += 1) {
+    const character = rawCommand[index] as string;
+    if (escaped) {
+      token += character;
+      tokenStarted = true;
+      escaped = false;
+      continue;
+    }
+    if (quote === "single") {
+      if (character === "'") {
+        quote = undefined;
+      } else {
+        token += character;
+      }
+      tokenStarted = true;
+      continue;
+    }
+    if (quote === "double") {
+      if (character === '"') {
+        quote = undefined;
+      } else if (character === "\\") {
+        const next = rawCommand[index + 1];
+        if (next !== undefined && ["$", "`", '"', "\\"].includes(next)) {
+          escaped = true;
+        } else {
+          token += "\\";
+        }
+      } else {
+        token += character;
+      }
+      tokenStarted = true;
+      continue;
+    }
+    if (character === "\\") {
+      escaped = true;
+      tokenStarted = true;
+    } else if (character === "'") {
+      quote = "single";
+      tokenStarted = true;
+    } else if (character === '"') {
+      quote = "double";
+      tokenStarted = true;
+    } else if (character === " " || character === "\t") {
+      finishToken();
+    } else {
+      token += character;
+      tokenStarted = true;
+    }
+  }
+  if (escaped || quote !== undefined) {
+    return undefined;
+  }
+  finishToken();
+  return tokens;
+}
+
+function assessment(
+  rawCommand: string,
+  disposition: PlanCommandAssessment["disposition"],
+  reasons: PlanCommandAssessment["reasons"],
+  status: PlanCommandAssessment["status"] = "assessed",
+  executionIdentity?: unknown,
+): PlanCommandAssessment {
+  const identity = {
+    status,
+    version: 1 as const,
+    policyVersion: "plan-shell-policy.v1" as const,
+    rawCommand,
+    disposition,
+    reasons,
+    ...(executionIdentity === undefined ? {} : { executionIdentity }),
+  };
+  return {
+    status: identity.status,
+    version: identity.version,
+    policyVersion: identity.policyVersion,
+    disposition: identity.disposition,
+    reasons: identity.reasons,
+    digest: `sha256:${createHash("sha256").update(JSON.stringify(identity)).digest("hex")}`,
+  };
+}

--- a/packages/agent/src/plan-executable-policy.ts
+++ b/packages/agent/src/plan-executable-policy.ts
@@ -1,0 +1,578 @@
+import { createHash } from "node:crypto";
+import { lstat, opendir, readFile, realpath, stat } from "node:fs/promises";
+import { isAbsolute, join, normalize, relative, resolve, sep } from "node:path";
+import { isDeepStrictEqual } from "node:util";
+
+import {
+  assessPlanCommandV1,
+  bindPlanCommandExecutionIdentityV1,
+  downgradePlanCommandAssessmentV1,
+  isPlanAutomaticGitCommandV1,
+  isPlanAutomaticRepositoryGitCommandV1,
+  type PlanCommandAssessment,
+  planAutomaticPathOperandsV1,
+  planCommandArgumentsV1,
+} from "./plan-command-assessment.js";
+import {
+  isPlanGitAttestationV1Valid,
+  type PlanGitAttestationV1,
+  planGitAutomaticPolicyV1,
+  planGitEnvironmentV1,
+} from "./plan-git-policy.js";
+import {
+  isPlanShellEnvironmentV1Valid,
+  type PlanShellEnvironmentV1,
+  type PlanShellFileIdentityV1,
+  readPlanShellFileIdentityV1,
+} from "./plan-shell-environment.js";
+
+type PlanExecutableProofV1 = {
+  readonly environmentDigest: `sha256:${string}`;
+  readonly shell: PlanShellFileIdentityV1;
+  readonly executables: readonly PlanShellFileIdentityV1[];
+  readonly paths: readonly PlanPathProofV1[];
+  readonly git?: {
+    readonly environmentDigest: `sha256:${string}`;
+    readonly policyVersion: "git-auto-policy.v1";
+    readonly policyDigest: `sha256:${string}`;
+    readonly repository?: PlanGitRepositoryProofV1;
+  };
+};
+
+type PlanPathProofV1 = {
+  readonly operand: string;
+  readonly canonicalPath: string;
+  readonly components: readonly {
+    readonly path: string;
+    readonly device: string;
+    readonly inode: string;
+    readonly mode: number;
+    readonly size: number;
+    readonly modifiedMilliseconds: number;
+  }[];
+};
+
+type PlanGitRepositoryProofV1 = {
+  readonly gitDirectory: string;
+  readonly configDigest: `sha256:${string}`;
+  readonly entries: readonly {
+    readonly path: string;
+    readonly device: string;
+    readonly inode: string;
+    readonly mode: number;
+    readonly size: number;
+    readonly modifiedMilliseconds: number;
+  }[];
+};
+
+export async function assessPlanCommandExecutionV1(input: {
+  readonly rawCommand: string;
+  readonly shellEnvironment: PlanShellEnvironmentV1;
+  readonly workspaceRoot: string;
+  readonly gitAttestation?: PlanGitAttestationV1;
+}): Promise<PlanCommandAssessment> {
+  const parsed = assessPlanCommandV1(input.rawCommand);
+  if (parsed.status === "invalid" || parsed.disposition === "deny_mutation") {
+    return parsed;
+  }
+  const shell = await verifiedShell(input.shellEnvironment, input.workspaceRoot);
+  if (shell === undefined || hasUnsafePathEntry(input.shellEnvironment, input.workspaceRoot)) {
+    return downgradePlanCommandAssessmentV1(input.rawCommand, "environment_untrusted");
+  }
+  if (parsed.disposition !== "allow_inspection") {
+    return bindPlanCommandExecutionIdentityV1(input.rawCommand, parsed, {
+      environmentDigest: input.shellEnvironment.digest,
+      shell,
+    });
+  }
+  const argumentsBySegment = planCommandArgumentsV1(input.rawCommand);
+  if (argumentsBySegment === undefined) {
+    return downgradePlanCommandAssessmentV1(input.rawCommand, "executable_untrusted");
+  }
+  const executables: PlanShellFileIdentityV1[] = [];
+  for (const argv of argumentsBySegment) {
+    const executable = await resolveTrustedExecutable(
+      argv[0],
+      input.shellEnvironment,
+      input.workspaceRoot,
+    );
+    if (executable === undefined) {
+      return downgradePlanCommandAssessmentV1(input.rawCommand, "executable_untrusted", {
+        environmentDigest: input.shellEnvironment.digest,
+        shell,
+      });
+    }
+    executables.push(executable);
+  }
+  const automaticGitArguments = argumentsBySegment.filter((argv) =>
+    isPlanAutomaticGitCommandV1(argv),
+  );
+  let gitProof: PlanExecutableProofV1["git"];
+  if (automaticGitArguments.length > 0) {
+    gitProof = {
+      environmentDigest: planGitEnvironmentV1.digest,
+      policyVersion: planGitAutomaticPolicyV1.version,
+      policyDigest: planGitAutomaticPolicyV1.digest,
+    };
+    if (automaticGitArguments.some((argv) => isPlanAutomaticRepositoryGitCommandV1(argv))) {
+      const gitExecutable = executables.find((identity) => identity.lookupPath.endsWith("/git"));
+      if (
+        input.gitAttestation === undefined ||
+        gitExecutable === undefined ||
+        !isPlanGitAttestationV1Valid(input.gitAttestation) ||
+        input.gitAttestation.shellEnvironmentDigest !== input.shellEnvironment.digest ||
+        input.gitAttestation.gitPolicyVersion !== planGitAutomaticPolicyV1.version ||
+        input.gitAttestation.gitPolicyDigest !== planGitAutomaticPolicyV1.digest ||
+        !isDeepStrictEqual(input.gitAttestation.executable, gitExecutable)
+      ) {
+        return downgradePlanCommandAssessmentV1(input.rawCommand, "git_attestation_required", {
+          environmentDigest: input.shellEnvironment.digest,
+          shell,
+          executables,
+          gitEnvironmentDigest: planGitEnvironmentV1.digest,
+        });
+      }
+      const repository = await verifyGitRepository(input.workspaceRoot);
+      if (repository === undefined) {
+        return downgradePlanCommandAssessmentV1(input.rawCommand, "git_repository_untrusted", {
+          environmentDigest: input.shellEnvironment.digest,
+          shell,
+          executables,
+          gitEnvironmentDigest: planGitEnvironmentV1.digest,
+        });
+      }
+      gitProof = { ...gitProof, repository };
+    }
+  }
+  const pathOperands = planAutomaticPathOperandsV1(input.rawCommand);
+  if (pathOperands === undefined) {
+    return downgradePlanCommandAssessmentV1(input.rawCommand, "path_untrusted");
+  }
+  const paths: PlanPathProofV1[] = [];
+  for (const operand of pathOperands) {
+    const proof = await verifyWorkspacePath(operand, input.workspaceRoot);
+    if (proof === undefined) {
+      return downgradePlanCommandAssessmentV1(input.rawCommand, "path_untrusted", {
+        environmentDigest: input.shellEnvironment.digest,
+        shell,
+        executables,
+      });
+    }
+    paths.push(proof);
+  }
+  const proof: PlanExecutableProofV1 = {
+    environmentDigest: input.shellEnvironment.digest,
+    shell,
+    executables,
+    paths,
+    ...(gitProof === undefined ? {} : { git: gitProof }),
+  };
+  return bindPlanCommandExecutionIdentityV1(input.rawCommand, parsed, proof);
+}
+
+async function verifyWorkspacePath(
+  operand: string,
+  workspaceRoot: string,
+): Promise<PlanPathProofV1 | undefined> {
+  if (Buffer.byteLength(operand, "utf8") > 4_096 || operand.includes("\0")) {
+    return undefined;
+  }
+  const canonicalWorkspace = await realpath(workspaceRoot);
+  let candidate: string;
+  if (isAbsolute(operand)) {
+    candidate = normalize(operand);
+    if (candidate !== operand || !isInside(canonicalWorkspace, candidate)) {
+      return undefined;
+    }
+  } else if (operand === ".") {
+    candidate = canonicalWorkspace;
+  } else {
+    if (
+      operand.length === 0 ||
+      normalize(operand) !== operand ||
+      operand
+        .split(sep)
+        .some((component) => component === "" || component === "." || component === "..")
+    ) {
+      return undefined;
+    }
+    candidate = resolve(canonicalWorkspace, operand);
+    if (!isInside(canonicalWorkspace, candidate)) {
+      return undefined;
+    }
+  }
+  const relativePath = relative(canonicalWorkspace, candidate);
+  const componentPaths = [canonicalWorkspace];
+  let current = canonicalWorkspace;
+  for (const component of relativePath.split(sep).filter((entry) => entry.length > 0)) {
+    current = join(current, component);
+    componentPaths.push(current);
+  }
+  try {
+    const components = [];
+    for (const path of componentPaths) {
+      const metadata = await lstat(path, { bigint: true });
+      if (metadata.isSymbolicLink()) {
+        return undefined;
+      }
+      components.push({
+        path,
+        device: metadata.dev.toString(10),
+        inode: metadata.ino.toString(10),
+        mode: Number(metadata.mode),
+        size: Number(metadata.size),
+        modifiedMilliseconds: Number(metadata.mtimeMs),
+      });
+    }
+    const canonicalPath = await realpath(candidate);
+    return canonicalPath === candidate && isInside(canonicalWorkspace, canonicalPath)
+      ? { operand, canonicalPath, components }
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function isPlanCommandExecutionIdentityCurrentV1(input: {
+  readonly rawCommand: string;
+  readonly assessment: PlanCommandAssessment;
+  readonly shellEnvironment: PlanShellEnvironmentV1;
+  readonly workspaceRoot: string;
+  readonly gitAttestation?: PlanGitAttestationV1;
+}): Promise<boolean> {
+  const current = await assessPlanCommandExecutionV1(input);
+  return current.status === "assessed" && current.digest === input.assessment.digest;
+}
+
+export async function resolvePlanTrustedExecutableV1(input: {
+  readonly commandName: string;
+  readonly shellEnvironment: PlanShellEnvironmentV1;
+  readonly workspaceRoot: string;
+}): Promise<PlanShellFileIdentityV1 | undefined> {
+  return resolveTrustedExecutable(input.commandName, input.shellEnvironment, input.workspaceRoot);
+}
+
+async function verifyGitRepository(
+  workspaceRoot: string,
+): Promise<PlanGitRepositoryProofV1 | undefined> {
+  const maximumEntries = 4_096;
+  try {
+    const canonicalWorkspace = await realpath(workspaceRoot);
+    const gitDirectory = join(canonicalWorkspace, ".git");
+    const gitMetadata = await lstat(gitDirectory);
+    if (!gitMetadata.isDirectory() || gitMetadata.isSymbolicLink()) {
+      return undefined;
+    }
+    const canonicalGitDirectory = await realpath(gitDirectory);
+    if (
+      canonicalGitDirectory !== gitDirectory ||
+      !isInside(canonicalWorkspace, canonicalGitDirectory)
+    ) {
+      return undefined;
+    }
+    const objectsDirectory = join(gitDirectory, "objects");
+    const objectsMetadata = await lstat(objectsDirectory);
+    if (
+      !objectsMetadata.isDirectory() ||
+      objectsMetadata.isSymbolicLink() ||
+      (await realpath(objectsDirectory)) !== objectsDirectory
+    ) {
+      return undefined;
+    }
+    for (const forbidden of [
+      "commondir",
+      "config.worktree",
+      "objects/info/alternates",
+      "objects/info/http-alternates",
+    ]) {
+      if (await pathExists(join(gitDirectory, forbidden))) {
+        return undefined;
+      }
+    }
+    const packDirectory = join(objectsDirectory, "pack");
+    if (await pathExists(packDirectory)) {
+      const packMetadata = await lstat(packDirectory);
+      if (
+        !packMetadata.isDirectory() ||
+        packMetadata.isSymbolicLink() ||
+        (await realpath(packDirectory)) !== packDirectory
+      ) {
+        return undefined;
+      }
+      let packEntries = 0;
+      for await (const entry of await opendir(packDirectory)) {
+        packEntries += 1;
+        if (packEntries > maximumEntries || entry.name.endsWith(".promisor")) {
+          return undefined;
+        }
+      }
+    }
+    const configBytes = await readFile(join(gitDirectory, "config"));
+    if (configBytes.byteLength > 256 * 1024) {
+      return undefined;
+    }
+    const config = new TextDecoder("utf-8", { fatal: true }).decode(configBytes);
+    const inertConfig = parseInertGitConfig(config);
+    if (inertConfig === undefined) {
+      return undefined;
+    }
+    if (inertConfig.hooksPath !== undefined) {
+      const hooksProof = await verifyWorkspacePath(inertConfig.hooksPath, canonicalWorkspace);
+      if (hooksProof === undefined || !(await stat(hooksProof.canonicalPath)).isDirectory()) {
+        return undefined;
+      }
+    }
+    const entries = [];
+    const pending = [gitDirectory];
+    while (pending.length > 0) {
+      const path = pending.pop() as string;
+      const metadata = await lstat(path, { bigint: true });
+      if (metadata.isSymbolicLink()) {
+        return undefined;
+      }
+      entries.push({
+        path: relative(canonicalWorkspace, path),
+        device: metadata.dev.toString(10),
+        inode: metadata.ino.toString(10),
+        mode: Number(metadata.mode),
+        size: Number(metadata.size),
+        modifiedMilliseconds: Number(metadata.mtimeMs),
+      });
+      if (entries.length > maximumEntries) {
+        return undefined;
+      }
+      if (metadata.isDirectory()) {
+        const children: string[] = [];
+        for await (const child of await opendir(path)) {
+          if (entries.length + pending.length + children.length >= maximumEntries) {
+            return undefined;
+          }
+          children.push(child.name);
+        }
+        children.sort().reverse();
+        for (const child of children) {
+          pending.push(join(path, child));
+        }
+      }
+    }
+    return {
+      gitDirectory,
+      configDigest: `sha256:${createHash("sha256").update(configBytes).digest("hex")}`,
+      entries,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function parseInertGitConfig(config: string): { readonly hooksPath?: string } | undefined {
+  let section = "";
+  const singletonKeys = new Set<string>();
+  let entries = 0;
+  let hooksPath: string | undefined;
+  for (const rawLine of config.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("#") || line.startsWith(";")) {
+      continue;
+    }
+    const sectionMatch = /^\[([A-Za-z0-9.-]+)(?:\s+"([A-Za-z0-9._/-]+)")?\]$/u.exec(line);
+    if (sectionMatch !== null) {
+      const sectionName = sectionMatch[1];
+      if (sectionName === undefined) {
+        return undefined;
+      }
+      section = (
+        sectionMatch[2] === undefined ? sectionName : `${sectionName}.${sectionMatch[2]}`
+      ).toLowerCase();
+      continue;
+    }
+    const separator = line.indexOf("=");
+    if (section.length === 0 || separator <= 0) {
+      return undefined;
+    }
+    const name = line.slice(0, separator).trim().toLowerCase();
+    const value = line.slice(separator + 1).trim();
+    const key = `${section}.${name}`;
+    entries += 1;
+    if (
+      entries > 4_096 ||
+      Buffer.byteLength(key, "utf8") > 4_096 ||
+      Buffer.byteLength(value, "utf8") > 4_096
+    ) {
+      return undefined;
+    }
+    if (
+      key.startsWith("include.") ||
+      key.startsWith("includeif.") ||
+      /["\\#;]/u.test(value) ||
+      [...value].some((character) => {
+        const code = character.codePointAt(0) as number;
+        return code < 0x20 || code === 0x7f;
+      })
+    ) {
+      return undefined;
+    }
+    const singleton = !/^remote\.[^.]+\.fetch$/u.test(key);
+    if ((singleton && singletonKeys.has(key)) || !isAllowedGitConfigEntry(key, value)) {
+      return undefined;
+    }
+    if (singleton) {
+      singletonKeys.add(key);
+    }
+    if (key === "core.hookspath") {
+      hooksPath = value;
+    }
+  }
+  if (!singletonKeys.has("core.repositoryformatversion") || !singletonKeys.has("core.bare")) {
+    return undefined;
+  }
+  return hooksPath === undefined ? {} : { hooksPath };
+}
+
+function isAllowedGitConfigEntry(key: string, value: string): boolean {
+  if (key === "core.repositoryformatversion") {
+    return value === "0";
+  }
+  if (key === "core.bare") {
+    return value.toLowerCase() === "false";
+  }
+  if (
+    [
+      "core.filemode",
+      "core.logallrefupdates",
+      "core.ignorecase",
+      "core.precomposeunicode",
+    ].includes(key)
+  ) {
+    return /^(?:true|false)$/iu.test(value);
+  }
+  if (key === "core.hookspath") {
+    return value.length > 0 && normalize(value) === value && !value.split(/[\\/]/u).includes("..");
+  }
+  return (
+    key === "user.name" ||
+    key === "user.email" ||
+    /^remote\.[^.]+\.(?:url|fetch)$/u.test(key) ||
+    /^branch\.[^.]+\.(?:remote|merge)$/u.test(key) ||
+    /^submodule\.[^.]+\.(?:url|active)$/u.test(key)
+  );
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if (isNodeError(error) && (error.code === "ENOENT" || error.code === "ENOTDIR")) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function verifiedShell(
+  environment: PlanShellEnvironmentV1,
+  workspaceRoot: string,
+): Promise<PlanShellFileIdentityV1 | undefined> {
+  if (!isPlanShellEnvironmentV1Valid(environment)) {
+    return undefined;
+  }
+  if ("status" in environment.shell) {
+    return undefined;
+  }
+  try {
+    const current = await readPlanShellFileIdentityV1(environment.shell.lookupPath);
+    return isDeepStrictEqual(current, environment.shell) &&
+      (await isTrustedSystemExecutable(current, workspaceRoot))
+      ? current
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasUnsafePathEntry(environment: PlanShellEnvironmentV1, workspaceRoot: string): boolean {
+  return environment.pathEntries.some(
+    (entry) => entry.length === 0 || !isAbsolute(entry) || isInside(workspaceRoot, entry),
+  );
+}
+
+async function resolveTrustedExecutable(
+  commandName: string | undefined,
+  environment: PlanShellEnvironmentV1,
+  workspaceRoot: string,
+): Promise<PlanShellFileIdentityV1 | undefined> {
+  if (commandName === undefined || commandName.length === 0 || commandName.includes("/")) {
+    return undefined;
+  }
+  for (const entry of environment.pathEntries) {
+    const lookupPath = join(entry, commandName);
+    try {
+      const metadata = await lstat(lookupPath);
+      if (!metadata.isFile() && !metadata.isSymbolicLink()) {
+        return undefined;
+      }
+      const identity = await readPlanShellFileIdentityV1(lookupPath);
+      return (identity.mode & 0o111) !== 0 &&
+        (await isTrustedSystemExecutable(identity, workspaceRoot))
+        ? identity
+        : undefined;
+    } catch (error) {
+      if (isNodeError(error) && (error.code === "ENOENT" || error.code === "ENOTDIR")) {
+        continue;
+      }
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+async function isTrustedSystemExecutable(
+  identity: PlanShellFileIdentityV1,
+  workspaceRoot: string,
+): Promise<boolean> {
+  const canonicalWorkspace = await realpath(workspaceRoot);
+  const canonicalPath = identity.canonicalPath;
+  if (
+    isInside(canonicalWorkspace, canonicalPath) ||
+    (!canonicalPath.startsWith("/usr/bin/") && !canonicalPath.startsWith("/bin/")) ||
+    !(await isTrustedLookupChain(identity.lookupPath, canonicalPath))
+  ) {
+    return false;
+  }
+  const components = canonicalPath.split("/").filter((component) => component.length > 0);
+  let current = "/";
+  for (const component of components) {
+    current = join(current, component);
+    const metadata = await stat(current);
+    if (metadata.uid !== 0 || (metadata.mode & 0o022) !== 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function isTrustedLookupChain(lookupPath: string, canonicalTarget: string): Promise<boolean> {
+  if (!isAbsolute(lookupPath) || (await realpath(lookupPath)) !== canonicalTarget) {
+    return false;
+  }
+  const components = lookupPath.split("/").filter((component) => component.length > 0);
+  let current = "/";
+  for (const component of components) {
+    current = join(current, component);
+    const metadata = await lstat(current);
+    if (metadata.uid !== 0 || (!metadata.isSymbolicLink() && (metadata.mode & 0o022) !== 0)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const child = relative(root, candidate);
+  return child === "" || (child !== ".." && !child.startsWith(`..${sep}`) && !isAbsolute(child));
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/packages/agent/src/plan-git-policy.ts
+++ b/packages/agent/src/plan-git-policy.ts
@@ -1,0 +1,124 @@
+import { createHash } from "node:crypto";
+
+import { planGitAutomaticCommandCorpusVersion } from "./plan-command-assessment.js";
+import type { PlanShellFileIdentityV1 } from "./plan-shell-environment.js";
+
+const gitConfigurationOverrides = [
+  ["core.fsmonitor", "false"],
+  ["core.hooksPath", "/dev/null"],
+  ["core.attributesFile", "/dev/null"],
+  ["core.excludesFile", "/dev/null"],
+  ["core.pager", "cat"],
+  ["diff.external", ""],
+  ["interactive.diffFilter", ""],
+  ["color.ui", "false"],
+  ["maintenance.auto", "false"],
+  ["gc.auto", "0"],
+  ["submodule.recurse", "false"],
+  ["status.submoduleSummary", "false"],
+  ["diff.ignoreSubmodules", "all"],
+  ["log.showSignature", "false"],
+  ["protocol.allow", "never"],
+] as const;
+
+export type PlanGitEnvironmentV1 = {
+  readonly version: "git-auto-env.v1";
+  readonly variables: Readonly<Record<string, string>>;
+  readonly digest: `sha256:${string}`;
+};
+
+export type PlanGitAutomaticPolicyV1 = {
+  readonly version: "git-auto-policy.v1";
+  readonly commandCorpusVersion: "plan-git-corpus.v1";
+  readonly environmentVersion: "git-auto-env.v1";
+  readonly environmentDigest: `sha256:${string}`;
+  readonly exactGitVersion: "git version 2.43.0";
+  readonly digest: `sha256:${string}`;
+};
+
+export type PlanGitAttestationV1 = {
+  readonly version: "git-auto-attestation.v1";
+  readonly gitVersion: "git version 2.43.0";
+  readonly executable: PlanShellFileIdentityV1;
+  readonly shellEnvironmentDigest: `sha256:${string}`;
+  readonly gitEnvironmentDigest: `sha256:${string}`;
+  readonly gitPolicyVersion: "git-auto-policy.v1";
+  readonly gitPolicyDigest: `sha256:${string}`;
+  readonly digest: `sha256:${string}`;
+};
+
+export const planGitEnvironmentV1: PlanGitEnvironmentV1 = (() => {
+  const variables: Record<string, string> = {
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_TERMINAL_PROMPT: "0",
+    GIT_OPTIONAL_LOCKS: "0",
+    GIT_PAGER: "cat",
+    PAGER: "cat",
+    GIT_CONFIG_COUNT: String(gitConfigurationOverrides.length),
+  };
+  gitConfigurationOverrides.forEach(([key, value], index) => {
+    variables[`GIT_CONFIG_KEY_${index}`] = key;
+    variables[`GIT_CONFIG_VALUE_${index}`] = value;
+  });
+  const identity = { version: "git-auto-env.v1" as const, variables };
+  return { ...identity, digest: digest(identity) };
+})();
+
+export const planGitAutomaticPolicyV1: PlanGitAutomaticPolicyV1 = (() => {
+  const identity = {
+    version: "git-auto-policy.v1" as const,
+    commandCorpusVersion: planGitAutomaticCommandCorpusVersion,
+    environmentVersion: planGitEnvironmentV1.version,
+    environmentDigest: planGitEnvironmentV1.digest,
+    exactGitVersion: "git version 2.43.0" as const,
+  };
+  return { ...identity, digest: digest(identity) };
+})();
+
+export function createPlanGitAttestationV1(input: {
+  readonly executable: PlanShellFileIdentityV1;
+  readonly shellEnvironmentDigest: `sha256:${string}`;
+}): PlanGitAttestationV1 {
+  const identity = {
+    version: "git-auto-attestation.v1" as const,
+    gitVersion: "git version 2.43.0" as const,
+    executable: input.executable,
+    shellEnvironmentDigest: input.shellEnvironmentDigest,
+    gitEnvironmentDigest: planGitEnvironmentV1.digest,
+    gitPolicyVersion: planGitAutomaticPolicyV1.version,
+    gitPolicyDigest: planGitAutomaticPolicyV1.digest,
+  };
+  return { ...identity, digest: digest(identity) };
+}
+
+export function isPlanGitAttestationV1Valid(attestation: PlanGitAttestationV1): boolean {
+  const { digest: attestationDigest, ...identity } = attestation;
+  return (
+    attestation.version === "git-auto-attestation.v1" &&
+    attestation.gitVersion === "git version 2.43.0" &&
+    attestation.gitEnvironmentDigest === planGitEnvironmentV1.digest &&
+    attestation.gitPolicyVersion === planGitAutomaticPolicyV1.version &&
+    attestation.gitPolicyDigest === planGitAutomaticPolicyV1.digest &&
+    attestationDigest === digest(identity)
+  );
+}
+
+function digest(value: unknown): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+  }
+  return `{${Object.entries(value)
+    .filter(([, entry]) => entry !== undefined)
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`)
+    .join(",")}}`;
+}

--- a/packages/agent/src/plan-mcp-permission-validation.ts
+++ b/packages/agent/src/plan-mcp-permission-validation.ts
@@ -1,0 +1,50 @@
+import type { RuntimeEvent } from "./agent-session-contracts.js";
+import { digestCanonicalMcpJson } from "./mcp-canonical-identity.js";
+import type { PlanEligibleToolProfileV1 } from "./plan-mode.js";
+
+export function isExactPlanMcpPermissionEventV1(input: {
+  readonly event: Extract<
+    RuntimeEvent,
+    { readonly type: "tool_permission_requested" | "tool_permission_decided" }
+  >;
+  readonly runId: string;
+  readonly callId: string;
+  readonly callName: string;
+  readonly argumentsJson: string;
+  readonly effect: "execute" | "network";
+  readonly definitionDigest: string | undefined;
+  readonly eligibleDefinition: PlanEligibleToolProfileV1["definitions"][number];
+}): boolean {
+  const subject = input.event.subject;
+  const expectedArgumentsDigest = exactMcpArgumentsDigest(input.argumentsJson);
+  return (
+    input.eligibleDefinition.source === "mcp" &&
+    input.eligibleDefinition.effect === input.effect &&
+    input.eligibleDefinition.definitionDigest === input.definitionDigest &&
+    input.eligibleDefinition.mcp !== undefined &&
+    subject?.type === "mcp_tool" &&
+    input.event.callId === input.callId &&
+    input.event.name === input.callName &&
+    input.event.effect === input.effect &&
+    input.event.scope === "call" &&
+    input.event.requestId === `${input.runId}:${input.callId}` &&
+    subject.qualifiedName === input.callName &&
+    subject.definitionDigest === input.definitionDigest &&
+    subject.serverId === input.eligibleDefinition.mcp.serverId &&
+    subject.originalName === input.eligibleDefinition.mcp.originalName &&
+    subject.serverDefinitionDigest === input.eligibleDefinition.mcp.serverDefinitionDigest &&
+    expectedArgumentsDigest !== undefined &&
+    subject.argumentsDigest === expectedArgumentsDigest
+  );
+}
+
+function exactMcpArgumentsDigest(argumentsJson: string): `sha256:${string}` | undefined {
+  try {
+    const parsed = JSON.parse(argumentsJson) as unknown;
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? digestCanonicalMcpJson(parsed)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/agent/src/plan-mode.ts
+++ b/packages/agent/src/plan-mode.ts
@@ -1,8 +1,11 @@
 import { createHash } from "node:crypto";
 
+import type { PlanShellPolicyVersion } from "./plan-command-assessment.js";
+import type { PlanGitAttestationV1 } from "./plan-git-policy.js";
+import type { PlanShellEnvironmentV1 } from "./plan-shell-environment.js";
 import type { ToolEffect } from "./tool-runtime.js";
 
-export const planPolicyVersions = ["plan-policy.read-v1"] as const;
+export const planPolicyVersions = ["plan-policy.read-v1", "plan-policy.hybrid-v1"] as const;
 
 export type PlanPolicyVersion = (typeof planPolicyVersions)[number];
 
@@ -17,6 +20,13 @@ export type PlanEligibleToolProfileV1 = {
     readonly definitionDigest: `sha256:${string}`;
     readonly effect: ToolEffect;
     readonly source: "builtin" | "mcp";
+    readonly mcp?:
+      | {
+          readonly serverId: string;
+          readonly originalName: string;
+          readonly serverDefinitionDigest: `sha256:${string}`;
+        }
+      | undefined;
   }[];
   readonly digest: `sha256:${string}`;
 };
@@ -26,10 +36,15 @@ export type PlanCycleSnapshot = {
   readonly cycleId: string;
   readonly revision: number;
   readonly policyVersion: PlanPolicyVersion;
+  readonly shellPolicyVersion?: PlanShellPolicyVersion;
+  readonly shellEnvironment?: PlanShellEnvironmentV1;
+  readonly gitPolicyVersion?: "git-auto-policy.v1";
+  readonly gitPolicyDigest?: `sha256:${string}`;
+  readonly gitAttestation?: PlanGitAttestationV1;
   readonly eligibleToolProfile: PlanEligibleToolProfileV1;
 };
 
-export function createReadOnlyPlanToolProfileV1(
+export function createPlanToolProfileV1(
   input: Omit<PlanEligibleToolProfileV1, "digest" | "version">,
 ): PlanEligibleToolProfileV1 {
   const profile = {
@@ -40,7 +55,10 @@ export function createReadOnlyPlanToolProfileV1(
   return { ...profile, digest: digestPlanProfile(profile) };
 }
 
-export function isReadOnlyPlanToolProfileV1Valid(profile: PlanEligibleToolProfileV1): boolean {
+export function isPlanToolProfileV1Valid(
+  profile: PlanEligibleToolProfileV1,
+  policyVersion: PlanPolicyVersion,
+): boolean {
   const { digest, ...withoutDigest } = profile;
   return (
     profile.version === 1 &&
@@ -54,8 +72,23 @@ export function isReadOnlyPlanToolProfileV1Valid(profile: PlanEligibleToolProfil
         definition.name.length > 0 &&
         definition.name.length <= 256 &&
         /^sha256:[0-9a-f]{64}$/u.test(definition.definitionDigest) &&
-        definition.effect === "read" &&
-        (definition.source === "builtin" || definition.source === "mcp"),
+        (definition.effect === "read" ||
+          (policyVersion === "plan-policy.hybrid-v1" &&
+            ((definition.source === "builtin" &&
+              definition.name === "run_shell" &&
+              definition.effect === "execute") ||
+              (definition.source === "mcp" &&
+                (definition.effect === "execute" || definition.effect === "network"))))) &&
+        (definition.source === "builtin" || definition.source === "mcp") &&
+        (definition.source === "builtin"
+          ? definition.mcp === undefined
+          : (definition.mcp === undefined && policyVersion === "plan-policy.read-v1") ||
+            (definition.mcp !== undefined &&
+              definition.mcp.serverId.length > 0 &&
+              definition.mcp.serverId.length <= 128 &&
+              definition.mcp.originalName.length > 0 &&
+              definition.mcp.originalName.length <= 256 &&
+              /^sha256:[0-9a-f]{64}$/u.test(definition.mcp.serverDefinitionDigest))),
     ) &&
     digest === digestPlanProfile(withoutDigest)
   );

--- a/packages/agent/src/plan-shell-environment.ts
+++ b/packages/agent/src/plan-shell-environment.ts
@@ -1,0 +1,153 @@
+import { createHash } from "node:crypto";
+import { readFile, realpath, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+
+export type PlanShellFileIdentityV1 = {
+  readonly lookupPath: string;
+  readonly canonicalPath: string;
+  readonly device: string;
+  readonly inode: string;
+  readonly mode: number;
+  readonly size: number;
+  readonly modifiedMilliseconds: number;
+  readonly digest: `sha256:${string}`;
+};
+
+export type PlanShellUnavailableV1 = {
+  readonly status: "unavailable";
+  readonly lookupPath: "/bin/sh";
+};
+
+export type PlanShellEnvironmentV1 = {
+  readonly version: "plan-shell-env.v1";
+  readonly pathEntries: readonly string[];
+  readonly variables: {
+    readonly PATH: string;
+    readonly LANG: "C";
+    readonly LC_ALL: "C";
+    readonly TERM: "dumb";
+    readonly TMPDIR: string;
+  };
+  readonly home: { readonly allocation: "owner-only-empty-per-call" };
+  readonly shell: PlanShellFileIdentityV1 | PlanShellUnavailableV1;
+  readonly digest: `sha256:${string}`;
+};
+
+export async function createPlanShellEnvironmentV1(): Promise<PlanShellEnvironmentV1> {
+  const { PATH: executablePath = "" } = process.env;
+  const shell = await readPlanShellFileIdentityV1("/bin/sh").catch(
+    (): PlanShellUnavailableV1 => ({ status: "unavailable", lookupPath: "/bin/sh" }),
+  );
+  const environment = {
+    version: "plan-shell-env.v1" as const,
+    pathEntries: executablePath.split(":"),
+    variables: {
+      PATH: executablePath,
+      LANG: "C" as const,
+      LC_ALL: "C" as const,
+      TERM: "dumb" as const,
+      TMPDIR: await realpath(tmpdir()),
+    },
+    home: { allocation: "owner-only-empty-per-call" as const },
+    shell,
+  };
+  return { ...environment, digest: digest(environment) };
+}
+
+/** Tests only: a deterministic snapshot for semantic lifecycle tests. */
+export function createUnavailablePlanShellEnvironmentV1(): PlanShellEnvironmentV1 {
+  const environment = {
+    version: "plan-shell-env.v1" as const,
+    pathEntries: ["/usr/bin", "/bin"],
+    variables: {
+      PATH: "/usr/bin:/bin",
+      LANG: "C" as const,
+      LC_ALL: "C" as const,
+      TERM: "dumb" as const,
+      TMPDIR: "/tmp",
+    },
+    home: { allocation: "owner-only-empty-per-call" as const },
+    shell: { status: "unavailable" as const, lookupPath: "/bin/sh" as const },
+  };
+  return { ...environment, digest: digest(environment) };
+}
+
+export function isPlanShellEnvironmentV1Valid(environment: PlanShellEnvironmentV1): boolean {
+  const { digest: environmentDigest, ...withoutDigest } = environment;
+  return (
+    environment.version === "plan-shell-env.v1" &&
+    environment.pathEntries.length > 0 &&
+    environment.pathEntries.length <= 128 &&
+    environment.pathEntries.every(
+      (entry) => Buffer.byteLength(entry, "utf8") <= 4_096 && !entry.includes("\0"),
+    ) &&
+    environment.variables.PATH === environment.pathEntries.join(":") &&
+    Buffer.byteLength(environment.variables.PATH, "utf8") <= 16_384 &&
+    environment.variables.LANG === "C" &&
+    environment.variables.LC_ALL === "C" &&
+    environment.variables.TERM === "dumb" &&
+    environment.variables.TMPDIR.startsWith("/") &&
+    environment.home.allocation === "owner-only-empty-per-call" &&
+    isPlanShellSnapshotValid(environment.shell) &&
+    environmentDigest === digest(withoutDigest)
+  );
+}
+
+function isPlanShellSnapshotValid(shell: PlanShellEnvironmentV1["shell"]): boolean {
+  if ("status" in shell) {
+    return shell.status === "unavailable" && shell.lookupPath === "/bin/sh";
+  }
+  return (
+    shell.lookupPath === "/bin/sh" &&
+    shell.canonicalPath.startsWith("/") &&
+    /^\d+$/u.test(shell.device) &&
+    /^\d+$/u.test(shell.inode) &&
+    Number.isSafeInteger(shell.mode) &&
+    shell.mode >= 0 &&
+    Number.isSafeInteger(shell.size) &&
+    shell.size >= 0 &&
+    shell.size <= 8 * 1024 * 1024 &&
+    Number.isFinite(shell.modifiedMilliseconds) &&
+    shell.modifiedMilliseconds >= 0 &&
+    /^sha256:[0-9a-f]{64}$/u.test(shell.digest)
+  );
+}
+
+export async function readPlanShellFileIdentityV1(
+  lookupPath: string,
+): Promise<PlanShellFileIdentityV1> {
+  const canonicalPath = await realpath(lookupPath);
+  const metadata = await stat(canonicalPath, { bigint: true });
+  if (!metadata.isFile() || metadata.size > 8n * 1024n * 1024n) {
+    throw new TypeError("The Plan shell target is not a bounded ordinary file.");
+  }
+  const bytes = await readFile(canonicalPath);
+  return {
+    lookupPath,
+    canonicalPath,
+    device: metadata.dev.toString(10),
+    inode: metadata.ino.toString(10),
+    mode: Number(metadata.mode),
+    size: Number(metadata.size),
+    modifiedMilliseconds: Number(metadata.mtimeMs),
+    digest: `sha256:${createHash("sha256").update(bytes).digest("hex")}`,
+  };
+}
+
+function digest(value: unknown): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(canonicalJson(value)).digest("hex")}`;
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+  }
+  return `{${Object.entries(value)
+    .filter(([, entry]) => entry !== undefined)
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`)
+    .join(",")}}`;
+}

--- a/packages/agent/src/presentation-tool-projection.ts
+++ b/packages/agent/src/presentation-tool-projection.ts
@@ -205,6 +205,12 @@ export function projectPendingPermissionCandidates(
         callId: entry.record.event.callId,
         effect: entry.record.event.effect,
         subject,
+        ...(entry.record.event.subject?.type === "plan_command"
+          ? {
+              warning:
+                "Plan parsing is not a sandbox. Approval may run project code, write cache or artifacts, read accessible data, or use network.",
+            }
+          : {}),
         canAllow: entry.record.event.effect !== "write",
         changePreviewRef,
       },
@@ -390,7 +396,7 @@ function safeToolSubject(
   if (subject?.type === "file" || subject?.type === "workspace_path") {
     return { type: "path", value: subject.path };
   }
-  if (subject?.type === "command") {
+  if (subject?.type === "command" || subject?.type === "plan_command") {
     return { type: "command", value: subject.command };
   }
   const outputRecord = jsonRecord(output);

--- a/packages/agent/src/session-history-folds.ts
+++ b/packages/agent/src/session-history-folds.ts
@@ -1012,8 +1012,28 @@ export function planCycleSnapshotFromRecords(
         cycleId: entry.record.cycleId,
         revision: entry.record.revision,
         policyVersion: entry.record.policyVersion,
+        ...(entry.record.shellPolicyVersion === undefined
+          ? {}
+          : { shellPolicyVersion: entry.record.shellPolicyVersion }),
+        ...(entry.record.shellEnvironment === undefined
+          ? {}
+          : { shellEnvironment: entry.record.shellEnvironment }),
+        ...(entry.record.gitPolicyVersion === undefined
+          ? {}
+          : { gitPolicyVersion: entry.record.gitPolicyVersion }),
+        ...(entry.record.gitPolicyDigest === undefined
+          ? {}
+          : { gitPolicyDigest: entry.record.gitPolicyDigest }),
+        ...("gitAttestation" in entry.record && entry.record.gitAttestation !== undefined
+          ? { gitAttestation: entry.record.gitAttestation }
+          : {}),
         eligibleToolProfile: entry.record.eligibleToolProfile,
       };
+    } else if (
+      entry.record.type === "plan_git_attested" &&
+      entry.record.cycleId === active?.cycleId
+    ) {
+      active = { ...active, gitAttestation: entry.record.attestation };
     } else if (
       entry.record.type === "plan_cycle_exited" &&
       entry.record.cycleId === active?.cycleId &&

--- a/packages/agent/src/session-history-validation.ts
+++ b/packages/agent/src/session-history-validation.ts
@@ -20,7 +20,11 @@ import {
 } from "./input-resources.js";
 import { isMcpToolProfileV1Valid } from "./mcp-profile-contracts.js";
 import { sameModelTargetIdentity } from "./model-targets.js";
-import { isReadOnlyPlanToolProfileV1Valid } from "./plan-mode.js";
+import { assessPlanCommandV1 } from "./plan-command-assessment.js";
+import { isPlanGitAttestationV1Valid, planGitAutomaticPolicyV1 } from "./plan-git-policy.js";
+import { isExactPlanMcpPermissionEventV1 } from "./plan-mcp-permission-validation.js";
+import { isPlanToolProfileV1Valid, type PlanEligibleToolProfileV1 } from "./plan-mode.js";
+import { isPlanShellEnvironmentV1Valid } from "./plan-shell-environment.js";
 import {
   commitMcpToolProfileV3,
   hasSkillPromptContext,
@@ -59,16 +63,19 @@ import type {
   SessionRecord,
 } from "./session-store.js";
 import { isSkillContextRecordV1Valid } from "./skills.js";
+import type { PermissionSubject } from "./tool-runtime.js";
 import { canonicalChangePreviewForToolCall } from "./tool-runtime.js";
 
 type ValidatedToolState = {
   readonly call: { readonly id: string; readonly name: string; readonly argumentsJson: string };
   readonly intent: {
+    readonly definitionDigest?: string | undefined;
     readonly effect?: string | undefined;
   };
   decision?: "allow" | "deny";
   changePreviewRef?: ArtifactReference<ChangePreviewArtifactSource>;
   permissionRequestId?: string;
+  permissionSubject?: PermissionSubject;
   requested: boolean;
   repositoryActivationPublished?: boolean;
   repositoryDisposition?: "mutation_retry_required" | "read_continue" | "unavailable";
@@ -162,6 +169,14 @@ export function validateCurrentSessionHistory(
   const titleGenerationIds = new Set<string>();
   let activePlanCycleId: string | undefined;
   let activePlanRevision: number | undefined;
+  let activePlanPolicyVersion: "plan-policy.read-v1" | "plan-policy.hybrid-v1" | undefined;
+  let activePlanShellPolicyVersion: "plan-shell-policy.v1" | undefined;
+  let activePlanShellEnvironmentDigest: string | undefined;
+  let activePlanToolProfileDigest: string | undefined;
+  let activePlanGitPolicyVersion: "git-auto-policy.v1" | undefined;
+  let activePlanGitPolicyDigest: string | undefined;
+  let activePlanEligibleToolProfile: PlanEligibleToolProfileV1 | undefined;
+  let activePlanGitAttested = false;
   const activatableRepositoryRevisions = new Map<number, ValidatedToolState>();
   const publishedRepositoryRevisions = new Set<number>();
   let mcpWorkspaceConfirmation: SessionMcpWorkspaceConfirmedRecord["record"] | undefined;
@@ -186,7 +201,17 @@ export function validateCurrentSessionHistory(
       if (
         run !== undefined ||
         activePlanCycleId !== undefined ||
-        !isReadOnlyPlanToolProfileV1Valid(record.eligibleToolProfile) ||
+        !isPlanToolProfileV1Valid(record.eligibleToolProfile, record.policyVersion) ||
+        (record.policyVersion === "plan-policy.hybrid-v1") !==
+          (record.shellPolicyVersion === "plan-shell-policy.v1") ||
+        (record.policyVersion === "plan-policy.hybrid-v1") !==
+          (record.shellEnvironment !== undefined) ||
+        (record.policyVersion === "plan-policy.hybrid-v1") !==
+          (record.gitPolicyVersion === planGitAutomaticPolicyV1.version) ||
+        (record.policyVersion === "plan-policy.hybrid-v1") !==
+          (record.gitPolicyDigest === planGitAutomaticPolicyV1.digest) ||
+        (record.shellEnvironment !== undefined &&
+          !isPlanShellEnvironmentV1Valid(record.shellEnvironment)) ||
         record.eligibleToolProfile.source.version !== activePromptContext?.toolProfile.version ||
         record.eligibleToolProfile.source.digest !== activePromptContext.toolProfile.digest
       ) {
@@ -194,6 +219,14 @@ export function validateCurrentSessionHistory(
       }
       activePlanCycleId = record.cycleId;
       activePlanRevision = record.revision;
+      activePlanPolicyVersion = record.policyVersion;
+      activePlanShellPolicyVersion = record.shellPolicyVersion;
+      activePlanShellEnvironmentDigest = record.shellEnvironment?.digest;
+      activePlanToolProfileDigest = record.eligibleToolProfile.digest;
+      activePlanGitPolicyVersion = record.gitPolicyVersion;
+      activePlanGitPolicyDigest = record.gitPolicyDigest;
+      activePlanEligibleToolProfile = record.eligibleToolProfile;
+      activePlanGitAttested = false;
       continue;
     }
     if (record.type === "plan_cycle_inherited") {
@@ -212,7 +245,22 @@ export function validateCurrentSessionHistory(
         lineage === undefined ||
         record.source.sessionId !== sourceSessionId ||
         record.source.throughSequence !== sourceSequence ||
-        !isReadOnlyPlanToolProfileV1Valid(record.eligibleToolProfile) ||
+        !isPlanToolProfileV1Valid(record.eligibleToolProfile, record.policyVersion) ||
+        (record.policyVersion === "plan-policy.hybrid-v1") !==
+          (record.shellPolicyVersion === "plan-shell-policy.v1") ||
+        (record.policyVersion === "plan-policy.hybrid-v1") !==
+          (record.shellEnvironment !== undefined) ||
+        (record.policyVersion === "plan-policy.hybrid-v1") !==
+          (record.gitPolicyVersion === planGitAutomaticPolicyV1.version) ||
+        (record.policyVersion === "plan-policy.hybrid-v1") !==
+          (record.gitPolicyDigest === planGitAutomaticPolicyV1.digest) ||
+        (record.shellEnvironment !== undefined &&
+          !isPlanShellEnvironmentV1Valid(record.shellEnvironment)) ||
+        (record.gitAttestation !== undefined &&
+          (!isPlanGitAttestationV1Valid(record.gitAttestation) ||
+            record.gitAttestation.shellEnvironmentDigest !== record.shellEnvironment?.digest ||
+            record.gitAttestation.gitPolicyVersion !== record.gitPolicyVersion ||
+            record.gitAttestation.gitPolicyDigest !== record.gitPolicyDigest)) ||
         record.eligibleToolProfile.source.version !== activePromptContext?.toolProfile.version ||
         record.eligibleToolProfile.source.digest !== activePromptContext.toolProfile.digest
       ) {
@@ -220,6 +268,44 @@ export function validateCurrentSessionHistory(
       }
       activePlanCycleId = record.cycleId;
       activePlanRevision = record.revision;
+      activePlanPolicyVersion = record.policyVersion;
+      activePlanShellPolicyVersion = record.shellPolicyVersion;
+      activePlanShellEnvironmentDigest = record.shellEnvironment?.digest;
+      activePlanToolProfileDigest = record.eligibleToolProfile.digest;
+      activePlanGitPolicyVersion = record.gitPolicyVersion;
+      activePlanGitPolicyDigest = record.gitPolicyDigest;
+      activePlanEligibleToolProfile = record.eligibleToolProfile;
+      activePlanGitAttested = record.gitAttestation !== undefined;
+      continue;
+    }
+    if (record.type === "plan_git_attested") {
+      const toolState = toolStates.get(record.callId);
+      const completed = currentRecords.some(
+        (candidate) =>
+          candidate.sequence < entry.sequence &&
+          candidate.schemaVersion === 3 &&
+          candidate.record.type === "runtime_event" &&
+          candidate.record.runId === record.runId &&
+          candidate.record.event.type === "tool_completed" &&
+          candidate.record.event.callId === record.callId &&
+          candidate.record.event.name === "run_shell" &&
+          isExactGitVersionOutput(candidate.record.event.output),
+      );
+      if (
+        run?.runId !== record.runId ||
+        record.cycleId !== activePlanCycleId ||
+        activePlanGitAttested ||
+        activePlanShellEnvironmentDigest !== record.attestation.shellEnvironmentDigest ||
+        activePlanGitPolicyVersion !== record.attestation.gitPolicyVersion ||
+        activePlanGitPolicyDigest !== record.attestation.gitPolicyDigest ||
+        !isPlanGitAttestationV1Valid(record.attestation) ||
+        toolState?.call.name !== "run_shell" ||
+        !isExactGitVersionArguments(toolState.call.argumentsJson) ||
+        !completed
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      activePlanGitAttested = true;
       continue;
     }
     if (record.type === "plan_cycle_exited") {
@@ -232,6 +318,14 @@ export function validateCurrentSessionHistory(
       }
       activePlanCycleId = undefined;
       activePlanRevision = undefined;
+      activePlanPolicyVersion = undefined;
+      activePlanShellPolicyVersion = undefined;
+      activePlanShellEnvironmentDigest = undefined;
+      activePlanToolProfileDigest = undefined;
+      activePlanGitPolicyVersion = undefined;
+      activePlanGitPolicyDigest = undefined;
+      activePlanEligibleToolProfile = undefined;
+      activePlanGitAttested = false;
       continue;
     }
     if (record.type === "mcp_workspace_confirmed") {
@@ -1454,6 +1548,24 @@ export function validateCurrentSessionHistory(
         throw new SessionLifecycleError("session_invalid");
       }
       if (
+        (event.type === "tool_permission_requested" || event.type === "tool_permission_decided") &&
+        !isValidPlanPermissionEvent({
+          event,
+          runId: run.runId,
+          state,
+          activePlanCycleId,
+          activePlanPolicyVersion,
+          activePlanShellPolicyVersion,
+          activePlanShellEnvironmentDigest,
+          activePlanToolProfileDigest,
+          activePlanGitPolicyVersion,
+          activePlanGitPolicyDigest,
+          activePlanEligibleToolProfile,
+        })
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      if (
         state.call.name === "read_skill_resource" &&
         event.type === "tool_completed" &&
         !committedSkillResourceReads.has(event.callId)
@@ -1466,6 +1578,20 @@ export function validateCurrentSessionHistory(
         }
         state.requested = true;
       } else if (event.type === "tool_permission_requested") {
+        const isPlanReassessment =
+          state.started === false &&
+          state.decision === "allow" &&
+          (state.permissionRequestId === undefined ||
+            state.permissionRequestId === event.requestId) &&
+          state.permissionSubject?.type === "plan_command" &&
+          state.permissionSubject.assessment.disposition !== "deny_mutation" &&
+          event.subject?.type === "plan_command" &&
+          event.subject.assessment.disposition === "ask_ambiguous" &&
+          !isDeepStrictEqual(state.permissionSubject, event.subject);
+        if (isPlanReassessment) {
+          delete state.decision;
+          delete state.permissionSubject;
+        }
         if (
           !state.requested ||
           state.started ||
@@ -1476,6 +1602,9 @@ export function validateCurrentSessionHistory(
         }
         validatePermissionEffect(state, event.effect);
         state.permissionRequestId ??= event.requestId;
+        if (event.subject !== undefined) {
+          state.permissionSubject = event.subject;
+        }
       } else if (event.type === "tool_permission_decided") {
         if (
           !state.requested ||
@@ -1488,6 +1617,15 @@ export function validateCurrentSessionHistory(
           throw new SessionLifecycleError("session_invalid");
         }
         validatePermissionEffect(state, event.effect);
+        if (
+          state.permissionSubject !== undefined &&
+          !isDeepStrictEqual(state.permissionSubject, event.subject)
+        ) {
+          throw new SessionLifecycleError("session_invalid");
+        }
+        if (event.subject !== undefined) {
+          state.permissionSubject = event.subject;
+        }
         state.decision = event.decision;
       } else if (event.type === "tool_started") {
         if (!state.requested || state.started || state.decision !== "allow") {
@@ -1514,6 +1652,40 @@ export function validateCurrentSessionHistory(
     throw new SessionLifecycleError("session_invalid");
   }
   validateContextCompactionHistory(genesis, currentRecords);
+}
+
+function isExactGitVersionArguments(argumentsJson: string): boolean {
+  try {
+    const parsed = JSON.parse(argumentsJson) as unknown;
+    return (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      !Array.isArray(parsed) &&
+      (parsed as { readonly command?: unknown }).command === "git --version"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isExactGitVersionOutput(output: unknown): boolean {
+  if (typeof output !== "object" || output === null || Array.isArray(output)) {
+    return false;
+  }
+  const value = output as {
+    readonly termination?: unknown;
+    readonly stdout?: unknown;
+    readonly stderr?: unknown;
+  };
+  return (
+    isDeepStrictEqual(value.termination, { type: "exited", exitCode: 0 }) &&
+    isDeepStrictEqual(value.stdout, {
+      tail: "git version 2.43.0\n",
+      totalBytes: 19,
+      omittedBytes: 0,
+    }) &&
+    isDeepStrictEqual(value.stderr, { tail: "", totalBytes: 0, omittedBytes: 0 })
+  );
 }
 
 function isContextTerminalFailure(
@@ -1833,6 +2005,132 @@ function validateCompletedResponse(record: SessionModelResponseCompletedRecord["
       throw new SessionLifecycleError("session_invalid");
     }
     callIds.add(call.id);
+  }
+}
+
+function isValidPlanPermissionEvent(input: {
+  readonly event: Extract<
+    RuntimeEvent,
+    { readonly type: "tool_permission_requested" | "tool_permission_decided" }
+  >;
+  readonly runId: string;
+  readonly state: ValidatedToolState;
+  readonly activePlanCycleId: string | undefined;
+  readonly activePlanPolicyVersion: "plan-policy.read-v1" | "plan-policy.hybrid-v1" | undefined;
+  readonly activePlanShellPolicyVersion: "plan-shell-policy.v1" | undefined;
+  readonly activePlanShellEnvironmentDigest: string | undefined;
+  readonly activePlanToolProfileDigest: string | undefined;
+  readonly activePlanGitPolicyVersion: "git-auto-policy.v1" | undefined;
+  readonly activePlanGitPolicyDigest: string | undefined;
+  readonly activePlanEligibleToolProfile: PlanEligibleToolProfileV1 | undefined;
+}): boolean {
+  if (input.activePlanCycleId === undefined) {
+    return input.event.subject?.type !== "plan_command";
+  }
+  const subject = input.event.subject;
+  const eligibleDefinition = input.activePlanEligibleToolProfile?.definitions.find(
+    (definition) => definition.name === input.state.call.name,
+  );
+  const hasExactEligibleDefinition =
+    eligibleDefinition !== undefined &&
+    eligibleDefinition.effect === input.state.intent.effect &&
+    eligibleDefinition.definitionDigest === input.state.intent.definitionDigest;
+  if (
+    input.activePlanPolicyVersion === "plan-policy.hybrid-v1" &&
+    input.state.call.name === "run_shell"
+  ) {
+    if (
+      !hasExactEligibleDefinition ||
+      eligibleDefinition.source !== "builtin" ||
+      subject?.type !== "plan_command" ||
+      input.event.effect !== "execute" ||
+      input.event.scope !== "call" ||
+      subject.command !== exactRunShellCommand(input.state.call.argumentsJson) ||
+      subject.cwd !== "." ||
+      subject.planCycleId !== input.activePlanCycleId ||
+      subject.planPolicyVersion !== input.activePlanPolicyVersion ||
+      subject.shellPolicyVersion !== input.activePlanShellPolicyVersion ||
+      subject.shellEnvironmentVersion !== "plan-shell-env.v1" ||
+      subject.shellEnvironmentDigest !== input.activePlanShellEnvironmentDigest ||
+      subject.toolProfileDigest !== input.activePlanToolProfileDigest ||
+      subject.gitPolicyVersion !== input.activePlanGitPolicyVersion ||
+      subject.gitPolicyDigest !== input.activePlanGitPolicyDigest
+    ) {
+      return false;
+    }
+    const rawAssessment = assessPlanCommandV1(subject.command);
+    if (
+      rawAssessment.status !== "assessed" ||
+      (subject.assessment.disposition === "allow_inspection" &&
+        rawAssessment.disposition !== "allow_inspection") ||
+      (subject.assessment.disposition === "deny_mutation" &&
+        rawAssessment.disposition !== "deny_mutation") ||
+      (subject.assessment.disposition === "ask_ambiguous" &&
+        rawAssessment.disposition === "deny_mutation")
+    ) {
+      return false;
+    }
+    if (subject.assessment.disposition === "ask_ambiguous") {
+      return input.event.requestId !== undefined;
+    }
+    if (input.event.type === "tool_permission_requested" || input.event.requestId !== undefined) {
+      return false;
+    }
+    return subject.assessment.disposition === "allow_inspection"
+      ? input.event.decision === "allow"
+      : input.event.decision === "deny";
+  }
+  if (subject?.type === "plan_command") {
+    return false;
+  }
+  if (!hasExactEligibleDefinition) {
+    return (
+      input.event.type === "tool_permission_decided" &&
+      input.event.requestId === undefined &&
+      input.event.decision === "deny"
+    );
+  }
+  if (
+    input.activePlanPolicyVersion === "plan-policy.hybrid-v1" &&
+    eligibleDefinition.source === "mcp" &&
+    (input.state.intent.effect === "execute" || input.state.intent.effect === "network")
+  ) {
+    return isExactPlanMcpPermissionEventV1({
+      event: input.event,
+      runId: input.runId,
+      callId: input.state.call.id,
+      callName: input.state.call.name,
+      argumentsJson: input.state.call.argumentsJson,
+      effect: input.state.intent.effect,
+      definitionDigest: input.state.intent.definitionDigest,
+      eligibleDefinition,
+    });
+  }
+  if (input.state.intent.effect === "read") {
+    return (
+      input.event.type === "tool_permission_decided" &&
+      input.event.requestId === undefined &&
+      input.event.decision === "allow"
+    );
+  }
+  return true;
+}
+
+function exactRunShellCommand(argumentsJson: string): string | undefined {
+  try {
+    const parsed = JSON.parse(argumentsJson) as unknown;
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed) ||
+      Object.keys(parsed).length !== 1
+    ) {
+      return undefined;
+    }
+    const command = (parsed as { readonly command?: unknown }).command;
+    return typeof command === "string" ? command : undefined;
+  } catch {
+    return undefined;
   }
 }
 

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -69,7 +69,16 @@ import {
   modelTargetUsesContextProfile,
   sameModelTargetIdentity,
 } from "./model-targets.js";
-import { createReadOnlyPlanToolProfileV1, type PlanEligibleToolProfileV1 } from "./plan-mode.js";
+import { planGitAutomaticPolicyV1 } from "./plan-git-policy.js";
+import {
+  createPlanToolProfileV1,
+  type PlanEligibleToolProfileV1,
+  type PlanPolicyVersion,
+} from "./plan-mode.js";
+import {
+  createPlanShellEnvironmentV1,
+  type PlanShellEnvironmentV1,
+} from "./plan-shell-environment.js";
 import {
   createProjectLifecycleOwner,
   type ProjectLifecycleOwner,
@@ -244,6 +253,13 @@ export type SessionLogicalRunStartedBarrier = {
 /** Tests only. Production lifecycle instances always default automatic titles on. */
 export const sessionAutomaticTitlesEnabled = Symbol("adam-agent.session-automatic-titles-enabled");
 
+/** Tests only. Production Plan entry captures the live shell environment. */
+export const planShellEnvironmentFactory = Symbol("adam-agent.plan-shell-environment-factory");
+
+export type PlanShellEnvironmentFactory = () =>
+  | PlanShellEnvironmentV1
+  | Promise<PlanShellEnvironmentV1>;
+
 /** Tests only. Production lifecycle instances use the OS-backed project owner. */
 export const sessionProjectLifecycleOwner = Symbol("adam-agent.session-project-lifecycle-owner");
 
@@ -311,6 +327,7 @@ export type SessionLifecycleOptions = {
   readonly [sessionTitleDeadlineScheduler]?: SessionTitleDeadlineScheduler;
   readonly [sessionLogicalRunStartedBarrier]?: SessionLogicalRunStartedBarrier;
   readonly [sessionAutomaticTitlesEnabled]?: boolean;
+  readonly [planShellEnvironmentFactory]?: PlanShellEnvironmentFactory;
   readonly [sessionCloseDrainBarrier]?: SessionCloseDrainBarrier;
   readonly [sessionProjectLifecycleOwner]?: ProjectLifecycleOwner;
   readonly [sessionStoreDirectory]?: SessionStoreDirectory<SessionRecord>;
@@ -2241,6 +2258,21 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
               cycleId: parentPlan.cycleId,
               revision: parentPlan.revision,
               policyVersion: parentPlan.policyVersion,
+              ...(parentPlan.shellPolicyVersion === undefined
+                ? {}
+                : { shellPolicyVersion: parentPlan.shellPolicyVersion }),
+              ...(parentPlan.shellEnvironment === undefined
+                ? {}
+                : { shellEnvironment: parentPlan.shellEnvironment }),
+              ...(parentPlan.gitPolicyVersion === undefined
+                ? {}
+                : { gitPolicyVersion: parentPlan.gitPolicyVersion }),
+              ...(parentPlan.gitPolicyDigest === undefined
+                ? {}
+                : { gitPolicyDigest: parentPlan.gitPolicyDigest }),
+              ...(parentPlan.gitAttestation === undefined
+                ? {}
+                : { gitAttestation: parentPlan.gitAttestation }),
               eligibleToolProfile: parentPlan.eligibleToolProfile,
               source: { sessionId: sourceSessionId, throughSequence: sourceEventPosition },
             },
@@ -4232,7 +4264,14 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           throw new SessionLifecycleError("session_plan_unavailable");
         }
         const records = await readSessionRecords(options, input.sessionId);
-        const eligibleToolProfile = readOnlyPlanToolProfile(inspected, options.tools);
+        const eligibleToolProfile = planToolProfile(
+          inspected,
+          options.tools,
+          "plan-policy.hybrid-v1",
+        );
+        const shellEnvironment = await (
+          options[planShellEnvironmentFactory] ?? createPlanShellEnvironmentV1
+        )();
         const store = await openSessionStore(options, input.sessionId);
         await store.append({
           schemaVersion: 3,
@@ -4242,7 +4281,11 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             recordVersion: 1,
             cycleId: randomUUID(),
             revision: 1,
-            policyVersion: "plan-policy.read-v1",
+            policyVersion: "plan-policy.hybrid-v1",
+            shellPolicyVersion: "plan-shell-policy.v1",
+            shellEnvironment,
+            gitPolicyVersion: planGitAutomaticPolicyV1.version,
+            gitPolicyDigest: planGitAutomaticPolicyV1.digest,
             eligibleToolProfile,
           },
         });
@@ -5728,8 +5771,7 @@ function createAgentResumeState(
             candidate.record.runId === runId &&
             candidate.record.event.type === "tool_permission_decided" &&
             candidate.record.event.callId === call.id &&
-            candidate.record.event.name === call.name &&
-            candidate.record.event.decision === "allow",
+            candidate.record.event.name === call.name,
         );
         const permissionEvent =
           permission?.record.type === "runtime_event" &&
@@ -5780,6 +5822,7 @@ function createAgentResumeState(
         const reusablePermission =
           repositoryTrigger === undefined &&
           exactIntent &&
+          permissionEvent?.decision === "allow" &&
           permissionEvent?.effect !== undefined &&
           permissionEvent.scope === "call" &&
           permissionEvent.subject !== undefined
@@ -5807,46 +5850,57 @@ function createAgentResumeState(
             candidate.record.callId === call.id,
         );
         const replayResult =
-          committedSkillResource?.record.type === "skill_resource_read_committed"
+          permissionEvent?.decision === "deny"
             ? {
-                status: "completed" as const,
-                output: {
-                  qualifiedId: committedSkillResource.record.qualifiedId,
-                  activationIndex: committedSkillResource.record.activationIndex,
-                  catalogRevision: committedSkillResource.record.catalogRevision,
-                  manifestRevision: committedSkillResource.record.manifestRevision,
-                  path: committedSkillResource.record.path,
-                  offset: committedSkillResource.record.offset,
-                  byteCount: committedSkillResource.record.byteCount,
-                  totalByteCount: committedSkillResource.record.totalByteCount,
-                  eof: committedSkillResource.record.eof,
-                  fileDigest: committedSkillResource.record.fileDigest,
-                  pageDigest: committedSkillResource.record.pageDigest,
-                  content: committedSkillResource.record.content,
-                  ...(committedSkillResource.record.executionToken === undefined
-                    ? {}
-                    : { executionToken: committedSkillResource.record.executionToken }),
+                status: "failed" as const,
+                error: {
+                  code: "permission_denied" as const,
+                  message:
+                    snapshot.plan !== undefined && permissionEvent.requestId === undefined
+                      ? `Permission denied for tool in Plan: ${call.name}`
+                      : `Permission denied for tool: ${call.name}`,
                 },
               }
-            : committedInputResource?.record.type === "input_resource_read_committed"
+            : committedSkillResource?.record.type === "skill_resource_read_committed"
               ? {
                   status: "completed" as const,
                   output: {
-                    occurrenceId: committedInputResource.record.occurrenceId,
-                    displayName: committedInputResource.record.displayName,
-                    offset: committedInputResource.record.offset,
-                    byteCount: committedInputResource.record.byteCount,
-                    totalByteCount: committedInputResource.record.totalByteCount,
-                    eof: committedInputResource.record.eof,
-                    nextCursor: committedInputResource.record.nextCursor,
-                    digest: committedInputResource.record.digest,
-                    pageDigest: committedInputResource.record.pageDigest,
-                    content: committedInputResource.record.content,
+                    qualifiedId: committedSkillResource.record.qualifiedId,
+                    activationIndex: committedSkillResource.record.activationIndex,
+                    catalogRevision: committedSkillResource.record.catalogRevision,
+                    manifestRevision: committedSkillResource.record.manifestRevision,
+                    path: committedSkillResource.record.path,
+                    offset: committedSkillResource.record.offset,
+                    byteCount: committedSkillResource.record.byteCount,
+                    totalByteCount: committedSkillResource.record.totalByteCount,
+                    eof: committedSkillResource.record.eof,
+                    fileDigest: committedSkillResource.record.fileDigest,
+                    pageDigest: committedSkillResource.record.pageDigest,
+                    content: committedSkillResource.record.content,
+                    ...(committedSkillResource.record.executionToken === undefined
+                      ? {}
+                      : { executionToken: committedSkillResource.record.executionToken }),
                   },
                 }
-              : committedInputResource?.record.type === "input_resource_image_read_committed"
-                ? { status: "completed" as const, output: committedInputResource.record.image }
-                : undefined;
+              : committedInputResource?.record.type === "input_resource_read_committed"
+                ? {
+                    status: "completed" as const,
+                    output: {
+                      occurrenceId: committedInputResource.record.occurrenceId,
+                      displayName: committedInputResource.record.displayName,
+                      offset: committedInputResource.record.offset,
+                      byteCount: committedInputResource.record.byteCount,
+                      totalByteCount: committedInputResource.record.totalByteCount,
+                      eof: committedInputResource.record.eof,
+                      nextCursor: committedInputResource.record.nextCursor,
+                      digest: committedInputResource.record.digest,
+                      pageDigest: committedInputResource.record.pageDigest,
+                      content: committedInputResource.record.content,
+                    },
+                  }
+                : committedInputResource?.record.type === "input_resource_image_read_committed"
+                  ? { status: "completed" as const, output: committedInputResource.record.image }
+                  : undefined;
         pendingToolCalls.push({
           call,
           requested,
@@ -6609,22 +6663,35 @@ async function openSessionStore(
   return store;
 }
 
-function readOnlyPlanToolProfile(
+function planToolProfile(
   snapshot: CurrentSessionSnapshot,
   tools: ToolRegistry | undefined,
+  policyVersion: PlanPolicyVersion,
 ): PlanEligibleToolProfileV1 {
   const source = snapshot.promptContext?.toolProfile;
   if (source === undefined || tools === undefined) {
     throw new SessionLifecycleError("session_invalid");
   }
-  return readOnlyPlanToolProfileFromAuthority(
-    source,
-    tools,
-    snapshot.mcp?.workspaceConfirmed === true ? snapshot.mcp.profile : undefined,
-  );
+  const mcpSnapshot = snapshot.mcp?.workspaceConfirmed === true ? snapshot.mcp : undefined;
+  const mcpProfile =
+    mcpSnapshot?.profile === undefined
+      ? undefined
+      : {
+          ...mcpSnapshot.profile,
+          tools: mcpSnapshot.profile.tools.map((tool) => {
+            const server = mcpSnapshot.servers.find(
+              (candidate) => candidate.serverId === tool.serverId,
+            );
+            if (server === undefined) {
+              throw new SessionLifecycleError("session_invalid");
+            }
+            return { ...tool, serverDefinitionDigest: server.definitionDigest };
+          }),
+        };
+  return planToolProfileFromAuthority(source, tools, mcpProfile, policyVersion);
 }
 
-function readOnlyPlanToolProfileFromAuthority(
+function planToolProfileFromAuthority(
   source: NonNullable<CurrentSessionSnapshot["promptContext"]>["toolProfile"],
   tools: ToolRegistry,
   mcpProfile:
@@ -6632,11 +6699,15 @@ function readOnlyPlanToolProfileFromAuthority(
         readonly digest: `sha256:${string}`;
         readonly tools: readonly {
           readonly qualifiedName: string;
+          readonly serverId: string;
+          readonly originalName: string;
+          readonly serverDefinitionDigest: `sha256:${string}`;
           readonly definitionDigest: `sha256:${string}`;
           readonly effect: ToolEffect;
         }[];
       }
     | undefined,
+  policyVersion: PlanPolicyVersion,
 ): PlanEligibleToolProfileV1 {
   const mcpTools = new Map(
     mcpProfile?.tools.map((tool) => [tool.qualifiedName, tool] as const) ?? [],
@@ -6645,12 +6716,25 @@ function readOnlyPlanToolProfileFromAuthority(
   for (const definition of source.definitions) {
     const mcp = mcpTools.get(definition.name);
     if (mcp !== undefined) {
-      if (mcp.effect === "read") {
+      if (
+        mcp.effect === "read" ||
+        (policyVersion === "plan-policy.hybrid-v1" &&
+          (mcp.effect === "execute" || mcp.effect === "network"))
+      ) {
         definitions.push({
           name: definition.name,
           definitionDigest: mcp.definitionDigest,
           effect: mcp.effect,
           source: "mcp",
+          ...(policyVersion === "plan-policy.hybrid-v1"
+            ? {
+                mcp: {
+                  serverId: mcp.serverId,
+                  originalName: mcp.originalName,
+                  serverDefinitionDigest: mcp.serverDefinitionDigest,
+                },
+              }
+            : {}),
         });
       }
       continue;
@@ -6659,7 +6743,12 @@ function readOnlyPlanToolProfileFromAuthority(
     if (adapter === undefined || !/^sha256:[0-9a-f]{64}$/u.test(adapter.definitionDigest)) {
       throw new SessionLifecycleError("session_invalid");
     }
-    if (adapter.effect === "read") {
+    if (
+      adapter.effect === "read" ||
+      (policyVersion === "plan-policy.hybrid-v1" &&
+        definition.name === "run_shell" &&
+        adapter.effect === "execute")
+    ) {
       definitions.push({
         name: definition.name,
         definitionDigest: adapter.definitionDigest as `sha256:${string}`,
@@ -6668,7 +6757,7 @@ function readOnlyPlanToolProfileFromAuthority(
       });
     }
   }
-  return createReadOnlyPlanToolProfileV1({
+  return createPlanToolProfileV1({
     source: { version: source.version, digest: source.digest },
     definitions,
   });
@@ -6705,10 +6794,11 @@ async function validatePlanToolProfilesFromLineage(
     ) {
       throw new SessionLifecycleError("session_invalid");
     }
-    const expected = readOnlyPlanToolProfileFromAuthority(
+    const expected = planToolProfileFromAuthority(
       promptContext.toolProfile,
       options.tools,
       mcpProfile,
+      entry.record.policyVersion,
     );
     if (!isDeepStrictEqual(entry.record.eligibleToolProfile, expected)) {
       throw new SessionLifecycleError("session_invalid");

--- a/packages/agent/src/session-lineage.ts
+++ b/packages/agent/src/session-lineage.ts
@@ -128,6 +128,21 @@ export function createSessionLineageTraversal(input: {
           cycleId: actual.record.cycleId,
           revision: actual.record.revision,
           policyVersion: actual.record.policyVersion,
+          ...(actual.record.shellPolicyVersion === undefined
+            ? {}
+            : { shellPolicyVersion: actual.record.shellPolicyVersion }),
+          ...(actual.record.shellEnvironment === undefined
+            ? {}
+            : { shellEnvironment: actual.record.shellEnvironment }),
+          ...(actual.record.gitPolicyVersion === undefined
+            ? {}
+            : { gitPolicyVersion: actual.record.gitPolicyVersion }),
+          ...(actual.record.gitPolicyDigest === undefined
+            ? {}
+            : { gitPolicyDigest: actual.record.gitPolicyDigest }),
+          ...(actual.record.gitAttestation === undefined
+            ? {}
+            : { gitAttestation: actual.record.gitAttestation }),
           eligibleToolProfile: actual.record.eligibleToolProfile,
         },
         expected,

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -19,7 +19,10 @@ import type { McpToolProfileV1 } from "./mcp-profile-contracts.js";
 import { modelDriverErrorCategories } from "./model-driver-error.js";
 import type { ModelTargetIdentity } from "./model-targets.js";
 import { imageInputLimitsV1, type ProjectedContentUsageV1 } from "./model-user-content.js";
+import type { PlanShellPolicyVersion } from "./plan-command-assessment.js";
+import type { PlanGitAttestationV1 } from "./plan-git-policy.js";
 import type { PlanEligibleToolProfileV1, PlanPolicyVersion } from "./plan-mode.js";
+import type { PlanShellEnvironmentV1 } from "./plan-shell-environment.js";
 import {
   type PromptContextRecord,
   type PromptContextRecordV1,
@@ -43,7 +46,7 @@ export type CanonicalRuntimeEvent = Exclude<
 
 type V1PermissionSubject = Exclude<
   PermissionSubject,
-  { readonly type: "extension_capability" | "mcp_tool" | "patch" | "skill" }
+  { readonly type: "extension_capability" | "mcp_tool" | "patch" | "plan_command" | "skill" }
 >;
 type V1ToolError = {
   readonly code:
@@ -304,7 +307,24 @@ export type SessionPlanCycleEnteredRecord = {
     readonly cycleId: string;
     readonly revision: 1;
     readonly policyVersion: PlanPolicyVersion;
+    readonly shellPolicyVersion?: PlanShellPolicyVersion;
+    readonly shellEnvironment?: PlanShellEnvironmentV1;
+    readonly gitPolicyVersion?: "git-auto-policy.v1";
+    readonly gitPolicyDigest?: `sha256:${string}`;
     readonly eligibleToolProfile: PlanEligibleToolProfileV1;
+  };
+};
+
+export type SessionPlanGitAttestedRecord = {
+  readonly schemaVersion: 3;
+  readonly sequence: number;
+  readonly record: {
+    readonly type: "plan_git_attested";
+    readonly recordVersion: 1;
+    readonly cycleId: string;
+    readonly runId: string;
+    readonly callId: string;
+    readonly attestation: PlanGitAttestationV1;
   };
 };
 
@@ -329,6 +349,11 @@ export type SessionPlanCycleInheritedRecord = {
     readonly cycleId: string;
     readonly revision: number;
     readonly policyVersion: PlanPolicyVersion;
+    readonly shellPolicyVersion?: PlanShellPolicyVersion;
+    readonly shellEnvironment?: PlanShellEnvironmentV1;
+    readonly gitPolicyVersion?: "git-auto-policy.v1";
+    readonly gitPolicyDigest?: `sha256:${string}`;
+    readonly gitAttestation?: PlanGitAttestationV1;
     readonly eligibleToolProfile: PlanEligibleToolProfileV1;
     readonly source: {
       readonly sessionId: string;
@@ -847,6 +872,7 @@ export type SessionV3Record =
   | SessionPlanCycleEnteredRecord
   | SessionPlanCycleExitedRecord
   | SessionPlanCycleInheritedRecord
+  | SessionPlanGitAttestedRecord
   | SessionManualNameSetRecord
   | SessionManualNameClearedRecord
   | SessionTitleGenerationStartedRecord
@@ -1241,6 +1267,56 @@ const inputResourcePermissionSubjectSchema = z.strictObject({
   type: z.literal("input_resource"),
   occurrenceId: z.string().min(1).max(256),
 });
+const planCommandPermissionSubjectSchema = z.strictObject({
+  type: z.literal("plan_command"),
+  command: z
+    .string()
+    .min(1)
+    .max(16 * 1024),
+  cwd: z.literal("."),
+  planCycleId: z.uuid(),
+  planPolicyVersion: z.literal("plan-policy.hybrid-v1"),
+  shellPolicyVersion: z.literal("plan-shell-policy.v1"),
+  shellEnvironmentVersion: z.literal("plan-shell-env.v1"),
+  shellEnvironmentDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+  toolProfileDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+  gitPolicyVersion: z.literal("git-auto-policy.v1"),
+  gitPolicyDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+  assessment: z.strictObject({
+    version: z.literal(1),
+    disposition: z.enum(["allow_inspection", "ask_ambiguous", "deny_mutation"]),
+    reasons: z
+      .array(
+        z.enum([
+          "automatic_system_inspection",
+          "automatic_git_inspection",
+          "automatic_workspace_inspection",
+          "command_too_large",
+          "environment_untrusted",
+          "executable_untrusted",
+          "git_attestation_required",
+          "git_repository_untrusted",
+          "in_place_mutation",
+          "invalid_unicode",
+          "malformed_command",
+          "output_redirection",
+          "path_untrusted",
+          "recognized_mutation",
+          "shell_builtin_or_indirection",
+          "token_too_large",
+          "too_many_arguments",
+          "too_many_paths",
+          "too_many_segments",
+          "unclassified_command",
+          "unsupported_control",
+          "unsupported_syntax",
+        ]),
+      )
+      .min(1)
+      .max(32),
+    digest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+  }),
+});
 const currentPermissionSubjectSchema = z.discriminatedUnion("type", [
   z.strictObject({ type: z.literal("file"), path: z.string() }),
   z.strictObject({ type: z.literal("workspace_path"), path: z.string() }),
@@ -1249,6 +1325,7 @@ const currentPermissionSubjectSchema = z.discriminatedUnion("type", [
   skillPermissionSubjectSchema,
   mcpPermissionSubjectSchema,
   inputResourcePermissionSubjectSchema,
+  planCommandPermissionSubjectSchema,
   z.strictObject({
     type: z.literal("command"),
     command: z.string(),
@@ -1658,10 +1735,68 @@ const planEligibleToolProfileV1Schema: z.ZodType<PlanEligibleToolProfileV1> = z.
         definitionDigest: sha256DigestSchema,
         effect: z.enum(["read", "write", "execute", "network", "delegate", "administrative"]),
         source: z.enum(["builtin", "mcp"]),
+        mcp: z
+          .strictObject({
+            serverId: z.string().min(1).max(128),
+            originalName: z.string().min(1).max(256),
+            serverDefinitionDigest: sha256DigestSchema,
+          })
+          .optional(),
       }),
     )
     .min(1)
     .max(64),
+  digest: sha256DigestSchema,
+});
+const planShellFileIdentityV1Schema = z.strictObject({
+  lookupPath: z.string().startsWith("/"),
+  canonicalPath: z.string().startsWith("/"),
+  device: z.string().regex(/^\d+$/u),
+  inode: z.string().regex(/^\d+$/u),
+  mode: z.number().int().nonnegative(),
+  size: z
+    .number()
+    .int()
+    .nonnegative()
+    .max(8 * 1024 * 1024),
+  modifiedMilliseconds: z.number().nonnegative(),
+  digest: sha256DigestSchema,
+});
+const planShellEnvironmentV1Schema: z.ZodType<PlanShellEnvironmentV1> = z
+  .strictObject({
+    version: z.literal("plan-shell-env.v1"),
+    pathEntries: z
+      .array(
+        z
+          .string()
+          .max(4_096)
+          .refine((entry) => !entry.includes("\0")),
+      )
+      .min(1)
+      .max(128),
+    variables: z.strictObject({
+      PATH: z.string().max(16_384),
+      LANG: z.literal("C"),
+      LC_ALL: z.literal("C"),
+      TERM: z.literal("dumb"),
+      TMPDIR: z.string().startsWith("/"),
+    }),
+    home: z.strictObject({ allocation: z.literal("owner-only-empty-per-call") }),
+    shell: z.union([
+      planShellFileIdentityV1Schema.extend({ lookupPath: z.literal("/bin/sh") }),
+      z.strictObject({ status: z.literal("unavailable"), lookupPath: z.literal("/bin/sh") }),
+    ]),
+    digest: sha256DigestSchema,
+  })
+  .refine((environment) => environment.variables.PATH === environment.pathEntries.join(":"));
+const planGitAttestationV1Schema: z.ZodType<PlanGitAttestationV1> = z.strictObject({
+  version: z.literal("git-auto-attestation.v1"),
+  gitVersion: z.literal("git version 2.43.0"),
+  executable: planShellFileIdentityV1Schema,
+  shellEnvironmentDigest: sha256DigestSchema,
+  gitEnvironmentDigest: sha256DigestSchema,
+  gitPolicyVersion: z.literal("git-auto-policy.v1"),
+  gitPolicyDigest: sha256DigestSchema,
   digest: sha256DigestSchema,
 });
 const sessionV3RecordSchema = z.union([
@@ -1869,13 +2004,37 @@ const sessionV3RecordSchema = z.union([
       .max(inputResourceLimitsV1.maximumOccurrencesPerRun)
       .optional(),
   }),
+  z
+    .strictObject({
+      type: z.literal("plan_cycle_entered"),
+      recordVersion: z.literal(1),
+      cycleId: z.uuid(),
+      revision: z.literal(1),
+      policyVersion: z.enum(["plan-policy.read-v1", "plan-policy.hybrid-v1"]),
+      shellPolicyVersion: z.literal("plan-shell-policy.v1").optional(),
+      shellEnvironment: planShellEnvironmentV1Schema.optional(),
+      gitPolicyVersion: z.literal("git-auto-policy.v1").optional(),
+      gitPolicyDigest: sha256DigestSchema.optional(),
+      eligibleToolProfile: planEligibleToolProfileV1Schema,
+    })
+    .refine(
+      (record) =>
+        (record.policyVersion === "plan-policy.hybrid-v1") ===
+          (record.shellPolicyVersion === "plan-shell-policy.v1") &&
+        (record.policyVersion === "plan-policy.hybrid-v1") ===
+          (record.shellEnvironment?.version === "plan-shell-env.v1") &&
+        (record.policyVersion === "plan-policy.hybrid-v1") ===
+          (record.gitPolicyVersion === "git-auto-policy.v1") &&
+        (record.policyVersion === "plan-policy.hybrid-v1") ===
+          (record.gitPolicyDigest !== undefined),
+    ),
   z.strictObject({
-    type: z.literal("plan_cycle_entered"),
+    type: z.literal("plan_git_attested"),
     recordVersion: z.literal(1),
     cycleId: z.uuid(),
-    revision: z.literal(1),
-    policyVersion: z.literal("plan-policy.read-v1"),
-    eligibleToolProfile: planEligibleToolProfileV1Schema,
+    runId: z.uuid(),
+    callId: z.string().min(1).max(256),
+    attestation: planGitAttestationV1Schema,
   }),
   z.strictObject({
     type: z.literal("plan_cycle_exited"),
@@ -1884,18 +2043,39 @@ const sessionV3RecordSchema = z.union([
     revision: z.number().int().positive(),
     reason: z.literal("user_cancelled"),
   }),
-  z.strictObject({
-    type: z.literal("plan_cycle_inherited"),
-    recordVersion: z.literal(1),
-    cycleId: z.uuid(),
-    revision: z.number().int().positive(),
-    policyVersion: z.literal("plan-policy.read-v1"),
-    eligibleToolProfile: planEligibleToolProfileV1Schema,
-    source: z.strictObject({
-      sessionId: z.uuid(),
-      throughSequence: z.number().int().positive(),
-    }),
-  }),
+  z
+    .strictObject({
+      type: z.literal("plan_cycle_inherited"),
+      recordVersion: z.literal(1),
+      cycleId: z.uuid(),
+      revision: z.number().int().positive(),
+      policyVersion: z.enum(["plan-policy.read-v1", "plan-policy.hybrid-v1"]),
+      shellPolicyVersion: z.literal("plan-shell-policy.v1").optional(),
+      shellEnvironment: planShellEnvironmentV1Schema.optional(),
+      gitPolicyVersion: z.literal("git-auto-policy.v1").optional(),
+      gitPolicyDigest: sha256DigestSchema.optional(),
+      gitAttestation: planGitAttestationV1Schema.optional(),
+      eligibleToolProfile: planEligibleToolProfileV1Schema,
+      source: z.strictObject({
+        sessionId: z.uuid(),
+        throughSequence: z.number().int().positive(),
+      }),
+    })
+    .refine(
+      (record) =>
+        (record.policyVersion === "plan-policy.hybrid-v1") ===
+          (record.shellPolicyVersion === "plan-shell-policy.v1") &&
+        (record.policyVersion === "plan-policy.hybrid-v1") ===
+          (record.shellEnvironment?.version === "plan-shell-env.v1") &&
+        (record.policyVersion === "plan-policy.hybrid-v1") ===
+          (record.gitPolicyVersion === "git-auto-policy.v1") &&
+        (record.policyVersion === "plan-policy.hybrid-v1") ===
+          (record.gitPolicyDigest !== undefined) &&
+        (record.gitAttestation === undefined ||
+          (record.gitAttestation.shellEnvironmentDigest === record.shellEnvironment?.digest &&
+            record.gitAttestation.gitPolicyVersion === record.gitPolicyVersion &&
+            record.gitAttestation.gitPolicyDigest === record.gitPolicyDigest)),
+    ),
   z.strictObject({
     type: z.literal("session_manual_name_set"),
     recordVersion: z.literal(1),

--- a/packages/agent/src/tool-runtime.ts
+++ b/packages/agent/src/tool-runtime.ts
@@ -1,7 +1,7 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
-import { type FileHandle, mkdir, mkdtemp, open, realpath, rm } from "node:fs/promises";
+import { chmod, type FileHandle, mkdir, mkdtemp, open, realpath, rm } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 
@@ -23,6 +23,14 @@ import {
   type PatchFileSystem,
   PatchTransactionError,
 } from "./patch-transaction.js";
+import {
+  isPlanAutomaticGitCommandV1,
+  type PlanCommandAssessment,
+  planCommandArgumentsV1,
+} from "./plan-command-assessment.js";
+import { isPlanCommandExecutionIdentityCurrentV1 } from "./plan-executable-policy.js";
+import { type PlanGitAttestationV1, planGitEnvironmentV1 } from "./plan-git-policy.js";
+import type { PlanShellEnvironmentV1 } from "./plan-shell-environment.js";
 import {
   createRepositorySearchToolAdapter,
   type RepositorySearchBackend,
@@ -205,6 +213,9 @@ type ToolExecutionContext = {
   readonly toolName: string;
   readonly sessionId: string;
   readonly toolProfileDigest: string;
+  readonly planShellEnvironment?: PlanShellEnvironmentV1;
+  readonly planCommandAssessment?: PlanCommandAssessment;
+  readonly planGitAttestation?: PlanGitAttestationV1;
 };
 
 class ToolExecutionError extends Error {
@@ -253,6 +264,25 @@ export type PermissionSubject =
       readonly type: "command";
       readonly command: string;
       readonly cwd: ".";
+    }
+  | {
+      readonly type: "plan_command";
+      readonly command: string;
+      readonly cwd: ".";
+      readonly planCycleId: string;
+      readonly planPolicyVersion: "plan-policy.hybrid-v1";
+      readonly shellPolicyVersion: "plan-shell-policy.v1";
+      readonly shellEnvironmentVersion: "plan-shell-env.v1";
+      readonly shellEnvironmentDigest: `sha256:${string}`;
+      readonly toolProfileDigest: `sha256:${string}`;
+      readonly gitPolicyVersion: "git-auto-policy.v1";
+      readonly gitPolicyDigest: `sha256:${string}`;
+      readonly assessment: {
+        readonly version: 1;
+        readonly disposition: "allow_inspection" | "ask_ambiguous" | "deny_mutation";
+        readonly reasons: readonly string[];
+        readonly digest: `sha256:${string}`;
+      };
     }
   | {
       readonly type: "skill";
@@ -814,6 +844,15 @@ function createCodingToolRegistryInternal(options: {
                 toolName: context.toolName,
                 artifactStore: options.artifactStore,
                 limits: shellLimits,
+                ...(context.planShellEnvironment === undefined
+                  ? {}
+                  : { planShellEnvironment: context.planShellEnvironment }),
+                ...(context.planCommandAssessment === undefined
+                  ? {}
+                  : { planCommandAssessment: context.planCommandAssessment }),
+                ...(context.planGitAttestation === undefined
+                  ? {}
+                  : { planGitAttestation: context.planGitAttestation }),
               }),
             );
           },
@@ -1107,16 +1146,52 @@ async function runShellCommand(options: {
   readonly toolName: string;
   readonly artifactStore: ArtifactStore | undefined;
   readonly limits: ShellRuntimeLimits;
+  readonly planShellEnvironment?: PlanShellEnvironmentV1;
+  readonly planCommandAssessment?: PlanCommandAssessment;
+  readonly planGitAttestation?: PlanGitAttestationV1;
 }): Promise<JsonValue> {
-  const isolatedHome = await mkdtemp(join(tmpdir(), "adam-agent-shell-home-"));
+  if (
+    options.planShellEnvironment !== undefined &&
+    "status" in options.planShellEnvironment.shell
+  ) {
+    throw new ToolExecutionError(
+      "shell_start_failed",
+      "The Plan shell was unavailable when this cycle captured its execution identity.",
+    );
+  }
+  if (
+    options.planShellEnvironment !== undefined &&
+    (options.planCommandAssessment === undefined ||
+      !(await isPlanCommandExecutionIdentityCurrentV1({
+        rawCommand: options.command,
+        assessment: options.planCommandAssessment,
+        shellEnvironment: options.planShellEnvironment,
+        workspaceRoot: options.workspaceRoot,
+        ...(options.planGitAttestation === undefined
+          ? {}
+          : { gitAttestation: options.planGitAttestation }),
+      })))
+  ) {
+    throw new ToolExecutionError(
+      "shell_start_failed",
+      "The frozen Plan shell execution identity changed before process start.",
+    );
+  }
+  const temporaryRoot = options.planShellEnvironment?.variables.TMPDIR ?? tmpdir();
+  const isolatedHome = await mkdtemp(join(temporaryRoot, "adam-agent-shell-home-"));
   try {
+    await chmod(isolatedHome, 0o700);
     const processOutput = await new Promise<ShellProcessOutput>((resolvePromise, rejectPromise) => {
       let child: ChildProcessWithoutNullStreams;
       try {
         child = spawn("/bin/sh", ["-c", options.command], {
           cwd: options.workspaceRoot,
           detached: true,
-          env: createShellEnvironment(isolatedHome),
+          env: createShellEnvironment(
+            isolatedHome,
+            options.planShellEnvironment,
+            isAutomaticGitCommand(options.command),
+          ),
           stdio: ["pipe", "pipe", "pipe"],
         });
         child.stdin.end();
@@ -1344,7 +1419,18 @@ type ShellProcessOutput = {
   readonly stderr: ShellStreamAccumulator;
 };
 
-function createShellEnvironment(isolatedHome: string): NodeJS.ProcessEnv {
+function createShellEnvironment(
+  isolatedHome: string,
+  planShellEnvironment?: PlanShellEnvironmentV1,
+  automaticGit = false,
+): NodeJS.ProcessEnv {
+  if (planShellEnvironment !== undefined) {
+    return {
+      HOME: isolatedHome,
+      ...planShellEnvironment.variables,
+      ...(automaticGit ? planGitEnvironmentV1.variables : {}),
+    };
+  }
   const { PATH: executablePath } = process.env;
   const environment: NodeJS.ProcessEnv = {
     HOME: isolatedHome,
@@ -1358,6 +1444,12 @@ function createShellEnvironment(isolatedHome: string): NodeJS.ProcessEnv {
     }
   }
   return environment;
+}
+
+function isAutomaticGitCommand(rawCommand: string): boolean {
+  return (
+    planCommandArgumentsV1(rawCommand)?.some((argv) => isPlanAutomaticGitCommandV1(argv)) === true
+  );
 }
 
 function signalProcessGroup(pid: number | undefined, signal: NodeJS.Signals): void {

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -377,7 +377,8 @@ export type ActiveSessionDisplay = {
     readonly state: "exploring";
     readonly cycleId: string;
     readonly revision: number;
-    readonly policyVersion: "plan-policy.read-v1";
+    readonly policyVersion: "plan-policy.read-v1" | "plan-policy.hybrid-v1";
+    readonly shellPolicyVersion?: "plan-shell-policy.v1";
     readonly eligibleToolProfile: {
       readonly version: 1;
       readonly source: { readonly version: 1; readonly digest: `sha256:${string}` };
@@ -663,6 +664,7 @@ export type PendingInteraction = {
   readonly callId: string;
   readonly effect: "read" | "write" | "execute" | "network" | "delegate" | "administrative";
   readonly subject: { readonly type: "path" | "command" | "generic"; readonly value: string };
+  readonly warning?: string;
   readonly canAllow: boolean;
   readonly changePreviewRef: ArtifactReference | null;
 };

--- a/packages/testkit/src/index.ts
+++ b/packages/testkit/src/index.ts
@@ -11,11 +11,13 @@ import {
 import {
   createInMemorySessionStoreDirectory,
   createTrustedWorkspaceTrustForTesting,
+  createUnavailablePlanShellEnvironmentV1,
   type McpClientTransport,
   type McpTransportFactory,
   type ProjectLifecycleOwner,
   ProjectLifecycleOwnerError,
   type ProjectLifecycleOwnerLease,
+  planShellEnvironmentFactory,
   type SessionRecord,
   type SessionStoreDirectory,
   sessionAutomaticTitlesEnabled,
@@ -319,6 +321,8 @@ export function createSessionLifecycleForTesting(
     workspaceTrust:
       options.workspaceTrust ?? createTrustedWorkspaceTrustForTesting(options.workspaceRoot),
     [sessionAutomaticTitlesEnabled]: false,
+    [planShellEnvironmentFactory]:
+      options[planShellEnvironmentFactory] ?? createUnavailablePlanShellEnvironmentV1,
   });
 }
 
@@ -343,6 +347,8 @@ export function createInMemorySessionLifecycleHarness(): {
         workspaceTrust:
           options.workspaceTrust ?? createTrustedWorkspaceTrustForTesting(options.workspaceRoot),
         [sessionAutomaticTitlesEnabled]: false,
+        [planShellEnvironmentFactory]:
+          options[planShellEnvironmentFactory] ?? createUnavailablePlanShellEnvironmentV1,
         [sessionProjectLifecycleOwner]: owner,
         [sessionStoreDirectory]: directory,
       });

--- a/packages/testkit/src/plan-command-assessment.test.ts
+++ b/packages/testkit/src/plan-command-assessment.test.ts
@@ -1,0 +1,555 @@
+import { assessPlanCommandV1 } from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+
+test("Plan command assessment decodes one quoted inspection argument", () => {
+  expect(assessPlanCommandV1("uname '-s'")).toMatchObject({
+    policyVersion: "plan-shell-policy.v1",
+    disposition: "allow_inspection",
+    reasons: ["automatic_system_inspection"],
+  });
+});
+
+test("Plan command assessment rejects input above the 16 KiB UTF-8 boundary", () => {
+  const boundary = [
+    "x".repeat(4_096),
+    "x".repeat(4_096),
+    "x".repeat(4_096),
+    "x".repeat(4_093),
+  ].join(" ");
+  expect(assessPlanCommandV1(boundary)).toMatchObject({
+    status: "assessed",
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1(`${boundary}x`)).toMatchObject({
+    status: "invalid",
+    reasons: ["command_too_large"],
+  });
+});
+
+test("Plan command assessment enforces segment, argv, token, and Unicode bounds", () => {
+  expect(assessPlanCommandV1(Array.from({ length: 32 }, () => "uname -s").join(";"))).toMatchObject(
+    {
+      status: "assessed",
+      disposition: "allow_inspection",
+    },
+  );
+  expect(assessPlanCommandV1(Array.from({ length: 33 }, () => "uname -s").join(";"))).toMatchObject(
+    {
+      status: "invalid",
+      reasons: ["too_many_segments"],
+    },
+  );
+  expect(
+    assessPlanCommandV1(["unknown", ...Array.from({ length: 127 }, () => "x")].join(" ")),
+  ).toMatchObject({
+    status: "assessed",
+    disposition: "ask_ambiguous",
+  });
+  expect(
+    assessPlanCommandV1(["unknown", ...Array.from({ length: 128 }, () => "x")].join(" ")),
+  ).toMatchObject({
+    status: "invalid",
+    reasons: ["too_many_arguments"],
+  });
+  expect(assessPlanCommandV1(`unknown ${"x".repeat(4 * 1024)}`)).toMatchObject({
+    status: "assessed",
+  });
+  expect(assessPlanCommandV1(`unknown ${"x".repeat(4 * 1024 + 1)}`)).toMatchObject({
+    status: "invalid",
+    reasons: ["token_too_large"],
+  });
+  expect(assessPlanCommandV1("uname \ud800")).toMatchObject({
+    status: "invalid",
+    reasons: ["invalid_unicode"],
+  });
+});
+
+test("Plan command assessment admits an exact two-segment inspection list", () => {
+  expect(assessPlanCommandV1("uname -s && uname '-s'")).toMatchObject({
+    status: "assessed",
+    disposition: "allow_inspection",
+    reasons: ["automatic_system_inspection"],
+  });
+});
+
+test("Plan command assessment hard-denies one output redirect", () => {
+  expect(assessPlanCommandV1("uname -s > system.txt")).toMatchObject({
+    status: "assessed",
+    disposition: "deny_mutation",
+    reasons: ["output_redirection"],
+  });
+});
+
+test("Plan command assessment hard-denies one in-place mutation flag", () => {
+  expect(assessPlanCommandV1("sed -i 's/before/after/' README.md")).toMatchObject({
+    status: "assessed",
+    disposition: "deny_mutation",
+    reasons: ["in_place_mutation"],
+  });
+});
+
+test("Plan command assessment rejects a multiline command before classification", () => {
+  expect(assessPlanCommandV1("uname -s\nuname -s")).toMatchObject({
+    status: "invalid",
+    reasons: ["unsupported_control"],
+  });
+});
+
+test("Plan command assessment separates malformed commands from unsupported shell syntax", () => {
+  for (const command of ["uname '", "uname \\", "uname -s &&", "uname -s;;uname -s"]) {
+    expect(assessPlanCommandV1(command), command).toMatchObject({
+      status: "invalid",
+      reasons: ["malformed_command"],
+    });
+  }
+  for (const command of [
+    "uname < input.txt",
+    "uname $HOME",
+    "uname $(date)",
+    "uname *",
+    "VALUE=x uname",
+    "uname &",
+    "(uname)",
+    "uname # comment",
+  ]) {
+    expect(assessPlanCommandV1(command), command).toMatchObject({
+      status: "assessed",
+      disposition: "ask_ambiguous",
+      reasons: ["unsupported_syntax"],
+    });
+  }
+});
+
+test("Plan command assessment enforces the exact system-observation family", () => {
+  for (const command of [
+    "uptime",
+    "hostname",
+    "uname",
+    "uname -a",
+    "uname -s",
+    "uname -r",
+    "uname -m",
+    "id -u",
+    "id -g",
+    "id -G",
+    "date",
+    "date -u",
+  ]) {
+    expect(assessPlanCommandV1(command), command).toMatchObject({
+      status: "assessed",
+      disposition: "allow_inspection",
+      reasons: ["automatic_system_inspection"],
+    });
+  }
+  for (const command of ["whoami", "id", "uname -n", "date +%s", "Hostname"]) {
+    expect(assessPlanCommandV1(command), command).toMatchObject({
+      status: "assessed",
+      disposition: "ask_ambiguous",
+    });
+  }
+});
+
+test("Plan command assessment enforces the exact version-observation family", () => {
+  for (const command of ["git --version", "rg --version", "node --version"]) {
+    expect(assessPlanCommandV1(command), command).toMatchObject({
+      status: "assessed",
+      disposition: "allow_inspection",
+    });
+  }
+  for (const command of ["git version", "rg -V", "node -v", "node --version extra"]) {
+    expect(assessPlanCommandV1(command), command).toMatchObject({
+      status: "assessed",
+      disposition: "ask_ambiguous",
+    });
+  }
+});
+
+test("Plan command assessment folds the frozen mutation corpus above ask and allow", () => {
+  for (const command of [
+    "rm -f result.txt",
+    "mkdir generated",
+    "mv before after",
+    "cp source target",
+    "chmod 755 script.sh",
+    "ln -s source target",
+    "truncate -s 0 output.log",
+    "tee output.txt",
+    "dd if=input of=output",
+    "git add README.md",
+    "git stage README.md",
+    "git push origin main",
+    "git diff --output=report.patch",
+    "git update-ref refs/heads/main HEAD",
+    "git hash-object -w README.md",
+    "git -c core.pager=cat add README.md",
+    "git --literal-pathspecs add README.md",
+    "git -P add README.md",
+    "git format-patch HEAD",
+    "npm install package",
+    "npm --silent install package",
+    "npm --ignore-scripts install package",
+    "npm --location=global install package",
+    "npm ci",
+    "npm rebuild package",
+    "npm dedupe",
+    "npm prune",
+    "pnpm add package",
+    "pnpm -w add package",
+    "pnpm --offline add package",
+    "pnpm -Cadam-agent install package",
+    "yarn",
+    "cargo --color always install crate",
+    "cargo +stable install crate",
+    "go get example.com/module",
+    "go -C . get example.com/module",
+    "sed --in-place=.bak -e s/a/b/ README.md",
+    "sed --in-plac=.bak -e s/a/b/ README.md",
+    "sed -ni s/a/b/ README.md",
+    "sed -Eni s/a/b/ README.md",
+    "perl -ni.bak -e s/a/b/ README.md",
+    "sort -ooutput README.md",
+    "sort -rooutput README.md",
+    "sort --out=output README.md",
+    "sort --o output README.md",
+    'touch "$HOME/forbidden"',
+    "uname -s && touch forbidden.txt",
+  ]) {
+    expect(assessPlanCommandV1(command), command).toMatchObject({
+      status: "assessed",
+      disposition: "deny_mutation",
+    });
+  }
+  expect(assessPlanCommandV1("uname -s && unknown --diagnose")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("uname -s | date -u")).toMatchObject({
+    disposition: "allow_inspection",
+  });
+});
+
+test("Plan command assessment hard-denies the frozen npm mutation aliases", () => {
+  for (const alias of [
+    "rb",
+    "ln",
+    "it",
+    "cit",
+    "clean-install",
+    "clean-install-test",
+    "ic",
+    "in",
+    "ins",
+    "inst",
+    "insta",
+    "instal",
+    "isnt",
+    "isnta",
+    "isntal",
+    "isntall",
+    "install-clean",
+    "isntall-clean",
+    "upgrade",
+    "udpate",
+    "sit",
+    "reb",
+    "publi",
+    "unpub",
+    "prun",
+    "install-cl",
+    "installTest",
+    "create",
+    "innit",
+  ]) {
+    expect(assessPlanCommandV1(`npm ${alias} package`), alias).toMatchObject({
+      status: "assessed",
+      disposition: "deny_mutation",
+    });
+  }
+  expect(assessPlanCommandV1("npm view isntall")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("npm verison patch")).toMatchObject({
+    disposition: "deny_mutation",
+  });
+  expect(assessPlanCommandV1("npm version")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("npm u package")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+});
+
+test("Plan command assessment classifies mutation only at command-specific positions", () => {
+  expect(
+    assessPlanCommandV1(
+      "git --no-pager diff --no-ext-diff --no-textconv --ignore-submodules=all -- add",
+    ),
+  ).toMatchObject({ disposition: "allow_inspection" });
+  expect(
+    assessPlanCommandV1(
+      "git --no-pager diff --no-ext-diff --no-textconv --ignore-submodules=all -- --output=report",
+    ),
+  ).toMatchObject({ disposition: "allow_inspection" });
+  expect(assessPlanCommandV1("find . -maxdepth 2 -type f -name -delete -print")).toMatchObject({
+    disposition: "allow_inspection",
+  });
+  expect(assessPlanCommandV1("npm view install")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("npm --timing view install")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("npm --user-agent install --version")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("npm --script-shell install --version")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("npm --unknown-option --user-agent install --version")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  for (const command of [
+    "npm --foreground-scripts reb package",
+    "npm --foreg reb package",
+    "npm --foreground-scripts false reb package",
+    "npm --yes false reb package",
+    "npm --color reb package",
+    "npm --colo reb package",
+    "npm --color always reb package",
+    "npm -silent reb package",
+    "npm -sil reb package",
+    "npm -g false publi package",
+    "npm -reg=install reb package",
+    "npm --user-agent=install reb package",
+    "npm --unknown-option=value reb package",
+    "npm --no-audit false install package",
+    "npm --unknown-option install --version",
+    "npm --unknown-option reb package",
+    "npm -dD reb package",
+    "npm -v false install package",
+    "npm -w view install package",
+    "npm -cn false install package",
+    "npm -ws false install package",
+    "npm -z reb package",
+    "npm -z false reb package",
+    "npm --depth -1 reb package",
+    "npm --access -x reb package",
+    "npm --yes null reb package",
+    "npm --silent=reb package",
+    "npm -silent=reb package",
+    "npm --no-replace-registry-host null reb package",
+    "npm --no-replace-registry-host public reb package",
+    "npm --local-address null reb package",
+  ]) {
+    expect(assessPlanCommandV1(command), command).toMatchObject({
+      disposition: "deny_mutation",
+    });
+  }
+  expect(assessPlanCommandV1("npm -reg install --version")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("npm --user-ag install --version")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("npm --silent false reb package")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("npm --no-audit false view install")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("npm -dD view reb")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  for (const command of [
+    "npm -v false view install",
+    "npm -w install view package",
+    "npm -cn false view install",
+    "npm -dq false install package",
+    "npm -Cw view install package",
+    "npm -wc view install package",
+    "npm --silent=false reb package",
+    "npm -silent=false reb package",
+    "npm --heading -- --long reb",
+    "npm --heading --- --long reb",
+    "npm -au=-- --long reb",
+    "npm --unknown-option=--- --long reb",
+    "npm --no-replace-registry-host reb package",
+    "npm --no-local-address null reb package",
+    "npm --local-address install --help",
+  ]) {
+    expect(assessPlanCommandV1(command), command).toMatchObject({
+      disposition: "ask_ambiguous",
+    });
+  }
+  expect(assessPlanCommandV1("git -c add status")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("npm --prefix install view package")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("npm --location install view package")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("cargo --color install metadata")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("go -C get env")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("sed -- --in-place=.bak")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("sed -e -i README.md")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("sed --expression=-i README.md")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("sed --express --in-place README.md")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("sort -k --output input")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("sort --key --output input")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("sort --random-source --out=input README.md")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1("sort -- --out=output")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+});
+
+test("Plan command assessment never treats a shell builtin, reserved word, or wrapper as external", () => {
+  for (const command of [
+    "pwd",
+    "echo value",
+    "printf value",
+    "test -f README.md",
+    "[ -f README.md ]",
+    "true",
+    "false",
+    "cd .",
+    "read value",
+    "export VALUE=x",
+    "! uname -s",
+    "command uname -s",
+    "builtin pwd",
+    "env uname -s",
+    "exec uname -s",
+    "xargs uname",
+  ]) {
+    expect(assessPlanCommandV1(command), command).toMatchObject({
+      status: "assessed",
+      disposition: "ask_ambiguous",
+      reasons: ["shell_builtin_or_indirection"],
+    });
+  }
+});
+
+test("Plan command assessment enforces exact workspace inspection and fallback families", () => {
+  for (const command of [
+    "ls",
+    "ls -1 -- .",
+    "ls -a README.md",
+    "stat -c '%f %s %Y' -- README.md",
+    "head -n 20 -- README.md",
+    "tail -n 200 -- README.md",
+    "wc -l -- README.md",
+    "rg --no-config --no-follow --line-number --fixed-strings -- needle .",
+    "rg --no-config --no-follow --line-number --fixed-strings --ignore-case -- needle packages",
+    "grep -nF -- needle README.md",
+    "grep -nF -i -- needle README.md",
+    "find . -maxdepth 2 -type f -name '*.ts' -print",
+  ]) {
+    expect(assessPlanCommandV1(command), command).toMatchObject({
+      status: "assessed",
+      disposition: "allow_inspection",
+      reasons: ["automatic_workspace_inspection"],
+    });
+  }
+  for (const command of [
+    "ls -l",
+    "stat README.md",
+    "head -n 0 -- README.md",
+    "tail -n 201 -- README.md",
+    "wc -L -- README.md",
+    "rg --no-config --line-number --fixed-strings -- needle .",
+    "grep -R needle .",
+    "find . -type f -print",
+  ]) {
+    expect(assessPlanCommandV1(command), command).toMatchObject({
+      status: "assessed",
+      disposition: "ask_ambiguous",
+    });
+  }
+});
+
+test("Plan command assessment enforces path operand count and byte bounds", () => {
+  expect(
+    assessPlanCommandV1(`ls -- ${Array.from({ length: 32 }, (_, index) => `p${index}`).join(" ")}`),
+  ).toMatchObject({ status: "assessed", disposition: "allow_inspection" });
+  expect(
+    assessPlanCommandV1(`ls -- ${Array.from({ length: 33 }, (_, index) => `p${index}`).join(" ")}`),
+  ).toMatchObject({ status: "invalid", reasons: ["too_many_paths"] });
+  expect(assessPlanCommandV1(`ls -- ${"x".repeat(4 * 1024 + 1)}`)).toMatchObject({
+    status: "invalid",
+    reasons: ["token_too_large"],
+  });
+});
+
+test("Plan command assessment enforces every mandatory automatic Git argv family", () => {
+  for (const command of [
+    "git --no-pager status --porcelain=v1 --untracked-files=normal --ignore-submodules=all",
+    "git --no-pager status --porcelain=v1 --untracked-files=normal --ignore-submodules=all --branch",
+    "git --no-pager rev-parse --show-toplevel",
+    "git --no-pager rev-parse --is-inside-work-tree",
+    "git --no-pager rev-parse --show-prefix",
+    "git --no-pager rev-parse --verify HEAD",
+    "git --no-pager log --oneline --decorate=no -n 20",
+    "git --no-pager diff --no-ext-diff --no-textconv --ignore-submodules=all",
+    "git --no-pager diff --no-ext-diff --no-textconv --ignore-submodules=all --name-only --cached -- README.md",
+    "git --no-pager show --no-ext-diff --no-textconv --ignore-submodules=all --stat HEAD",
+    `git --no-pager show --no-ext-diff --no-textconv --ignore-submodules=all --name-status ${"a".repeat(40)}`,
+  ]) {
+    expect(assessPlanCommandV1(command), command).toMatchObject({
+      status: "assessed",
+      disposition: "allow_inspection",
+      reasons: ["automatic_git_inspection"],
+    });
+  }
+});
+
+test("Plan command assessment admits grep without files only from an automatic pipeline", () => {
+  const rg = "rg --no-config --no-follow --line-number --fixed-strings -- needle .";
+  expect(assessPlanCommandV1(`${rg} | grep -nF -- needle`)).toMatchObject({
+    disposition: "allow_inspection",
+    reasons: ["automatic_workspace_inspection"],
+  });
+  expect(assessPlanCommandV1("grep -nF -- needle")).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+  expect(assessPlanCommandV1(`${rg} && grep -nF -- needle`)).toMatchObject({
+    disposition: "ask_ambiguous",
+  });
+});
+
+test("Plan command assessment keeps every mandatory Git family near miss ambiguous", () => {
+  for (const command of [
+    "git status",
+    "git --no-pager status --branch --porcelain=v1 --untracked-files=normal --ignore-submodules=all",
+    "git --no-pager rev-parse HEAD",
+    "git --no-pager log --oneline --decorate=no -n 0",
+    "git --no-pager log --oneline --decorate=short -n 20",
+    "git --no-pager diff --cached --no-ext-diff --no-textconv --ignore-submodules=all",
+    "git --no-pager diff --no-ext-diff --no-textconv --ignore-submodules=all HEAD",
+    "git --no-pager show --no-ext-diff --no-textconv --ignore-submodules=all --stat HEAD~1",
+    "git -C .. status",
+  ]) {
+    expect(assessPlanCommandV1(command), command).toMatchObject({
+      status: "assessed",
+      disposition: "ask_ambiguous",
+    });
+  }
+});

--- a/packages/testkit/src/plan-executable-policy.os.test.ts
+++ b/packages/testkit/src/plan-executable-policy.os.test.ts
@@ -1,0 +1,236 @@
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  assessPlanCommandExecutionV1,
+  createPlanGitAttestationV1,
+  createPlanShellEnvironmentV1,
+  resolvePlanTrustedExecutableV1,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+
+test("Plan executable policy rejects hostile Git config and symlink path operands", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-plan-executable-policy-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const outsidePath = join(testRoot, "outside.txt");
+  const executablePathName = "PATH";
+  const previousPath = process.env[executablePathName];
+  process.env[executablePathName] = "/usr/bin:/bin";
+  await mkdir(workspaceRoot);
+  await writeFile(outsidePath, "outside\n", "utf8");
+  await writeFile(join(workspaceRoot, "safeq"), "safe\n", "utf8");
+  await symlink(outsidePath, join(workspaceRoot, "linked.txt"));
+  await symlink(outsidePath, join(workspaceRoot, "safe\\q"));
+  await runGit(workspaceRoot, ["init"]);
+
+  try {
+    const shellEnvironment = await createPlanShellEnvironmentV1();
+    const gitExecutable = await resolvePlanTrustedExecutableV1({
+      commandName: "git",
+      shellEnvironment,
+      workspaceRoot,
+    });
+    if (gitExecutable === undefined) {
+      throw new Error("Expected the supported trusted Git executable.");
+    }
+    const gitAttestation = createPlanGitAttestationV1({
+      executable: gitExecutable,
+      shellEnvironmentDigest: shellEnvironment.digest,
+    });
+    const linkedPath = await assessPlanCommandExecutionV1({
+      rawCommand: "head -n 1 -- linked.txt",
+      shellEnvironment,
+      workspaceRoot,
+      gitAttestation,
+    });
+    const quotedBackslashPath = await assessPlanCommandExecutionV1({
+      rawCommand: 'head -n 1 -- "safe\\q"',
+      shellEnvironment,
+      workspaceRoot,
+      gitAttestation,
+    });
+    const configPath = join(workspaceRoot, ".git", "config");
+    const config = await readFile(configPath, "utf8");
+    const absoluteHooksPath = join(workspaceRoot, "hooks");
+    await mkdir(absoluteHooksPath);
+    await writeFile(configPath, `${config}\n[core]\n\thooksPath = ${absoluteHooksPath}\n`, "utf8");
+    const absoluteHooksGit = await assessPlanCommandExecutionV1({
+      rawCommand:
+        "git --no-pager status --porcelain=v1 --untracked-files=normal --ignore-submodules=all",
+      shellEnvironment,
+      workspaceRoot,
+      gitAttestation,
+    });
+    await writeFile(configPath, `${config}\n[alias]\n\tinspect = !touch escaped\n`, "utf8");
+    const hostileGit = await assessPlanCommandExecutionV1({
+      rawCommand:
+        "git --no-pager status --porcelain=v1 --untracked-files=normal --ignore-submodules=all",
+      shellEnvironment,
+      workspaceRoot,
+      gitAttestation,
+    });
+
+    expect(linkedPath).toMatchObject({
+      disposition: "ask_ambiguous",
+      reasons: ["path_untrusted"],
+    });
+    expect(quotedBackslashPath).toMatchObject({
+      disposition: "ask_ambiguous",
+      reasons: ["path_untrusted"],
+    });
+    expect(absoluteHooksGit).toMatchObject({
+      disposition: "allow_inspection",
+      reasons: ["automatic_git_inspection"],
+    });
+    expect(hostileGit).toMatchObject({
+      disposition: "ask_ambiguous",
+      reasons: ["git_repository_untrusted"],
+    });
+  } finally {
+    if (previousPath === undefined) {
+      delete process.env[executablePathName];
+    } else {
+      process.env[executablePathName] = previousPath;
+    }
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("Plan executable policy rejects every untrusted Git repository topology and config family", async () => {
+  const executablePathName = "PATH";
+  const previousPath = process.env[executablePathName];
+  process.env[executablePathName] = "/usr/bin:/bin";
+  const cases = [
+    {
+      label: "missing canonical objects directory",
+      mutate: async (workspaceRoot: string) => {
+        await rm(join(workspaceRoot, ".git", "objects"), { recursive: true, force: true });
+      },
+    },
+    {
+      label: "partial-clone promisor pack",
+      mutate: async (workspaceRoot: string) => {
+        const packRoot = join(workspaceRoot, ".git", "objects", "pack");
+        await mkdir(packRoot, { recursive: true });
+        await writeFile(join(packRoot, "pack-test.promisor"), "", "utf8");
+      },
+    },
+    {
+      label: "Git administration traversal above its entry cap",
+      mutate: async (workspaceRoot: string) => {
+        const oversizedRoot = join(workspaceRoot, ".git", "oversized");
+        await mkdir(oversizedRoot);
+        const names = Array.from({ length: 4_097 }, (_, index) =>
+          join(oversizedRoot, index.toString(16).padStart(4, "0")),
+        );
+        for (let index = 0; index < names.length; index += 128) {
+          await Promise.all(names.slice(index, index + 128).map((path) => mkdir(path)));
+        }
+      },
+    },
+    {
+      label: "malformed quoted config value",
+      mutate: async (workspaceRoot: string) => {
+        await writeFile(
+          join(workspaceRoot, ".git", "config"),
+          '[core]\n\trepositoryformatversion = 0\n\tbare = false\n[user]\n\tname = "unterminated\n',
+          "utf8",
+        );
+      },
+    },
+    {
+      label: "duplicate singleton config value",
+      mutate: async (workspaceRoot: string) => {
+        await writeFile(
+          join(workspaceRoot, ".git", "config"),
+          "[core]\n\trepositoryformatversion = 0\n\tbare = false\n[user]\n\tname = first\n\tname = second\n",
+          "utf8",
+        );
+      },
+    },
+    {
+      label: "symlinked hooksPath",
+      mutate: async (workspaceRoot: string, testRoot: string) => {
+        const outsideHooks = join(testRoot, "outside-hooks");
+        await mkdir(outsideHooks);
+        await symlink(outsideHooks, join(workspaceRoot, "hooks-link"));
+        await writeFile(
+          join(workspaceRoot, ".git", "config"),
+          "[core]\n\trepositoryformatversion = 0\n\tbare = false\n\thooksPath = hooks-link\n",
+          "utf8",
+        );
+      },
+    },
+  ] as const;
+
+  try {
+    for (const fixture of cases) {
+      const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-plan-git-repository-"));
+      const workspaceRoot = join(testRoot, "workspace");
+      await mkdir(workspaceRoot);
+      try {
+        await runGit(workspaceRoot, ["init"]);
+        const shellEnvironment = await createPlanShellEnvironmentV1();
+        const gitExecutable = await resolvePlanTrustedExecutableV1({
+          commandName: "git",
+          shellEnvironment,
+          workspaceRoot,
+        });
+        if (gitExecutable === undefined) {
+          throw new Error("Expected the supported trusted Git executable.");
+        }
+        const gitAttestation = createPlanGitAttestationV1({
+          executable: gitExecutable,
+          shellEnvironmentDigest: shellEnvironment.digest,
+        });
+        await fixture.mutate(workspaceRoot, testRoot);
+        const assessed = await assessPlanCommandExecutionV1({
+          rawCommand:
+            "git --no-pager status --porcelain=v1 --untracked-files=normal --ignore-submodules=all",
+          shellEnvironment,
+          workspaceRoot,
+          gitAttestation,
+        });
+        expect(assessed, fixture.label).toMatchObject({
+          disposition: "ask_ambiguous",
+          reasons: ["git_repository_untrusted"],
+        });
+      } finally {
+        await rm(testRoot, { recursive: true, force: true });
+      }
+    }
+  } finally {
+    if (previousPath === undefined) {
+      delete process.env[executablePathName];
+    } else {
+      process.env[executablePathName] = previousPath;
+    }
+  }
+});
+
+async function runGit(workspaceRoot: string, arguments_: readonly string[]): Promise<void> {
+  const { spawn } = await import("node:child_process");
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const child = spawn("/usr/bin/git", arguments_, {
+      cwd: workspaceRoot,
+      env: {
+        HOME: workspaceRoot,
+        PATH: "/usr/bin:/bin",
+        LANG: "C",
+        LC_ALL: "C",
+        GIT_CONFIG_NOSYSTEM: "1",
+        GIT_CONFIG_GLOBAL: "/dev/null",
+      },
+      stdio: "ignore",
+    });
+    child.once("error", rejectPromise);
+    child.once("close", (code, signal) => {
+      if (code === 0 && signal === null) {
+        resolvePromise();
+      } else {
+        rejectPromise(new Error(`Git fixture failed: ${String(code)}/${String(signal)}`));
+      }
+    });
+  });
+}

--- a/packages/testkit/src/plan-git-policy.test.ts
+++ b/packages/testkit/src/plan-git-policy.test.ts
@@ -1,0 +1,60 @@
+import { planGitAutomaticPolicyV1, planGitEnvironmentV1 } from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+
+test("Plan Git automatic environment freezes every noninteractive override in order", () => {
+  expect(planGitEnvironmentV1).toEqual({
+    version: "git-auto-env.v1",
+    variables: {
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_CONFIG_SYSTEM: "/dev/null",
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_TERMINAL_PROMPT: "0",
+      GIT_OPTIONAL_LOCKS: "0",
+      GIT_PAGER: "cat",
+      PAGER: "cat",
+      GIT_CONFIG_COUNT: "15",
+      GIT_CONFIG_KEY_0: "core.fsmonitor",
+      GIT_CONFIG_VALUE_0: "false",
+      GIT_CONFIG_KEY_1: "core.hooksPath",
+      GIT_CONFIG_VALUE_1: "/dev/null",
+      GIT_CONFIG_KEY_2: "core.attributesFile",
+      GIT_CONFIG_VALUE_2: "/dev/null",
+      GIT_CONFIG_KEY_3: "core.excludesFile",
+      GIT_CONFIG_VALUE_3: "/dev/null",
+      GIT_CONFIG_KEY_4: "core.pager",
+      GIT_CONFIG_VALUE_4: "cat",
+      GIT_CONFIG_KEY_5: "diff.external",
+      GIT_CONFIG_VALUE_5: "",
+      GIT_CONFIG_KEY_6: "interactive.diffFilter",
+      GIT_CONFIG_VALUE_6: "",
+      GIT_CONFIG_KEY_7: "color.ui",
+      GIT_CONFIG_VALUE_7: "false",
+      GIT_CONFIG_KEY_8: "maintenance.auto",
+      GIT_CONFIG_VALUE_8: "false",
+      GIT_CONFIG_KEY_9: "gc.auto",
+      GIT_CONFIG_VALUE_9: "0",
+      GIT_CONFIG_KEY_10: "submodule.recurse",
+      GIT_CONFIG_VALUE_10: "false",
+      GIT_CONFIG_KEY_11: "status.submoduleSummary",
+      GIT_CONFIG_VALUE_11: "false",
+      GIT_CONFIG_KEY_12: "diff.ignoreSubmodules",
+      GIT_CONFIG_VALUE_12: "all",
+      GIT_CONFIG_KEY_13: "log.showSignature",
+      GIT_CONFIG_VALUE_13: "false",
+      GIT_CONFIG_KEY_14: "protocol.allow",
+      GIT_CONFIG_VALUE_14: "never",
+    },
+    digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+  });
+});
+
+test("Plan Git automatic policy freezes the corpus and environment identity", () => {
+  expect(planGitAutomaticPolicyV1).toEqual({
+    version: "git-auto-policy.v1",
+    commandCorpusVersion: "plan-git-corpus.v1",
+    environmentVersion: "git-auto-env.v1",
+    environmentDigest: planGitEnvironmentV1.digest,
+    exactGitVersion: "git version 2.43.0",
+    digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+  });
+});

--- a/packages/testkit/src/plan-mcp-permission-validation.test.ts
+++ b/packages/testkit/src/plan-mcp-permission-validation.test.ts
@@ -1,0 +1,77 @@
+import { createHash } from "node:crypto";
+
+import type { RuntimeEvent } from "@adam-agent/agent";
+import { isExactPlanMcpPermissionEventV1 } from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+
+test("Plan MCP permission validation binds the exact call, profile, and canonical arguments", () => {
+  const runId = "123e4567-e89b-42d3-a456-426614176020";
+  const callId = "plan-mcp-execute";
+  const callName = "mcp__fixture__echo__123456789abc";
+  const definitionDigest = `sha256:${"1".repeat(64)}` as const;
+  const serverDefinitionDigest = `sha256:${"2".repeat(64)}` as const;
+  const argumentsJson = '{"value":"exact"}';
+  const argumentsDigest =
+    `sha256:${createHash("sha256").update(argumentsJson).digest("hex")}` as const;
+  const eligibleDefinition = {
+    name: callName,
+    definitionDigest,
+    effect: "execute" as const,
+    source: "mcp" as const,
+    mcp: {
+      serverId: "fixture",
+      originalName: "echo",
+      serverDefinitionDigest,
+    },
+  };
+  const subject = {
+    type: "mcp_tool" as const,
+    serverId: "fixture",
+    originalName: "echo",
+    qualifiedName: callName,
+    serverDefinitionDigest,
+    definitionDigest,
+    argumentsDigest,
+  };
+  const event = {
+    type: "tool_permission_requested" as const,
+    requestId: `${runId}:${callId}`,
+    callId,
+    name: callName,
+    effect: "execute" as const,
+    scope: "call" as const,
+    subject,
+  } satisfies Extract<RuntimeEvent, { readonly type: "tool_permission_requested" }>;
+  const validate = (candidate: unknown) =>
+    isExactPlanMcpPermissionEventV1({
+      event: candidate as Extract<
+        RuntimeEvent,
+        { readonly type: "tool_permission_requested" | "tool_permission_decided" }
+      >,
+      runId,
+      callId,
+      callName,
+      argumentsJson,
+      effect: "execute",
+      definitionDigest,
+      eligibleDefinition,
+    });
+
+  expect(validate(event)).toBe(true);
+  for (const candidate of [
+    { ...event, requestId: `wrong:${callId}` },
+    { ...event, subject: undefined },
+    { ...event, subject: { type: "file" as const, path: "README.md" } },
+    { ...event, subject: { ...subject, serverId: "other" } },
+    { ...event, subject: { ...subject, originalName: "other" } },
+    { ...event, subject: { ...subject, qualifiedName: `${callName}-other` } },
+    {
+      ...event,
+      subject: { ...subject, serverDefinitionDigest: `sha256:${"3".repeat(64)}` as const },
+    },
+    { ...event, subject: { ...subject, definitionDigest: `sha256:${"4".repeat(64)}` as const } },
+    { ...event, subject: { ...subject, argumentsDigest: `sha256:${"5".repeat(64)}` as const } },
+  ]) {
+    expect(validate(candidate), JSON.stringify(candidate)).toBe(false);
+  }
+});

--- a/packages/testkit/src/plan-shell-policy-topology.test.ts
+++ b/packages/testkit/src/plan-shell-policy-topology.test.ts
@@ -1,0 +1,856 @@
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "vitest";
+
+const sourceRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "agent", "src");
+const childProcessLaunchers = new Set(["execFile", "execFileSync", "spawn", "spawnSync"]);
+const childProcessModuleSpecifiers = new Set(["child_process", "node:child_process"]);
+
+type StructuralToken = {
+  readonly kind: "identifier" | "punctuator" | "string";
+  readonly offset: number;
+  readonly value: string;
+};
+
+function structuralTokens(source: string): readonly StructuralToken[] {
+  const tokens: StructuralToken[] = [];
+  for (let index = 0; index < source.length; ) {
+    const character = source[index] as string;
+    if (/\s/u.test(character)) {
+      index += 1;
+      continue;
+    }
+    if (source.startsWith("//", index)) {
+      const lineEnd = source.indexOf("\n", index + 2);
+      index = lineEnd === -1 ? source.length : lineEnd + 1;
+      continue;
+    }
+    if (source.startsWith("/*", index)) {
+      const commentEnd = source.indexOf("*/", index + 2);
+      index = commentEnd === -1 ? source.length : commentEnd + 2;
+      continue;
+    }
+    if (/[A-Za-z_$]/u.test(character)) {
+      let end = index + 1;
+      while (end < source.length && /[A-Za-z0-9_$]/u.test(source[end] as string)) {
+        end += 1;
+      }
+      tokens.push({ kind: "identifier", offset: index, value: source.slice(index, end) });
+      index = end;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      const quote = character;
+      let end = index + 1;
+      let value = "";
+      while (end < source.length) {
+        const current = source[end] as string;
+        if (current === "\\" && end + 1 < source.length) {
+          value += source[end + 1] as string;
+          end += 2;
+          continue;
+        }
+        if (current === quote) {
+          end += 1;
+          break;
+        }
+        value += current;
+        end += 1;
+      }
+      tokens.push({ kind: "string", offset: index, value });
+      index = end;
+      continue;
+    }
+    if (character === "`") {
+      let end = index + 1;
+      let interpolated = false;
+      let value = "";
+      while (end < source.length) {
+        if (source[end] === "\\") {
+          value += source[end + 1] as string;
+          end += 2;
+          continue;
+        }
+        if (source.startsWith("${", end)) {
+          interpolated = true;
+        }
+        if (source[end] === "`") {
+          end += 1;
+          break;
+        }
+        value += source[end] as string;
+        end += 1;
+      }
+      if (!interpolated) {
+        tokens.push({ kind: "string", offset: index, value });
+      }
+      index = end;
+      continue;
+    }
+    tokens.push({ kind: "punctuator", offset: index, value: character });
+    index += 1;
+  }
+  return tokens;
+}
+
+function structuralCallArguments(
+  tokens: readonly StructuralToken[],
+  openIndex: number,
+): readonly (readonly StructuralToken[])[] | undefined {
+  const arguments_: StructuralToken[][] = [];
+  let current: StructuralToken[] = [];
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  let parenthesisDepth = 0;
+  for (let index = openIndex + 1; index < tokens.length; index += 1) {
+    const token = tokens[index] as StructuralToken;
+    if (token.value === ")" && parenthesisDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+      arguments_.push(current);
+      return arguments_;
+    }
+    if (token.value === "," && parenthesisDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+      arguments_.push(current);
+      current = [];
+      continue;
+    }
+    current.push(token);
+    if (token.value === "(") {
+      parenthesisDepth += 1;
+    } else if (token.value === ")") {
+      parenthesisDepth -= 1;
+    } else if (token.value === "[") {
+      bracketDepth += 1;
+    } else if (token.value === "]") {
+      bracketDepth -= 1;
+    } else if (token.value === "{") {
+      braceDepth += 1;
+    } else if (token.value === "}") {
+      braceDepth -= 1;
+    }
+  }
+  return undefined;
+}
+
+function structuralAssignmentValue(
+  tokens: readonly StructuralToken[],
+  startIndex: number,
+): readonly StructuralToken[] {
+  const value: StructuralToken[] = [];
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  let parenthesisDepth = 0;
+  for (let index = startIndex; index < tokens.length; index += 1) {
+    const token = tokens[index] as StructuralToken;
+    if (
+      (token.value === ";" || token.value === ",") &&
+      parenthesisDepth === 0 &&
+      bracketDepth === 0 &&
+      braceDepth === 0
+    ) {
+      break;
+    }
+    value.push(token);
+    if (token.value === "(") {
+      parenthesisDepth += 1;
+    } else if (token.value === ")") {
+      parenthesisDepth -= 1;
+    } else if (token.value === "[") {
+      bracketDepth += 1;
+    } else if (token.value === "]") {
+      bracketDepth -= 1;
+    } else if (token.value === "{") {
+      braceDepth += 1;
+    } else if (token.value === "}") {
+      braceDepth -= 1;
+    }
+  }
+  return value;
+}
+
+function structuralAssignmentIndex(
+  tokens: readonly StructuralToken[],
+  identifierIndex: number,
+): number | undefined {
+  if (tokens[identifierIndex + 1]?.value === "=") {
+    return identifierIndex + 1;
+  }
+  if (tokens[identifierIndex + 1]?.value !== ":") {
+    return undefined;
+  }
+  let angleDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  let parenthesisDepth = 0;
+  for (let index = identifierIndex + 2; index < tokens.length; index += 1) {
+    const token = tokens[index] as StructuralToken;
+    const atTopLevel =
+      angleDepth === 0 && bracketDepth === 0 && braceDepth === 0 && parenthesisDepth === 0;
+    if (atTopLevel && (token.value === ";" || token.value === ",")) {
+      return undefined;
+    }
+    if (atTopLevel && token.value === "=" && tokens[index + 1]?.value !== ">") {
+      return index;
+    }
+    if (token.value === "(") {
+      parenthesisDepth += 1;
+    } else if (token.value === ")") {
+      parenthesisDepth -= 1;
+    } else if (token.value === "[") {
+      bracketDepth += 1;
+    } else if (token.value === "]") {
+      bracketDepth -= 1;
+    } else if (token.value === "{") {
+      braceDepth += 1;
+    } else if (token.value === "}") {
+      braceDepth -= 1;
+    } else if (token.value === "<") {
+      angleDepth += 1;
+    } else if (token.value === ">" && angleDepth > 0) {
+      angleDepth -= 1;
+    }
+  }
+  return undefined;
+}
+
+function structuralTransparentExpression(
+  expression: readonly StructuralToken[],
+): readonly StructuralToken[] {
+  let transparent = expression;
+  let changed = true;
+  while (changed && transparent.length > 0) {
+    changed = false;
+    if (transparent[0]?.value === "(") {
+      let depth = 0;
+      let matchingClose = -1;
+      for (let index = 0; index < transparent.length; index += 1) {
+        if (transparent[index]?.value === "(") {
+          depth += 1;
+        } else if (transparent[index]?.value === ")") {
+          depth -= 1;
+          if (depth === 0) {
+            matchingClose = index;
+            break;
+          }
+        }
+      }
+      if (matchingClose === transparent.length - 1) {
+        transparent = transparent.slice(1, -1);
+        changed = true;
+        continue;
+      }
+    }
+    let bracketDepth = 0;
+    let braceDepth = 0;
+    let parenthesisDepth = 0;
+    for (let index = 0; index < transparent.length; index += 1) {
+      const token = transparent[index] as StructuralToken;
+      if (
+        (token.value === "as" || token.value === "satisfies") &&
+        parenthesisDepth === 0 &&
+        bracketDepth === 0 &&
+        braceDepth === 0
+      ) {
+        transparent = transparent.slice(0, index);
+        changed = true;
+        break;
+      }
+      if (token.value === "(") {
+        parenthesisDepth += 1;
+      } else if (token.value === ")") {
+        parenthesisDepth -= 1;
+      } else if (token.value === "[") {
+        bracketDepth += 1;
+      } else if (token.value === "]") {
+        bracketDepth -= 1;
+      } else if (token.value === "{") {
+        braceDepth += 1;
+      } else if (token.value === "}") {
+        braceDepth -= 1;
+      }
+    }
+  }
+  return transparent;
+}
+
+function structuralArrayElements(
+  untrustedExpression: readonly StructuralToken[],
+): readonly (readonly StructuralToken[])[] | undefined {
+  const transparent = structuralTransparentExpression(untrustedExpression);
+  const expression =
+    transparent[0]?.value === "." && transparent[1]?.value === "." && transparent[2]?.value === "."
+      ? structuralTransparentExpression(transparent.slice(3))
+      : transparent;
+  if (expression[0]?.value !== "[" || expression.at(-1)?.value !== "]") {
+    return undefined;
+  }
+  const elements: StructuralToken[][] = [[]];
+  let bracketDepth = 0;
+  let braceDepth = 0;
+  let parenthesisDepth = 0;
+  for (const token of expression.slice(1, -1)) {
+    if (token.value === "," && parenthesisDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+      elements.push([]);
+      continue;
+    }
+    elements.at(-1)?.push(token);
+    if (token.value === "(") {
+      parenthesisDepth += 1;
+    } else if (token.value === ")") {
+      parenthesisDepth -= 1;
+    } else if (token.value === "[") {
+      bracketDepth += 1;
+    } else if (token.value === "]") {
+      bracketDepth -= 1;
+    } else if (token.value === "{") {
+      braceDepth += 1;
+    } else if (token.value === "}") {
+      braceDepth -= 1;
+    }
+  }
+  return elements;
+}
+
+function structuralExpressionReferences(
+  untrustedExpression: readonly StructuralToken[],
+  literal: string,
+  bindings: ReadonlySet<string>,
+): boolean {
+  const expression = structuralTransparentExpression(untrustedExpression);
+  return (
+    expression.length === 1 &&
+    ((expression[0]?.kind === "string" && expression[0]?.value === literal) ||
+      (expression[0]?.kind === "identifier" && bindings.has(expression[0]?.value as string)))
+  );
+}
+
+function structuralExpressionReferencesArgv(
+  untrustedExpression: readonly StructuralToken[],
+  bindings: ReadonlySet<string>,
+): boolean {
+  const expression = structuralTransparentExpression(untrustedExpression);
+  return (
+    (expression.length === 1 &&
+      expression[0]?.kind === "identifier" &&
+      bindings.has(expression[0]?.value)) ||
+    (expression[0]?.value === "[" &&
+      expression[1]?.kind === "string" &&
+      expression[1]?.value === "-c" &&
+      expression.at(-1)?.value === "]")
+  );
+}
+
+function structuralExpressionReferencesBinding(
+  untrustedExpression: readonly StructuralToken[],
+  bindings: ReadonlySet<string>,
+): boolean {
+  const transparent = structuralTransparentExpression(untrustedExpression);
+  const expression =
+    transparent[0]?.value === "." && transparent[1]?.value === "." && transparent[2]?.value === "."
+      ? structuralTransparentExpression(transparent.slice(3))
+      : transparent;
+  return (
+    expression.length === 1 &&
+    expression[0]?.kind === "identifier" &&
+    bindings.has(expression[0]?.value)
+  );
+}
+
+function planShellExecutorLocations(sources: ReadonlyMap<string, string>): readonly string[] {
+  const locations: string[] = [];
+  for (const [name, source] of sources) {
+    const tokens = structuralTokens(source);
+    const launcherBindings = new Set<string>();
+    const childProcessNamespaces = new Set<string>();
+    const shellBindings = new Set<string>();
+    const argvBindings = new Set<string>();
+    const packedArgumentBindings = new Set<string>();
+    const sourceBridgeLocations = new Set<string>();
+    for (let index = 0; index < tokens.length; index += 1) {
+      if (
+        tokens[index]?.kind === "string" &&
+        childProcessModuleSpecifiers.has(tokens[index]?.value as string) &&
+        tokens[index - 1]?.value === "("
+      ) {
+        const offset = tokens[index]?.offset as number;
+        const line = source.slice(0, offset).split("\n").length;
+        sourceBridgeLocations.add(`${name}:${line}`);
+      }
+    }
+    for (let index = 0; index < tokens.length; index += 1) {
+      if (tokens[index]?.value !== "import") {
+        continue;
+      }
+      let fromIndex = -1;
+      for (let cursor = index + 1; cursor < tokens.length; cursor += 1) {
+        if (tokens[cursor]?.value === ";") {
+          break;
+        }
+        if (
+          tokens[cursor]?.value === "from" &&
+          tokens[cursor + 1]?.kind === "string" &&
+          childProcessModuleSpecifiers.has(tokens[cursor + 1]?.value as string)
+        ) {
+          fromIndex = cursor;
+          break;
+        }
+      }
+      if (fromIndex === -1) {
+        continue;
+      }
+      if (tokens[index + 1]?.value === "type") {
+        continue;
+      }
+      const defaultBinding = tokens[index + 1];
+      if (defaultBinding?.kind === "identifier") {
+        childProcessNamespaces.add(defaultBinding.value);
+      }
+      for (let bindingIndex = index + 1; bindingIndex < fromIndex; bindingIndex += 1) {
+        if (
+          tokens[bindingIndex]?.value === "*" &&
+          tokens[bindingIndex + 1]?.value === "as" &&
+          tokens[bindingIndex + 2]?.kind === "identifier"
+        ) {
+          childProcessNamespaces.add(tokens[bindingIndex + 2]?.value as string);
+          bindingIndex += 2;
+          continue;
+        }
+        if (tokens[bindingIndex]?.value !== "{") {
+          continue;
+        }
+        const close = tokens.findIndex(
+          (token, tokenIndex) =>
+            tokenIndex > bindingIndex && tokenIndex < fromIndex && token.value === "}",
+        );
+        if (close === -1) {
+          continue;
+        }
+        for (let namedIndex = bindingIndex + 1; namedIndex < close; namedIndex += 1) {
+          const importedName = tokens[namedIndex]?.value;
+          if (importedName === undefined || !childProcessLaunchers.has(importedName)) {
+            continue;
+          }
+          const localName =
+            tokens[namedIndex + 1]?.value === "as" && tokens[namedIndex + 2]?.kind === "identifier"
+              ? tokens[namedIndex + 2]?.value
+              : importedName;
+          launcherBindings.add(localName as string);
+        }
+        bindingIndex = close;
+      }
+    }
+    let discoveredBinding = true;
+    while (discoveredBinding) {
+      discoveredBinding = false;
+      for (let index = 0; index < tokens.length; index += 1) {
+        const localName = tokens[index];
+        if (localName?.kind === "identifier" && tokens[index + 1]?.value === "=") {
+          const sourceName = tokens[index + 2];
+          if (sourceName?.kind === "identifier" && childProcessNamespaces.has(sourceName.value)) {
+            if (
+              tokens[index + 3]?.value === "." &&
+              childProcessLaunchers.has(tokens[index + 4]?.value as string)
+            ) {
+              const previousSize = launcherBindings.size;
+              launcherBindings.add(localName.value);
+              discoveredBinding ||= launcherBindings.size !== previousSize;
+              continue;
+            }
+            if (
+              tokens[index + 3]?.value === "[" &&
+              tokens[index + 4]?.kind === "string" &&
+              childProcessLaunchers.has(tokens[index + 4]?.value as string) &&
+              tokens[index + 5]?.value === "]"
+            ) {
+              const previousSize = launcherBindings.size;
+              launcherBindings.add(localName.value);
+              discoveredBinding ||= launcherBindings.size !== previousSize;
+              continue;
+            }
+            const previousSize = childProcessNamespaces.size;
+            childProcessNamespaces.add(localName.value);
+            discoveredBinding ||= childProcessNamespaces.size !== previousSize;
+            continue;
+          }
+          if (sourceName?.kind === "identifier" && launcherBindings.has(sourceName.value)) {
+            const previousSize = launcherBindings.size;
+            launcherBindings.add(localName.value);
+            discoveredBinding ||= launcherBindings.size !== previousSize;
+          }
+        }
+        if (tokens[index]?.value !== "{") {
+          continue;
+        }
+        const close = tokens.findIndex(
+          (token, tokenIndex) => tokenIndex > index && token.value === "}",
+        );
+        if (
+          close === -1 ||
+          tokens[close + 1]?.value !== "=" ||
+          tokens[close + 2]?.kind !== "identifier" ||
+          !childProcessNamespaces.has(tokens[close + 2]?.value as string)
+        ) {
+          continue;
+        }
+        for (let bindingIndex = index + 1; bindingIndex < close; bindingIndex += 1) {
+          const importedName = tokens[bindingIndex];
+          if (
+            importedName?.kind !== "identifier" ||
+            !childProcessLaunchers.has(importedName.value)
+          ) {
+            continue;
+          }
+          const reboundName =
+            tokens[bindingIndex + 1]?.value === ":" &&
+            tokens[bindingIndex + 2]?.kind === "identifier"
+              ? tokens[bindingIndex + 2]?.value
+              : importedName.value;
+          const previousSize = launcherBindings.size;
+          launcherBindings.add(reboundName as string);
+          discoveredBinding ||= launcherBindings.size !== previousSize;
+        }
+        index = close;
+      }
+    }
+    let discoveredArgumentBinding = true;
+    while (discoveredArgumentBinding) {
+      discoveredArgumentBinding = false;
+      for (let index = 0; index < tokens.length; index += 1) {
+        const localName = tokens[index];
+        if (localName?.kind !== "identifier") {
+          continue;
+        }
+        const assignmentIndex = structuralAssignmentIndex(tokens, index);
+        if (assignmentIndex === undefined) {
+          continue;
+        }
+        const expression = structuralAssignmentValue(tokens, assignmentIndex + 1);
+        if (structuralExpressionReferences(expression, "/bin/sh", shellBindings)) {
+          const previousSize = shellBindings.size;
+          shellBindings.add(localName.value);
+          discoveredArgumentBinding ||= shellBindings.size !== previousSize;
+        }
+        if (structuralExpressionReferencesArgv(expression, argvBindings)) {
+          const previousSize = argvBindings.size;
+          argvBindings.add(localName.value);
+          discoveredArgumentBinding ||= argvBindings.size !== previousSize;
+        }
+        const packedArguments = structuralArrayElements(expression);
+        if (
+          (packedArguments !== undefined &&
+            structuralExpressionReferences(packedArguments[0] ?? [], "/bin/sh", shellBindings) &&
+            structuralExpressionReferencesArgv(packedArguments[1] ?? [], argvBindings)) ||
+          structuralExpressionReferencesBinding(expression, packedArgumentBindings)
+        ) {
+          const previousSize = packedArgumentBindings.size;
+          packedArgumentBindings.add(localName.value);
+          discoveredArgumentBinding ||= packedArgumentBindings.size !== previousSize;
+        }
+      }
+    }
+    for (let index = 0; index < tokens.length; index += 1) {
+      if (tokens[index]?.value !== "export") {
+        continue;
+      }
+      let statementEnd = tokens.length;
+      for (let cursor = index + 1; cursor < tokens.length; cursor += 1) {
+        if (tokens[cursor]?.value === ";") {
+          statementEnd = cursor;
+          break;
+        }
+      }
+      if (tokens[index + 1]?.value === "type") {
+        index = statementEnd;
+        continue;
+      }
+      let directChildProcessReexport = tokens
+        .slice(index + 1, statementEnd)
+        .some((token) => token.kind === "string" && childProcessModuleSpecifiers.has(token.value));
+      if (directChildProcessReexport && tokens[index + 1]?.value === "{") {
+        const close = tokens.findIndex(
+          (token, tokenIndex) =>
+            tokenIndex > index + 1 && tokenIndex < statementEnd && token.value === "}",
+        );
+        if (close !== -1) {
+          const exportedEntries: StructuralToken[][] = [[]];
+          for (const token of tokens.slice(index + 2, close)) {
+            if (token.value === ",") {
+              exportedEntries.push([]);
+            } else {
+              exportedEntries.at(-1)?.push(token);
+            }
+          }
+          directChildProcessReexport = exportedEntries.some(
+            (entry) => entry.length > 0 && entry[0]?.value !== "type",
+          );
+        }
+      }
+      const boundChildProcessReexport = tokens
+        .slice(index + 1, statementEnd)
+        .some(
+          (token) =>
+            token.kind === "identifier" &&
+            (launcherBindings.has(token.value) || childProcessNamespaces.has(token.value)),
+        );
+      if (directChildProcessReexport || boundChildProcessReexport) {
+        const offset = tokens[index]?.offset as number;
+        const line = source.slice(0, offset).split("\n").length;
+        sourceBridgeLocations.add(`${name}:${line}`);
+      }
+      index = statementEnd;
+    }
+    locations.push(...sourceBridgeLocations);
+    for (let openIndex = 0; openIndex < tokens.length; openIndex += 1) {
+      if (tokens[openIndex]?.value !== "(") {
+        continue;
+      }
+      const arguments_ = structuralCallArguments(tokens, openIndex);
+      if (arguments_ === undefined) {
+        continue;
+      }
+      const memberInvocation = tokens[openIndex - 2]?.value === ".";
+      const memberName = memberInvocation ? tokens[openIndex - 1]?.value : undefined;
+      const shiftedInvocation = memberName === "call" || memberName === "bind";
+      const candidatePairs: Array<
+        readonly [readonly StructuralToken[], readonly StructuralToken[]]
+      > = [
+        [arguments_[shiftedInvocation ? 1 : 0] ?? [], arguments_[shiftedInvocation ? 2 : 1] ?? []],
+      ];
+      for (const argument of arguments_) {
+        const packedArguments = structuralArrayElements(argument);
+        if (packedArguments !== undefined) {
+          candidatePairs.push([packedArguments[0] ?? [], packedArguments[1] ?? []]);
+        }
+      }
+      const exactPlanShellPair = candidatePairs.some(
+        ([shellArgument, argvArgument]) =>
+          structuralExpressionReferences(shellArgument, "/bin/sh", shellBindings) &&
+          structuralExpressionReferencesArgv(argvArgument, argvBindings),
+      );
+      const exactPackedPlanShellPair = arguments_.some((argument) =>
+        structuralExpressionReferencesBinding(argument, packedArgumentBindings),
+      );
+      if (!exactPlanShellPair && !exactPackedPlanShellPair) {
+        continue;
+      }
+      const offset = tokens[openIndex - 1]?.offset ?? tokens[openIndex]?.offset ?? 0;
+      const line = source.slice(0, offset).split("\n").length;
+      const location = `${name}:${line}`;
+      if (!sourceBridgeLocations.has(location)) {
+        locations.push(location);
+      }
+    }
+  }
+  return locations;
+}
+
+async function readTypeScriptSources(
+  directory: string,
+  prefix = "",
+): Promise<ReadonlyMap<string, string>> {
+  const sources = new Map<string, string>();
+  const entries = (await readdir(directory, { withFileTypes: true })).sort((left, right) =>
+    left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+  );
+  for (const entry of entries) {
+    const relativePath = prefix.length === 0 ? entry.name : `${prefix}/${entry.name}`;
+    if (entry.isDirectory()) {
+      for (const [name, source] of await readTypeScriptSources(
+        join(directory, entry.name),
+        relativePath,
+      )) {
+        sources.set(name, source);
+      }
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".ts")) {
+      sources.set(relativePath, await readFile(join(directory, entry.name), "utf8"));
+    }
+  }
+  return sources;
+}
+
+test("Plan shell executor detector follows every child-process launcher binding", () => {
+  const fixtureSources = new Map([
+    ["direct.ts", 'import { spawn } from "node:child_process"; spawn("/bin/sh", ["-c", command]);'],
+    [
+      "alias.ts",
+      'import { execFile as run } from "node:child_process"; run /* bound alias */ ("/bin/sh", ["-c", raw]);',
+    ],
+    [
+      "namespace.ts",
+      'import * as childProcess from "node:child_process"; childProcess.spawnSync("/bin/sh", ["-c", value]);',
+    ],
+    [
+      "default-dot.ts",
+      'import childProcess from "node:child_process"; childProcess.spawn("/bin/sh", ["-c", value]);',
+    ],
+    [
+      "default-bracket.ts",
+      'import childProcess from "node:child_process"; childProcess["execFileSync"]("/bin/sh", ["-c", value]);',
+    ],
+    [
+      "default-named.ts",
+      'import childProcess, { spawnSync as run } from "node:child_process"; childProcess.spawn("/bin/sh", ["-c", value]); run("/bin/sh", ["-c", raw]);',
+    ],
+    [
+      "default-namespace.ts",
+      'import childProcess, * as child from "node:child_process"; childProcess.execFile("/bin/sh", ["-c", value]); child.spawn("/bin/sh", ["-c", raw]);',
+    ],
+    [
+      "rebinding.ts",
+      'import childProcess from "node:child_process"; const child = childProcess; const { spawn: run, execFileSync } = child; const sync = childProcess.spawnSync; const file = child["execFile"]; run("/bin/sh", ["-c", raw]); execFileSync("/bin/sh", ["-c", value]); sync("/bin/sh", ["-c", command]); file("/bin/sh", ["-c", command]);',
+    ],
+    ["bridge.ts", 'export { spawn as run } from "node:child_process";'],
+    ["bare-module.ts", 'import { spawn } from "child_process"; spawn("/bin/sh", ["-c", raw]);'],
+    ["bare-reexport.ts", 'export * from "child_process";'],
+    [
+      "dynamic-import.ts",
+      'const { spawn: run } = await import("node:child_process"); run("/bin/sh", ["-c", raw]);',
+    ],
+    [
+      "dynamic-template.ts",
+      'const child = await import(`child_process`); child.spawn("/bin/sh", ["-c", raw]);',
+    ],
+    [
+      "create-require.ts",
+      'import { createRequire } from "node:module"; const load = createRequire(import.meta.url); const { spawn } = load("child_process"); spawn("/bin/sh", ["-c", raw]);',
+    ],
+    [
+      "dynamic-options.ts",
+      'const child = await import("node:child_process", {}); child.spawn("/bin/sh", ["-c", raw]);',
+    ],
+    [
+      "require-options.ts",
+      'const child = require("child_process", {}); child.spawn("/bin/sh", ["-c", raw]);',
+    ],
+    [
+      "dynamic-trailing-comma.ts",
+      'const child = await import("node:child_process",); child.spawn("/bin/sh", ["-c", raw]);',
+    ],
+    ["origin-independent.ts", 'function launch() {} launch("/bin/sh", ["-c", raw]);'],
+    [
+      "two-on-line.ts",
+      'function launch() {} launch("/bin/sh", ["-c", first]); launch("/bin/sh", ["-c", second]);',
+    ],
+    ["transparent-shell.ts", 'function launch() {} launch(("/bin/sh"), ["-c", raw]);'],
+    ["transparent-argv.ts", 'function launch() {} launch("/bin/sh", (["-c", raw] as const));'],
+    [
+      "constant-shell.ts",
+      'import { spawn } from "node:child_process"; const shell = "/bin/sh"; spawn(shell, ["-c", raw]);',
+    ],
+    ["constant-argv.ts", 'function launch() {} const argv = ["-c", raw]; launch("/bin/sh", argv);'],
+    [
+      "typed-shell.ts",
+      'import { spawn } from "node:child_process"; const shell: string = "/bin/sh"; spawn(shell, ["-c", raw]);',
+    ],
+    [
+      "typed-argv.ts",
+      'function launch() {} const argv: readonly string[] = ["-c", raw]; launch("/bin/sh", argv);',
+    ],
+    [
+      "call.ts",
+      'import { spawn } from "node:child_process"; spawn.call(undefined, "/bin/sh", ["-c", raw]);',
+    ],
+    [
+      "apply.ts",
+      'import { spawn } from "node:child_process"; spawn.apply(undefined, ["/bin/sh", ["-c", raw]]);',
+    ],
+    [
+      "packed-apply.ts",
+      'import { spawn } from "node:child_process"; const args = ["/bin/sh", ["-c", raw]]; spawn.apply(undefined, args);',
+    ],
+    [
+      "reflect-apply.ts",
+      'import { spawn } from "node:child_process"; Reflect.apply(spawn, undefined, ["/bin/sh", ["-c", raw]]);',
+    ],
+    [
+      "literal-spread.ts",
+      'import { spawn } from "node:child_process"; spawn(...["/bin/sh", ["-c", raw]]);',
+    ],
+    [
+      "aliased-spread.ts",
+      'import { spawn } from "node:child_process"; const args: Parameters<typeof spawn> = ["/bin/sh", ["-c", raw]]; const aliased = args; spawn(...aliased);',
+    ],
+    [
+      "bind.ts",
+      'import { spawn } from "node:child_process"; spawn.bind(undefined, "/bin/sh", ["-c", raw])();',
+    ],
+    ["type-reexport.ts", 'export type { ChildProcess } from "node:child_process";'],
+    ["named-type-reexport.ts", 'export { type ChildProcess } from "node:child_process";'],
+    [
+      "imported-reexport.ts",
+      'import { execFile as run } from "node:child_process"; export { run };',
+    ],
+    [
+      "decoys.ts",
+      'import { spawn as run } from "node:child_process"; function spawn() {} spawn("/bin/bash", ["-c", value]); run("/bin/bash", ["-c", value]); run("/bin/sh", ["-lc", value]);',
+    ],
+  ]);
+
+  expect(
+    planShellExecutorLocations(fixtureSources).map((location) => location.split(":")[0]),
+  ).toEqual([
+    "direct.ts",
+    "alias.ts",
+    "namespace.ts",
+    "default-dot.ts",
+    "default-bracket.ts",
+    "default-named.ts",
+    "default-named.ts",
+    "default-namespace.ts",
+    "default-namespace.ts",
+    "rebinding.ts",
+    "rebinding.ts",
+    "rebinding.ts",
+    "rebinding.ts",
+    "bridge.ts",
+    "bare-module.ts",
+    "bare-reexport.ts",
+    "dynamic-import.ts",
+    "dynamic-template.ts",
+    "create-require.ts",
+    "dynamic-options.ts",
+    "require-options.ts",
+    "dynamic-trailing-comma.ts",
+    "origin-independent.ts",
+    "two-on-line.ts",
+    "two-on-line.ts",
+    "transparent-shell.ts",
+    "transparent-argv.ts",
+    "constant-shell.ts",
+    "constant-argv.ts",
+    "typed-shell.ts",
+    "typed-argv.ts",
+    "call.ts",
+    "apply.ts",
+    "packed-apply.ts",
+    "reflect-apply.ts",
+    "literal-spread.ts",
+    "aliased-spread.ts",
+    "bind.ts",
+    "imported-reexport.ts",
+  ]);
+});
+
+test("Plan shell policy has one executor, exact provenance, and no configurable safe bypass", async () => {
+  const sources = await readTypeScriptSources(sourceRoot);
+  const sourceNames = [...sources.keys()];
+  const assessment = sources.get("plan-command-assessment.ts") ?? "";
+  const runtime = sources.get("tool-runtime.ts") ?? "";
+  const planModules = sourceNames
+    .filter((name) => name.split("/").at(-1)?.startsWith("plan-") === true)
+    .map((name) => sources.get(name) ?? "")
+    .join("\n");
+  expect(assessment).toContain("@narumitw/pi-plan-mode@0.56.0");
+  expect(assessment).toContain("gitHead 9b4cab310013a71d7990e7736452c3c1aebfd148");
+  expect(planModules).not.toMatch(/\bspawn\s*\(/u);
+  expect(planModules).not.toMatch(
+    /safe(?:Command|Prefix|Suffix|Regex)|trustedCommand|allowCommandCallback/iu,
+  );
+  expect(planShellExecutorLocations(sources)).toEqual([
+    expect.stringMatching(/^tool-runtime\.ts:\d+$/u),
+  ]);
+  expect(runtime).not.toContain('spawn("/bin/sh", ["-c", normalized');
+});

--- a/packages/testkit/src/plan-shell-recovery.test-support.ts
+++ b/packages/testkit/src/plan-shell-recovery.test-support.ts
@@ -1,0 +1,389 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createCodingToolRegistry,
+  type ModelMessage,
+  type ModelTargets,
+  type RuntimeEvent,
+  type ToolResult,
+} from "@adam-agent/agent";
+import {
+  assessPlanCommandExecutionV1,
+  digestPromptRequestV1,
+  type PlanShellEnvironmentFactory,
+  planShellEnvironmentFactory,
+  type SessionRecord,
+} from "@adam-agent/agent/internal-testing";
+import { createInMemorySessionLifecycleHarness, FakeModelDriver } from "./index.js";
+import {
+  sessionLifecycleBasePrompt as basePrompt,
+  sessionLifecycleSkillUsagePrompt as skillUsagePrompt,
+  sessionLifecycleTargetIdentity as targetIdentity,
+} from "./session-lifecycle.test-support.js";
+
+const contextProfile = {
+  version: 1 as const,
+  contextWindowTokens: 1_000_000,
+  maximumOutputTokens: 32_768,
+  compactAtTokens: 800_000,
+  postCompactTargetTokens: 200_000,
+  retainedTargetTokens: 20_000,
+  estimatorVersion: 1 as const,
+};
+
+export type PlanShellRecoveryFixtureResult = {
+  readonly resume:
+    | { readonly status: "rejected"; readonly code: string | undefined }
+    | {
+        readonly status: "ready";
+        readonly snapshotStatus: "idle" | "interrupted" | "settled";
+        readonly runResult: unknown;
+      };
+  readonly continuationResult?: unknown;
+  readonly secondResume?: {
+    readonly snapshotStatus: "idle" | "interrupted" | "settled";
+    readonly runResult: unknown;
+  };
+  readonly publicEvents: readonly RuntimeEvent[];
+  readonly observedToolResult?: ToolResult;
+  readonly providerCalls: number;
+};
+
+export async function exercisePlanShellRecoveryFixture(options: {
+  readonly shellEnvironmentFactory: PlanShellEnvironmentFactory;
+  readonly command: string;
+  readonly decision: "allow" | "deny";
+  readonly assessmentMatches?: boolean;
+  readonly omitPermissionRequest?: boolean;
+  readonly started?: boolean;
+}): Promise<PlanShellRecoveryFixtureResult> {
+  const assessmentMatches = options.assessmentMatches ?? true;
+  const omitPermissionRequest = options.omitPermissionRequest ?? false;
+  const started = options.started ?? false;
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-plan-shell-recovery-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const call = {
+    id: "plan-shell-recovery",
+    name: "run_shell",
+    argumentsJson: JSON.stringify({ command: options.command }),
+  } as const;
+  const runId = "123e4567-e89b-42d3-a456-426614176010";
+  let providerCalls = 0;
+  let observedToolResult: ToolResult | undefined;
+  const driver = new FakeModelDriver((request) => {
+    providerCalls += 1;
+    const toolMessage = request.messages.findLast(
+      (message): message is Extract<ModelMessage, { readonly role: "tool" }> =>
+        message.role === "tool" && message.callId === call.id,
+    );
+    observedToolResult = toolMessage?.result;
+    return [
+      { type: "text_delta", text: "Recovered the exact Plan shell boundary." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const tools = createCodingToolRegistry({ workspaceRoot });
+  const warm = harness.createLifecycle({
+    modelTargets,
+    stateRoot,
+    tools,
+    workspaceRoot,
+    [planShellEnvironmentFactory]: options.shellEnvironmentFactory,
+  });
+  let cold: ReturnType<typeof harness.createLifecycle> | undefined;
+  let secondCold: ReturnType<typeof harness.createLifecycle> | undefined;
+
+  try {
+    const created = await warm.create({ targetIdentity });
+    const entered = await warm.enterPlan({ sessionId: created.sessionId });
+    const plan = entered.plan;
+    const shellTool = tools.resolve("run_shell");
+    if (
+      plan?.shellEnvironment === undefined ||
+      plan.gitPolicyVersion !== "git-auto-policy.v1" ||
+      plan.gitPolicyDigest === undefined ||
+      shellTool === undefined ||
+      entered.promptContext === undefined
+    ) {
+      throw new Error("Expected the hybrid Plan shell authority.");
+    }
+    const assessment = await assessPlanCommandExecutionV1({
+      rawCommand: options.command,
+      shellEnvironment: plan.shellEnvironment,
+      workspaceRoot,
+    });
+    if (assessment.status !== "assessed") {
+      throw new Error("Expected one bounded Plan shell assessment.");
+    }
+    const subject = {
+      type: "plan_command" as const,
+      command: options.command,
+      cwd: "." as const,
+      planCycleId: plan.cycleId,
+      planPolicyVersion: "plan-policy.hybrid-v1" as const,
+      shellPolicyVersion: "plan-shell-policy.v1" as const,
+      shellEnvironmentVersion: "plan-shell-env.v1" as const,
+      shellEnvironmentDigest: plan.shellEnvironment.digest,
+      toolProfileDigest: plan.eligibleToolProfile.digest,
+      gitPolicyVersion: plan.gitPolicyVersion,
+      gitPolicyDigest: plan.gitPolicyDigest,
+      assessment: {
+        version: 1 as const,
+        disposition: assessment.disposition,
+        reasons: assessment.reasons,
+        digest: assessmentMatches ? assessment.digest : (`sha256:${"0".repeat(64)}` as const),
+      },
+    };
+    const planToolNames = new Set(
+      plan.eligibleToolProfile.definitions.map((definition) => definition.name),
+    );
+    const requestTools = tools
+      .definitions()
+      .filter((definition) => planToolNames.has(definition.name));
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the created Plan session store.");
+    }
+    const records = [
+      {
+        schemaVersion: 3,
+        record: {
+          type: "logical_run_started",
+          runId,
+          userMessage: "Recover one exact Plan diagnostic.",
+        },
+      },
+      {
+        schemaVersion: 3,
+        record: {
+          type: "runtime_event",
+          runId,
+          event: { type: "user_message", text: "Recover one exact Plan diagnostic." },
+        },
+      },
+      {
+        schemaVersion: 3,
+        record: {
+          type: "provider_attempt_started",
+          runId,
+          turn: 1,
+          attempt: 1,
+          targetIdentity,
+          promptProjection: {
+            version: 1,
+            assemblyIdentityDigest: entered.promptContext.assemblyIdentityDigest,
+            requestProjectionDigest: digestPromptRequestV1(
+              [
+                { role: "system", content: basePrompt },
+                { role: "developer", content: skillUsagePrompt },
+                { role: "user", content: "Recover one exact Plan diagnostic." },
+              ],
+              requestTools,
+            ),
+          },
+        },
+      },
+      {
+        schemaVersion: 3,
+        record: { type: "runtime_event", runId, event: { type: "model_message_started" } },
+      },
+      {
+        schemaVersion: 3,
+        record: {
+          type: "model_response_completed",
+          runId,
+          turn: 1,
+          attempt: 1,
+          targetIdentity,
+          response: {
+            text: "",
+            toolCalls: [call],
+            toolIntents: [
+              {
+                callId: call.id,
+                name: call.name,
+                argumentsDigest: `sha256:${createHash("sha256")
+                  .update(call.argumentsJson)
+                  .digest("hex")}`,
+                effect: "execute",
+                definitionDigest: shellTool.definitionDigest,
+                replay: "never",
+              },
+            ],
+            finishReason: "tool_calls",
+          },
+        },
+      },
+      {
+        schemaVersion: 3,
+        record: {
+          type: "runtime_event",
+          runId,
+          event: { type: "model_message_completed", text: "" },
+        },
+      },
+      {
+        schemaVersion: 3,
+        record: {
+          type: "runtime_event",
+          runId,
+          event: { type: "tool_requested", callId: call.id, name: call.name },
+        },
+      },
+      ...(!omitPermissionRequest
+        ? [
+            {
+              schemaVersion: 3,
+              record: {
+                type: "runtime_event",
+                runId,
+                event: {
+                  type: "tool_permission_requested",
+                  requestId: `${runId}:${call.id}`,
+                  callId: call.id,
+                  name: call.name,
+                  effect: "execute",
+                  scope: "call",
+                  subject,
+                },
+              },
+            } as const,
+          ]
+        : []),
+      {
+        schemaVersion: 3,
+        record: {
+          type: "runtime_event",
+          runId,
+          event: {
+            type: "tool_permission_decided",
+            ...(omitPermissionRequest ? {} : { requestId: `${runId}:${call.id}` }),
+            callId: call.id,
+            name: call.name,
+            decision: options.decision,
+            effect: "execute",
+            scope: "call",
+            subject,
+          },
+        },
+      },
+      ...(started
+        ? [
+            {
+              schemaVersion: 3,
+              record: {
+                type: "runtime_event",
+                runId,
+                event: { type: "tool_started", callId: call.id, name: call.name },
+              },
+            } as const,
+          ]
+        : []),
+    ] satisfies readonly Omit<Extract<SessionRecord, { readonly schemaVersion: 3 }>, "sequence">[];
+    for (const [index, record] of records.entries()) {
+      await store.append({
+        ...record,
+        sequence: entered.lastSequence + index + 1,
+      } as SessionRecord);
+    }
+    await warm.close();
+    cold = harness.createLifecycle({
+      modelTargets,
+      stateRoot,
+      tools,
+      workspaceRoot,
+      [planShellEnvironmentFactory]: options.shellEnvironmentFactory,
+    });
+    const publicEvents: RuntimeEvent[] = [];
+    cold.subscribe((event) => {
+      publicEvents.push(event);
+      if (event.type === "tool_permission_requested") {
+        cold?.decidePermission({ requestId: event.requestId, decision: "deny" });
+      }
+    });
+
+    let resumed: Extract<PlanShellRecoveryFixtureResult["resume"], { readonly status: "ready" }>;
+    try {
+      const result = await cold.resume({ sessionId: created.sessionId });
+      if (result.snapshot.schemaVersion !== 3) {
+        throw new Error("Expected one current session recovery snapshot.");
+      }
+      resumed = {
+        status: "ready" as const,
+        snapshotStatus: result.snapshot.status,
+        runResult: result.snapshot.run?.result,
+      };
+    } catch (error) {
+      return {
+        resume: {
+          status: "rejected" as const,
+          code:
+            typeof error === "object" && error !== null && "code" in error
+              ? String(error.code)
+              : undefined,
+        },
+        publicEvents,
+        providerCalls,
+      };
+    }
+    const continuationResult =
+      resumed.snapshotStatus === "interrupted"
+        ? (await cold.continue({ sessionId: created.sessionId })).result
+        : undefined;
+    let secondResume: PlanShellRecoveryFixtureResult["secondResume"];
+    if (continuationResult !== undefined) {
+      await cold.close();
+      cold = undefined;
+      secondCold = harness.createLifecycle({
+        modelTargets,
+        stateRoot,
+        tools,
+        workspaceRoot,
+        [planShellEnvironmentFactory]: options.shellEnvironmentFactory,
+      });
+      const second = await secondCold.resume({ sessionId: created.sessionId });
+      if (second.snapshot.schemaVersion !== 3) {
+        throw new Error("Expected one current settled recovery snapshot.");
+      }
+      secondResume = {
+        snapshotStatus: second.snapshot.status,
+        runResult: second.snapshot.run?.result,
+      };
+    }
+    return {
+      resume: resumed,
+      ...(continuationResult === undefined ? {} : { continuationResult }),
+      ...(secondResume === undefined ? {} : { secondResume }),
+      publicEvents,
+      ...(observedToolResult === undefined ? {} : { observedToolResult }),
+      providerCalls,
+    };
+  } finally {
+    await warm.close();
+    await cold?.close();
+    await secondCold?.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+}

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -40,11 +40,13 @@ import {
   assemblePromptMessagesV1,
   createInMemorySessionStoreDirectory,
   createTrustedWorkspaceTrustForTesting,
+  createUnavailablePlanShellEnvironmentV1,
   digestPromptRequestV1,
   inputResourceIngestBarrier,
   mcpCatalogStaleDurableBarrier,
   mcpTransportFactory,
   openJsonlSessionStore,
+  planShellEnvironmentFactory,
   preparedDirectDeepSeekV2ContextProfile,
   presentationCatalogPageSize,
   presentationHistoryPageSize,
@@ -96,6 +98,8 @@ function createSessionLifecycle(
     ...options,
     workspaceTrust:
       options.workspaceTrust ?? createTrustedWorkspaceTrustForTesting(options.workspaceRoot),
+    [planShellEnvironmentFactory]:
+      options[planShellEnvironmentFactory] ?? createUnavailablePlanShellEnvironmentV1,
   });
 }
 
@@ -828,7 +832,7 @@ test("PresentationSession opens an empty project catalog without creating a sess
   }
 });
 
-test("PresentationSession durably enters a read-only Plan cycle and rehydrates its exact identity", async () => {
+test("PresentationSession durably enters a hybrid Plan cycle and rehydrates its exact identity", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-plan-enter-"));
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
@@ -854,7 +858,8 @@ test("PresentationSession durably enters a read-only Plan cycle and rehydrates i
       state: "exploring",
       cycleId: expect.stringMatching(/^[0-9a-f-]{36}$/u),
       revision: 1,
-      policyVersion: "plan-policy.read-v1",
+      policyVersion: "plan-policy.hybrid-v1",
+      shellPolicyVersion: "plan-shell-policy.v1",
     });
 
     await presentation.close();
@@ -877,7 +882,7 @@ test("PresentationSession durably enters a read-only Plan cycle and rehydrates i
   }
 });
 
-test("PresentationSession freezes the exact eligible read-only Tool Profile for a Plan cycle", async () => {
+test("PresentationSession freezes the exact eligible hybrid Tool Profile for a Plan cycle", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-plan-profile-"));
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
@@ -913,13 +918,14 @@ test("PresentationSession freezes the exact eligible read-only Tool Profile for 
       [
         "read_file",
         "search_repository",
+        "run_shell",
         "activate_skill",
         "read_skill_resource",
         "read_input_resource",
       ].map((name) => ({
         name,
         definitionDigest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
-        effect: "read",
+        effect: name === "run_shell" ? "execute" : "read",
         source: "builtin",
       })),
     );
@@ -972,7 +978,8 @@ test("PresentationSession exits one Plan cycle and enters a distinct later cycle
     expect(second).toMatchObject({
       state: "exploring",
       revision: 1,
-      policyVersion: "plan-policy.read-v1",
+      policyVersion: "plan-policy.hybrid-v1",
+      shellPolicyVersion: "plan-shell-policy.v1",
       eligibleToolProfile: first.eligibleToolProfile,
     });
     expect(second?.cycleId).not.toBe(first.cycleId);
@@ -9285,6 +9292,100 @@ test("PresentationSession projects one live pending permission with its inline t
     }
   } finally {
     unsubscribeLifecycle();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession projects the truthful Plan shell warning for one exact pending command", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-plan-permission-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const command = "/usr/bin/printf 'diagnostic\\n'";
+  const model = new FakeModelDriver([
+    { type: "tool_call_start", id: "pending-plan-shell", name: "run_shell" },
+    {
+      type: "tool_call_delta",
+      id: "pending-plan-shell",
+      json: JSON.stringify({ command }),
+    },
+    { type: "tool_call_end", id: "pending-plan-shell" },
+    { type: "finish", reason: "tool_calls" },
+  ]);
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver: model, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createSessionLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["execute"] }),
+    stateRoot,
+    tools: createCodingToolRegistry({ workspaceRoot }),
+    workspaceRoot,
+  });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      projectLabel: "workspace",
+      targetIdentity,
+      stateRoot,
+      workspaceRoot,
+    });
+    const sessionId = presentation.getState().authoritative.active?.session.id;
+    if (sessionId === undefined) {
+      throw new Error("Expected an active session.");
+    }
+    await presentation.dispatch({ type: "enter_plan", sessionId });
+    const pendingVisible = Promise.withResolvers<void>();
+    const unsubscribe = presentation.subscribe(() => {
+      if (presentation.getState().authoritative.active?.pendingInteractions.length === 1) {
+        pendingVisible.resolve();
+      }
+    });
+    const continuation = lifecycle.continue({
+      sessionId,
+      input: { text: "Run the exact ambiguous diagnostic." },
+      limits: { maxTurns: 1 },
+    });
+    await pendingVisible.promise;
+    const pending = presentation.getState().authoritative.active?.pendingInteractions[0];
+
+    expect(pending).toMatchObject({
+      type: "permission",
+      callId: "pending-plan-shell",
+      effect: "execute",
+      subject: { type: "command", value: command },
+      warning:
+        "Plan parsing is not a sandbox. Approval may run project code, write cache or artifacts, read accessible data, or use network.",
+      canAllow: true,
+      changePreviewRef: null,
+    });
+    if (pending === undefined) {
+      throw new Error("Expected the pending Plan shell permission.");
+    }
+    await presentation.dispatch({
+      type: "decide_permission",
+      requestId: pending.requestId,
+      decision: "deny",
+    });
+    await continuation;
+    unsubscribe();
+    await presentation.close();
+  } finally {
     await lifecycle.close();
     await rm(testRoot, { recursive: true, force: true });
   }

--- a/packages/testkit/src/public-product-contract.test.ts
+++ b/packages/testkit/src/public-product-contract.test.ts
@@ -718,7 +718,9 @@ test("MCP canonical identity and durable Tool Profile contracts have package-int
 
   expect.soft(actualOwners).toEqual(expectedOwners);
   expect.soft(actualTypeOwners).toEqual(expectedTypeOwners);
-  expect.soft(canonicalConsumers).toEqual(["mcp-host.ts", "mcp-profile-contracts.ts"]);
+  expect
+    .soft(canonicalConsumers)
+    .toEqual(["mcp-host.ts", "mcp-profile-contracts.ts", "plan-mcp-permission-validation.ts"]);
   expect
     .soft(profileConsumers)
     .toEqual([

--- a/packages/testkit/src/session-lifecycle-test-topology.test.ts
+++ b/packages/testkit/src/session-lifecycle-test-topology.test.ts
@@ -25,7 +25,7 @@ const operatingSystemTestNames = [
   "SessionLifecycle hybrid Plan asks before a workspace PATH shadow can execute",
   "SessionLifecycle hybrid Plan asks for a near miss from each mandatory Git family",
   "SessionLifecycle hybrid Plan asks once for one exact ambiguous diagnostic",
-  "SessionLifecycle hybrid Plan attests Git and automatically executes all five repository families",
+  "SessionLifecycle hybrid Plan binds repository Git automation to the frozen installed build",
   "SessionLifecycle hybrid Plan automatically executes one exact simple inspection",
   "SessionLifecycle hybrid Plan durably freezes its shell environment identity",
   "SessionLifecycle hybrid Plan executes an approved call with only its frozen environment",

--- a/packages/testkit/src/session-lifecycle-test-topology.test.ts
+++ b/packages/testkit/src/session-lifecycle-test-topology.test.ts
@@ -9,6 +9,9 @@ const operatingSystemSuitePath = fileURLToPath(
   new URL("./session-lifecycle.os.test.ts", import.meta.url),
 );
 const supportPath = fileURLToPath(new URL("./session-lifecycle.test-support.ts", import.meta.url));
+const planRecoverySupportPath = fileURLToPath(
+  new URL("./plan-shell-recovery.test-support.ts", import.meta.url),
+);
 const topologySuitePath = fileURLToPath(import.meta.url);
 const testkitSourcePath = fileURLToPath(new URL(".", import.meta.url));
 
@@ -19,6 +22,15 @@ const operatingSystemTestNames = [
   "SessionLifecycle cold resume reconstructs the exact historical Vision Chat image bytes",
   "SessionLifecycle cold resume reads an immutable input resource after its source is deleted",
   "SessionLifecycle follows one selected symlink without persisting its source path",
+  "SessionLifecycle hybrid Plan asks before a workspace PATH shadow can execute",
+  "SessionLifecycle hybrid Plan asks for a near miss from each mandatory Git family",
+  "SessionLifecycle hybrid Plan asks once for one exact ambiguous diagnostic",
+  "SessionLifecycle hybrid Plan attests Git and automatically executes all five repository families",
+  "SessionLifecycle hybrid Plan automatically executes one exact simple inspection",
+  "SessionLifecycle hybrid Plan durably freezes its shell environment identity",
+  "SessionLifecycle hybrid Plan executes an approved call with only its frozen environment",
+  "SessionLifecycle hybrid Plan hard-denies one recognized shell mutation",
+  "SessionLifecycle hybrid Plan recovery reuses 'the exact durable assessment' only before shell start",
   "SessionLifecycle rejects a competing project writer before model dispatch and takes over after owner death",
   "SessionLifecycle rejects a corrupt immutable input resource before cold provider projection",
   "SessionLifecycle rejects a dangling selected symlink before provider dispatch",
@@ -35,18 +47,22 @@ const operatingSystemTestNames = [
 ] as const;
 
 test("SessionLifecycle behavior and OS contracts keep separate environment ownership", async () => {
-  const [behaviorSource, operatingSystemSource, supportSource] = await Promise.all([
-    readFile(behaviorSuitePath, "utf8"),
-    readOptional(operatingSystemSuitePath),
-    readOptional(supportPath),
-  ]);
+  const [behaviorSource, operatingSystemSource, supportSource, planRecoverySupportSource] =
+    await Promise.all([
+      readFile(behaviorSuitePath, "utf8"),
+      readOptional(operatingSystemSuitePath),
+      readOptional(supportPath),
+      readOptional(planRecoverySupportPath),
+    ]);
 
   expect.soft(operatingSystemSource.length).toBeGreaterThan(0);
   expect.soft(supportSource.length).toBeGreaterThan(0);
+  expect.soft(planRecoverySupportSource.length).toBeGreaterThan(0);
   expect
     .soft(uniqueRuntimeModuleSpecifiers(behaviorSource))
     .toEqual([
       "./index.js",
+      "./plan-shell-recovery.test-support.js",
       "./session-lifecycle.test-support.js",
       "@adam-agent/agent",
       "@adam-agent/agent/internal-testing",
@@ -85,7 +101,12 @@ test("SessionLifecycle behavior and OS contracts keep separate environment owner
     .toEqual(["createSessionLifecycle"]);
   expect
     .soft(runtimeImportedBindings(supportSource, "@adam-agent/agent/internal-testing"))
-    .toEqual(["createTrustedWorkspaceTrustForTesting", "sessionAutomaticTitlesEnabled"]);
+    .toEqual([
+      "createTrustedWorkspaceTrustForTesting",
+      "createUnavailablePlanShellEnvironmentV1",
+      "planShellEnvironmentFactory",
+      "sessionAutomaticTitlesEnabled",
+    ]);
   expect
     .soft(topLevelValueDeclarations(supportSource))
     .toEqual([
@@ -96,12 +117,32 @@ test("SessionLifecycle behavior and OS contracts keep separate environment owner
       "function:createSessionLifecycleForTests",
     ]);
   expect
+    .soft(uniqueRuntimeModuleSpecifiers(planRecoverySupportSource))
+    .toEqual([
+      "./index.js",
+      "./session-lifecycle.test-support.js",
+      "@adam-agent/agent",
+      "@adam-agent/agent/internal-testing",
+      "node:crypto",
+      "node:fs/promises",
+      "node:os",
+      "node:path",
+    ]);
+  expect
+    .soft(topLevelValueDeclarations(planRecoverySupportSource))
+    .toEqual([
+      "const:contextProfile=ObjectLiteralExpression",
+      "function:exercisePlanShellRecoveryFixture",
+    ]);
+  expect
     .soft(topLevelValueDeclarations(operatingSystemSource))
     .toEqual([
       "const:lifecycleOwnerFixturePath=CallExpression",
       "const:childObservations=NewExpression",
       "const:visionResponsesIdentity=ObjectLiteralExpression",
+      "const:planTestContextProfile=ObjectLiteralExpression",
       "function:exerciseColdVisionResponsesArtifactFailure",
+      "function:runGitFixtureCommand",
       "function:observeChild",
       "function:waitForChildMessage",
       "function:waitForFixtureRecord",
@@ -119,12 +160,20 @@ test("SessionLifecycle behavior and OS contracts keep separate environment owner
     .toEqual(["session-lifecycle.os.test.ts"]);
   expect.soft(presentFragments(behaviorSource, ["beforeAll(", "afterAll("])).toEqual([]);
   expect.soft(presentFragments(operatingSystemSource, ["beforeAll(", "afterAll("])).toEqual([]);
-  expect.soft(presentFragments(supportSource, ["beforeAll(", "afterAll("])).toEqual([]);
   expect
     .soft(
-      presentFragments(`${behaviorSource}\n${operatingSystemSource}\n${supportSource}`, [
-        "vi.mock(",
+      presentFragments(`${supportSource}\n${planRecoverySupportSource}`, [
+        "beforeAll(",
+        "afterAll(",
       ]),
+    )
+    .toEqual([]);
+  expect
+    .soft(
+      presentFragments(
+        `${behaviorSource}\n${operatingSystemSource}\n${supportSource}\n${planRecoverySupportSource}`,
+        ["vi.mock("],
+      ),
     )
     .toEqual([]);
   expect
@@ -143,7 +192,7 @@ test("SessionLifecycle behavior and OS contracts keep separate environment owner
   expect.soft(presentFragments(operatingSystemSource, ["session-lifecycle.test.js"])).toEqual([]);
   expect
     .soft(
-      presentFragments(supportSource, [
+      presentFragments(`${supportSource}\n${planRecoverySupportSource}`, [
         "session-lifecycle.test.js",
         "session-lifecycle.os.test.js",
       ]),
@@ -152,9 +201,9 @@ test("SessionLifecycle behavior and OS contracts keep separate environment owner
 
   const behaviorNames = declaredTestNames(behaviorSource);
   const operatingSystemNames = declaredTestNames(operatingSystemSource);
-  expect.soft(behaviorNames).toHaveLength(89);
+  expect.soft(behaviorNames).toHaveLength(96);
   expect.soft(operatingSystemNames).toEqual([...operatingSystemTestNames].sort());
-  expect.soft(operatingSystemNames).toHaveLength(19);
+  expect.soft(operatingSystemNames).toHaveLength(28);
   expect.soft(operatingSystemTestNames.filter((name) => behaviorNames.includes(name))).toEqual([]);
   const combinedNames = [...behaviorNames, ...operatingSystemNames];
   expect.soft(new Set(combinedNames).size).toBe(combinedNames.length);

--- a/packages/testkit/src/session-lifecycle.os.test.ts
+++ b/packages/testkit/src/session-lifecycle.os.test.ts
@@ -5,6 +5,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  realpath,
   rm,
   symlink,
   truncate,
@@ -21,16 +22,21 @@ import {
   createPermissionPolicy,
   createReadToolRegistry,
   type ModelTargets,
+  type RuntimeEvent,
   SessionLifecycleError,
   type ToolRegistry,
 } from "@adam-agent/agent";
 import {
+  assessPlanCommandExecutionV1,
+  createPlanShellEnvironmentV1,
+  digestPromptRequestV1,
   inputResourceIngestBarrier,
   openJsonlSessionStore,
+  planShellEnvironmentFactory,
   type SessionRecord,
 } from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
-import { FakeModelDriver } from "./index.js";
+import { createInMemorySessionLifecycleHarness, FakeModelDriver } from "./index.js";
 import {
   sessionLifecycleAnswerOnlyDeepSeekStream as answerOnlyDeepSeekStream,
   sessionLifecycleBasePrompt as basePrompt,
@@ -58,6 +64,663 @@ const visionResponsesIdentity = {
   profileVersion: 2,
   certification: "certified",
 } as const;
+
+const planTestContextProfile = {
+  version: 1,
+  contextWindowTokens: 1_000_000,
+  maximumOutputTokens: 32_768,
+  compactAtTokens: 800_000,
+  postCompactTargetTokens: 200_000,
+  retainedTargetTokens: 20_000,
+  estimatorVersion: 1,
+} as const;
+
+test("SessionLifecycle hybrid Plan automatically executes one exact simple inspection", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-hybrid-inspection-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const executablePathName = "PATH";
+  const previousPath = process.env[executablePathName];
+  process.env[executablePathName] = "/usr/bin:/bin";
+  await mkdir(workspaceRoot);
+  let requestCount = 0;
+  const driver = new FakeModelDriver((request) => {
+    requestCount += 1;
+    if (requestCount === 1) {
+      return [
+        { type: "tool_call_start", id: "plan-uname", name: "run_shell" },
+        {
+          type: "tool_call_delta",
+          id: "plan-uname",
+          json: JSON.stringify({ command: "uname -s" }),
+        },
+        { type: "tool_call_end", id: "plan-uname" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    const latestMessage = request.messages.at(-1);
+    const completedAutomatically =
+      latestMessage?.role === "tool" &&
+      latestMessage.name === "run_shell" &&
+      latestMessage.result.status === "completed" &&
+      JSON.stringify(latestMessage.result.output) ===
+        JSON.stringify({
+          termination: { type: "exited", exitCode: 0 },
+          stdout: { tail: "Linux\n", totalBytes: 6, omittedBytes: 0 },
+          stderr: { tail: "", totalBytes: 0, omittedBytes: 0 },
+        });
+    return [
+      {
+        type: "text_delta",
+        text: completedAutomatically
+          ? "The Plan inspection completed automatically."
+          : "The Plan inspection did not complete automatically.",
+      },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: planTestContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: planTestContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["execute"] }),
+    stateRoot,
+    tools: createCodingToolRegistry({ workspaceRoot }),
+    workspaceRoot,
+    [planShellEnvironmentFactory]: createPlanShellEnvironmentV1,
+  });
+  const events: RuntimeEvent[] = [];
+  lifecycle.subscribe((event) => {
+    events.push(event);
+    if (event.type === "tool_permission_requested") {
+      lifecycle.decidePermission({ requestId: event.requestId, decision: "deny" });
+    }
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.enterPlan({ sessionId: created.sessionId });
+    const continued = await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Inspect the Linux system name without changing anything." },
+      limits: { maxTurns: 2 },
+    });
+
+    expect({
+      result: continued.result,
+      plan: continued.snapshot.plan,
+      permissionRequests: events.filter((event) => event.type === "tool_permission_requested")
+        .length,
+      permissionSubject: events.find((event) => event.type === "tool_permission_requested")
+        ?.subject,
+      toolStarted: events.some(
+        (event) =>
+          event.type === "tool_started" &&
+          event.callId === "plan-uname" &&
+          event.name === "run_shell",
+      ),
+    }).toMatchObject({
+      result: { status: "completed", answer: "The Plan inspection completed automatically." },
+      plan: {
+        state: "exploring",
+        policyVersion: "plan-policy.hybrid-v1",
+        shellPolicyVersion: "plan-shell-policy.v1",
+      },
+      permissionRequests: 0,
+      permissionSubject: undefined,
+      toolStarted: true,
+    });
+  } finally {
+    await lifecycle.close();
+    if (previousPath === undefined) {
+      delete process.env[executablePathName];
+    } else {
+      process.env[executablePathName] = previousPath;
+    }
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle hybrid Plan durably freezes its shell environment identity", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-shell-environment-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const { PATH: executablePath = "" } = process.env;
+  await mkdir(workspaceRoot);
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    stateRoot,
+    tools: createCodingToolRegistry({ workspaceRoot }),
+    workspaceRoot,
+    [planShellEnvironmentFactory]: createPlanShellEnvironmentV1,
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    const entered = await lifecycle.enterPlan({ sessionId: created.sessionId });
+
+    expect(entered.plan).toMatchObject({
+      policyVersion: "plan-policy.hybrid-v1",
+      shellPolicyVersion: "plan-shell-policy.v1",
+      shellEnvironment: {
+        version: "plan-shell-env.v1",
+        pathEntries: executablePath.split(":"),
+        variables: {
+          PATH: executablePath,
+          LANG: "C",
+          LC_ALL: "C",
+          TERM: "dumb",
+        },
+        home: { allocation: "owner-only-empty-per-call" },
+        shell: {
+          lookupPath: "/bin/sh",
+          canonicalPath: "/usr/bin/dash",
+          digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+        },
+        digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+      },
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle hybrid Plan executes an approved call with only its frozen environment", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-shell-execution-env-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const sentinelName = "ADAM_PLAN_SECRET_SENTINEL";
+  const previousSentinel = process.env[sentinelName];
+  const { PATH: executablePath = "" } = process.env;
+  process.env[sentinelName] = "must-not-reach-plan-shell";
+  await mkdir(workspaceRoot);
+  const canonicalTemporaryRoot = await realpath(tmpdir());
+  let requestCount = 0;
+  const command = `/usr/bin/env && /usr/bin/stat -c 'HOME_MODE=%a' "$HOME" && /usr/bin/find "$HOME" -mindepth 1 -print`;
+  const driver = new FakeModelDriver((request) => {
+    requestCount += 1;
+    if (requestCount === 1) {
+      return [
+        { type: "tool_call_start", id: "plan-env", name: "run_shell" },
+        {
+          type: "tool_call_delta",
+          id: "plan-env",
+          json: JSON.stringify({ command }),
+        },
+        { type: "tool_call_end", id: "plan-env" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    const latestMessage = request.messages.at(-1);
+    const toolOutput =
+      latestMessage?.role === "tool" &&
+      latestMessage.name === "run_shell" &&
+      latestMessage.result.status === "completed" &&
+      typeof latestMessage.result.output === "object" &&
+      latestMessage.result.output !== null
+        ? (latestMessage.result.output as { readonly stdout?: { readonly tail?: unknown } })
+        : undefined;
+    const stdout = toolOutput?.stdout;
+    const lines = typeof stdout?.tail === "string" ? stdout.tail.trimEnd().split("\n") : [];
+    const environment = Object.fromEntries(
+      lines
+        .filter((line) => line.includes("=") && !line.startsWith("HOME_MODE="))
+        .map((line) => [line.slice(0, line.indexOf("=")), line.slice(line.indexOf("=") + 1)]),
+    );
+    const {
+      PATH: observedPath,
+      LANG: observedLang,
+      LC_ALL: observedLcAll,
+      TERM: observedTerm,
+      TMPDIR: observedTemporaryRoot,
+      HOME: observedHome,
+    } = environment;
+    return [
+      {
+        type: "text_delta",
+        text:
+          observedPath === executablePath &&
+          observedLang === "C" &&
+          observedLcAll === "C" &&
+          observedTerm === "dumb" &&
+          observedTemporaryRoot === canonicalTemporaryRoot &&
+          environment[sentinelName] === undefined &&
+          observedHome?.startsWith(`${canonicalTemporaryRoot}/adam-agent-shell-home-`) === true &&
+          lines.at(-1) === "HOME_MODE=700"
+            ? "The approved Plan shell used only its frozen environment."
+            : "The approved Plan shell environment drifted.",
+      },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: planTestContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: planTestContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["execute"] }),
+    stateRoot,
+    tools: createCodingToolRegistry({ workspaceRoot }),
+    workspaceRoot,
+    [planShellEnvironmentFactory]: createPlanShellEnvironmentV1,
+  });
+  const events: RuntimeEvent[] = [];
+  lifecycle.subscribe((event) => {
+    events.push(event);
+    if (event.type === "tool_permission_requested") {
+      lifecycle.decidePermission({ requestId: event.requestId, decision: "allow" });
+    }
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    const entered = await lifecycle.enterPlan({ sessionId: created.sessionId });
+    const continued = await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Inspect the frozen Plan shell environment." },
+      limits: { maxTurns: 2 },
+    });
+    const request = events.find(
+      (event) => event.type === "tool_permission_requested" && event.callId === "plan-env",
+    );
+
+    expect({ result: continued.result, request }).toMatchObject({
+      result: {
+        status: "completed",
+        answer: "The approved Plan shell used only its frozen environment.",
+      },
+      request: {
+        subject: {
+          type: "plan_command",
+          shellEnvironmentVersion: "plan-shell-env.v1",
+          shellEnvironmentDigest: entered.plan?.shellEnvironment?.digest,
+        },
+      },
+    });
+  } finally {
+    if (previousSentinel === undefined) {
+      delete process.env[sentinelName];
+    } else {
+      process.env[sentinelName] = previousSentinel;
+    }
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle hybrid Plan asks before a workspace PATH shadow can execute", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-shell-shadow-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const executableRoot = join(workspaceRoot, "bin");
+  const executablePathName = "PATH";
+  const previousPath = process.env[executablePathName];
+  await mkdir(executableRoot, { recursive: true });
+  await writeFile(
+    join(executableRoot, "uname"),
+    "#!/bin/sh\n/usr/bin/printf 'shadowed\\n'\n",
+    "utf8",
+  );
+  await chmod(join(executableRoot, "uname"), 0o755);
+  process.env[executablePathName] = `${executableRoot}:/usr/bin:/bin`;
+  let requestCount = 0;
+  const driver = new FakeModelDriver((request) => {
+    requestCount += 1;
+    if (requestCount === 1) {
+      return [
+        { type: "tool_call_start", id: "plan-shadow", name: "run_shell" },
+        { type: "tool_call_delta", id: "plan-shadow", json: '{"command":"uname -s"}' },
+        { type: "tool_call_end", id: "plan-shadow" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    const latestMessage = request.messages.at(-1);
+    const shadowExecuted =
+      latestMessage?.role === "tool" &&
+      latestMessage.name === "run_shell" &&
+      latestMessage.result.status === "completed" &&
+      typeof latestMessage.result.output === "object" &&
+      latestMessage.result.output !== null &&
+      JSON.stringify(latestMessage.result.output).includes("shadowed\\n");
+    return [
+      {
+        type: "text_delta",
+        text: shadowExecuted
+          ? "The PATH shadow executed only after exact approval."
+          : "The PATH shadow did not execute as approved.",
+      },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: planTestContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: planTestContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["execute"] }),
+    stateRoot,
+    tools: createCodingToolRegistry({ workspaceRoot }),
+    workspaceRoot,
+    [planShellEnvironmentFactory]: createPlanShellEnvironmentV1,
+  });
+  const events: RuntimeEvent[] = [];
+  lifecycle.subscribe((event) => {
+    events.push(event);
+    if (event.type === "tool_permission_requested") {
+      lifecycle.decidePermission({ requestId: event.requestId, decision: "allow" });
+    }
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.enterPlan({ sessionId: created.sessionId });
+    const continued = await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Inspect the system identity." },
+      limits: { maxTurns: 2 },
+    });
+    const requests = events.filter(
+      (event) => event.type === "tool_permission_requested" && event.callId === "plan-shadow",
+    );
+
+    expect({ result: continued.result, requests }).toMatchObject({
+      result: {
+        status: "completed",
+        answer: "The PATH shadow executed only after exact approval.",
+      },
+      requests: [
+        {
+          subject: {
+            type: "plan_command",
+            assessment: {
+              disposition: "ask_ambiguous",
+              reasons: ["environment_untrusted"],
+            },
+          },
+        },
+      ],
+    });
+  } finally {
+    if (previousPath === undefined) {
+      delete process.env[executablePathName];
+    } else {
+      process.env[executablePathName] = previousPath;
+    }
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle hybrid Plan hard-denies one recognized shell mutation", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-hybrid-mutation-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const markerPath = join(workspaceRoot, "forbidden.txt");
+  await mkdir(workspaceRoot);
+  let requestCount = 0;
+  const driver = new FakeModelDriver((request) => {
+    requestCount += 1;
+    if (requestCount === 1) {
+      return [
+        { type: "tool_call_start", id: "plan-touch", name: "run_shell" },
+        {
+          type: "tool_call_delta",
+          id: "plan-touch",
+          json: JSON.stringify({ command: "touch forbidden.txt" }),
+        },
+        { type: "tool_call_end", id: "plan-touch" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    const latestMessage = request.messages.at(-1);
+    const deniedByPlan =
+      latestMessage?.role === "tool" &&
+      latestMessage.name === "run_shell" &&
+      latestMessage.result.status === "failed" &&
+      latestMessage.result.error.code === "permission_denied";
+    return [
+      {
+        type: "text_delta",
+        text: deniedByPlan
+          ? "The shell mutation was denied by Plan."
+          : "The shell mutation escaped Plan denial.",
+      },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: planTestContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: planTestContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: ["execute"] }),
+    stateRoot,
+    tools: createCodingToolRegistry({ workspaceRoot }),
+    workspaceRoot,
+    [planShellEnvironmentFactory]: createPlanShellEnvironmentV1,
+  });
+  const events: RuntimeEvent[] = [];
+  lifecycle.subscribe((event) => {
+    events.push(event);
+    if (event.type === "tool_permission_requested") {
+      lifecycle.decidePermission({ requestId: event.requestId, decision: "allow" });
+    }
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.enterPlan({ sessionId: created.sessionId });
+    const continued = await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Try to create forbidden.txt while Plan is active." },
+      limits: { maxTurns: 2 },
+    });
+
+    expect({
+      result: continued.result,
+      permissionRequests: events.filter((event) => event.type === "tool_permission_requested")
+        .length,
+      toolStarted: events.some(
+        (event) => event.type === "tool_started" && event.callId === "plan-touch",
+      ),
+    }).toEqual({
+      result: { status: "completed", answer: "The shell mutation was denied by Plan." },
+      permissionRequests: 0,
+      toolStarted: false,
+    });
+    await expect(readFile(markerPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle hybrid Plan asks once for one exact ambiguous diagnostic", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-hybrid-ambiguous-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const command = "/usr/bin/printf 'approved diagnostic\\n'";
+  const executablePathName = "PATH";
+  const previousPath = process.env[executablePathName];
+  process.env[executablePathName] = "/usr/bin:/bin";
+  await mkdir(workspaceRoot);
+  let requestCount = 0;
+  const driver = new FakeModelDriver((request) => {
+    requestCount += 1;
+    if (requestCount === 1) {
+      return [
+        { type: "tool_call_start", id: "plan-diagnostic", name: "run_shell" },
+        {
+          type: "tool_call_delta",
+          id: "plan-diagnostic",
+          json: JSON.stringify({ command }),
+        },
+        { type: "tool_call_end", id: "plan-diagnostic" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    const latestMessage = request.messages.at(-1);
+    const approvedExactCall =
+      latestMessage?.role === "tool" &&
+      latestMessage.name === "run_shell" &&
+      latestMessage.result.status === "completed" &&
+      JSON.stringify(latestMessage.result.output) ===
+        JSON.stringify({
+          termination: { type: "exited", exitCode: 0 },
+          stdout: { tail: "approved diagnostic\n", totalBytes: 20, omittedBytes: 0 },
+          stderr: { tail: "", totalBytes: 0, omittedBytes: 0 },
+        });
+    return [
+      {
+        type: "text_delta",
+        text: approvedExactCall
+          ? "The exact ambiguous diagnostic was approved once."
+          : "The ambiguous diagnostic approval was not exact.",
+      },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: planTestContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: planTestContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["execute"] }),
+    stateRoot,
+    tools: createCodingToolRegistry({ workspaceRoot }),
+    workspaceRoot,
+    [planShellEnvironmentFactory]: createPlanShellEnvironmentV1,
+  });
+  const events: RuntimeEvent[] = [];
+  lifecycle.subscribe((event) => {
+    events.push(event);
+    if (event.type === "tool_permission_requested") {
+      lifecycle.decidePermission({ requestId: event.requestId, decision: "allow" });
+    }
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    const entered = await lifecycle.enterPlan({ sessionId: created.sessionId });
+    const plan = entered.plan;
+    if (plan === undefined) {
+      throw new Error("Expected the entered hybrid Plan cycle.");
+    }
+    const continued = await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Run the exact diagnostic only after asking me." },
+      limits: { maxTurns: 2 },
+    });
+    const permissionRequest = events.find(
+      (event) => event.type === "tool_permission_requested" && event.callId === "plan-diagnostic",
+    );
+
+    expect({ result: continued.result, permissionRequest }).toMatchObject({
+      result: {
+        status: "completed",
+        answer: "The exact ambiguous diagnostic was approved once.",
+      },
+      permissionRequest: {
+        name: "run_shell",
+        effect: "execute",
+        scope: "call",
+        subject: {
+          type: "plan_command",
+          command,
+          cwd: ".",
+          planCycleId: plan.cycleId,
+          planPolicyVersion: "plan-policy.hybrid-v1",
+          shellPolicyVersion: "plan-shell-policy.v1",
+          toolProfileDigest: plan.eligibleToolProfile.digest,
+          assessment: {
+            disposition: "ask_ambiguous",
+            reasons: ["unclassified_command"],
+            digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+          },
+        },
+      },
+    });
+    expect(
+      events.filter(
+        (event) => event.type === "tool_permission_requested" && event.callId === "plan-diagnostic",
+      ),
+    ).toHaveLength(1);
+  } finally {
+    await lifecycle.close();
+    if (previousPath === undefined) {
+      delete process.env[executablePathName];
+    } else {
+      process.env[executablePathName] = previousPath;
+    }
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
 
 test("SessionLifecycle cold resume reads an immutable input resource after its source is deleted", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-input-resource-cold-resume-"));
@@ -1303,6 +1966,619 @@ test("SessionLifecycle real-process branch writes independently, survives restar
   }
 }, 20_000);
 
+test("SessionLifecycle hybrid Plan attests Git and automatically executes all five repository families", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-git-families-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const executablePathName = "PATH";
+  const previousPath = process.env[executablePathName];
+  const contextProfile = {
+    version: 1 as const,
+    contextWindowTokens: 1_000_000,
+    maximumOutputTokens: 32_768,
+    compactAtTokens: 800_000,
+    postCompactTargetTokens: 200_000,
+    retainedTargetTokens: 20_000,
+    estimatorVersion: 1 as const,
+  };
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "README.md"), "Git Plan fixture\n", "utf8");
+  await runGitFixtureCommand(workspaceRoot, ["init"]);
+  await runGitFixtureCommand(workspaceRoot, ["config", "user.name", "Adam Test"]);
+  await runGitFixtureCommand(workspaceRoot, ["config", "user.email", "adam@example.test"]);
+  await runGitFixtureCommand(workspaceRoot, ["add", "README.md"]);
+  await runGitFixtureCommand(workspaceRoot, ["commit", "-m", "fixture"]);
+  process.env[executablePathName] = "/usr/bin:/bin";
+  const commands = [
+    "git --version",
+    "git --no-pager status --porcelain=v1 --untracked-files=normal --ignore-submodules=all",
+    "git --no-pager rev-parse --is-inside-work-tree",
+    "git --no-pager log --oneline --decorate=no -n 1",
+    "git --no-pager diff --no-ext-diff --no-textconv --ignore-submodules=all --name-only -- README.md",
+    "git --no-pager show --no-ext-diff --no-textconv --ignore-submodules=all --stat HEAD",
+  ] as const;
+  let requestCount = 0;
+  const driver = new FakeModelDriver((request) => {
+    const command = commands[requestCount];
+    requestCount += 1;
+    if (command !== undefined) {
+      const callId = `plan-git-${requestCount}`;
+      return [
+        { type: "tool_call_start", id: callId, name: "run_shell" },
+        { type: "tool_call_delta", id: callId, json: JSON.stringify({ command }) },
+        { type: "tool_call_end", id: callId },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    const latestMessage = request.messages.at(-1);
+    return [
+      {
+        type: "text_delta",
+        text:
+          latestMessage?.role === "tool" && latestMessage.result.status === "completed"
+            ? "Every mandatory Git family executed automatically after attestation."
+            : "A mandatory Git family did not execute automatically.",
+      },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["execute"] }),
+    stateRoot,
+    tools: createCodingToolRegistry({ workspaceRoot }),
+    workspaceRoot,
+    [planShellEnvironmentFactory]: createPlanShellEnvironmentV1,
+  });
+  const events: RuntimeEvent[] = [];
+  lifecycle.subscribe((event) => {
+    events.push(event);
+    if (event.type === "tool_permission_requested") {
+      lifecycle.decidePermission({ requestId: event.requestId, decision: "deny" });
+    }
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.enterPlan({ sessionId: created.sessionId });
+    const continued = await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Inspect this ordinary Git repository." },
+      limits: { maxTurns: commands.length + 1 },
+    });
+
+    expect({ result: continued.result, plan: continued.snapshot.plan }).toMatchObject({
+      result: {
+        status: "completed",
+        answer: "Every mandatory Git family executed automatically after attestation.",
+      },
+      plan: {
+        gitAttestation: {
+          version: "git-auto-attestation.v1",
+          gitVersion: "git version 2.43.0",
+          digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+        },
+      },
+    });
+    expect(events.filter((event) => event.type === "tool_permission_requested")).toHaveLength(0);
+    const completedShellEvents = events.filter(
+      (event): event is Extract<RuntimeEvent, { readonly type: "tool_completed" }> =>
+        event.type === "tool_completed" && event.name === "run_shell",
+    );
+    expect(completedShellEvents).toHaveLength(commands.length);
+    for (const event of completedShellEvents) {
+      expect(event.output).toMatchObject({
+        termination: { type: "exited", exitCode: 0 },
+        stderr: { tail: "", omittedBytes: 0 },
+      });
+    }
+    expect(completedShellEvents[0]?.output).toMatchObject({
+      stdout: { tail: "git version 2.43.0\n", omittedBytes: 0 },
+    });
+    expect(completedShellEvents[1]?.output).toMatchObject({
+      stdout: { tail: "", omittedBytes: 0 },
+    });
+    expect(completedShellEvents[2]?.output).toMatchObject({
+      stdout: { tail: "true\n", omittedBytes: 0 },
+    });
+    expect(completedShellEvents[3]?.output).toMatchObject({
+      stdout: { tail: expect.stringContaining("fixture"), omittedBytes: 0 },
+    });
+    expect(completedShellEvents[4]?.output).toMatchObject({
+      stdout: { tail: "", omittedBytes: 0 },
+    });
+    expect(completedShellEvents[5]?.output).toMatchObject({
+      stdout: { tail: expect.stringContaining("README.md"), omittedBytes: 0 },
+    });
+    const child = await lifecycle.branch({
+      parentSessionId: created.sessionId,
+      atSequence: continued.snapshot.lastSequence,
+    });
+    expect(child.plan?.gitAttestation).toEqual(continued.snapshot.plan?.gitAttestation);
+  } finally {
+    await lifecycle.close();
+    if (previousPath === undefined) {
+      delete process.env[executablePathName];
+    } else {
+      process.env[executablePathName] = previousPath;
+    }
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle hybrid Plan asks for a near miss from each mandatory Git family", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-git-near-misses-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const executablePathName = "PATH";
+  const previousPath = process.env[executablePathName];
+  const contextProfile = {
+    version: 1 as const,
+    contextWindowTokens: 1_000_000,
+    maximumOutputTokens: 32_768,
+    compactAtTokens: 800_000,
+    postCompactTargetTokens: 200_000,
+    retainedTargetTokens: 20_000,
+    estimatorVersion: 1 as const,
+  };
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "README.md"), "Git Plan near misses\n", "utf8");
+  await runGitFixtureCommand(workspaceRoot, ["init"]);
+  process.env[executablePathName] = "/usr/bin:/bin";
+  const commands = [
+    "git --version",
+    "git status",
+    "git --no-pager rev-parse HEAD",
+    "git --no-pager log --oneline --decorate=short -n 1",
+    "git --no-pager diff --cached --no-ext-diff --no-textconv --ignore-submodules=all",
+    "git --no-pager show --no-ext-diff --no-textconv --ignore-submodules=all --stat HEAD~1",
+  ] as const;
+  let requestCount = 0;
+  const driver = new FakeModelDriver(() => {
+    const command = commands[requestCount];
+    requestCount += 1;
+    if (command !== undefined) {
+      const callId = `plan-git-near-${requestCount}`;
+      return [
+        { type: "tool_call_start", id: callId, name: "run_shell" },
+        { type: "tool_call_delta", id: callId, json: JSON.stringify({ command }) },
+        { type: "tool_call_end", id: callId },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    return [
+      { type: "text_delta", text: "Every mandatory Git near miss required exact approval." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["execute"] }),
+    stateRoot,
+    tools: createCodingToolRegistry({ workspaceRoot }),
+    workspaceRoot,
+    [planShellEnvironmentFactory]: createPlanShellEnvironmentV1,
+  });
+  const events: RuntimeEvent[] = [];
+  lifecycle.subscribe((event) => {
+    events.push(event);
+    if (event.type === "tool_permission_requested") {
+      lifecycle.decidePermission({ requestId: event.requestId, decision: "deny" });
+    }
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.enterPlan({ sessionId: created.sessionId });
+    const continued = await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Try one near miss from every Git family." },
+      limits: { maxTurns: commands.length + 1 },
+    });
+    const permissionRequests = events.filter(
+      (event): event is Extract<RuntimeEvent, { readonly type: "tool_permission_requested" }> =>
+        event.type === "tool_permission_requested" && event.name === "run_shell",
+    );
+
+    expect(continued.result).toEqual({
+      status: "completed",
+      answer: "Every mandatory Git near miss required exact approval.",
+    });
+    expect(permissionRequests).toHaveLength(5);
+    expect(
+      permissionRequests.map((event) =>
+        event.subject.type === "plan_command" ? event.subject.command : undefined,
+      ),
+    ).toEqual(commands.slice(1));
+    expect(
+      events.filter((event) => event.type === "tool_completed" && event.name === "run_shell"),
+    ).toHaveLength(1);
+  } finally {
+    await lifecycle.close();
+    if (previousPath === undefined) {
+      delete process.env[executablePathName];
+    } else {
+      process.env[executablePathName] = previousPath;
+    }
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test.each([
+  {
+    label: "the exact durable assessment",
+    assessmentMatches: true,
+    omitPermissionRequest: false,
+    started: false,
+  },
+])(
+  "SessionLifecycle hybrid Plan recovery reuses $label only before shell start",
+  async ({ assessmentMatches, omitPermissionRequest, started }) => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-shell-recovery-"));
+    const stateRoot = join(testRoot, "state");
+    const workspaceRoot = join(testRoot, "workspace");
+    const executablePathName = "PATH";
+    const previousPath = process.env[executablePathName];
+    process.env[executablePathName] = "/usr/bin:/bin";
+    await mkdir(workspaceRoot);
+    const command = "/usr/bin/printf 'recovered diagnostic\\n'";
+    const call = {
+      id: "plan-shell-recovery",
+      name: "run_shell",
+      argumentsJson: JSON.stringify({ command }),
+    } as const;
+    const runId = assessmentMatches
+      ? "123e4567-e89b-42d3-a456-426614176001"
+      : "123e4567-e89b-42d3-a456-426614176002";
+    let cold:
+      | ReturnType<ReturnType<typeof createInMemorySessionLifecycleHarness>["createLifecycle"]>
+      | undefined;
+    const driver = new FakeModelDriver((request) => {
+      expect(request.messages.at(-1)).toMatchObject({
+        role: "tool",
+        callId: call.id,
+        name: call.name,
+        result: assessmentMatches
+          ? { status: "completed" }
+          : { status: "failed", error: { code: "permission_denied" } },
+      });
+      return [
+        { type: "text_delta", text: "Recovered the exact Plan shell boundary." },
+        { type: "finish", reason: "stop" },
+      ];
+    });
+    const modelTargets: ModelTargets = {
+      async resolve() {
+        return {
+          identity: targetIdentity,
+          driver,
+          contextProfile: {
+            version: 1,
+            contextWindowTokens: 1_000_000,
+            maximumOutputTokens: 32_768,
+            compactAtTokens: 800_000,
+            postCompactTargetTokens: 200_000,
+            retainedTargetTokens: 20_000,
+            estimatorVersion: 1,
+          },
+        };
+      },
+      async snapshot() {
+        return {
+          targets: [
+            {
+              identity: targetIdentity,
+              readiness: { status: "available", credentialSource: "deterministic test adapter" },
+              contextProfile: {
+                version: 1,
+                contextWindowTokens: 1_000_000,
+                maximumOutputTokens: 32_768,
+                compactAtTokens: 800_000,
+                postCompactTargetTokens: 200_000,
+                retainedTargetTokens: 20_000,
+                estimatorVersion: 1,
+              },
+            },
+          ],
+        };
+      },
+    };
+    const harness = createInMemorySessionLifecycleHarness();
+    const tools = createCodingToolRegistry({ workspaceRoot });
+    const warm = harness.createLifecycle({
+      modelTargets,
+      stateRoot,
+      tools,
+      workspaceRoot,
+      [planShellEnvironmentFactory]: createPlanShellEnvironmentV1,
+    });
+
+    try {
+      const created = await warm.create({ targetIdentity });
+      const entered = await warm.enterPlan({ sessionId: created.sessionId });
+      const plan = entered.plan;
+      const shellTool = tools.resolve("run_shell");
+      if (
+        plan?.shellEnvironment === undefined ||
+        plan.gitPolicyVersion !== "git-auto-policy.v1" ||
+        plan.gitPolicyDigest === undefined ||
+        shellTool === undefined
+      ) {
+        throw new Error("Expected the hybrid Plan shell authority.");
+      }
+      const assessment = await assessPlanCommandExecutionV1({
+        rawCommand: command,
+        shellEnvironment: plan.shellEnvironment,
+        workspaceRoot,
+      });
+      if (assessment.status !== "assessed" || assessment.disposition !== "ask_ambiguous") {
+        throw new Error("Expected one ambiguous Plan shell assessment.");
+      }
+      const subject = {
+        type: "plan_command" as const,
+        command,
+        cwd: "." as const,
+        planCycleId: plan.cycleId,
+        planPolicyVersion: "plan-policy.hybrid-v1" as const,
+        shellPolicyVersion: "plan-shell-policy.v1" as const,
+        shellEnvironmentVersion: "plan-shell-env.v1" as const,
+        shellEnvironmentDigest: plan.shellEnvironment.digest,
+        toolProfileDigest: plan.eligibleToolProfile.digest,
+        gitPolicyVersion: plan.gitPolicyVersion,
+        gitPolicyDigest: plan.gitPolicyDigest,
+        assessment: {
+          version: 1 as const,
+          disposition: assessment.disposition,
+          reasons: assessment.reasons,
+          digest: assessmentMatches ? assessment.digest : (`sha256:${"0".repeat(64)}` as const),
+        },
+      };
+      const planToolNames = new Set(
+        plan.eligibleToolProfile.definitions.map((definition) => definition.name),
+      );
+      const requestTools = tools
+        .definitions()
+        .filter((definition) => planToolNames.has(definition.name));
+      const store = await harness.sessions.open(created.sessionId);
+      if (store === undefined || entered.promptContext === undefined) {
+        throw new Error("Expected the created Plan session store and prompt context.");
+      }
+      const records = [
+        {
+          schemaVersion: 3,
+          record: {
+            type: "logical_run_started",
+            runId,
+            userMessage: "Recover one exact Plan diagnostic.",
+          },
+        },
+        {
+          schemaVersion: 3,
+          record: {
+            type: "runtime_event",
+            runId,
+            event: { type: "user_message", text: "Recover one exact Plan diagnostic." },
+          },
+        },
+        {
+          schemaVersion: 3,
+          record: {
+            type: "provider_attempt_started",
+            runId,
+            turn: 1,
+            attempt: 1,
+            targetIdentity,
+            promptProjection: {
+              version: 1,
+              assemblyIdentityDigest: entered.promptContext.assemblyIdentityDigest,
+              requestProjectionDigest: digestPromptRequestV1(
+                [
+                  { role: "system", content: basePrompt },
+                  { role: "developer", content: skillUsagePrompt },
+                  { role: "user", content: "Recover one exact Plan diagnostic." },
+                ],
+                requestTools,
+              ),
+            },
+          },
+        },
+        {
+          schemaVersion: 3,
+          record: { type: "runtime_event", runId, event: { type: "model_message_started" } },
+        },
+        {
+          schemaVersion: 3,
+          record: {
+            type: "model_response_completed",
+            runId,
+            turn: 1,
+            attempt: 1,
+            targetIdentity,
+            response: {
+              text: "",
+              toolCalls: [call],
+              toolIntents: [
+                {
+                  callId: call.id,
+                  name: call.name,
+                  argumentsDigest: `sha256:${createHash("sha256")
+                    .update(call.argumentsJson)
+                    .digest("hex")}`,
+                  effect: "execute",
+                  definitionDigest: shellTool.definitionDigest,
+                  replay: "never",
+                },
+              ],
+              finishReason: "tool_calls",
+            },
+          },
+        },
+        {
+          schemaVersion: 3,
+          record: {
+            type: "runtime_event",
+            runId,
+            event: { type: "model_message_completed", text: "" },
+          },
+        },
+        {
+          schemaVersion: 3,
+          record: {
+            type: "runtime_event",
+            runId,
+            event: { type: "tool_requested", callId: call.id, name: call.name },
+          },
+        },
+        ...(!omitPermissionRequest
+          ? [
+              {
+                schemaVersion: 3,
+                record: {
+                  type: "runtime_event",
+                  runId,
+                  event: {
+                    type: "tool_permission_requested",
+                    requestId: `${runId}:${call.id}`,
+                    callId: call.id,
+                    name: call.name,
+                    effect: "execute",
+                    scope: "call",
+                    subject,
+                  },
+                },
+              } as const,
+            ]
+          : []),
+        {
+          schemaVersion: 3,
+          record: {
+            type: "runtime_event",
+            runId,
+            event: {
+              type: "tool_permission_decided",
+              ...(omitPermissionRequest ? {} : { requestId: `${runId}:${call.id}` }),
+              callId: call.id,
+              name: call.name,
+              decision: "allow",
+              effect: "execute",
+              scope: "call",
+              subject,
+            },
+          },
+        },
+        ...(started
+          ? [
+              {
+                schemaVersion: 3,
+                record: {
+                  type: "runtime_event",
+                  runId,
+                  event: { type: "tool_started", callId: call.id, name: call.name },
+                },
+              } as const,
+            ]
+          : []),
+      ] satisfies readonly Omit<
+        Extract<SessionRecord, { readonly schemaVersion: 3 }>,
+        "sequence"
+      >[];
+      for (const [index, record] of records.entries()) {
+        await store.append({
+          ...record,
+          sequence: entered.lastSequence + index + 1,
+        } as SessionRecord);
+      }
+      await warm.close();
+      cold = harness.createLifecycle({
+        modelTargets,
+        stateRoot,
+        tools,
+        workspaceRoot,
+        [planShellEnvironmentFactory]: createPlanShellEnvironmentV1,
+      });
+      const publicEvents: RuntimeEvent[] = [];
+      cold.subscribe((event) => {
+        publicEvents.push(event);
+        if (event.type === "tool_permission_requested") {
+          cold?.decidePermission({ requestId: event.requestId, decision: "deny" });
+        }
+      });
+
+      if (omitPermissionRequest) {
+        await expect(cold.resume({ sessionId: created.sessionId })).rejects.toMatchObject({
+          code: "session_invalid",
+        });
+        return;
+      }
+      if (started) {
+        await expect(cold.resume({ sessionId: created.sessionId })).resolves.toMatchObject({
+          status: "ready",
+          snapshot: {
+            status: "settled",
+            run: { result: { status: "failed", error: { code: "tool_effect_indeterminate" } } },
+          },
+        });
+        expect(publicEvents).toHaveLength(0);
+        return;
+      }
+      await expect(cold.resume({ sessionId: created.sessionId })).resolves.toMatchObject({
+        status: "ready",
+        snapshot: { status: "interrupted", plan: { cycleId: plan.cycleId } },
+      });
+      await expect(cold.continue({ sessionId: created.sessionId })).resolves.toMatchObject({
+        result: { status: "completed", answer: "Recovered the exact Plan shell boundary." },
+      });
+      expect(
+        publicEvents.filter((event) => event.type === "tool_permission_requested"),
+      ).toHaveLength(assessmentMatches ? 0 : 1);
+      expect(publicEvents.filter((event) => event.type === "tool_started")).toHaveLength(
+        assessmentMatches ? 1 : 0,
+      );
+    } finally {
+      await warm.close();
+      await cold?.close();
+      if (previousPath === undefined) {
+        delete process.env[executablePathName];
+      } else {
+        process.env[executablePathName] = previousPath;
+      }
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
 type CurrentSessionSnapshotForFixture = {
   readonly sessionId: string;
   readonly lineage?: {
@@ -1465,6 +2741,43 @@ async function exerciseColdVisionResponsesArtifactFailure(
     await warm.close();
     await rm(testRoot, { recursive: true, force: true });
   }
+}
+
+async function runGitFixtureCommand(
+  workspaceRoot: string,
+  arguments_: readonly string[],
+): Promise<void> {
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const child = spawn("/usr/bin/git", arguments_, {
+      cwd: workspaceRoot,
+      env: {
+        HOME: workspaceRoot,
+        PATH: "/usr/bin:/bin",
+        LANG: "C",
+        LC_ALL: "C",
+        GIT_CONFIG_NOSYSTEM: "1",
+        GIT_CONFIG_SYSTEM: "/dev/null",
+        GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_TERMINAL_PROMPT: "0",
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", rejectPromise);
+    child.once("close", (code, signal) => {
+      if (code === 0 && signal === null) {
+        resolvePromise();
+      } else {
+        rejectPromise(
+          new Error(`Git fixture command failed (${String(code)}/${String(signal)}): ${stderr}`),
+        );
+      }
+    });
+  });
 }
 
 function observeChild(child: ChildProcess): void {

--- a/packages/testkit/src/session-lifecycle.os.test.ts
+++ b/packages/testkit/src/session-lifecycle.os.test.ts
@@ -1966,7 +1966,12 @@ test("SessionLifecycle real-process branch writes independently, survives restar
   }
 }, 20_000);
 
-test("SessionLifecycle hybrid Plan attests Git and automatically executes all five repository families", async () => {
+test("SessionLifecycle hybrid Plan binds repository Git automation to the frozen installed build", async () => {
+  const installedGitVersion = execFileSync("/usr/bin/git", ["--version"], {
+    encoding: "utf8",
+    env: { PATH: "/usr/bin:/bin", LANG: "C", LC_ALL: "C" },
+  }).trimEnd();
+  const supportedGitBuild = installedGitVersion === "git version 2.43.0";
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-git-families-"));
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
@@ -1988,7 +1993,6 @@ test("SessionLifecycle hybrid Plan attests Git and automatically executes all fi
   await runGitFixtureCommand(workspaceRoot, ["config", "user.email", "adam@example.test"]);
   await runGitFixtureCommand(workspaceRoot, ["add", "README.md"]);
   await runGitFixtureCommand(workspaceRoot, ["commit", "-m", "fixture"]);
-  process.env[executablePathName] = "/usr/bin:/bin";
   const commands = [
     "git --version",
     "git --no-pager status --porcelain=v1 --untracked-files=normal --ignore-submodules=all",
@@ -2055,6 +2059,7 @@ test("SessionLifecycle hybrid Plan attests Git and automatically executes all fi
   });
 
   try {
+    process.env[executablePathName] = "/usr/bin:/bin";
     const created = await lifecycle.create({ targetIdentity });
     await lifecycle.enterPlan({ sessionId: created.sessionId });
     const continued = await lifecycle.continue({
@@ -2063,25 +2068,26 @@ test("SessionLifecycle hybrid Plan attests Git and automatically executes all fi
       limits: { maxTurns: commands.length + 1 },
     });
 
-    expect({ result: continued.result, plan: continued.snapshot.plan }).toMatchObject({
-      result: {
-        status: "completed",
-        answer: "Every mandatory Git family executed automatically after attestation.",
-      },
-      plan: {
-        gitAttestation: {
-          version: "git-auto-attestation.v1",
-          gitVersion: "git version 2.43.0",
-          digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
-        },
-      },
+    expect(continued.result).toEqual({
+      status: "completed",
+      answer: supportedGitBuild
+        ? "Every mandatory Git family executed automatically after attestation."
+        : "A mandatory Git family did not execute automatically.",
     });
-    expect(events.filter((event) => event.type === "tool_permission_requested")).toHaveLength(0);
     const completedShellEvents = events.filter(
       (event): event is Extract<RuntimeEvent, { readonly type: "tool_completed" }> =>
         event.type === "tool_completed" && event.name === "run_shell",
     );
-    expect(completedShellEvents).toHaveLength(commands.length);
+    const permissionRequests = events.filter(
+      (event): event is Extract<RuntimeEvent, { readonly type: "tool_permission_requested" }> =>
+        event.type === "tool_permission_requested" && event.name === "run_shell",
+    );
+    expect(completedShellEvents).toHaveLength(supportedGitBuild ? commands.length : 1);
+    expect(
+      permissionRequests.map((event) =>
+        event.subject.type === "plan_command" ? event.subject.command : undefined,
+      ),
+    ).toEqual(supportedGitBuild ? [] : commands.slice(1));
     for (const event of completedShellEvents) {
       expect(event.output).toMatchObject({
         termination: { type: "exited", exitCode: 0 },
@@ -2089,23 +2095,42 @@ test("SessionLifecycle hybrid Plan attests Git and automatically executes all fi
       });
     }
     expect(completedShellEvents[0]?.output).toMatchObject({
-      stdout: { tail: "git version 2.43.0\n", omittedBytes: 0 },
+      stdout: { tail: `${installedGitVersion}\n`, omittedBytes: 0 },
     });
-    expect(completedShellEvents[1]?.output).toMatchObject({
-      stdout: { tail: "", omittedBytes: 0 },
-    });
-    expect(completedShellEvents[2]?.output).toMatchObject({
-      stdout: { tail: "true\n", omittedBytes: 0 },
-    });
-    expect(completedShellEvents[3]?.output).toMatchObject({
-      stdout: { tail: expect.stringContaining("fixture"), omittedBytes: 0 },
-    });
-    expect(completedShellEvents[4]?.output).toMatchObject({
-      stdout: { tail: "", omittedBytes: 0 },
-    });
-    expect(completedShellEvents[5]?.output).toMatchObject({
-      stdout: { tail: expect.stringContaining("README.md"), omittedBytes: 0 },
-    });
+    if (supportedGitBuild) {
+      expect(continued.snapshot.plan?.gitAttestation).toMatchObject({
+        version: "git-auto-attestation.v1",
+        gitVersion: "git version 2.43.0",
+        digest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+      });
+      expect(completedShellEvents[1]?.output).toMatchObject({
+        stdout: { tail: "", omittedBytes: 0 },
+      });
+      expect(completedShellEvents[2]?.output).toMatchObject({
+        stdout: { tail: "true\n", omittedBytes: 0 },
+      });
+      expect(completedShellEvents[3]?.output).toMatchObject({
+        stdout: { tail: expect.stringContaining("fixture"), omittedBytes: 0 },
+      });
+      expect(completedShellEvents[4]?.output).toMatchObject({
+        stdout: { tail: "", omittedBytes: 0 },
+      });
+      expect(completedShellEvents[5]?.output).toMatchObject({
+        stdout: { tail: expect.stringContaining("README.md"), omittedBytes: 0 },
+      });
+    } else {
+      expect(continued.snapshot.plan?.gitAttestation).toBeUndefined();
+      expect(permissionRequests).toHaveLength(commands.length - 1);
+      for (const request of permissionRequests) {
+        expect(request.subject).toMatchObject({
+          type: "plan_command",
+          assessment: {
+            disposition: "ask_ambiguous",
+            reasons: ["git_attestation_required"],
+          },
+        });
+      }
+    }
     const child = await lifecycle.branch({
       parentSessionId: created.sessionId,
       atSequence: continued.snapshot.lastSequence,

--- a/packages/testkit/src/session-lifecycle.test-support.ts
+++ b/packages/testkit/src/session-lifecycle.test-support.ts
@@ -4,6 +4,8 @@ import {
 } from "@adam-agent/agent";
 import {
   createTrustedWorkspaceTrustForTesting,
+  createUnavailablePlanShellEnvironmentV1,
+  planShellEnvironmentFactory,
   sessionAutomaticTitlesEnabled,
 } from "@adam-agent/agent/internal-testing";
 
@@ -38,5 +40,7 @@ export function createSessionLifecycleForTests(
     workspaceTrust:
       options.workspaceTrust ?? createTrustedWorkspaceTrustForTesting(options.workspaceRoot),
     [sessionAutomaticTitlesEnabled]: false,
+    [planShellEnvironmentFactory]:
+      options[planShellEnvironmentFactory] ?? createUnavailablePlanShellEnvironmentV1,
   });
 }

--- a/packages/testkit/src/session-lifecycle.test.ts
+++ b/packages/testkit/src/session-lifecycle.test.ts
@@ -33,6 +33,8 @@ import {
 } from "@adam-agent/agent";
 import {
   createInMemorySessionStoreDirectory,
+  createPlanToolProfileV1,
+  createUnavailablePlanShellEnvironmentV1,
   inputResourceIngestBarrier,
   openJsonlSessionStore,
   type ProjectLifecycleOwner,
@@ -48,6 +50,7 @@ import {
 } from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
 import { createInMemorySessionLifecycleHarness, FakeModelDriver } from "./index.js";
+import { exercisePlanShellRecoveryFixture } from "./plan-shell-recovery.test-support.js";
 import {
   sessionLifecycleAnswerOnlyDeepSeekStream as answerOnlyDeepSeekStream,
   sessionLifecycleBasePrompt as basePrompt,
@@ -96,7 +99,326 @@ const codingToolDefinitions = createCodingToolRegistry({
   workspaceRoot: "/tmp/adam-agent-session-lifecycle-tool-definitions",
 }).definitions();
 
-test("SessionLifecycle Plan exposes only its exact read profile and denies a forged write call", async () => {
+test("SessionLifecycle enters Plan with an unavailable shell snapshot and fails before spawn", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-shell-unavailable-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  let requestCount = 0;
+  const driver = new FakeModelDriver((request) => {
+    requestCount += 1;
+    if (requestCount === 1) {
+      return [
+        { type: "tool_call_start", id: "unavailable-shell", name: "run_shell" },
+        {
+          type: "tool_call_delta",
+          id: "unavailable-shell",
+          json: JSON.stringify({ command: "uname -s" }),
+        },
+        { type: "tool_call_end", id: "unavailable-shell" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    expect(request.messages.at(-1)).toMatchObject({
+      role: "tool",
+      callId: "unavailable-shell",
+      result: { status: "failed", error: { code: "shell_start_failed" } },
+    });
+    return [
+      { type: "text_delta", text: "The unavailable shell failed closed before spawn." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createInMemorySessionLifecycleHarness().createLifecycle({
+    modelTargets,
+    stateRoot,
+    tools: createCodingToolRegistry({ workspaceRoot }),
+    workspaceRoot,
+  });
+  const events: RuntimeEvent[] = [];
+  lifecycle.subscribe((event) => {
+    events.push(event);
+    if (event.type === "tool_permission_requested") {
+      lifecycle.decidePermission({ requestId: event.requestId, decision: "allow" });
+    }
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    const entered = await lifecycle.enterPlan({ sessionId: created.sessionId });
+    expect(entered.plan?.shellEnvironment?.shell).toEqual({
+      status: "unavailable",
+      lookupPath: "/bin/sh",
+    });
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: "Inspect the operating system." },
+      }),
+    ).resolves.toMatchObject({
+      result: {
+        status: "completed",
+        answer: "The unavailable shell failed closed before spawn.",
+      },
+    });
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_permission_requested",
+        name: "run_shell",
+        subject: expect.objectContaining({
+          type: "plan_command",
+          assessment: expect.objectContaining({ reasons: ["environment_untrusted"] }),
+        }),
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_failed",
+        name: "run_shell",
+        error: expect.objectContaining({ code: "shell_start_failed" }),
+      }),
+    );
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test.each([
+  {
+    label: "a mismatched durable assessment",
+    command: "unknown --diagnose",
+    decision: "allow",
+    assessmentMatches: false,
+    omitPermissionRequest: false,
+    started: false,
+    outcome: "reask",
+  },
+  {
+    label: "a forged direct allow",
+    command: "unknown --diagnose",
+    decision: "allow",
+    assessmentMatches: true,
+    omitPermissionRequest: true,
+    started: false,
+    outcome: "invalid",
+  },
+  {
+    label: "a started shell effect",
+    command: "unknown --diagnose",
+    decision: "allow",
+    assessmentMatches: true,
+    omitPermissionRequest: false,
+    started: true,
+    outcome: "indeterminate",
+  },
+  {
+    label: "an exact ambiguous deny before result",
+    command: "unknown --diagnose",
+    decision: "deny",
+    assessmentMatches: true,
+    omitPermissionRequest: false,
+    started: false,
+    outcome: "denied",
+  },
+  {
+    label: "an exact hard deny before result",
+    command: "touch forbidden.txt",
+    decision: "deny",
+    assessmentMatches: true,
+    omitPermissionRequest: true,
+    started: false,
+    outcome: "denied",
+  },
+])(
+  "SessionLifecycle hybrid Plan semantic recovery folds $label",
+  async ({ command, decision, assessmentMatches, omitPermissionRequest, started, outcome }) => {
+    const recovered = await exercisePlanShellRecoveryFixture({
+      shellEnvironmentFactory: createUnavailablePlanShellEnvironmentV1,
+      command,
+      decision: decision as "allow" | "deny",
+      assessmentMatches,
+      omitPermissionRequest,
+      started,
+    });
+
+    if (outcome === "invalid") {
+      expect(recovered).toMatchObject({
+        resume: { status: "rejected", code: "session_invalid" },
+        providerCalls: 0,
+        publicEvents: [],
+      });
+      return;
+    }
+    if (outcome === "indeterminate") {
+      expect(recovered).toMatchObject({
+        resume: {
+          status: "ready",
+          snapshotStatus: "settled",
+          runResult: { status: "failed", error: { code: "tool_effect_indeterminate" } },
+        },
+        providerCalls: 0,
+        publicEvents: [],
+      });
+      return;
+    }
+    expect(recovered).toMatchObject({
+      resume: { status: "ready", snapshotStatus: "interrupted" },
+      continuationResult: {
+        status: "completed",
+        answer: "Recovered the exact Plan shell boundary.",
+      },
+      observedToolResult: { status: "failed", error: { code: "permission_denied" } },
+      providerCalls: 1,
+      secondResume: {
+        snapshotStatus: "settled",
+        runResult: {
+          status: "completed",
+          answer: "Recovered the exact Plan shell boundary.",
+        },
+      },
+    });
+    expect(
+      recovered.publicEvents.filter((event) => event.type === "tool_permission_requested"),
+    ).toHaveLength(outcome === "reask" ? 1 : 0);
+    expect(recovered.publicEvents.filter((event) => event.type === "tool_started")).toHaveLength(0);
+    if (outcome === "denied") {
+      expect(
+        recovered.publicEvents.filter((event) => event.type === "tool_permission_decided"),
+      ).toHaveLength(0);
+    }
+  },
+);
+
+test("SessionLifecycle cold recovery preserves a historical read-v1 Plan profile", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-read-v1-recovery-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const registry = createCodingToolRegistry({ workspaceRoot });
+  let requestCount = 0;
+  const driver = new FakeModelDriver((request) => {
+    requestCount += 1;
+    if (requestCount === 1) {
+      expect(request.tools.map((tool) => tool.name)).toEqual([
+        "read_file",
+        "search_repository",
+        "activate_skill",
+        "read_skill_resource",
+        "read_input_resource",
+      ]);
+      return [
+        { type: "tool_call_start", id: "historical-shell", name: "run_shell" },
+        { type: "tool_call_delta", id: "historical-shell", json: '{"command":"uname -s"}' },
+        { type: "tool_call_end", id: "historical-shell" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    expect(request.messages.at(-1)).toMatchObject({
+      role: "tool",
+      callId: "historical-shell",
+      result: { status: "failed", error: { code: "permission_denied" } },
+    });
+    return [
+      { type: "text_delta", text: "The historical Plan remained read-only." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile: testContextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: testContextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const warm = harness.createLifecycle({ modelTargets, stateRoot, tools: registry, workspaceRoot });
+  let cold: ReturnType<typeof harness.createLifecycle> | undefined;
+
+  try {
+    const created = await warm.create({ targetIdentity });
+    const source = created.promptContext?.toolProfile;
+    const store = await harness.sessions.open(created.sessionId);
+    if (source === undefined || store === undefined) {
+      throw new Error("Expected the created session authority.");
+    }
+    const eligibleToolProfile = createPlanToolProfileV1({
+      source: { version: source.version, digest: source.digest },
+      definitions: source.definitions.flatMap((definition) => {
+        const adapter = registry.resolve(definition.name);
+        return adapter?.effect === "read"
+          ? [
+              {
+                name: definition.name,
+                definitionDigest: adapter.definitionDigest as `sha256:${string}`,
+                effect: adapter.effect,
+                source: "builtin" as const,
+              },
+            ]
+          : [];
+      }),
+    });
+    await store.append({
+      schemaVersion: 3,
+      sequence: created.lastSequence + 1,
+      record: {
+        type: "plan_cycle_entered",
+        recordVersion: 1,
+        cycleId: "123e4567-e89b-42d3-a456-426614176100",
+        revision: 1,
+        policyVersion: "plan-policy.read-v1",
+        eligibleToolProfile,
+      },
+    });
+    await warm.close();
+    cold = harness.createLifecycle({ modelTargets, stateRoot, tools: registry, workspaceRoot });
+
+    await expect(cold.resume({ sessionId: created.sessionId })).resolves.toMatchObject({
+      status: "ready",
+      snapshot: { plan: { policyVersion: "plan-policy.read-v1" } },
+    });
+    await expect(
+      cold.continue({
+        sessionId: created.sessionId,
+        input: { text: "Try a shell command in the historical Plan." },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "The historical Plan remained read-only." },
+      snapshot: { plan: { policyVersion: "plan-policy.read-v1" } },
+    });
+  } finally {
+    await warm.close();
+    await cold?.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle Plan exposes only its exact eligible profile and denies a forged write call", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-write-deny-"));
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
@@ -108,6 +430,7 @@ test("SessionLifecycle Plan exposes only its exact read profile and denies a for
       expect(request.tools.map((tool) => tool.name)).toEqual([
         "read_file",
         "search_repository",
+        "run_shell",
         "activate_skill",
         "read_skill_resource",
         "read_input_resource",
@@ -169,7 +492,13 @@ test("SessionLifecycle Plan exposes only its exact read profile and denies a for
       }),
     ).resolves.toMatchObject({
       result: { status: "completed", answer: "The mutation was denied by Plan." },
-      snapshot: { plan: { state: "exploring", policyVersion: "plan-policy.read-v1" } },
+      snapshot: {
+        plan: {
+          state: "exploring",
+          policyVersion: "plan-policy.hybrid-v1",
+          shellPolicyVersion: "plan-shell-policy.v1",
+        },
+      },
     });
     await expect(readFile(join(workspaceRoot, "forbidden.txt"), "utf8")).rejects.toMatchObject({
       code: "ENOENT",
@@ -522,10 +851,10 @@ test("SessionLifecycle rejects an unsupported durable Plan policy before model u
       `${created.sessionId}.jsonl`,
     );
     const durableHistory = await readFile(sessionPath, "utf8");
-    expect(durableHistory.match(/plan-policy\.read-v1/gu)).toHaveLength(1);
+    expect(durableHistory.match(/plan-policy\.hybrid-v1/gu)).toHaveLength(1);
     await writeFile(
       sessionPath,
-      durableHistory.replace("plan-policy.read-v1", "plan-policy.future-v99"),
+      durableHistory.replace("plan-policy.hybrid-v1", "plan-policy.future-v99"),
       "utf8",
     );
     const modelTargets: ModelTargets = {
@@ -850,6 +1179,18 @@ test("SessionLifecycle rejects forged Plan inheritance from an inactive source p
         cycleId: donorPlan.cycleId,
         revision: donorPlan.revision,
         policyVersion: donorPlan.policyVersion,
+        ...(donorPlan.shellPolicyVersion === undefined
+          ? {}
+          : { shellPolicyVersion: donorPlan.shellPolicyVersion }),
+        ...(donorPlan.shellEnvironment === undefined
+          ? {}
+          : { shellEnvironment: donorPlan.shellEnvironment }),
+        ...(donorPlan.gitPolicyVersion === undefined
+          ? {}
+          : { gitPolicyVersion: donorPlan.gitPolicyVersion }),
+        ...(donorPlan.gitPolicyDigest === undefined
+          ? {}
+          : { gitPolicyDigest: donorPlan.gitPolicyDigest }),
         eligibleToolProfile: donorPlan.eligibleToolProfile,
         source: {
           sessionId: inactiveParent.sessionId,

--- a/packages/testkit/src/trusted-mcp-host-test-topology.test.ts
+++ b/packages/testkit/src/trusted-mcp-host-test-topology.test.ts
@@ -108,7 +108,7 @@ test("MCP deterministic and operating-system contracts keep separate harness own
 
   const behaviorNames = declaredTestNames(behaviorSource);
   const operatingSystemNames = declaredTestNames(operatingSystemSource);
-  expect.soft(behaviorNames).toHaveLength(81);
+  expect.soft(behaviorNames).toHaveLength(84);
   expect.soft(operatingSystemNames).toHaveLength(19);
   expect.soft(operatingSystemNames).toEqual([...operatingSystemTestNames].sort());
   expect.soft(operatingSystemTestNames.filter((name) => behaviorNames.includes(name))).toEqual([]);

--- a/packages/testkit/src/trusted-mcp-host.test-support.ts
+++ b/packages/testkit/src/trusted-mcp-host.test-support.ts
@@ -81,6 +81,9 @@ export async function commitFixtureEchoTool(
   readonly sessionId: string;
   readonly qualifiedName: string;
   readonly definitionDigest: `sha256:${string}`;
+  readonly serverId: string;
+  readonly originalName: string;
+  readonly serverDefinitionDigest: `sha256:${string}`;
 }> {
   const created = await lifecycle.create({ targetIdentity: trustedMcpTargetIdentity });
   if (created.mcp === undefined) {
@@ -131,5 +134,8 @@ export async function commitFixtureEchoTool(
     sessionId: created.sessionId,
     qualifiedName: echo.qualifiedName,
     definitionDigest: echo.definitionDigest,
+    serverId: preview.serverId,
+    originalName: echo.originalName,
+    serverDefinitionDigest: preview.definitionDigest,
   };
 }

--- a/packages/testkit/src/trusted-mcp-host.test.ts
+++ b/packages/testkit/src/trusted-mcp-host.test.ts
@@ -25,6 +25,7 @@ import {
 } from "@adam-agent/agent";
 import {
   createInMemorySessionStoreDirectory,
+  createPlanToolProfileV1,
   mcpActivationSettlementBarrier,
   mcpBeforeToolDispatchBarrier,
   mcpCatalogStaleDurableBarrier,
@@ -5119,6 +5120,106 @@ test("SessionLifecycle rejects a core and MCP qualified-name collision before mo
   }
 });
 
+test("SessionLifecycle cold inspection preserves a historical read-v1 MCP Plan profile", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-mcp-plan-read-v1-recovery-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeScriptedMcpConfiguration(testRoot, workspaceRoot);
+
+  const {
+    harness,
+    lifecycle: initial,
+    peer,
+  } = createScriptedMcpLifecycle(
+    { stateRoot, workspaceRoot },
+    { fixture: ordinaryScriptedMcpServer() },
+  );
+  let cold: ReturnType<typeof createSessionLifecycle> | undefined;
+  try {
+    const committed = await commitFixtureEchoTool(initial, "read");
+    await initial.enterPlan({ sessionId: committed.sessionId });
+    const initialStore = await harness.sessions.open(committed.sessionId);
+    if (initialStore === undefined) {
+      throw new Error("The fixture requires the historical Plan session store.");
+    }
+    const hybridRecords = await initialStore.read();
+    const transportClosed = peer.nextClose("fixture");
+    await expect(initial.close()).resolves.toEqual({ status: "closed" });
+    await transportClosed;
+
+    const historicalDirectory = createInMemorySessionStoreDirectory<SessionRecord>();
+    const historicalStore = await historicalDirectory.create(committed.sessionId);
+    let convertedCycles = 0;
+    for (const entry of hybridRecords) {
+      const historicalEntry: SessionRecord =
+        entry.schemaVersion === 3 && entry.record.type === "plan_cycle_entered"
+          ? {
+              ...entry,
+              record: {
+                type: entry.record.type,
+                recordVersion: entry.record.recordVersion,
+                cycleId: entry.record.cycleId,
+                revision: entry.record.revision,
+                policyVersion: "plan-policy.read-v1",
+                eligibleToolProfile: createPlanToolProfileV1({
+                  source: entry.record.eligibleToolProfile.source,
+                  definitions: entry.record.eligibleToolProfile.definitions.flatMap(
+                    (definition) => {
+                      if (definition.effect !== "read") {
+                        return [];
+                      }
+                      return [
+                        {
+                          name: definition.name,
+                          definitionDigest: definition.definitionDigest,
+                          effect: definition.effect,
+                          source: definition.source,
+                        },
+                      ];
+                    },
+                  ),
+                }),
+              },
+            }
+          : entry;
+      if (historicalEntry !== entry) {
+        convertedCycles += 1;
+      }
+      await historicalStore.append(historicalEntry);
+    }
+    expect(convertedCycles).toBe(1);
+
+    cold = createSessionLifecycle({
+      [mcpTransportFactory]: createScriptedMcpTransportFactory({
+        fixture: ordinaryScriptedMcpServer(),
+      }),
+      [sessionStoreDirectory]: historicalDirectory,
+      stateRoot,
+      workspaceRoot,
+    });
+    await expect(cold.inspect({ sessionId: committed.sessionId })).resolves.toMatchObject({
+      plan: {
+        policyVersion: "plan-policy.read-v1",
+        eligibleToolProfile: {
+          definitions: expect.arrayContaining([
+            {
+              name: committed.qualifiedName,
+              definitionDigest: committed.definitionDigest,
+              effect: "read",
+              source: "mcp",
+            },
+          ]),
+        },
+      },
+    });
+  } finally {
+    await initial.close();
+    await cold?.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("SessionLifecycle Plan auto-allows an exact committed read-only MCP tool", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-mcp-plan-read-"));
   const stateRoot = join(testRoot, "state");
@@ -5134,6 +5235,7 @@ test("SessionLifecycle Plan auto-allows an exact committed read-only MCP tool", 
       expect(request.tools.map((tool) => tool.name)).toEqual([
         "read_file",
         "search_repository",
+        "run_shell",
         "activate_skill",
         "read_skill_resource",
         "read_input_resource",
@@ -5201,6 +5303,11 @@ test("SessionLifecycle Plan auto-allows an exact committed read-only MCP tool", 
       definitionDigest: committed.definitionDigest,
       effect: "read",
       source: "mcp",
+      mcp: {
+        serverId: committed.serverId,
+        originalName: committed.originalName,
+        serverDefinitionDigest: committed.serverDefinitionDigest,
+      },
     });
 
     await expect(
@@ -5222,8 +5329,291 @@ test("SessionLifecycle Plan auto-allows an exact committed read-only MCP tool", 
   }
 });
 
-test("SessionLifecycle Plan denies every committed non-read MCP effect before dispatch", async () => {
-  const deniedEffects = ["execute", "network", "delegate", "administrative"] as const;
+test("SessionLifecycle hybrid Plan asks for each exact committed executable MCP effect", async () => {
+  const askedEffects = ["execute", "network"] as const;
+
+  for (const effect of askedEffects) {
+    const testRoot = await mkdtemp(join(tmpdir(), `adam-agent-mcp-plan-${effect}-ask-`));
+    const stateRoot = join(testRoot, "state");
+    const workspaceRoot = join(testRoot, "workspace");
+    await mkdir(workspaceRoot);
+    await writeScriptedMcpConfiguration(testRoot, workspaceRoot);
+
+    let qualifiedName: string | undefined;
+    let requestCount = 0;
+    const driver = new FakeModelDriver((request) => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        expect(request.tools.some((tool) => tool.name === qualifiedName)).toBe(true);
+        return [
+          { type: "tool_call_start", id: `plan-mcp-${effect}`, name: qualifiedName as string },
+          { type: "tool_call_delta", id: `plan-mcp-${effect}`, json: '{"value":"forbidden"}' },
+          { type: "tool_call_end", id: `plan-mcp-${effect}` },
+          { type: "finish", reason: "tool_calls" },
+        ];
+      }
+      expect(request.messages.at(-1)).toMatchObject({
+        role: "tool",
+        name: qualifiedName,
+        result: { status: "failed", error: { code: "permission_denied" } },
+      });
+      return [
+        { type: "text_delta", text: `Plan requested exact approval for the ${effect} MCP effect.` },
+        { type: "finish", reason: "stop" },
+      ];
+    });
+    const modelTargets: ModelTargets = {
+      async resolve() {
+        return { identity: targetIdentity, driver, contextProfile };
+      },
+      async snapshot() {
+        return {
+          targets: [
+            {
+              identity: targetIdentity,
+              readiness: { status: "available", credentialSource: "test" },
+              contextProfile,
+            },
+          ],
+        };
+      },
+    };
+    const { lifecycle, peer } = createScriptedMcpLifecycle(
+      {
+        modelTargets,
+        permissions: createPermissionPolicy({
+          allowedEffects: ["read", "write", "execute", "network", "delegate", "administrative"],
+        }),
+        stateRoot,
+        workspaceRoot,
+      },
+      { fixture: ordinaryScriptedMcpServer() },
+    );
+    const permissionEvents: RuntimeEvent[] = [];
+    lifecycle.subscribe((event) => {
+      if (event.type === "tool_permission_requested") {
+        permissionEvents.push(event);
+        lifecycle.decidePermission({ requestId: event.requestId, decision: "deny" });
+      }
+    });
+
+    try {
+      const committed = await commitFixtureEchoTool(lifecycle, effect);
+      qualifiedName = committed.qualifiedName;
+      const entered = await lifecycle.enterPlan({ sessionId: committed.sessionId });
+      expect(
+        entered.plan?.eligibleToolProfile.definitions.some(
+          (definition) => definition.name === committed.qualifiedName,
+        ),
+      ).toBe(true);
+
+      await expect(
+        lifecycle.continue({
+          sessionId: committed.sessionId,
+          input: { text: `Try the committed ${effect} MCP tool in Plan.` },
+          limits: { maxTurns: 2 },
+        }),
+      ).resolves.toMatchObject({
+        result: {
+          status: "completed",
+          answer: `Plan requested exact approval for the ${effect} MCP effect.`,
+        },
+      });
+      expect(permissionEvents).toHaveLength(1);
+      expect(permissionEvents[0]).toMatchObject({
+        name: qualifiedName,
+        effect,
+        scope: "call",
+        subject: {
+          type: "mcp_tool",
+          qualifiedName,
+          argumentsDigest: expect.stringMatching(/^sha256:[0-9a-f]{64}$/u),
+        },
+      });
+      expect(peer.requests("fixture").filter((request) => request.method === "tools/call")).toEqual(
+        [],
+      );
+    } finally {
+      await lifecycle.close();
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  }
+});
+
+test("SessionLifecycle cold inspection rejects consistently forged hybrid Plan MCP permission identity", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-mcp-plan-permission-tamper-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeScriptedMcpConfiguration(testRoot, workspaceRoot);
+
+  let qualifiedName: string | undefined;
+  let requestCount = 0;
+  const driver = new FakeModelDriver(() => {
+    requestCount += 1;
+    return requestCount === 1
+      ? [
+          {
+            type: "tool_call_start",
+            id: "plan-mcp-durable-identity",
+            name: qualifiedName as string,
+          },
+          {
+            type: "tool_call_delta",
+            id: "plan-mcp-durable-identity",
+            json: '{"value":"durable"}',
+          },
+          { type: "tool_call_end", id: "plan-mcp-durable-identity" },
+          { type: "finish", reason: "tool_calls" },
+        ]
+      : [
+          { type: "text_delta", text: "The exact durable permission was denied." },
+          { type: "finish", reason: "stop" },
+        ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "test" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const {
+    harness,
+    lifecycle: initial,
+    peer,
+  } = createScriptedMcpLifecycle(
+    {
+      modelTargets,
+      permissions: createPermissionPolicy({
+        allowedEffects: ["read", "write", "execute", "network", "delegate", "administrative"],
+      }),
+      stateRoot,
+      workspaceRoot,
+    },
+    { fixture: ordinaryScriptedMcpServer() },
+  );
+  initial.subscribe((event) => {
+    if (event.type === "tool_permission_requested") {
+      initial.decidePermission({ requestId: event.requestId, decision: "deny" });
+    }
+  });
+
+  try {
+    const committed = await commitFixtureEchoTool(initial, "execute");
+    qualifiedName = committed.qualifiedName;
+    await initial.enterPlan({ sessionId: committed.sessionId });
+    await expect(
+      initial.continue({
+        sessionId: committed.sessionId,
+        input: { text: "Request the exact executable MCP tool." },
+        limits: { maxTurns: 2 },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "The exact durable permission was denied." },
+    });
+    const initialStore = await harness.sessions.open(committed.sessionId);
+    if (initialStore === undefined) {
+      throw new Error("The fixture requires the durable Plan permission session store.");
+    }
+    const validRecords = await initialStore.read();
+    const transportClosed = peer.nextClose("fixture");
+    await expect(initial.close()).resolves.toEqual({ status: "closed" });
+    await transportClosed;
+
+    const tamperCases = [
+      { field: "requestId" },
+      { field: "serverId" },
+      { field: "originalName" },
+      { field: "qualifiedName" },
+      { field: "serverDefinitionDigest" },
+      { field: "definitionDigest" },
+      { field: "argumentsDigest" },
+    ] as const;
+    for (const tamper of tamperCases) {
+      const corruptedDirectory = createInMemorySessionStoreDirectory<SessionRecord>();
+      const corruptedStore = await corruptedDirectory.create(committed.sessionId);
+      let corruptedEvents = 0;
+      for (const entry of validRecords) {
+        let corruptedEntry: SessionRecord = entry;
+        if (
+          entry.schemaVersion === 3 &&
+          entry.record.type === "runtime_event" &&
+          (entry.record.event.type === "tool_permission_requested" ||
+            entry.record.event.type === "tool_permission_decided") &&
+          entry.record.event.subject?.type === "mcp_tool"
+        ) {
+          const event = entry.record.event;
+          const subject = event.subject;
+          if (subject?.type !== "mcp_tool") {
+            throw new Error("The fixture requires an MCP permission subject.");
+          }
+          const corruptedEvent: typeof event =
+            tamper.field === "requestId"
+              ? { ...event, requestId: `${event.requestId}-forged` }
+              : {
+                  ...event,
+                  subject: {
+                    ...subject,
+                    ...(tamper.field === "serverId" ? { serverId: "forged" } : {}),
+                    ...(tamper.field === "originalName" ? { originalName: "forged" } : {}),
+                    ...(tamper.field === "qualifiedName" ? { qualifiedName: "forged" } : {}),
+                    ...(tamper.field === "serverDefinitionDigest"
+                      ? { serverDefinitionDigest: `sha256:${"3".repeat(64)}` as const }
+                      : {}),
+                    ...(tamper.field === "definitionDigest"
+                      ? { definitionDigest: `sha256:${"4".repeat(64)}` as const }
+                      : {}),
+                    ...(tamper.field === "argumentsDigest"
+                      ? { argumentsDigest: `sha256:${"5".repeat(64)}` as const }
+                      : {}),
+                  },
+                };
+          corruptedEntry = {
+            ...entry,
+            record: { ...entry.record, event: corruptedEvent },
+          };
+          corruptedEvents += 1;
+        }
+        await corruptedStore.append(corruptedEntry);
+      }
+      expect(corruptedEvents, tamper.field).toBe(2);
+
+      const cold = createSessionLifecycle({
+        [mcpTransportFactory]: createScriptedMcpTransportFactory({
+          fixture: ordinaryScriptedMcpServer(),
+        }),
+        [sessionStoreDirectory]: corruptedDirectory,
+        modelTargets,
+        stateRoot,
+        workspaceRoot,
+      });
+      try {
+        await expect(
+          cold.inspect({ sessionId: committed.sessionId }),
+          tamper.field,
+        ).rejects.toMatchObject({ code: "session_invalid" });
+      } finally {
+        await cold.close();
+      }
+    }
+  } finally {
+    await initial.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle hybrid Plan denies every generic mutating MCP effect before dispatch", async () => {
+  const deniedEffects = ["write", "delegate", "administrative"] as const;
 
   for (const effect of deniedEffects) {
     const testRoot = await mkdtemp(join(tmpdir(), `adam-agent-mcp-plan-${effect}-deny-`));


### PR DESCRIPTION
Summary:
- add the frozen hybrid Plan shell policy, command assessment, Git/path/environment proofs, and durable recovery identity
- validate Plan MCP permission decisions and expose CLI/TUI unsafe-command warnings
- add semantic, OS-contract, recovery, provenance, and no-second-executor structural coverage

Validation:
- pnpm quality:check
- 58 test files passed, 1445 tests passed, 13 skipped
- independent specification review: 0 findings
- independent standards/provenance review: 0 findings