### PR TITLE
Fix Direct DeepSeek tool request compatibility

### DIFF
--- a/apps/cli/src/main.test.ts
+++ b/apps/cli/src/main.test.ts
@@ -993,7 +993,7 @@ describe("one-shot CLI", () => {
 
       expect(result).toEqual({
         stdout: "",
-        stderr: "The model provider rejected authentication.\n",
+        stderr: "The model provider rejected the configured credential.\n",
         exitCode: 1,
         signal: null,
       });

--- a/packages/agent/src/agent-session-contracts.ts
+++ b/packages/agent/src/agent-session-contracts.ts
@@ -1,7 +1,7 @@
 import type { ArtifactReference, ChangePreviewArtifactSource } from "./artifact-store.js";
 import type { ContextCallUsage } from "./durable-context.js";
 import type { InputResourceOccurrenceV1 } from "./input-resources.js";
-import type { ModelDriverErrorCategory } from "./model-driver-error.js";
+import type { ModelDriverDiagnosticCode, ModelDriverErrorCategory } from "./model-driver-error.js";
 import type { ApprovedPlanProjectionV1 } from "./plan-mode.js";
 import type { ThinkingPolicySnapshotV1 } from "./thinking-policy.js";
 import type {
@@ -180,6 +180,7 @@ export type RunResult =
             readonly code: "model_request_failed";
             readonly message: string;
             readonly category: ModelDriverErrorCategory;
+            readonly diagnosticCode?: ModelDriverDiagnosticCode | undefined;
             readonly status?: number | undefined;
             readonly providerCode?: string | undefined;
             readonly requestId?: string | undefined;
@@ -188,6 +189,7 @@ export type RunResult =
             readonly code: "context_compaction_failed";
             readonly message: string;
             readonly category: ModelDriverErrorCategory;
+            readonly diagnosticCode?: ModelDriverDiagnosticCode | undefined;
             readonly status?: number | undefined;
             readonly providerCode?: string | undefined;
             readonly requestId?: string | undefined;

--- a/packages/agent/src/agent-session.ts
+++ b/packages/agent/src/agent-session.ts
@@ -55,7 +55,13 @@ import {
   inputResourcePageV1Schema,
   materializeInputResourceImageV1,
 } from "./input-resources.js";
-import { ModelDriverError } from "./model-driver-error.js";
+import {
+  type ModelDriverDiagnosticCode,
+  ModelDriverError,
+  type ModelDriverErrorCategory,
+  modelDriverDiagnosticCodes,
+  modelDriverErrorCategories,
+} from "./model-driver-error.js";
 import {
   applyPreparedExplicitUserImageMessagesV1,
   prepareExplicitUserImageMessagesV1,
@@ -3532,15 +3538,13 @@ export class AgentSession {
   }
 
   async #settleModelRequestFailed(error: ModelDriverError): Promise<RunResult> {
+    const diagnostic = normalizeModelDriverFailure(error);
     const result: RunResult = {
       status: "failed",
       error: {
         code: "model_request_failed",
-        message: error.message,
-        category: error.category,
-        ...(error.status === undefined ? {} : { status: error.status }),
-        ...(error.providerCode === undefined ? {} : { providerCode: error.providerCode }),
-        ...(error.requestId === undefined ? {} : { requestId: error.requestId }),
+        message: modelRequestFailureMessage(diagnostic.category, diagnostic.diagnosticCode),
+        ...diagnostic,
       },
     };
     return this.#settle(result);
@@ -3637,17 +3641,16 @@ export class AgentSession {
   async #settleContextCompactionFailed(error: ContextCompactionError): Promise<RunResult> {
     if (error.code === "context_compaction_failed") {
       const providerError = error.cause instanceof ModelDriverError ? error.cause : undefined;
+      const diagnostic =
+        providerError === undefined
+          ? ({ category: "unknown" } as const)
+          : normalizeModelDriverFailure(providerError);
       const result: RunResult = {
         status: "failed",
         error: {
           code: error.code,
           message: error.message,
-          category: providerError?.category ?? "unknown",
-          ...(providerError?.status === undefined ? {} : { status: providerError.status }),
-          ...(providerError?.providerCode === undefined
-            ? {}
-            : { providerCode: providerError.providerCode }),
-          ...(providerError?.requestId === undefined ? {} : { requestId: providerError.requestId }),
+          ...diagnostic,
         },
       };
       return this.#settle(result);
@@ -4134,6 +4137,75 @@ export class AgentSession {
           }),
       replay: adapter?.replay ?? "never",
     };
+  }
+}
+
+function normalizeModelDriverFailure(error: ModelDriverError): {
+  readonly category: ModelDriverErrorCategory;
+  readonly diagnosticCode?: ModelDriverDiagnosticCode | undefined;
+  readonly status?: number | undefined;
+  readonly providerCode?: string | undefined;
+  readonly requestId?: string | undefined;
+} {
+  const category = modelDriverErrorCategories.includes(error.category) ? error.category : "unknown";
+  const diagnosticCode =
+    category === "protocol_incompatibility" &&
+    modelDriverDiagnosticCodes.includes(error.diagnosticCode as ModelDriverDiagnosticCode)
+      ? (error.diagnosticCode as ModelDriverDiagnosticCode)
+      : undefined;
+  const status =
+    Number.isSafeInteger(error.status) &&
+    (error.status as number) >= 100 &&
+    (error.status as number) <= 599
+      ? error.status
+      : undefined;
+  const providerCode = normalizeModelDriverToken(error.providerCode);
+  const requestId = normalizeModelDriverToken(error.requestId);
+  return {
+    category,
+    ...(diagnosticCode === undefined ? {} : { diagnosticCode }),
+    ...(status === undefined ? {} : { status }),
+    ...(providerCode === undefined ? {} : { providerCode }),
+    ...(requestId === undefined ? {} : { requestId }),
+  };
+}
+
+function normalizeModelDriverToken(value: string | undefined): string | undefined {
+  return value !== undefined && value.length > 0 && value.length <= 128 && /^[!-~]+$/u.test(value)
+    ? value
+    : undefined;
+}
+
+function modelRequestFailureMessage(
+  category: ModelDriverErrorCategory,
+  diagnosticCode: ModelDriverDiagnosticCode | undefined,
+): string {
+  if (diagnosticCode === "tool_schema_root_not_object") {
+    return "A model tool schema is incompatible with the selected provider.";
+  }
+  switch (category) {
+    case "authentication":
+      return "The model provider rejected the configured credential.";
+    case "authorization":
+      return "The model provider denied the request.";
+    case "billing":
+      return "The model provider could not run the request because billing is unavailable.";
+    case "rate_limit":
+      return "The model provider rate limit was reached.";
+    case "invalid_request":
+      return "The model provider rejected the request as invalid.";
+    case "provider":
+      return "The model provider could not complete the request.";
+    case "transport":
+      return "The model provider connection failed.";
+    case "protocol_incompatibility":
+      return "The model provider response was incompatible with Adam.";
+    case "timeout":
+      return "The model provider request reached its deadline.";
+    case "aborted":
+      return "The model provider request was aborted.";
+    case "unknown":
+      return "The model provider request failed.";
   }
 }
 

--- a/packages/agent/src/ai-sdk-model-driver.ts
+++ b/packages/agent/src/ai-sdk-model-driver.ts
@@ -11,6 +11,10 @@ import type { ModelDriver, ModelEvent, ModelRequest } from "./agent-session-cont
 import { modelMessagesWithApprovedPlanProjectionV1 } from "./approved-plan-projection.js";
 import { maximumModelResponseContentBytes } from "./durable-model-response-policy.js";
 import { ModelDriverError } from "./model-driver-error.js";
+import {
+  type ModelToolSchemaProjectionProfile,
+  projectModelToolDefinitions,
+} from "./model-tool-schema-projection.js";
 import type { ThinkingPolicyMappingV1 } from "./thinking-policy.js";
 
 const maximumToolArgumentBytes = 2 * 1024 * 1024;
@@ -40,6 +44,7 @@ export class AiSdkModelDriver implements ModelDriver {
     | Readonly<Partial<Record<"title" | "compaction", ThinkingPolicyMappingV1>>>
     | undefined;
   readonly #sensitiveValues: readonly string[];
+  readonly #toolSchemaProjection: ModelToolSchemaProjectionProfile | undefined;
 
   constructor(options: {
     readonly model: LanguageModelV4;
@@ -50,6 +55,7 @@ export class AiSdkModelDriver implements ModelDriver {
       Partial<Record<"title" | "compaction", ThinkingPolicyMappingV1>>
     >;
     readonly sensitiveValues: readonly string[];
+    readonly toolSchemaProjection?: ModelToolSchemaProjectionProfile | undefined;
   }) {
     this.#deadlineMs = options.deadlineMs;
     this.#model = options.model;
@@ -57,6 +63,7 @@ export class AiSdkModelDriver implements ModelDriver {
     this.#providerOptions = options.providerOptions;
     this.#sideCallThinkingPolicies = options.sideCallThinkingPolicies;
     this.#sensitiveValues = options.sensitiveValues;
+    this.#toolSchemaProjection = options.toolSchemaProjection;
   }
 
   async *stream(request: ModelRequest): AsyncIterable<ModelEvent> {
@@ -94,7 +101,10 @@ export class AiSdkModelDriver implements ModelDriver {
         ...(request.tools.length === 0
           ? {}
           : {
-              tools: request.tools.map(
+              tools: (this.#toolSchemaProjection === undefined
+                ? request.tools
+                : projectModelToolDefinitions(request.tools, this.#toolSchemaProjection)
+              ).map(
                 (tool): LanguageModelV4FunctionTool => ({
                   type: "function",
                   name: tool.name,
@@ -121,7 +131,7 @@ export class AiSdkModelDriver implements ModelDriver {
         if (isIgnoredStructuralPart(part)) {
           continue;
         }
-        const events = [...mapStreamPart(part, normalization)];
+        const events = [...mapStreamPart(part, normalization, this.#sensitiveValues)];
         if (part.type === "finish") {
           if (deadlineTimer !== undefined) {
             clearTimeout(deadlineTimer);
@@ -281,6 +291,7 @@ function parseToolInput(argumentsJson: string): unknown {
 function* mapStreamPart(
   part: LanguageModelV4StreamPart,
   normalization: StreamNormalization,
+  sensitiveValues: readonly string[],
 ): Iterable<ModelEvent> {
   switch (part.type) {
     case "stream-start":
@@ -394,6 +405,9 @@ function* mapStreamPart(
       }
       return;
     case "error":
+      if (APICallError.isInstance(part.error)) {
+        throw classifyAiSdkError(part.error, sensitiveValues);
+      }
       throw new ModelDriverError(
         "protocol_incompatibility",
         `The Vercel provider returned an invalid stream part (${errorKind(part.error)}).`,

--- a/packages/agent/src/deepseek-responses-model-driver.ts
+++ b/packages/agent/src/deepseek-responses-model-driver.ts
@@ -8,6 +8,7 @@ import type {
 import { modelMessagesWithApprovedPlanProjectionV1 } from "./approved-plan-projection.js";
 import { maximumModelResponseContentBytes } from "./durable-model-response-policy.js";
 import { ModelDriverError } from "./model-driver-error.js";
+import { projectModelToolDefinitions } from "./model-tool-schema-projection.js";
 
 const maximumSseFrameBytes = 2 * 1024 * 1024;
 const maximumToolArgumentBytes = 2 * 1024 * 1024;
@@ -142,13 +143,15 @@ function mapRequest(request: ModelRequest, model: string, maximumOutputTokens: n
     ...(request.tools.length === 0
       ? {}
       : {
-          tools: request.tools.map((tool) => ({
-            type: "function",
-            name: tool.name,
-            description: tool.description,
-            parameters: tool.inputSchema,
-            strict: false,
-          })),
+          tools: projectModelToolDefinitions(request.tools, "deepseek-function-parameters-v1").map(
+            (tool) => ({
+              type: "function",
+              name: tool.name,
+              description: tool.description,
+              parameters: tool.inputSchema,
+              strict: false,
+            }),
+          ),
         }),
     ...(request.thinkingPolicy === undefined
       ? {}
@@ -546,6 +549,8 @@ async function responseError(response: Response, apiKey: string): Promise<ModelD
     providerMessage = undefined;
   }
   const summary = (providerMessage ?? raw).split(apiKey).join("[REDACTED]").slice(0, 512);
+  const rawRequestId = response.headers.get("x-request-id");
+  const requestId = rawRequestId?.split(apiKey).join("[REDACTED]").slice(0, 128);
   const category =
     response.status === 401
       ? "authentication"
@@ -564,9 +569,7 @@ async function responseError(response: Response, apiKey: string): Promise<ModelD
     cause: undefined,
     status: response.status,
     ...(providerCode === undefined ? {} : { providerCode }),
-    ...(response.headers.get("x-request-id") === null
-      ? {}
-      : { requestId: response.headers.get("x-request-id")?.slice(0, 128) }),
+    ...(requestId === undefined ? {} : { requestId }),
     ...(summary.length === 0 ? {} : { responseSummary: summary }),
   });
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -60,7 +60,11 @@ export {
   type LocalInputResourceSelectionV1,
   type StagedInputResourceSelectionV1,
 } from "./input-resources.js";
-export { ModelDriverError, type ModelDriverErrorCategory } from "./model-driver-error.js";
+export {
+  type ModelDriverDiagnosticCode,
+  ModelDriverError,
+  type ModelDriverErrorCategory,
+} from "./model-driver-error.js";
 export {
   createModelTargets,
   type ModelTargetConnectionTestResult,

--- a/packages/agent/src/model-driver-error.ts
+++ b/packages/agent/src/model-driver-error.ts
@@ -14,8 +14,13 @@ export const modelDriverErrorCategories = [
 
 export type ModelDriverErrorCategory = (typeof modelDriverErrorCategories)[number];
 
+export const modelDriverDiagnosticCodes = ["tool_schema_root_not_object"] as const;
+
+export type ModelDriverDiagnosticCode = (typeof modelDriverDiagnosticCodes)[number];
+
 export class ModelDriverError extends Error {
   readonly category: ModelDriverErrorCategory;
+  readonly diagnosticCode: ModelDriverDiagnosticCode | undefined;
   readonly status: number | undefined;
   readonly providerCode: string | undefined;
   readonly requestId: string | undefined;
@@ -26,6 +31,7 @@ export class ModelDriverError extends Error {
     message: string,
     options: {
       readonly cause: unknown;
+      readonly diagnosticCode?: ModelDriverDiagnosticCode | undefined;
       readonly status?: number | undefined;
       readonly providerCode?: string | undefined;
       readonly requestId?: string | undefined;
@@ -35,6 +41,7 @@ export class ModelDriverError extends Error {
     super(message, { cause: options.cause });
     this.name = "ModelDriverError";
     this.category = category;
+    this.diagnosticCode = options.diagnosticCode;
     this.status = options.status;
     this.providerCode = options.providerCode;
     this.requestId = options.requestId;

--- a/packages/agent/src/model-targets.ts
+++ b/packages/agent/src/model-targets.ts
@@ -460,6 +460,7 @@ export function createModelTargets(options: ModelTargetsOptions): ModelTargets {
           model: provider(identity.modelId),
           maximumOutputTokens: contextProfile.maximumOutputTokens,
           deadlineMs,
+          toolSchemaProjection: "deepseek-function-parameters-v1",
           sideCallThinkingPolicies: {
             title: {
               requestPath: "provider_options.deepseek",

--- a/packages/agent/src/model-tool-schema-projection.ts
+++ b/packages/agent/src/model-tool-schema-projection.ts
@@ -1,0 +1,60 @@
+import { ModelDriverError } from "./model-driver-error.js";
+import type { ModelToolDefinition } from "./tool-runtime.js";
+
+export type ModelToolSchemaProjectionProfile = "deepseek-function-parameters-v1";
+
+type ToolSchemaRoot = Readonly<Record<string, unknown>> & {
+  readonly type?: unknown;
+  readonly oneOf?: unknown;
+  readonly anyOf?: unknown;
+};
+
+export function projectModelToolDefinitions(
+  tools: readonly ModelToolDefinition[],
+  profile: ModelToolSchemaProjectionProfile,
+): readonly ModelToolDefinition[] {
+  switch (profile) {
+    case "deepseek-function-parameters-v1":
+      return tools.map((tool) => ({
+        ...tool,
+        inputSchema: projectDeepSeekFunctionParameters(tool.inputSchema),
+      }));
+  }
+}
+
+function projectDeepSeekFunctionParameters(
+  schema: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> {
+  const copy = structuredClone(schema) as ToolSchemaRoot;
+  if (copy.type === "object") {
+    return copy;
+  }
+  const oneOf = copy.oneOf;
+  const anyOf = copy.anyOf;
+  const branches = oneOf === undefined || anyOf === undefined ? (oneOf ?? anyOf) : undefined;
+  if (
+    copy.type === undefined &&
+    Array.isArray(branches) &&
+    branches.length > 0 &&
+    branches.every(isObjectSchema)
+  ) {
+    return { ...copy, type: "object" };
+  }
+  throw new ModelDriverError(
+    "protocol_incompatibility",
+    "A model tool schema is incompatible with the Direct DeepSeek function interface.",
+    {
+      cause: undefined,
+      diagnosticCode: "tool_schema_root_not_object",
+    },
+  );
+}
+
+function isObjectSchema(value: unknown): boolean {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (value as ToolSchemaRoot).type === "object"
+  );
+}

--- a/packages/agent/src/openai-compatible-model-driver.ts
+++ b/packages/agent/src/openai-compatible-model-driver.ts
@@ -17,6 +17,7 @@ import type {
 } from "./agent-session-contracts.js";
 import { modelMessagesWithApprovedPlanProjectionV1 } from "./approved-plan-projection.js";
 import { ModelDriverError } from "./model-driver-error.js";
+import { projectModelToolDefinitions } from "./model-tool-schema-projection.js";
 
 const maximumNormalizedTextBytes = 512 * 1024;
 const maximumNormalizedReasoningBytes = 512 * 1024;
@@ -107,7 +108,10 @@ export class OpenAICompatibleModelDriver implements ModelDriver {
     const messages = modelMessagesWithApprovedPlanProjectionV1(request).map((message) =>
       mapMessage(message, this.#model.startsWith("deepseek-v4-")),
     );
-    const tools: ChatCompletionTool[] = request.tools.map((tool) => ({
+    const tools: ChatCompletionTool[] = projectModelToolDefinitions(
+      request.tools,
+      "deepseek-function-parameters-v1",
+    ).map((tool) => ({
       type: "function",
       function: {
         name: tool.name,

--- a/packages/agent/src/presentation-transcript-projection.ts
+++ b/packages/agent/src/presentation-transcript-projection.ts
@@ -5,7 +5,7 @@ import type {
   ToolCallDisplay,
   TranscriptItem,
 } from "@adam-agent/presentation";
-import type { RuntimeEvent } from "./agent-session-contracts.js";
+import type { RunResult, RuntimeEvent } from "./agent-session-contracts.js";
 import type { SessionRecord } from "./session-store.js";
 
 type PresentationTranscriptHistoryRecord = {
@@ -249,7 +249,7 @@ export function projectTranscript(
               branchBoundary: { sessionId, sequence: entry.sequence },
               status: "failed",
               code: result.error.code,
-              message: safeRunFailureMessage(result.error.code),
+              message: safeRunFailureMessage(result.error),
             }
           : {
               type: "session_notice",
@@ -468,12 +468,25 @@ export function providerDisplayName(vendor: string | undefined): string {
   return vendor === "deepseek" ? "DeepSeek" : (vendor ?? "Provider");
 }
 
-function safeRunFailureMessage(code: string): string {
+type FailedRunError = Extract<RunResult, { readonly status: "failed" }>["error"];
+
+function safeRunFailureMessage(error: FailedRunError): string {
+  const code = error.code;
   if (code === "tool_effect_indeterminate") {
     return "A tool effect requires inspection before continuing.";
   }
   if (code === "session_persistence_failed") {
     return "The session could not make its result durable.";
+  }
+  if (code === "model_request_failed" || code === "context_compaction_failed") {
+    const summary = safeModelDriverFailureSummary(error);
+    const status = error.status;
+    const metadata = [
+      status !== undefined && Number.isSafeInteger(status) && status >= 100 && status <= 599
+        ? `HTTP ${status}`
+        : undefined,
+    ].filter((value): value is string => value !== undefined);
+    return metadata.length === 0 ? summary : `${summary} ${metadata.join(" · ")}`;
   }
   if (code.startsWith("context_") || code.startsWith("token_")) {
     return "The run could not continue within its context limits.";
@@ -482,4 +495,44 @@ function safeRunFailureMessage(code: string): string {
     return "The requested Skill activation failed.";
   }
   return "The model run failed.";
+}
+
+function safeModelDriverFailureSummary(
+  error: Extract<
+    FailedRunError,
+    { readonly code: "model_request_failed" | "context_compaction_failed" }
+  >,
+): string {
+  if (
+    error.category === "protocol_incompatibility" &&
+    error.diagnosticCode === "tool_schema_root_not_object"
+  ) {
+    return "A tool schema is incompatible with the selected provider.";
+  }
+  const subject =
+    error.code === "context_compaction_failed" ? "Context compaction" : "The provider";
+  switch (error.category) {
+    case "authentication":
+      return `${subject} rejected the configured credential.`;
+    case "authorization":
+      return `${subject} denied the request.`;
+    case "billing":
+      return `${subject} could not run the request because billing is unavailable.`;
+    case "rate_limit":
+      return `${subject} rate limit was reached.`;
+    case "invalid_request":
+      return `${subject} rejected the request as invalid.`;
+    case "provider":
+      return `${subject} could not complete the request.`;
+    case "transport":
+      return `${subject} connection failed.`;
+    case "protocol_incompatibility":
+      return `${subject} response was incompatible with Adam.`;
+    case "timeout":
+      return `${subject} request reached its deadline.`;
+    case "aborted":
+      return `${subject} request was aborted.`;
+    case "unknown":
+      return `${subject} request failed.`;
+  }
 }

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -20,7 +20,7 @@ import {
   inputResourceOccurrenceV1Schema,
 } from "./input-resources.js";
 import type { McpToolProfileV1 } from "./mcp-profile-contracts.js";
-import { modelDriverErrorCategories } from "./model-driver-error.js";
+import { modelDriverDiagnosticCodes, modelDriverErrorCategories } from "./model-driver-error.js";
 import type { ModelTargetIdentity } from "./model-targets.js";
 import { imageInputLimitsV1, type ProjectedContentUsageV1 } from "./model-user-content.js";
 import type { PlanShellPolicyVersion } from "./plan-command-assessment.js";
@@ -1098,6 +1098,7 @@ const runFailureSchema: z.ZodType<RunFailure> = z.discriminatedUnion("code", [
     code: z.literal("model_request_failed"),
     message: z.string(),
     category: z.enum(modelDriverErrorCategories),
+    diagnosticCode: z.enum(modelDriverDiagnosticCodes).optional(),
     status: z.number().int().min(100).max(599).optional(),
     providerCode: z.string().max(128).optional(),
     requestId: z.string().max(128).optional(),
@@ -1106,6 +1107,7 @@ const runFailureSchema: z.ZodType<RunFailure> = z.discriminatedUnion("code", [
     code: z.literal("context_compaction_failed"),
     message: z.string(),
     category: z.enum(modelDriverErrorCategories),
+    diagnosticCode: z.enum(modelDriverDiagnosticCodes).optional(),
     status: z.number().int().min(100).max(599).optional(),
     providerCode: z.string().max(128).optional(),
     requestId: z.string().max(128).optional(),

--- a/packages/testkit/src/agent-session.test.ts
+++ b/packages/testkit/src/agent-session.test.ts
@@ -627,7 +627,7 @@ describe("AgentSession", () => {
       status: "failed",
       error: {
         code: "model_request_failed",
-        message: "The provider stream failed.",
+        message: "The model provider connection failed.",
         category: "transport",
       },
     });
@@ -655,12 +655,104 @@ describe("AgentSession", () => {
           status: "failed",
           error: {
             code: "model_request_failed",
-            message: "The provider stream failed.",
+            message: "The model provider connection failed.",
             category: "transport",
           },
         },
       },
     ]);
+  });
+
+  test("a model request failure settles with bounded diagnostics and no provider text", async () => {
+    const privateValue = "private-provider-body-and-secret";
+    const model: ModelDriver = {
+      async *stream() {
+        yield await Promise.reject(
+          new ModelDriverError(
+            "protocol_incompatibility",
+            `The provider exposed ${privateValue}.`,
+            {
+              cause: new Error(`private cause ${privateValue}`),
+              diagnosticCode: "tool_schema_root_not_object",
+              status: 400,
+              providerCode: "invalid_request_error",
+              requestId: "request-safe-1",
+              responseSummary: `private summary ${privateValue}`,
+            },
+          ),
+        );
+      },
+    };
+    const store = createInMemorySessionStore<SessionRecord>();
+    const session = createTestSession({ model, store: store as unknown as SessionStore });
+    const events: RuntimeEvent[] = [];
+    session.subscribe((event) => events.push(event));
+
+    const result = await session.run({ text: "Keep only safe provider diagnostics" });
+
+    const expectedResult = {
+      status: "failed",
+      error: {
+        code: "model_request_failed",
+        message: "A model tool schema is incompatible with the selected provider.",
+        category: "protocol_incompatibility",
+        diagnosticCode: "tool_schema_root_not_object",
+        status: 400,
+        providerCode: "invalid_request_error",
+        requestId: "request-safe-1",
+      },
+    } as const;
+    expect(result).toEqual(expectedResult);
+    expect(events.at(-1)).toEqual({ type: "session_settled", result: expectedResult });
+    expect(await store.read()).toContainEqual(
+      expect.objectContaining({
+        event: expect.objectContaining({ type: "session_settled", result: expectedResult }),
+      }),
+    );
+    expect(JSON.stringify({ result, events, records: await store.read() })).not.toContain(
+      privateValue,
+    );
+    expect(JSON.stringify({ result, events, records: await store.read() })).not.toContain(
+      "responseSummary",
+    );
+  });
+
+  test("malformed model failure metadata cannot turn settlement into a persistence failure", async () => {
+    const malformedError = Object.assign(
+      new ModelDriverError("unknown", "private provider failure", {
+        cause: new Error("private provider cause"),
+        status: 99,
+        providerCode: "x".repeat(129),
+        requestId: "request\nwith-control-character",
+      }),
+      { category: "invented_category", diagnosticCode: "tool_schema_root_not_object" },
+    );
+    const model: ModelDriver = {
+      async *stream() {
+        yield await Promise.reject(malformedError);
+      },
+    };
+    const store = createInMemorySessionStore<SessionRecord>();
+    const session = createTestSession({ model, store: store as unknown as SessionStore });
+
+    const result = await session.run({ text: "Normalize malformed provider metadata" });
+
+    expect(result).toEqual({
+      status: "failed",
+      error: {
+        code: "model_request_failed",
+        message: "The model provider request failed.",
+        category: "unknown",
+      },
+    });
+    expect(await store.read()).toContainEqual(
+      expect.objectContaining({
+        event: expect.objectContaining({ type: "session_settled", result }),
+      }),
+    );
+    expect(JSON.stringify({ result, records: await store.read() })).not.toContain(
+      "private provider",
+    );
   });
 
   test("cancelling an active provider reasoning block settles it as interrupted", async () => {

--- a/packages/testkit/src/context-compaction.test.ts
+++ b/packages/testkit/src/context-compaction.test.ts
@@ -3841,7 +3841,7 @@ test("AgentSession never retries a context overflow after ordinary output has be
     status: "failed",
     error: {
       code: "model_request_failed",
-      message: "The provider rejected the context length.",
+      message: "The model provider rejected the request as invalid.",
       category: "invalid_request",
       status: 400,
       providerCode: "context_length_exceeded",

--- a/packages/testkit/src/deepseek-responses-model-driver.test.ts
+++ b/packages/testkit/src/deepseek-responses-model-driver.test.ts
@@ -77,6 +77,68 @@ test("Direct Responses maps one stateless answer-only request and semantic SSE",
   });
 });
 
+test("Direct Responses projects an object-only union tool schema on the provider wire", async () => {
+  let body: { readonly tools?: readonly unknown[] } | undefined;
+  const canonicalInputSchema = {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    anyOf: [
+      {
+        type: "object",
+        properties: { kind: { type: "string", const: "content" } },
+        required: ["kind"],
+        additionalProperties: false,
+      },
+      {
+        type: "object",
+        properties: { kind: { type: "string", const: "path" } },
+        required: ["kind"],
+        additionalProperties: false,
+      },
+    ],
+  } as const;
+  const canonicalBefore = structuredClone(canonicalInputSchema);
+  const driver = new DirectDeepSeekResponsesModelDriverForTesting({
+    apiKey: "test-secret",
+    baseURL: "https://api.deepseek.com",
+    deadlineMs: 10_000,
+    maximumOutputTokens: 4_096,
+    model: "deepseek-v4-flash-vision-exp",
+    fetch: async (_input, init) => {
+      body = JSON.parse(String(init?.body)) as { readonly tools?: readonly unknown[] };
+      return new Response(
+        'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed"}}\n\n',
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      );
+    },
+  });
+
+  for await (const _event of driver.stream({
+    messages: [{ role: "user", content: "Search the repository" }],
+    tools: [
+      {
+        name: "search_repository",
+        description: "Search repository content or paths.",
+        inputSchema: canonicalInputSchema,
+      },
+    ],
+    maximumOutputTokens: 2_048,
+    signal: new AbortController().signal,
+  })) {
+    // Consume the complete semantic stream.
+  }
+
+  expect(body?.tools).toEqual([
+    {
+      type: "function",
+      name: "search_repository",
+      description: "Search repository content or paths.",
+      parameters: { ...canonicalBefore, type: "object" },
+      strict: false,
+    },
+  ]);
+  expect(canonicalInputSchema).toEqual(canonicalBefore);
+});
+
 test("Direct Responses serializes the exact approved Plan as one assistant projection", async () => {
   let body: { readonly input: readonly unknown[] } | undefined;
   const driver = new DirectDeepSeekResponsesModelDriverForTesting({
@@ -775,7 +837,7 @@ test("Direct Responses classifies bounded provider errors without retaining its 
     fetch: async () =>
       Response.json(
         { error: { code: "billing_error", message: "balance test-secret" } },
-        { status: 402 },
+        { status: 402, headers: { "x-request-id": "request-test-secret" } },
       ),
   });
   const error = await collectError(
@@ -791,6 +853,7 @@ test("Direct Responses classifies bounded provider errors without retaining its 
     category: "billing",
     status: 402,
     providerCode: "billing_error",
+    requestId: "request-[REDACTED]",
     responseSummary: "balance [REDACTED]",
   });
   expect(JSON.stringify(error)).not.toContain("test-secret");

--- a/packages/testkit/src/model-targets.test.ts
+++ b/packages/testkit/src/model-targets.test.ts
@@ -78,6 +78,141 @@ test("an exact Direct DeepSeek target returns a public answer-only model driver"
   });
 });
 
+test("a Direct DeepSeek target projects an object-only union tool schema on the provider wire", async () => {
+  const requests: unknown[] = [];
+  const canonicalInputSchema = {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    oneOf: [
+      {
+        type: "object",
+        properties: {
+          kind: { type: "string", const: "content" },
+          query: { type: "string" },
+        },
+        required: ["kind", "query"],
+        additionalProperties: false,
+      },
+      {
+        type: "object",
+        properties: {
+          kind: { type: "string", const: "path" },
+          query: { type: "string" },
+        },
+        required: ["kind", "query"],
+        additionalProperties: false,
+      },
+    ],
+  } as const;
+  const canonicalBefore = structuredClone(canonicalInputSchema);
+  const targets = createModelTargets({
+    environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
+    fetch: async (_input, init) => {
+      requests.push(JSON.parse(String(init?.body)));
+      return new Response(answerOnlyDeepSeekStream, {
+        headers: { "content-type": "text/event-stream" },
+        status: 200,
+      });
+    },
+  });
+  const { driver } = await targets.resolve({
+    targetId: "deepseek-v4-flash.direct",
+    allowExperimental: false,
+    signal: new AbortController().signal,
+  });
+
+  await collect(
+    driver.stream({
+      messages: [{ role: "user", content: "Search the repository" }],
+      tools: [
+        {
+          name: "search_repository",
+          description: "Search repository content or paths.",
+          inputSchema: canonicalInputSchema,
+        },
+      ],
+      maximumOutputTokens: 4_096,
+      signal: new AbortController().signal,
+    }),
+  );
+
+  expect(requests).toEqual([
+    expect.objectContaining({
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "search_repository",
+            description: "Search repository content or paths.",
+            parameters: { ...canonicalBefore, type: "object" },
+          },
+        },
+      ],
+    }),
+  ]);
+  expect(canonicalInputSchema).toEqual(canonicalBefore);
+});
+
+test.each([
+  ["a scalar root", { type: "string" }],
+  ["an array root", { type: "array", items: { type: "string" } }],
+  ["a nullable object type array", { type: ["object", "null"] }],
+  [
+    "a root reference",
+    { $ref: "#/$defs/input", $defs: { input: { type: "object", properties: {} } } },
+  ],
+  ["properties without an object type", { properties: { query: { type: "string" } } }],
+  ["an empty object union", { oneOf: [] }],
+  ["an allOf object", { allOf: [{ type: "object", properties: {} }] }],
+  ["a mixed object and scalar union", { oneOf: [{ type: "object" }, { type: "string" }] }],
+  [
+    "simultaneous oneOf and anyOf roots",
+    { oneOf: [{ type: "object" }], anyOf: [{ type: "object" }] },
+  ],
+] as const)(
+  "a Direct DeepSeek target rejects %s before provider dispatch",
+  async (_scenario, inputSchema) => {
+    const fetchProvider = vi.fn(async () =>
+      Promise.resolve(
+        new Response(answerOnlyDeepSeekStream, {
+          headers: { "content-type": "text/event-stream" },
+          status: 200,
+        }),
+      ),
+    );
+    const targets = createModelTargets({
+      environment: { DEEPSEEK_API_KEY: "test-deepseek-key" },
+      fetch: fetchProvider,
+    });
+    const { driver } = await targets.resolve({
+      targetId: "deepseek-v4-flash.direct",
+      allowExperimental: false,
+      signal: new AbortController().signal,
+    });
+
+    const error = await collectError(
+      driver.stream({
+        messages: [{ role: "user", content: "Use the invalid tool" }],
+        tools: [
+          {
+            name: "invalid_tool",
+            description: "This fixture has a provider-incompatible root schema.",
+            inputSchema,
+          },
+        ],
+        maximumOutputTokens: 4_096,
+        signal: new AbortController().signal,
+      }),
+    );
+
+    expect(error).toMatchObject({
+      category: "protocol_incompatibility",
+      diagnosticCode: "tool_schema_root_not_object",
+      message: "A model tool schema is incompatible with the Direct DeepSeek function interface.",
+    });
+    expect(fetchProvider).not.toHaveBeenCalled();
+  },
+);
+
 test("the exact Vision Chat target projects immutable PNG bytes through Direct Chat", async () => {
   const requests: Array<{ readonly url: string; readonly body: unknown }> = [];
   const targets = createModelTargets({
@@ -1951,6 +2086,64 @@ test.each([
   },
 );
 
+test("the unified driver classifies a provider API error delivered as a stream part", async () => {
+  const privateValue = "provider-private-secret";
+  const apiCallError = Object.assign(new Error(`private ${privateValue}`), {
+    [Symbol.for("vercel.ai.error.AI_APICallError")]: true,
+    statusCode: 429,
+    responseHeaders: { "x-request-id": `request-${privateValue}` },
+    data: {
+      error: {
+        code: `rate-${privateValue}`,
+        message: `private summary ${privateValue}`,
+      },
+    },
+  });
+  const model = {
+    specificationVersion: "v4",
+    provider: "test",
+    modelId: "stream-api-error",
+    supportedUrls: {},
+    async doGenerate() {
+      throw new Error("Generation is not used by this test.");
+    },
+    async doStream() {
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "error", error: apiCallError });
+            controller.close();
+          },
+        }),
+      };
+    },
+  } as unknown as ConstructorParameters<typeof AiSdkModelDriverForTesting>[0]["model"];
+  const driver = new AiSdkModelDriverForTesting({
+    model,
+    maximumOutputTokens: 4_096,
+    deadlineMs: 120_000,
+    sensitiveValues: [privateValue],
+  });
+
+  const error = await collectError(
+    driver.stream({
+      maximumOutputTokens: 4_096,
+      messages: [{ role: "user", content: "Classify the provider stream failure." }],
+      tools: [],
+      signal: new AbortController().signal,
+    }),
+  );
+
+  expect(error).toMatchObject({
+    category: "rate_limit",
+    status: 429,
+    providerCode: "rate-[REDACTED]",
+    requestId: "request-[REDACTED]",
+    responseSummary: "private summary [REDACTED]",
+  });
+  expect(JSON.stringify(error)).not.toContain(privateValue);
+});
+
 test("the unified driver counts every Provider V4 part against the 2,000,000 part ceiling", async () => {
   let emitted = 0;
   const model = {
@@ -2459,6 +2652,12 @@ test("an opted-in Gateway target resolves only as an exact Experimental identity
 });
 
 test("the Experimental Gateway target pins one upstream in the public V4 request", async () => {
+  const canonicalInputSchema = {
+    oneOf: [
+      { type: "object", properties: { kind: { const: "content" } }, required: ["kind"] },
+      { type: "object", properties: { kind: { const: "path" } }, required: ["kind"] },
+    ],
+  } as const;
   const requests: Array<{
     readonly url: string;
     readonly modelId: string | null;
@@ -2488,7 +2687,13 @@ test("the Experimental Gateway target pins one upstream in the public V4 request
     driver.stream({
       maximumOutputTokens: 4_096,
       messages: [{ role: "user", content: "Introduce yourself" }],
-      tools: [],
+      tools: [
+        {
+          name: "search_repository",
+          description: "Search repository content or paths.",
+          inputSchema: canonicalInputSchema,
+        },
+      ],
       signal: new AbortController().signal,
     }),
   );
@@ -2500,6 +2705,14 @@ test("the Experimental Gateway target pins one upstream in the public V4 request
       body: expect.objectContaining({
         prompt: [{ role: "user", content: [{ type: "text", text: "Introduce yourself" }] }],
         providerOptions: { gateway: { only: ["poolside"] } },
+        tools: [
+          {
+            type: "function",
+            name: "search_repository",
+            description: "Search repository content or paths.",
+            inputSchema: canonicalInputSchema,
+          },
+        ],
       }),
     },
   ]);

--- a/packages/testkit/src/openai-compatible-model-driver.live.test.ts
+++ b/packages/testkit/src/openai-compatible-model-driver.live.test.ts
@@ -21,9 +21,15 @@ const {
   DEEPSEEK_API_KEY: apiKey,
   ADAM_AGENT_LIVE_TESTS: liveTestSelection,
   ADAM_AGENT_MODEL: configuredModel,
+  NODE_TLS_REJECT_UNAUTHORIZED: tlsVerificationOverride,
 } = process.env;
 const liveTestsEnabled = liveTestSelection === "1";
-const liveTest = test.skipIf(!liveTestsEnabled || apiKey === undefined || apiKey.length === 0);
+const liveTest = test.skipIf(
+  !liveTestsEnabled ||
+    apiKey === undefined ||
+    apiKey.length === 0 ||
+    tlsVerificationOverride === "0",
+);
 const liveApiKey = apiKey ?? "";
 const model = configuredModel ?? "deepseek-v4-pro";
 
@@ -58,6 +64,10 @@ for (const targetId of ["deepseek-v4-flash.direct", "deepseek-v4-pro.direct"] as
 
 test.skipIf(!liveTestsEnabled)("requires DEEPSEEK_API_KEY for the live gate", () => {
   expect(liveApiKey.length).toBeGreaterThan(0);
+});
+
+test.skipIf(!liveTestsEnabled)("requires normal TLS verification for the live gate", () => {
+  expect(tlsVerificationOverride).not.toBe("0");
 });
 
 liveTest(
@@ -192,6 +202,97 @@ liveTest(
   },
   180_000,
 );
+
+for (const scenario of [
+  {
+    targetId: "deepseek-v4-flash.direct",
+    projectName: "Silver Meridian",
+    profileVersion: 3,
+    slug: "flash",
+  },
+  {
+    targetId: "deepseek-v4-pro.direct",
+    projectName: "Cobalt Lantern",
+    profileVersion: 3,
+    slug: "pro",
+  },
+  {
+    targetId: "deepseek-v4-flash-vision-exp.direct",
+    projectName: "Indigo Atlas",
+    profileVersion: 1,
+    slug: "vision-chat",
+  },
+  {
+    targetId: "deepseek-v4-flash-vision-exp.direct",
+    projectName: "Golden Vector",
+    profileVersion: 2,
+    slug: "vision-responses",
+  },
+] as const) {
+  liveTest(
+    `R0 ${scenario.targetId} profile ${scenario.profileVersion} completes one read-tool round trip`,
+    async () => {
+      const testRoot = await mkdtemp(join(tmpdir(), `adam-agent-live-r0-${scenario.slug}-`));
+      const workspaceRoot = join(testRoot, "workspace");
+      const events: RuntimeEvent[] = [];
+      try {
+        await mkdir(workspaceRoot);
+        await writeFile(join(workspaceRoot, "README.md"), `# ${scenario.projectName}\n`, "utf8");
+        const modelTargets = createModelTargets({
+          environment: { DEEPSEEK_API_KEY: liveApiKey },
+          deadlineMs: 90_000,
+        });
+        const target = (
+          await modelTargets.snapshot({
+            includeHistoricalProfiles: true,
+            signal: new AbortController().signal,
+          })
+        ).targets.find(
+          ({ identity }) =>
+            identity.targetId === scenario.targetId &&
+            identity.profileVersion === scenario.profileVersion,
+        );
+        if (target === undefined) {
+          throw new Error(`Expected ${scenario.targetId} profile ${scenario.profileVersion}.`);
+        }
+        const resolved = await modelTargets.resolve({
+          targetId: target.identity.targetId,
+          targetIdentity: target.identity,
+          allowExperimental: false,
+          signal: new AbortController().signal,
+        });
+        const session = new AgentSession({
+          maximumOutputTokens: 4_096,
+          model: resolved.driver,
+          store: createInMemorySessionStore(),
+          permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+          tools: createReadToolRegistry({ workspaceRoot }),
+        });
+        session.subscribe((event) => events.push(event));
+
+        const result = await session.run({
+          text: "Use read_file to read README.md, then reply with only the H1 project name.",
+        });
+
+        expect({ result, targetIdentity: resolved.identity }).toEqual({
+          result: {
+            status: "completed",
+            answer: expect.stringContaining(scenario.projectName),
+          },
+          targetIdentity: target.identity,
+        });
+        expect(events).toContainEqual({
+          type: "tool_requested",
+          callId: expect.any(String),
+          name: "read_file",
+        });
+      } finally {
+        await rm(testRoot, { recursive: true, force: true });
+      }
+    },
+    180_000,
+  );
+}
 
 liveTest(
   "Vision Chat eager image observes one exact quadrant order and durable resource truth",

--- a/packages/testkit/src/openai-compatible-model-driver.test.ts
+++ b/packages/testkit/src/openai-compatible-model-driver.test.ts
@@ -385,7 +385,7 @@ describe("OpenAICompatibleModelDriver", () => {
       status: "failed",
       error: {
         code: "model_request_failed",
-        message: "The model provider rejected authentication.",
+        message: "The model provider rejected the configured credential.",
         category: "authentication",
         status: 401,
         providerCode: "invalid-[REDACTED]",
@@ -966,6 +966,59 @@ describe("OpenAICompatibleModelDriver", () => {
     ]);
   });
 
+  test("projects an object-only union tool schema on the DeepSeek provider wire", async () => {
+    let body: { readonly tools?: readonly unknown[] } | undefined;
+    const canonicalInputSchema = {
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      oneOf: [
+        { type: "object", properties: { kind: { const: "content" } }, required: ["kind"] },
+        { type: "object", properties: { kind: { const: "path" } }, required: ["kind"] },
+      ],
+    } as const;
+    const canonicalBefore = structuredClone(canonicalInputSchema);
+    const driver = new OpenAICompatibleModelDriver({
+      profile: "deepseek",
+      apiKey: "test-deepseek-key",
+      baseURL: "https://deepseek.invalid",
+      model: "deepseek-test",
+      maximumOutputTokens: 4_096,
+      fetch: async (_input, init) => {
+        body = JSON.parse(String(init?.body)) as { readonly tools?: readonly unknown[] };
+        return new Response(answerOnlyStream, {
+          headers: { "content-type": "text/event-stream" },
+          status: 200,
+        });
+      },
+    });
+
+    await collect(
+      driver.stream({
+        maximumOutputTokens: 4_096,
+        messages: [{ role: "user", content: "Search the repository." }],
+        tools: [
+          {
+            name: "search_repository",
+            description: "Search repository content or paths.",
+            inputSchema: canonicalInputSchema,
+          },
+        ],
+        signal: new AbortController().signal,
+      }),
+    );
+
+    expect(body?.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "search_repository",
+          description: "Search repository content or paths.",
+          parameters: { ...canonicalBefore, type: "object" },
+        },
+      },
+    ]);
+    expect(canonicalInputSchema).toEqual(canonicalBefore);
+  });
+
   test("serializes the exact approved Plan as one non-authoritative assistant projection", async () => {
     const requests: Array<{ readonly messages: readonly unknown[] }> = [];
     const driver = new OpenAICompatibleModelDriver({
@@ -1229,7 +1282,7 @@ describe("OpenAICompatibleModelDriver", () => {
           status: "failed",
           error: {
             code: "model_request_failed",
-            message: "The model provider returned an incomplete tool call.",
+            message: "The model provider response was incompatible with Adam.",
             category: "protocol_incompatibility",
           },
         },

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -12285,6 +12285,40 @@ test("PresentationSession maps canonical failure codes to bounded safe run notic
       },
       expectedMessage: "The model run failed.",
     },
+    {
+      code: "model_request_failed",
+      error: {
+        code: "model_request_failed",
+        message: "private provider detail",
+        category: "invalid_request",
+        status: 400,
+        providerCode: "invalid_request_error",
+        requestId: "request-safe-1",
+      },
+      expectedMessage: "The provider rejected the request as invalid. HTTP 400",
+    },
+    {
+      code: "context_compaction_failed",
+      error: {
+        code: "context_compaction_failed",
+        message: "private compaction detail",
+        category: "rate_limit",
+        status: 429,
+        providerCode: "rate_limit_exceeded",
+        requestId: "request-safe-2",
+      },
+      expectedMessage: "Context compaction rate limit was reached. HTTP 429",
+    },
+    {
+      code: "model_request_failed",
+      error: {
+        code: "model_request_failed",
+        message: "private provider detail",
+        category: "authentication",
+        diagnosticCode: "tool_schema_root_not_object",
+      },
+      expectedMessage: "The provider rejected the configured credential.",
+    },
   ] as const;
 
   for (const [index, scenario] of scenarios.entries()) {
@@ -12344,6 +12378,12 @@ test("PresentationSession maps canonical failure codes to bounded safe run notic
           message: scenario.expectedMessage,
         });
         expect(JSON.stringify(notice)).not.toContain(scenario.error.message);
+        if ("providerCode" in scenario.error) {
+          expect(JSON.stringify(notice)).not.toContain(scenario.error.providerCode);
+        }
+        if ("requestId" in scenario.error) {
+          expect(JSON.stringify(notice)).not.toContain(scenario.error.requestId);
+        }
       } finally {
         await presentation.close();
       }

--- a/packages/testkit/src/public-product-contract.test.ts
+++ b/packages/testkit/src/public-product-contract.test.ts
@@ -1164,6 +1164,90 @@ test("PresentationSession transcript projection has one package-internal owner",
   expect.soft(directTestImports).toEqual([]);
 });
 
+test("Direct DeepSeek tool schema projection has one package-internal owner", async () => {
+  const agentSourceRoot = join(productRoot, "packages", "agent", "src");
+  const sourceFiles = (await readdir(agentSourceRoot, { recursive: true }))
+    .filter((entry) => entry.endsWith(".ts"))
+    .sort();
+  const sources = await Promise.all(
+    sourceFiles.map(async (sourceFile) => ({
+      path: sourceFile,
+      source: await readFile(join(agentSourceRoot, sourceFile), "utf8"),
+    })),
+  );
+  const ownerSource =
+    sources.find(({ path }) => path === "model-tool-schema-projection.ts")?.source ?? "";
+  const owners = sources
+    .filter(({ source }) => /\bfunction\s+projectModelToolDefinitions\s*\(/u.test(source))
+    .map(({ path }) => path);
+  const consumers = sources
+    .filter(({ source }) => moduleSpecifiers(source).includes("./model-tool-schema-projection.js"))
+    .map(({ path }) => path);
+  const publicFacadeSource = sources.find(({ path }) => path === "index.ts")?.source ?? "";
+  const testingFacadeSource =
+    sources.find(({ path }) => path === "internal-testing.ts")?.source ?? "";
+  const testPaths = (
+    await Promise.all(
+      ["apps", "packages"].map(async (root) => {
+        const packageRoots = await readdir(join(productRoot, root), { withFileTypes: true });
+        return (
+          await Promise.all(
+            packageRoots
+              .filter((entry) => entry.isDirectory())
+              .map(async (entry) => {
+                try {
+                  return (
+                    await readdir(join(productRoot, root, entry.name, "src"), {
+                      recursive: true,
+                    })
+                  )
+                    .filter((path) => path.endsWith(".test.ts"))
+                    .map((path) => join(productRoot, root, entry.name, "src", path));
+                } catch (error) {
+                  if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+                    return [];
+                  }
+                  throw error;
+                }
+              }),
+          )
+        ).flat();
+      }),
+    )
+  ).flat();
+  const directTestImports = (
+    await Promise.all(
+      testPaths
+        .filter((testPath) => testPath !== fileURLToPath(import.meta.url))
+        .map(async (testPath) =>
+          moduleSpecifiers(await readFile(testPath, "utf8")).some((specifier) =>
+            /model-tool-schema-projection\.js$/u.test(specifier),
+          )
+            ? relative(productRoot, testPath)
+            : undefined,
+        ),
+    )
+  ).filter((path): path is string => path !== undefined);
+
+  expect.soft(ownerSource).toMatch(/export function projectModelToolDefinitions\s*\(/u);
+  expect.soft(owners).toEqual(["model-tool-schema-projection.ts"]);
+  expect
+    .soft(consumers)
+    .toEqual([
+      "ai-sdk-model-driver.ts",
+      "deepseek-responses-model-driver.ts",
+      "openai-compatible-model-driver.ts",
+    ]);
+  expect
+    .soft([...moduleSpecifiers(ownerSource)].sort())
+    .toEqual(["./model-driver-error.js", "./tool-runtime.js"]);
+  for (const facadeSource of [publicFacadeSource, testingFacadeSource]) {
+    expect.soft(moduleSpecifiers(facadeSource)).not.toContain("./model-tool-schema-projection.js");
+    expect.soft(facadeSource).not.toContain("projectModelToolDefinitions");
+  }
+  expect.soft(directTestImports).toEqual([]);
+});
+
 test("the runtime module detector covers every value-bearing module form", () => {
   expect(
     runtimeModuleSpecifiers(`


### PR DESCRIPTION
## Summary

- repair Direct DeepSeek tool-bearing requests by projecting only provider wire copies whose root oneOf or anyOf branches are provably object-compatible
- keep canonical tool schemas, Tool Profile digests, historical replay, validation and Gateway requests unchanged
- use one package-private projection owner across Direct Chat, Direct Responses and the public legacy DeepSeek-compatible driver, with fail-closed local rejection for unsafe roots
- preserve safe model failure categories and bounded diagnostics through AgentSession persistence and Presentation while excluding raw provider text, response bodies, causes, credentials and request content
- classify AI SDK error stream parts through the same typed path as thrown provider failures

## Verification

- pnpm quality:check: 62 test files passed, 2 skipped; 1540 tests passed, 18 explicitly skipped
- normal-TLS live R0 gate: TLS guard plus all four exact Direct DeepSeek targets passed, including Flash, Pro, historical Flash Vision Chat and Flash Vision Responses tool calls
- deterministic adapter tests cover identity, object-only oneOf/anyOf projection, canonical immutability, unsafe-root rejection before dispatch and Gateway non-projection
- caller-visible AgentSession and Presentation tests cover durable safe diagnostics, compaction failures, metadata validation and secret exclusion
- structural contract fixes one projection owner and exactly the three authorized consumers

## Publication boundary

Owner merge is required. M1 does not begin until this PR is merged, remote main and exact-main Quality are verified, and the workspace gitlink/evidence closeout is published.
