### PR TITLE
C0: add recoverable structured turn composer

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -27,6 +27,18 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+## `p-queue` 9.3.3
+
+Adam Agent uses [`p-queue`](https://github.com/sindresorhus/p-queue/tree/v9.3.3) to serialize recoverable TUI draft intents, licensed under the MIT License.
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (<https://sindresorhus.com>)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 ## `highlight.js` 11.11.1
 
 Adam Agent uses [`highlight.js`](https://github.com/highlightjs/highlight.js/tree/11.11.1), licensed under the BSD 3-Clause License.

--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -10,6 +10,7 @@
     "@adam-agent/agent": "workspace:*",
     "@adam-agent/presentation": "workspace:*",
     "@earendil-works/pi-tui": "0.84.2",
-    "highlight.js": "11.11.1"
+    "highlight.js": "11.11.1",
+    "p-queue": "9.3.3"
   }
 }

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -56,8 +56,9 @@ test("the real TUI process restores the terminal after staging one input resourc
       workspaceRoot,
     });
     await fixture.waitFor("Adam · New session");
+    const beforeAttach = fixture.output().length;
     fixture.write(`/attach ${selectedPath}\r`);
-    await fixture.waitFor("ready · process-notes.txt · 23 bytes");
+    await fixture.waitForCompleteFrameAfter("Input resource staged.", beforeAttach);
     fixture.write("\u0011");
     const result = await fixture.closed;
     expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
@@ -377,14 +378,14 @@ test.each([
       await fixture.terminate(signal);
       const result = await fixture.closed;
       expect(result).toMatchObject({ code, signal: null, stderr: "" });
-      await expect(readFile(join(controlRoot, "tui-fixture-closed"), "utf8")).resolves.toBe(
-        "closed\n",
-      );
       expect(result.stdout).toContain("\u001b[?2004l");
       expect(result.stdout).toContain("\u001b[?25h");
       const afterExit = outputAfterFinalAltScreenExit(result.stdout);
       expect(afterExit).toBe("\u001b[?25h\u001b[?2026l");
       expect(afterExit).not.toContain(privateDraftSentinel);
+      await expect(readFile(join(controlRoot, "tui-runtime-closed"), "utf8")).resolves.toBe(
+        "closed\n",
+      );
     } finally {
       await rm(testRoot, { recursive: true, force: true });
     }

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -1617,26 +1617,34 @@ test("the production target picker repairs an absent saved default through the f
   }
 });
 
-test("the production TUI keeps an edited new-session draft out of persistence until submit", async () => {
+test("the production TUI recovers an edited new-session draft without creating session identity", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-main-session-draft-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
   await mkdir(workspaceRoot);
 
   try {
-    const fixture = startFixture({ launch: {}, stateRoot, workspaceRoot });
-    await fixture.waitFor("Select an exact model target");
-    const beforeTarget = fixture.output().length;
-    fixture.write("\r");
-    await fixture.waitForAfter("Adam · New session", beforeTarget);
-    fixture.write("temporary unsent draft");
-    await fixture.waitForAfter("temporary unsent draft", beforeTarget);
-    fixture.write("\u0011");
-    const result = await fixture.closed;
+    const first = startFixture({ launch: {}, stateRoot, workspaceRoot });
+    await first.waitFor("Select an exact model target");
+    const beforeTarget = first.output().length;
+    first.write("\r");
+    await first.waitForAfter("Adam · New session", beforeTarget);
+    first.write("temporary unsent draft");
+    await first.waitForAfter("temporary unsent draft", beforeTarget);
+    first.write("\u0011");
+    const result = await first.closed;
 
     expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
     expect(result.stdout).toContain("deepseek-v4-flash.direct · Certified");
     expect(await readFilesRecursively(stateRoot)).not.toContain('"type":"session_genesis"');
+
+    const restarted = startFixture({ launch: {}, stateRoot, workspaceRoot });
+    await restarted.waitFor("Select an exact model target");
+    restarted.write("\r");
+    await restarted.waitFor("temporary unsent draft");
+    expect(restarted.screen()?.join("\n") ?? "").toContain("temporary unsent draft");
+    restarted.write("\u0011");
+    await expect(restarted.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }
@@ -1665,7 +1673,7 @@ test("the production TUI stages and sends one linked input resource", async () =
     await expect(
       Promise.race([
         fixture
-          .waitForCompleteFrameAfter("ready · outside-notes.txt · 17 bytes", beforeAttach)
+          .waitForCompleteFrameAfter("Input resource staged.", beforeAttach)
           .then(() => "ready" as const),
         fixture
           .waitForAfter("Unknown command /attach", beforeAttach)
@@ -1680,7 +1688,103 @@ test("the production TUI stages and sends one linked input resource", async () =
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
     const durable = await readFilesRecursively(stateRoot);
     expect(durable).toContain('"displayName":"outside-notes.txt"');
+    expect(durable).toContain('"recordVersion":2');
+    expect(durable).toContain('"userMessage":"Use the linked notes if needed."');
+    expect(durable).toMatch(
+      /"userContent":\[\{"type":"input_resource","occurrenceId":"[^"]+","draftOrdinal":1\},\{"type":"text","text":"Use the linked notes if needed\."\}\]/u,
+    );
+    expect(durable).not.toContain('"userMessage":"[File #1]');
     expect(durable).not.toContain(selectedPath);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI keeps one staged file token and its Draft inputs rail beside the editor", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-structured-file-token-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const selectedPath = join(testRoot, "ordered-notes.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "ordered TUI bytes\n", "utf8");
+
+  try {
+    const fixture = startFixture({ launch: {}, stateRoot, workspaceRoot });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    fixture.write(`/attach ${selectedPath}\r`);
+    await fixture.waitFor("Input resource staged.");
+
+    const screen = fixture.screen()?.join("\n") ?? "";
+    expect(screen).toContain("[File #1]");
+    expect(screen).toContain("Draft inputs");
+    expect(screen).not.toContain("Linked input resources");
+
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI inserts ordinary text after one staged file atom", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-structured-file-edit-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const selectedPath = join(testRoot, "ordered-notes.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "ordered TUI bytes\n", "utf8");
+
+  try {
+    const fixture = startFixture({ launch: {}, stateRoot, workspaceRoot });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    fixture.write(`/attach ${selectedPath}\r`);
+    await fixture.waitFor("Input resource staged.");
+
+    fixture.write("after");
+    await fixture.waitFor("[File #1]after");
+    expect(fixture.screen()?.join("\n") ?? "").toContain("[File #1]after");
+
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production TUI deletes and undoes one whole staged file atom", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-structured-file-undo-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const selectedPath = join(testRoot, "ordered-notes.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "ordered TUI bytes\n", "utf8");
+
+  try {
+    const fixture = startFixture({ launch: {}, stateRoot, workspaceRoot });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    fixture.write(`/attach ${selectedPath}\r`);
+    await fixture.waitFor("Input resource staged.");
+    fixture.write("after");
+    await fixture.waitFor("[File #1]after");
+
+    fixture.write(`${"\u001b[D".repeat(6)}\u001b[3~`);
+    await fixture.waitFor("Input resource removed.");
+    expect(fixture.screen()?.join("\n") ?? "").not.toContain("[File #1]");
+    expect(fixture.screen()?.join("\n") ?? "").not.toContain("Draft inputs");
+
+    fixture.write(String.fromCharCode(31));
+    await fixture.waitFor("Draft edit undone.");
+    expect(fixture.screen()?.join("\n") ?? "").toContain("[File #1]after");
+    expect(fixture.screen()?.join("\n") ?? "").toContain("Draft inputs");
+
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }
@@ -1749,7 +1853,7 @@ test("the production TUI removes a ready linked input resource by its visible in
     fixture.write("\r");
     await fixture.waitFor("Adam · New session");
     fixture.write(`/attach ${selectedPath}\r`);
-    await fixture.waitFor("ready · discard-notes.txt · 20 bytes");
+    await fixture.waitFor("Input resource staged.");
 
     const beforeRemove = fixture.output().length;
     fixture.write("/detach 1\r");
@@ -1764,58 +1868,10 @@ test("the production TUI removes a ready linked input resource by its visible in
       ]),
     ).resolves.toBe("removed");
     expect(fixture.screen()?.join("\n") ?? "").not.toContain("discard-notes.txt");
+    expect(fixture.screen()?.join("\n") ?? "").not.toContain("/detach 1");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("the production TUI cancels a copying input resource by its visible index", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-cancel-input-resource-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  const controlRoot = join(testRoot, "control");
-  const selectedPath = join(testRoot, "slow-notes.txt");
-  await mkdir(workspaceRoot);
-  await mkdir(controlRoot);
-  await writeFile(selectedPath, "slow linked bytes\n", "utf8");
-
-  try {
-    const fixture = startFixture({
-      controlRoot,
-      launch: {},
-      scenario: "input-resource-copying",
-      stateRoot,
-      workspaceRoot,
-    });
-    await fixture.waitFor("Select an exact model target");
-    fixture.write("\r");
-    await fixture.waitFor("Adam · New session");
-    fixture.write(`/attach ${selectedPath}\r`);
-    await waitForPath(join(controlRoot, "input-resource-copying"));
-    await fixture.waitFor("copying · slow-notes.txt · size pending");
-
-    const beforeCancel = fixture.output().length;
-    fixture.write("/cancelattach 1\r");
-    await expect(
-      Promise.race([
-        fixture
-          .waitForAfter("cancelled · slow-notes.txt", beforeCancel)
-          .then(() => "cancelled" as const),
-        fixture
-          .waitForAfter("Unknown command /cancelattach", beforeCancel)
-          .then(() => "unknown" as const),
-      ]),
-    ).resolves.toBe("cancelled");
-    await writeFile(join(controlRoot, "release-input-resource-copy"), "release\n", "utf8");
-    await fixture.waitFor("Input resource cancelled.");
-    fixture.write("\u0011");
-    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-  } finally {
-    await writeFile(join(controlRoot, "release-input-resource-copy"), "release\n", "utf8").catch(
-      () => undefined,
-    );
     await rm(testRoot, { recursive: true, force: true });
   }
 });
@@ -1840,13 +1896,13 @@ test("linked input resources stay sanitized, colorless, and bounded at supported
     fixture.write("\r");
     await fixture.waitFor("Adam · New session");
     fixture.write(`/attach ${selectedPath}\r`);
-    await fixture.waitFor("ready · unsafe�name.txt · 19 bytes");
+    await fixture.waitFor("Input resource staged.");
 
     for (const columns of [40, 80, 120]) {
       const beforeResize = fixture.output().length;
       await fixture.resize(columns, 40);
       const frame = latestSynchronizedFrame(fixture.output().slice(beforeResize));
-      expect(frame.join("\n")).toContain("Linked input resources");
+      expect(frame.join("\n")).toContain("Draft inputs");
       expect(frame.join("\n")).not.toContain("\u0085");
       expect(frame.join("\n")).not.toContain("\u001b[38;2;");
       expect(frame.join("\n")).not.toContain("\u001b[48;2;");
@@ -6217,7 +6273,7 @@ test("the real TUI fuzzy-selects and quotes a normalized project path without re
     await fixture.closed;
 
     const durableState = await readFilesRecursively(stateRoot);
-    expect(durableState).not.toContain("src/alpha.ts");
+    expect(durableState).toContain("Inspect `src/alpha.ts`");
     expect(durableState).not.toContain("PRIVATE_ALPHA_BYTES");
     expect(fixture.output()).not.toContain("PRIVATE_ALPHA_BYTES");
   } finally {

--- a/apps/tui/src/pi-editor-atoms.test.ts
+++ b/apps/tui/src/pi-editor-atoms.test.ts
@@ -1,0 +1,121 @@
+import { Editor } from "@earendil-works/pi-tui";
+import { expect, test } from "vitest";
+
+import { createAdamTuiTheme } from "./theme.js";
+
+type DocumentPart =
+  | { readonly type: "text"; readonly id: string; readonly text: string }
+  | { readonly type: "atom"; readonly id: string; readonly label: string };
+
+type DocumentPoint =
+  | { readonly partId: string; readonly offset: number }
+  | { readonly partId: string; readonly edge: "before" | "after" };
+
+type EditIntent =
+  | {
+      readonly type: "replace";
+      readonly range: { readonly anchor: DocumentPoint; readonly focus: DocumentPoint };
+      readonly text: string;
+      readonly document: readonly DocumentPart[];
+    }
+  | { readonly type: "remove_atom"; readonly atomId: string; readonly direction: string }
+  | { readonly type: "undo" };
+
+type AtomEditor = Editor & {
+  onEditIntent?: (intent: EditIntent) => void;
+  getDocumentCursor(): DocumentPoint;
+  setDocument(parts: readonly DocumentPart[], cursor?: DocumentPoint): void;
+};
+
+test("Pi Editor treats one host-owned resource label as an atomic navigable part", () => {
+  const editor = new Editor(
+    { requestRender() {} } as never,
+    createAdamTuiTheme(true).editor,
+  ) as AtomEditor;
+  const intents: EditIntent[] = [];
+  editor.onEditIntent = (intent) => intents.push(intent);
+  const parts: readonly DocumentPart[] = [
+    { type: "text", id: "left", text: "before" },
+    { type: "atom", id: "resource", label: "[File #1]" },
+    { type: "text", id: "right", text: "after" },
+  ];
+
+  editor.setDocument(parts, { partId: "resource", edge: "before" });
+  editor.handleInput("\u001b[C");
+  expect(editor.getDocumentCursor()).toEqual({ partId: "resource", edge: "after" });
+
+  editor.handleInput("\u007f");
+  expect(intents).toEqual([{ type: "remove_atom", atomId: "resource", direction: "backward" }]);
+  expect(editor.getText()).toBe("beforeafter");
+  expect(editor.getDocumentCursor()).toEqual({ partId: "left", offset: 6 });
+
+  editor.setDocument(parts, { partId: "right", offset: 0 });
+  editor.handleInput("!");
+  editor.handleInput(String.fromCharCode(31));
+  expect(intents.slice(1)).toEqual([
+    {
+      type: "replace",
+      range: {
+        anchor: { partId: "right", offset: 0 },
+        focus: { partId: "right", offset: 0 },
+      },
+      text: "!",
+      document: [
+        { type: "text", id: "left", text: "before" },
+        { type: "atom", id: "resource", label: "[File #1]" },
+        { type: "text", id: "right", text: "!after" },
+      ],
+    },
+    { type: "undo" },
+  ]);
+});
+
+test("Pi Editor rejects unsupported structured mutations without changing its document", () => {
+  const editor = new Editor(
+    { requestRender() {} } as never,
+    createAdamTuiTheme(true).editor,
+  ) as AtomEditor;
+  const intents: EditIntent[] = [];
+  editor.onEditIntent = (intent) => intents.push(intent);
+  editor.setDocument(
+    [
+      { type: "atom", id: "resource", label: "[File #1]" },
+      { type: "text", id: "right", text: "after" },
+    ],
+    { partId: "right", offset: 5 },
+  );
+
+  editor.handleInput(String.fromCharCode(23));
+
+  expect(editor.getText()).toBe("[File #1]after");
+  expect(editor.getDocumentCursor()).toEqual({ partId: "right", offset: 5 });
+  expect(intents).toEqual([]);
+});
+
+test("Pi Editor deletes the last adjacent text grapheme without losing its atom cursor", () => {
+  const editor = new Editor(
+    { requestRender() {} } as never,
+    createAdamTuiTheme(true).editor,
+  ) as AtomEditor;
+  const intents: EditIntent[] = [];
+  editor.onEditIntent = (intent) => intents.push(intent);
+  editor.setDocument(
+    [
+      { type: "atom", id: "resource", label: "[File #1]" },
+      { type: "text", id: "right", text: "x" },
+    ],
+    { partId: "right", offset: 1 },
+  );
+
+  editor.handleInput("\u007f");
+
+  expect(editor.getText()).toBe("[File #1]");
+  expect(editor.getDocumentCursor()).toEqual({ partId: "resource", edge: "after" });
+  expect(intents).toMatchObject([
+    {
+      type: "replace",
+      document: [{ type: "atom", id: "resource", label: "[File #1]" }],
+      text: "",
+    },
+  ]);
+});

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -517,9 +517,10 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
       } catch (error) {
         presentationFailure = error;
       }
-      if (options.scenario === "mcp-close-unconfirmed") {
-        lifecycleCloseAttempted = true;
-        requireConfirmedLifecycleClose(await lifecycle.close());
+      lifecycleCloseAttempted = true;
+      requireConfirmedLifecycleClose(await lifecycle.close());
+      if (options.controlRoot !== undefined) {
+        await writeFile(join(options.controlRoot, "tui-runtime-closed"), "closed\n", "utf8");
       }
       if (presentationFailure !== undefined) {
         throw presentationFailure;

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { MessageChannel } from "node:worker_threads";
 
 import type {
   ActiveSessionDisplay,
@@ -18,6 +19,7 @@ import {
   type Component,
   Container,
   Editor,
+  type EditorDocumentPart,
   isKeyRelease,
   isKeyRepeat,
   Loader,
@@ -31,6 +33,7 @@ import {
   truncateToWidth,
   VStack,
 } from "@earendil-works/pi-tui";
+import PQueue from "p-queue";
 import {
   ArtifactNavigator,
   activeChronologyArtifacts,
@@ -250,6 +253,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   const header = new Text();
   const transcriptViewport = new TranscriptViewport();
   const transcript = transcriptViewport.document;
+  const draftInputsSlot = new Container();
   const editorSlot = new Container();
   const createEditor = (active: ActiveSessionDisplay | null): Editor => {
     const created = new Editor(tui, theme.editor, { paddingX: 1 });
@@ -296,6 +300,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     return created;
   };
   let editor = createEditor(options.presentation.getState().authoritative.active);
+  const draftMutationQueue = new PQueue({ concurrency: 1 });
   let projectedPromptHistory = authoritativePromptHistory(
     options.presentation.getState().authoritative.active,
   );
@@ -536,6 +541,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     },
     {
       component: new VStack([
+        draftInputsSlot,
         editorSlot,
         {
           component: statusLine,
@@ -587,17 +593,108 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     if (previousEditor.onChange !== undefined) {
       replacement.onChange = previousEditor.onChange;
     }
+    if (previousEditor.onEditIntent !== undefined) {
+      replacement.onEditIntent = previousEditor.onEditIntent;
+    }
     if (previousEditor.onSubmit !== undefined) {
       replacement.onSubmit = previousEditor.onSubmit;
     }
     editorSlot.clear();
     editorSlot.addChild(replacement);
     editor = replacement;
+    structuredEditorActive = false;
+    projectedComposerKey = null;
     projectedPromptHistory = nextHistory;
     projectedHistorySessionId = nextSessionId;
     if (wasFocused) {
       tui.setFocus(editor);
     }
+  };
+
+  let structuredEditorActive = false;
+  let localStructuredDocument: readonly EditorDocumentPart[] | null = null;
+  let projectedComposerKey: string | null = null;
+  let projectedComposerScope: string | null = null;
+  const synchronizeStructuredComposer = (
+    composer: ReturnType<PresentationSession["getState"]>["composer"],
+    scope: string | null,
+  ): void => {
+    const scopeChanged = scope !== projectedComposerScope;
+    projectedComposerScope = scope;
+    const composerKey = `${scope ?? ""}\0${composer.draftRevision}\0${composer.resources
+      .map((resource) => `${resource.id}:${resource.state}:${resource.kind}`)
+      .join("|")}`;
+    if (!scopeChanged && composerKey === projectedComposerKey) {
+      return;
+    }
+    projectedComposerKey = composerKey;
+    if (
+      composer.resources.some(
+        (resource) => resource.state === "queued" || resource.state === "copying",
+      )
+    ) {
+      return;
+    }
+    if (!composer.elements.some((element) => element.type === "resource")) {
+      if (structuredEditorActive && composer.elements.length > 0) {
+        editor.setDocument(
+          composer.elements.map((element) => ({
+            type: "text" as const,
+            id: element.elementId,
+            text: element.type === "text" ? element.text : "",
+          })),
+        );
+      } else if (structuredEditorActive) {
+        editor.setText(composer.renderedText);
+        structuredEditorActive = false;
+        localStructuredDocument = null;
+      } else if (scopeChanged && composer.elements.length > 0) {
+        editor.setText(composer.renderedText);
+      }
+      return;
+    }
+    const parts: readonly EditorDocumentPart[] = composer.elements.map((element) =>
+      element.type === "text"
+        ? { type: "text", id: element.elementId, text: element.text }
+        : {
+            type: "atom",
+            id: element.elementId,
+            label: `[${element.kind === "image" ? "Image" : "File"} #${element.ordinal}]`,
+          },
+    );
+    editor.setDocument(parts);
+    structuredEditorActive = true;
+    localStructuredDocument = parts;
+  };
+
+  const synchronizeDraftInputs = (
+    composer: ReturnType<PresentationSession["getState"]>["composer"],
+  ): void => {
+    draftInputsSlot.clear();
+    if (composer.resources.length === 0) {
+      return;
+    }
+    const resources = new Box(1, 1, theme.toolBackground);
+    resources.addChild(new ResponsiveLine(theme.toolTitle("Draft inputs")));
+    for (const resource of composer.resources) {
+      const size = resource.byteCount === null ? "size pending" : `${resource.byteCount} bytes`;
+      const media = resource.mediaHint === null ? "media pending" : resource.mediaHint;
+      const support = resource.support === null ? "support pending" : resource.support;
+      resources.addChild(
+        new ResponsiveLine(
+          theme.toolOutput(
+            safeTerminalText(
+              `${resource.token} · Selected file · ${resource.state} · ${resource.displayName} · ${size} · ${media} · ${support}`,
+            ),
+          ),
+        ),
+      );
+      if (resource.diagnostic !== null) {
+        resources.addChild(new ResponsiveLine(theme.muted(safeTerminalText(resource.diagnostic))));
+      }
+    }
+    resources.addChild(new ResponsiveLine(theme.muted("/detach <index> · /cancelattach <index>")));
+    draftInputsSlot.addChild(resources);
   };
 
   const clearExitWindow = () => {
@@ -974,6 +1071,11 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       clearNotice();
     }
     synchronizePromptHistory(active);
+    synchronizeStructuredComposer(
+      state.composer,
+      active?.session.id ?? state.draft?.targetId ?? null,
+    );
+    synchronizeDraftInputs(state.composer);
     const activeSessionChanged = active?.session.id !== previousActiveSessionId;
     if (activeSessionChanged) {
       transcriptViewport.followEnd();
@@ -1748,33 +1850,6 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         transcriptViewport.focus(operationAnchorId(operation.operationId), terminal.columns);
       }
     }
-    if (state.composer.resources.length > 0) {
-      transcript.addChild(new Spacer(1));
-      const resources = new Box(1, 1, theme.toolBackground);
-      resources.addChild(new ResponsiveLine(theme.toolTitle("Linked input resources")));
-      for (const [index, resource] of state.composer.resources.entries()) {
-        const size = resource.byteCount === null ? "size pending" : `${resource.byteCount} bytes`;
-        const support = resource.support === null ? "support pending" : resource.support;
-        resources.addChild(
-          new ResponsiveLine(
-            theme.toolOutput(
-              safeTerminalText(
-                `${index + 1} · ${resource.state} · ${resource.displayName} · ${size} · ${support}`,
-              ),
-            ),
-          ),
-        );
-        if (resource.diagnostic !== null) {
-          resources.addChild(
-            new ResponsiveLine(theme.muted(safeTerminalText(resource.diagnostic))),
-          );
-        }
-      }
-      resources.addChild(
-        new ResponsiveLine(theme.muted("/detach <index> · /cancelattach <index>")),
-      );
-      transcript.addChild(resources);
-    }
     const transientReasoning = state.transient?.reasoning;
     if (
       transientReasoning !== null &&
@@ -2000,6 +2075,9 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     } else {
       statusLine.setText("");
     }
+    if (permission === undefined && focusedCloseableOverlay() === undefined) {
+      tui.setFocus(editor);
+    }
     tui.requestRender();
   };
   const handleThinkingCommand = (argumentsText: string): void => {
@@ -2082,11 +2160,41 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     clearNotice();
     tui.requestRender();
   };
+  const persistEditorText = (text: string): void => {
+    if (options.presentation.getState().composer.sealed) {
+      return;
+    }
+    void draftMutationQueue
+      .add(() => options.presentation.dispatch({ type: "update_draft_text", text }))
+      .then((receipt) => {
+        if (receipt?.status === "rejected" && receipt.code !== "conflict") {
+          showNotice("error", receipt.message, "until_edit");
+          renderState();
+        }
+      })
+      .catch(() => {
+        showNotice("error", "The recoverable draft text could not be saved.", "until_edit");
+        renderState();
+      });
+  };
+  let emptyDraftChangeGeneration = 0;
   editor.onChange = () => {
-    void options.presentation.dispatch({
-      type: "update_draft_text",
-      text: editor.getExpandedText(),
-    });
+    const text = editor.getExpandedText();
+    emptyDraftChangeGeneration += 1;
+    if (text.length === 0) {
+      const generation = emptyDraftChangeGeneration;
+      queueMicrotask(() => {
+        if (
+          generation === emptyDraftChangeGeneration &&
+          !structuredEditorActive &&
+          editor.getExpandedText().length === 0
+        ) {
+          persistEditorText("");
+        }
+      });
+    } else if (!text.startsWith("/")) {
+      persistEditorText(text);
+    }
     if (statusNotice?.lifetime === "until_edit" || statusNotice?.lifetime === "until_next_action") {
       clearNotice();
       renderState();
@@ -2134,6 +2242,94 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       });
       pathPicker = { close, hide: () => handle?.hide() };
     }
+  };
+  editor.onEditIntent = (intent) => {
+    if (intent.type === "remove_atom") {
+      void draftMutationQueue
+        .add(() => {
+          const composer = options.presentation.getState().composer;
+          return options.presentation.dispatch({
+            type: "remove_draft_element",
+            baseRevision: composer.draftRevision,
+            elementId: intent.atomId,
+          });
+        })
+        .then((receipt) => {
+          if (receipt?.status === "admitted") {
+            showNotice("success", "Input resource removed.", "until_next_action");
+          } else {
+            showNotice(
+              "error",
+              receipt?.message ?? "The input resource could not be removed.",
+              "until_edit",
+            );
+          }
+          renderState();
+        })
+        .catch(() => {
+          showNotice("error", "The input resource could not be removed.", "until_edit");
+          renderState();
+        });
+      return;
+    }
+    if (intent.type === "undo") {
+      void draftMutationQueue
+        .add(() => {
+          const composer = options.presentation.getState().composer;
+          return options.presentation.dispatch({
+            type: "undo_draft",
+            baseRevision: composer.draftRevision,
+          });
+        })
+        .then((receipt) => {
+          if (receipt?.status === "admitted") {
+            showNotice("success", "Draft edit undone.", "until_next_action");
+          } else {
+            showNotice(
+              "error",
+              receipt?.message ?? "The draft edit could not be undone.",
+              "until_edit",
+            );
+          }
+          renderState();
+        })
+        .catch(() => {
+          showNotice("error", "The draft edit could not be undone.", "until_edit");
+          renderState();
+        });
+      return;
+    }
+    localStructuredDocument = intent.document;
+    const localLiteralText = intent.document
+      .flatMap((part) => (part.type === "text" ? [part.text] : []))
+      .join("");
+    if (localLiteralText.startsWith("/")) {
+      renderState();
+      return;
+    }
+    void draftMutationQueue
+      .add(() => {
+        const composer = options.presentation.getState().composer;
+        return options.presentation.dispatch({
+          type: "replace_draft_text",
+          baseRevision: composer.draftRevision,
+          document: intent.document.map((part) =>
+            part.type === "text"
+              ? { type: "text", text: part.text }
+              : { type: "resource", elementId: part.id },
+          ),
+        });
+      })
+      .then((receipt) => {
+        if (receipt?.status === "rejected") {
+          showNotice("error", receipt.message, "until_edit");
+        }
+        renderState();
+      })
+      .catch(() => {
+        showNotice("error", "The recoverable draft edit could not be saved.", "until_edit");
+        renderState();
+      });
   };
   const showChronologyPicker = (mode: "fork" | "read_only"): void => {
     const state = options.presentation.getState();
@@ -2921,10 +3117,15 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     editor.setText("");
     editor.disableSubmit = false;
     const actionId = showNotice("progress", "Staging input resource…", "until_replaced", sessionId);
-    void options.presentation
-      .dispatch({ type: "stage_input_resource", path })
+    void draftMutationQueue
+      .add(() => options.presentation.dispatch({ type: "update_draft_text", text: "" }))
+      .then((cleared) =>
+        cleared?.status === "rejected"
+          ? cleared
+          : options.presentation.dispatch({ type: "stage_input_resource", path }),
+      )
       .then((receipt) => {
-        if (receipt.status === "admitted") {
+        if (receipt?.status === "admitted") {
           settleNotice(
             actionId,
             "success",
@@ -2933,7 +3134,13 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
             sessionId,
           );
         } else {
-          settleNotice(actionId, "error", receipt.message, "until_edit", sessionId);
+          settleNotice(
+            actionId,
+            "error",
+            receipt?.message ?? "The selected input resource could not be staged.",
+            "until_edit",
+            sessionId,
+          );
         }
       })
       .catch(() => {
@@ -3032,7 +3239,22 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     }
     return false;
   };
-  editor.onSubmit = (text) => {
+  const requestSessionPickerAfterDraftFlush = (): void => {
+    editor.setText("");
+    editor.disableSubmit = false;
+    void draftMutationQueue
+      .onIdle()
+      .then(() => {
+        sessionPickerDismissed = false;
+        sessionPickerRequested = true;
+        renderState();
+      })
+      .catch(() => {
+        showNotice("error", "The current draft could not be saved before resume.", "until_edit");
+        renderState();
+      });
+  };
+  const submitEditorValue = (text: string) => {
     const state = options.presentation.getState();
     const active = state.authoritative.active;
     if (text.trim().length === 0) {
@@ -3101,11 +3323,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         parsedDraft.command.id === "resume" &&
         parsedDraft.argumentsText.length === 0
       ) {
-        editor.setText("");
-        editor.disableSubmit = false;
-        sessionPickerDismissed = false;
-        sessionPickerRequested = true;
-        renderState();
+        requestSessionPickerAfterDraftFlush();
         return;
       }
       if (
@@ -3759,11 +3977,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       parsedCommand.command.id === "resume" &&
       parsedCommand.argumentsText.length === 0
     ) {
-      editor.setText("");
-      editor.disableSubmit = false;
-      sessionPickerDismissed = false;
-      sessionPickerRequested = true;
-      renderState();
+      requestSessionPickerAfterDraftFlush();
       return;
     }
     if (
@@ -4275,6 +4489,41 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         tui.requestRender();
       });
   };
+  editor.onSubmit = (visibleText) => {
+    emptyDraftChangeGeneration += 1;
+    if (!structuredEditorActive && visibleText.startsWith("/")) {
+      submitEditorValue(visibleText);
+      return;
+    }
+    if (structuredEditorActive) {
+      const localLiteralText = (localStructuredDocument ?? [])
+        .flatMap((part) => (part.type === "text" ? [part.text] : []))
+        .join("");
+      if (localLiteralText.startsWith("/")) {
+        submitEditorValue(localLiteralText);
+        return;
+      }
+    }
+    editor.disableSubmit = true;
+    void draftMutationQueue
+      .onIdle()
+      .then(() => {
+        if (structuredEditorActive) {
+          const composer = options.presentation.getState().composer;
+          const literalText = composer.elements
+            .flatMap((element) => (element.type === "text" ? [element.text] : []))
+            .join("");
+          submitEditorValue(literalText);
+        } else {
+          submitEditorValue(visibleText);
+        }
+      })
+      .catch(() => {
+        editor.disableSubmit = false;
+        showNotice("error", "The recoverable draft could not be sealed.", "until_edit");
+        renderState();
+      });
+  };
   requestPolicyRender = renderState;
   renderState();
   const unsubscribe = options.presentation.subscribe(renderState);
@@ -4297,7 +4546,6 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         failures.push(error);
       }
     };
-    attempt(removeTerminationListeners);
     attempt(clearExitWindow);
     attempt(unsubscribe);
     for (const overlay of closeableOverlaysInPrecedence()) {
@@ -4311,6 +4559,19 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     }
     operationLoaders.clear();
     attempt(() => tui.stop({ preserveScreen: true }));
+    try {
+      const visibleDraft = editor.getExpandedText();
+      if (
+        draftMutationQueue.pending > 0 ||
+        draftMutationQueue.size > 0 ||
+        structuredEditorActive ||
+        (visibleDraft.length > 0 && !visibleDraft.startsWith("/"))
+      ) {
+        await draftMutationQueue.onIdle();
+      }
+    } catch (error) {
+      failures.push(error);
+    }
     try {
       if (copyDraft) {
         const clipboardResult = await copyDraftToClipboard(
@@ -4337,6 +4598,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     } catch (error) {
       failures.push(error);
     }
+    attempt(removeTerminationListeners);
     if (failures.length === 0) {
       exited.resolve();
     } else if (failures.length === 1) {
@@ -4349,8 +4611,19 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     void stop(true);
   };
   const handleTerminationSignal = (signal: "SIGHUP" | "SIGTERM") => {
-    process.exitCode = signal === "SIGHUP" ? 129 : 143;
-    void stop(false);
+    if (stopping) {
+      return;
+    }
+    const exitCode = signal === "SIGHUP" ? 129 : 143;
+    // Promises do not retain the Node process while the queued draft mutation starts.
+    const closeLease = new MessageChannel();
+    closeLease.port1.ref();
+    closeLease.port2.ref();
+    void stop(false).finally(() => {
+      process.exitCode = exitCode;
+      closeLease.port1.close();
+      closeLease.port2.close();
+    });
   };
   function handleSighup(): void {
     handleTerminationSignal("SIGHUP");

--- a/packages/agent/src/agent-session-contracts.ts
+++ b/packages/agent/src/agent-session-contracts.ts
@@ -3,6 +3,7 @@ import type { ContextCallUsage } from "./durable-context.js";
 import type { InputResourceOccurrenceV1 } from "./input-resources.js";
 import type { ModelDriverDiagnosticCode, ModelDriverErrorCategory } from "./model-driver-error.js";
 import type { ApprovedPlanProjectionV1 } from "./plan-mode.js";
+import type { SessionUserContentElementV1 } from "./structured-user-content.js";
 import type { ThinkingPolicySnapshotV1 } from "./thinking-policy.js";
 import type {
   ModelToolDefinition,
@@ -16,6 +17,7 @@ export type UserInput = {
   readonly text: string;
   readonly skills?: readonly string[];
   readonly inputResources?: readonly InputResourceOccurrenceV1[];
+  readonly userContent?: readonly SessionUserContentElementV1[];
 };
 
 export type RunOptions = {

--- a/packages/agent/src/agent-session.ts
+++ b/packages/agent/src/agent-session.ts
@@ -106,6 +106,7 @@ import {
   sessionDurableContext,
   sessionDurableOutputLimits,
 } from "./session-durable-context.js";
+import { createLogicalRunUserMessageV1 } from "./session-history-replay.js";
 import { sessionTitleFallback } from "./session-naming.js";
 import {
   type CanonicalRuntimeEvent,
@@ -126,6 +127,10 @@ import {
   SkillResourceError,
   SkillsError,
 } from "./skills.js";
+import {
+  createSessionUserContentMessageV1,
+  validateSessionUserContentV1,
+} from "./structured-user-content.js";
 import {
   createTodoInputV1Schema,
   createTodoMutationV1,
@@ -401,6 +406,15 @@ export class AgentSession {
         },
       };
     }
+    if (!isStructuredUserContentValid(input)) {
+      return {
+        status: "failed",
+        error: {
+          code: "input_resource_invalid",
+          message: "Structured user content must exactly reference its immutable input resources.",
+        },
+      };
+    }
     if (this.#activeAbortController !== undefined) {
       return {
         status: "failed",
@@ -423,6 +437,14 @@ export class AgentSession {
     this.#activeAbortController = abortController;
     try {
       try {
+        const projectedUserMessage =
+          input.userContent === undefined
+            ? createInputResourceUserMessageV1(input.text, input.inputResources)
+            : createSessionUserContentMessageV1({
+                elements: input.userContent,
+                occurrences: input.inputResources ?? [],
+                userMessage: input.text,
+              });
         const explicitSkills = (input.skills ?? []).map((selection, index) => ({
           selection,
           requestId: `${this.#activeRunId}:skill:${index + 1}`,
@@ -443,9 +465,15 @@ export class AgentSession {
             sequence: logicalRunStartedSequence,
             record: {
               type: "logical_run_started",
-              ...(input.inputResources === undefined || input.inputResources.length === 0
-                ? {}
-                : { recordVersion: 1 as const, inputResources: input.inputResources }),
+              ...(input.userContent === undefined
+                ? input.inputResources === undefined || input.inputResources.length === 0
+                  ? {}
+                  : { recordVersion: 1 as const, inputResources: input.inputResources }
+                : {
+                    recordVersion: 2 as const,
+                    inputResources: input.inputResources ?? [],
+                    userContent: input.userContent,
+                  }),
               runId: this.#activeRunId,
               userMessage: input.text,
               ...(this.#durableContext.planKickoff === undefined
@@ -478,7 +506,13 @@ export class AgentSession {
             });
           }
         }
-        return await this.#run(input, abortController.signal, options.limits, explicitSkills);
+        return await this.#run(
+          input,
+          abortController.signal,
+          options.limits,
+          explicitSkills,
+          projectedUserMessage,
+        );
       } catch (error) {
         if (abortController.signal.aborted && this.#terminalResult === undefined) {
           return await this.#settleCancelled();
@@ -519,9 +553,9 @@ export class AgentSession {
     signal: AbortSignal,
     limits: RunOptions["limits"],
     explicitSkills: readonly { readonly selection: string; readonly requestId: string }[],
+    projectedUserMessage: ModelMessage,
   ): Promise<RunResult> {
     const resume = this.#durableContext?.resume;
-    const projectedUserMessage = createInputResourceUserMessageV1(input.text, input.inputResources);
     if (resume === undefined) {
       await this.#emit({ type: "user_message", text: input.text });
       if (signal.aborted) {
@@ -4262,7 +4296,7 @@ function findRetainedFromSequence(
       record.type === "logical_run_started" &&
       record.runId === runId &&
       firstRetained.role === "user" &&
-      record.userMessage === firstRetained.content
+      isDeepStrictEqual(createLogicalRunUserMessageV1(record), firstRetained)
     ) {
       return entry.sequence;
     }
@@ -4622,6 +4656,25 @@ function areInputResourcesValid(resources: UserInput["inputResources"]): boolean
       resources.every((resource) => inputResourceOccurrenceV1Schema.safeParse(resource).success) &&
       new Set(resources.map((resource) => resource.occurrenceId)).size === resources.length)
   );
+}
+
+function isStructuredUserContentValid(input: UserInput): boolean {
+  if (input.userContent === undefined) {
+    return true;
+  }
+  if (input.inputResources === undefined || input.inputResources.length === 0) {
+    return false;
+  }
+  try {
+    validateSessionUserContentV1({
+      elements: input.userContent,
+      occurrences: input.inputResources,
+      userMessage: input.text,
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function skillActivationFailure(

--- a/packages/agent/src/artifact-store.ts
+++ b/packages/agent/src/artifact-store.ts
@@ -127,6 +127,7 @@ export type ArtifactStagingStore = {
     readonly bytes: Uint8Array;
     readonly mediaType: string;
   }): Promise<StagedArtifactReference>;
+  retain(reference: StagedArtifactReference): Promise<void>;
   discard(reference: StagedArtifactReference): Promise<void>;
   close(): Promise<void>;
 };
@@ -166,6 +167,13 @@ export async function createFileArtifactStagingStore(options: {
       owned.delete(reference.stagingId);
       await unlinkTemporary(join(stagingRoot, reference.stagingId));
       await removeEmptyDirectory(stagingRoot);
+    },
+    async retain(reference) {
+      requireStagingId(reference.stagingId);
+      if (!owned.delete(reference.stagingId)) {
+        throw new Error("The provisional artifact is not owned by this staging store.");
+      }
+      await syncDirectory(stagingRoot);
     },
     async close() {
       const retained = [...owned];

--- a/packages/agent/src/input-resource-staging.os.test.ts
+++ b/packages/agent/src/input-resource-staging.os.test.ts
@@ -1,0 +1,35 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { expect, test } from "vitest";
+
+import { createFileTurnComposerResourceStager } from "./input-resource-staging.js";
+
+test("file turn-composer staging retains recoverable provisional bytes across close", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-turn-staging-retain-"));
+  const artifactRoot = join(testRoot, "artifacts");
+  const workspaceRoot = join(testRoot, "workspace");
+  const selectedPath = join(testRoot, "notes.txt");
+  await mkdir(workspaceRoot);
+  await writeFile(selectedPath, "retained draft bytes\n", "utf8");
+  const stager = await createFileTurnComposerResourceStager({ artifactRoot });
+
+  try {
+    const selection = await stager.stage({
+      id: crypto.randomUUID(),
+      path: selectedPath,
+      signal: new AbortController().signal,
+    });
+    await stager.retain({ resourceId: crypto.randomUUID(), selection });
+    await stager.close();
+
+    const recovered = await readFile(
+      join(artifactRoot, ".input-resource-staging", selection.staged.stagingId),
+    );
+    expect(recovered.toString("utf8")).toBe("retained draft bytes\n");
+  } finally {
+    await stager.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/agent/src/input-resource-staging.ts
+++ b/packages/agent/src/input-resource-staging.ts
@@ -20,6 +20,10 @@ export type TurnComposerResourceStager = {
     readonly path: string;
     readonly signal: AbortSignal;
   }): Promise<StagedInputResourceSelectionV1>;
+  retain(input: {
+    readonly resourceId: string;
+    readonly selection: StagedInputResourceSelectionV1;
+  }): Promise<void>;
   discard(selection: StagedInputResourceSelectionV1): Promise<void>;
   close(): Promise<void>;
 };
@@ -75,6 +79,9 @@ export async function createFileTurnComposerResourceStager(options: {
         }
         throw error;
       }
+    },
+    async retain(input) {
+      await staging.retain(input.selection.staged);
     },
     discard(selection) {
       return staging.discard(selection.staged);

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -53,6 +53,11 @@ import {
 } from "./presentation-transcript-projection.js";
 import { listProjectPaths } from "./project-path-catalog.js";
 import {
+  createRecoverableTurnDraftRepository,
+  type RecoverableTurnDraftRepository,
+  type TurnDraftScopeV1,
+} from "./recoverable-turn-draft.js";
+import {
   type SessionNamingHistoryState,
   sessionNamingStateFromRecords,
 } from "./session-history-folds.js";
@@ -109,6 +114,7 @@ export type PresentationSessionRecordReader = (
 ) => Promise<readonly SessionRecord[]>;
 
 type PresentationSessionBaseOptions = {
+  readonly draftPersistencePolicy?: "process_only" | "recoverable";
   readonly lifecycle: SessionLifecycle;
   readonly modelTargets?: ModelTargets;
   readonly operations?: OperationHost;
@@ -535,6 +541,9 @@ export async function createPresentationSession(
             },
       composer: {
         attachmentAvailable,
+        draftRevision: 0,
+        elements: [],
+        renderedText: "",
         unavailableReason: attachmentUnavailableReason,
         sealed: false,
         revisionIntent: planRevisionIntent,
@@ -603,6 +612,9 @@ export async function createPresentationSession(
       const snapshot = turnComposer?.snapshot() ?? { sealed: false, resources: [] };
       return {
         attachmentAvailable,
+        draftRevision: snapshot.revision,
+        elements: snapshot.elements,
+        renderedText: snapshot.renderedText,
         unavailableReason: attachmentUnavailableReason,
         sealed: snapshot.sealed,
         revisionIntent: planRevisionIntent,
@@ -628,6 +640,65 @@ export async function createPresentationSession(
           : { stageBarrier: options[turnComposerStageBarrier] }),
       }),
     });
+    const recoverableDrafts: RecoverableTurnDraftRepository | null =
+      options.draftPersistencePolicy === "process_only"
+        ? null
+        : await createRecoverableTurnDraftRepository({
+            projectId: state.authoritative.project.id,
+            stateRoot: effectiveSessionStateRoot(options.stateRoot),
+          });
+    const currentDraftScope = (): TurnDraftScopeV1 | null => {
+      const active = state.authoritative.active;
+      if (active !== null) {
+        return { type: "session", sessionId: active.session.id };
+      }
+      return state.draft === null ? null : { type: "new_session" };
+    };
+    const persistCurrentTurnDraft = async (): Promise<void> => {
+      const scope = currentDraftScope();
+      if (recoverableDrafts === null || scope === null) {
+        return;
+      }
+      const snapshot = turnComposer.snapshot();
+      if (snapshot.elements.length === 0) {
+        await recoverableDrafts.delete(scope);
+        return;
+      }
+      await recoverableDrafts.save(
+        await turnComposer.captureDraft(
+          scope.type === "new_session"
+            ? { type: "new_session", targetId: state.draft?.targetId ?? "" }
+            : scope,
+        ),
+      );
+    };
+    const persistSettledCurrentTurnDraft = async (): Promise<void> => {
+      if (
+        turnComposer
+          .snapshot()
+          .resources.every((resource) => resource.state === "ready" || resource.state === "failed")
+      ) {
+        await persistCurrentTurnDraft();
+      }
+    };
+    const loadTurnDraft = async (scope: TurnDraftScopeV1, targetId?: string) => {
+      const recovered = await recoverableDrafts?.load(scope);
+      if (
+        recovered === undefined ||
+        recovered === null ||
+        (recovered.scope.type === "new_session" && recovered.scope.targetId !== targetId)
+      ) {
+        return null;
+      }
+      return recovered;
+    };
+    const initialDraftScope = currentDraftScope();
+    if (initialDraftScope !== null) {
+      const recovered = await loadTurnDraft(initialDraftScope, state.draft?.targetId);
+      if (recovered !== null) {
+        await turnComposer.restoreDraft(recovered);
+      }
+    }
     const operationAdmissions = new Set<Promise<void>>();
     const operationRefreshes = new Set<Promise<void>>();
     const operationObservers = new Map<string, AbortController>();
@@ -2127,7 +2198,9 @@ export async function createPresentationSession(
         operationRepairs.clear();
         operationCursors.clear();
         activeSessionThroughSequence = 0;
-        await turnComposer.clear();
+        await persistSettledCurrentTurnDraft();
+        const recovered = await loadTurnDraft({ type: "new_session" }, targetIdentity.targetId);
+        await turnComposer.clear({ preserveRetained: true });
         attachmentAvailable = true;
         attachmentUnavailableReason = null;
         state = {
@@ -2150,6 +2223,9 @@ export async function createPresentationSession(
           transient: null,
         };
         draftTargetIdentity = targetIdentity;
+        if (recovered !== null) {
+          await turnComposer.restoreDraft(recovered);
+        }
         publishStateChange();
         return { status: "admitted", commandId: randomUUID(), resource: null };
       }
@@ -2182,8 +2258,16 @@ export async function createPresentationSession(
             }
             snapshot = resumed.snapshot;
           }
-          await turnComposer.clear();
+          await persistSettledCurrentTurnDraft();
+          const recovered = await loadTurnDraft({
+            type: "session",
+            sessionId: command.sessionId,
+          });
+          await turnComposer.clear({ preserveRetained: true });
           await activateSnapshot(snapshot);
+          if (recovered !== null) {
+            await turnComposer.restoreDraft(recovered);
+          }
           return { status: "admitted", commandId: randomUUID(), resource: null };
         } catch {
           return {
@@ -2209,13 +2293,120 @@ export async function createPresentationSession(
           };
         }
         try {
-          await turnComposer.stage(command.path);
+          await turnComposer.stage(command.path, command.mutation, persistCurrentTurnDraft);
           return { status: "admitted", commandId: randomUUID(), resource: null };
         } catch {
           return {
             status: "rejected",
             code: "not_available",
             message: "The selected input resource could not be staged.",
+          };
+        }
+      }
+      if (command.type === "replace_draft_text") {
+        if (activeRun !== undefined || state.composer.sealed) {
+          return {
+            status: "rejected",
+            code: "conflict",
+            message: "The current turn cannot change while it is sealed.",
+          };
+        }
+        try {
+          return (await turnComposer.replaceText(command, persistCurrentTurnDraft))
+            ? { status: "admitted", commandId: randomUUID(), resource: null }
+            : {
+                status: "rejected",
+                code: "stale_interaction",
+                message: "The structured draft no longer matches the current composer revision.",
+              };
+        } catch {
+          return {
+            status: "rejected",
+            code: "persistence_failed",
+            message: "The recoverable structured draft could not be saved.",
+          };
+        }
+      }
+      if (command.type === "remove_draft_element") {
+        if (activeRun !== undefined || state.composer.sealed) {
+          return {
+            status: "rejected",
+            code: "conflict",
+            message: "The current turn cannot change while it is sealed.",
+          };
+        }
+        const snapshot = turnComposer.snapshot();
+        const element = snapshot.elements.find(
+          (candidate) => candidate.elementId === command.elementId,
+        );
+        if (command.baseRevision !== snapshot.revision || element?.type !== "resource") {
+          return {
+            status: "rejected",
+            code: "stale_interaction",
+            message: "The draft element is no longer present in the current composer.",
+          };
+        }
+        try {
+          return (await turnComposer.remove(element.resourceId, persistCurrentTurnDraft))
+            ? { status: "admitted", commandId: randomUUID(), resource: null }
+            : {
+                status: "rejected",
+                code: "stale_interaction",
+                message: "The draft element is no longer present in the current composer.",
+              };
+        } catch {
+          return {
+            status: "rejected",
+            code: "persistence_failed",
+            message: "The recoverable turn draft could not be saved.",
+          };
+        }
+      }
+      if (command.type === "undo_draft") {
+        if (activeRun !== undefined || state.composer.sealed) {
+          return {
+            status: "rejected",
+            code: "conflict",
+            message: "The current turn cannot be undone while it is sealed.",
+          };
+        }
+        try {
+          return (await turnComposer.undo(command.baseRevision, persistCurrentTurnDraft))
+            ? { status: "admitted", commandId: randomUUID(), resource: null }
+            : {
+                status: "rejected",
+                code: "stale_interaction",
+                message: "The draft undo no longer targets the current composer revision.",
+              };
+        } catch {
+          return {
+            status: "rejected",
+            code: "persistence_failed",
+            message: "The restored turn draft could not be saved.",
+          };
+        }
+      }
+      if (command.type === "clear_draft") {
+        if (activeRun !== undefined || state.composer.sealed) {
+          return {
+            status: "rejected",
+            code: "conflict",
+            message: "The current turn cannot be cleared while it is sealed.",
+          };
+        }
+        try {
+          return (await turnComposer.reset(command.baseRevision, persistCurrentTurnDraft))
+            ? { status: "admitted", commandId: randomUUID(), resource: null }
+            : {
+                status: "rejected",
+                code: "stale_interaction",
+                message: "The draft clear no longer targets the current settled composer revision.",
+              };
+        } catch {
+          return {
+            status: "rejected",
+            code: "persistence_failed",
+            message: "The cleared turn draft could not be saved.",
           };
         }
       }
@@ -2227,8 +2418,16 @@ export async function createPresentationSession(
             message: "The current turn text cannot change while the turn is sealed.",
           };
         }
-        turnComposer.setText(command.text);
-        return { status: "admitted", commandId: randomUUID(), resource: null };
+        try {
+          await turnComposer.commitText(command.text, persistCurrentTurnDraft);
+          return { status: "admitted", commandId: randomUUID(), resource: null };
+        } catch {
+          return {
+            status: "rejected",
+            code: "persistence_failed",
+            message: "The recoverable turn draft could not be saved.",
+          };
+        }
       }
       if (command.type === "remove_input_resource") {
         if (activeRun !== undefined || state.composer.sealed) {
@@ -2238,13 +2437,21 @@ export async function createPresentationSession(
             message: "An input resource cannot be removed while the current turn is sealed.",
           };
         }
-        return (await turnComposer.remove(command.resourceId))
-          ? { status: "admitted", commandId: randomUUID(), resource: null }
-          : {
-              status: "rejected",
-              code: "stale_interaction",
-              message: "The input resource is no longer present in the current composer.",
-            };
+        try {
+          return (await turnComposer.remove(command.resourceId, persistCurrentTurnDraft))
+            ? { status: "admitted", commandId: randomUUID(), resource: null }
+            : {
+                status: "rejected",
+                code: "stale_interaction",
+                message: "The input resource is no longer present in the current composer.",
+              };
+        } catch {
+          return {
+            status: "rejected",
+            code: "persistence_failed",
+            message: "The recoverable turn draft could not be saved.",
+          };
+        }
       }
       if (command.type === "cancel_input_resource") {
         if (activeRun !== undefined || state.composer.sealed) {
@@ -2313,6 +2520,7 @@ export async function createPresentationSession(
         if (skillResolution.status === "ambiguous") {
           return ambiguousSkillMentionRejection(skillResolution);
         }
+        const submittedScope = currentDraftScope();
         const controller = new AbortController();
         const commandId = randomUUID();
         const runState = {
@@ -2331,6 +2539,7 @@ export async function createPresentationSession(
         try {
           turnComposer.setText(command.text);
           sealedDraft = await turnComposer.seal(controller.signal);
+          await persistCurrentTurnDraft();
         } catch (error) {
           if (activeRun === runState) {
             activeRun = undefined;
@@ -2376,6 +2585,9 @@ export async function createPresentationSession(
           ...(sealedDraft.selections.length === 0
             ? {}
             : { resourceSelections: sealedDraft.selections }),
+          ...(sealedDraft.selections.length === 0
+            ? {}
+            : { structuredContent: sealedDraft.structuredContent }),
           ...(command.thinkingSelection === null
             ? {}
             : { thinkingSelection: command.thinkingSelection }),
@@ -2438,6 +2650,9 @@ export async function createPresentationSession(
           );
         }
         planRevisionIntent = null;
+        if (recoverableDrafts !== null && submittedScope !== null) {
+          await recoverableDrafts.delete(submittedScope);
+        }
         await turnComposer.clear();
         return { status: "admitted", commandId, resource: null };
       }
@@ -2473,6 +2688,7 @@ export async function createPresentationSession(
         if (skillResolution.status === "ambiguous") {
           return ambiguousSkillMentionRejection(skillResolution);
         }
+        const submittedScope = currentDraftScope();
         const controller = new AbortController();
         const commandId = randomUUID();
         const runState = {
@@ -2491,6 +2707,7 @@ export async function createPresentationSession(
         try {
           turnComposer.setText(command.text);
           sealedDraft = await turnComposer.seal(controller.signal);
+          await persistCurrentTurnDraft();
         } catch (error) {
           if (activeRun === runState) {
             activeRun = undefined;
@@ -2521,6 +2738,9 @@ export async function createPresentationSession(
           ...(sealedDraft.selections.length === 0
             ? {}
             : { resourceSelections: sealedDraft.selections }),
+          ...(sealedDraft.selections.length === 0
+            ? {}
+            : { structuredContent: sealedDraft.structuredContent }),
           ...(command.thinkingSelection === null
             ? {}
             : { thinkingSelection: command.thinkingSelection }),
@@ -2596,6 +2816,9 @@ export async function createPresentationSession(
             message: "The admitted draft session could not be read from durable history.",
           };
         }
+        if (recoverableDrafts !== null && submittedScope !== null) {
+          await recoverableDrafts.delete(submittedScope);
+        }
         await turnComposer.clear();
         await activateSnapshot(admittedSnapshot);
         return { status: "admitted", commandId, resource: null };
@@ -2623,6 +2846,7 @@ export async function createPresentationSession(
           };
         }
         try {
+          await persistSettledCurrentTurnDraft();
           const snapshot = await options.lifecycle.branch({
             parentSessionId: command.parentSessionId,
             ...(command.sourceBoundary === undefined
@@ -2630,7 +2854,7 @@ export async function createPresentationSession(
               : { sourceBoundary: command.sourceBoundary }),
             ...(command.targetId === null ? {} : { targetId: command.targetId }),
           });
-          await turnComposer.clear();
+          await turnComposer.clear({ preserveRetained: true });
           await activateSnapshot(snapshot);
           return { status: "admitted", commandId: randomUUID(), resource: null };
         } catch {
@@ -3561,6 +3785,7 @@ export async function createPresentationSession(
         if (closed) {
           return;
         }
+        await persistSettledCurrentTurnDraft();
         closed = true;
         activeRun?.controller.abort();
         const connectionSettlements = [...activeConnectionTests.values()].flatMap((active) =>

--- a/packages/agent/src/presentation-transcript-projection.ts
+++ b/packages/agent/src/presentation-transcript-projection.ts
@@ -7,6 +7,7 @@ import type {
 } from "@adam-agent/presentation";
 import type { RunResult, RuntimeEvent } from "./agent-session-contracts.js";
 import type { SessionRecord } from "./session-store.js";
+import { projectSessionUserContentTextV1 } from "./structured-user-content.js";
 
 type PresentationTranscriptHistoryRecord = {
   readonly sessionId: string;
@@ -117,7 +118,13 @@ export function projectTranscript(
         sequence: entry.sequence,
         sourceSessionId: sessionId,
         branchBoundary: null,
-        text: entry.record.userMessage,
+        text:
+          entry.record.recordVersion === 2
+            ? projectSessionUserContentTextV1({
+                elements: entry.record.userContent,
+                occurrences: entry.record.inputResources,
+              })
+            : entry.record.userMessage,
       });
       continue;
     }

--- a/packages/agent/src/recoverable-turn-draft.os.test.ts
+++ b/packages/agent/src/recoverable-turn-draft.os.test.ts
@@ -1,0 +1,46 @@
+import { mkdtemp, readdir, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { expect, test } from "vitest";
+
+import { createRecoverableTurnDraftRepository } from "./recoverable-turn-draft.js";
+
+const projectId = `sha256:${"b".repeat(64)}` as const;
+
+test("recoverable turn draft atomically replaces one owner-private project manifest", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-recoverable-turn-draft-"));
+  const repository = await createRecoverableTurnDraftRepository({
+    projectId,
+    stateRoot: testRoot,
+  });
+  const first = {
+    schemaVersion: 1 as const,
+    scope: { type: "new_session" as const, targetId: "deepseek-v4-flash.direct" },
+    nextOrdinal: 1,
+    elements: [{ elementId: "text-1", type: "text" as const, text: "first" }],
+    resources: [],
+  };
+  const second = {
+    ...first,
+    elements: [{ elementId: "text-1", type: "text" as const, text: "second" }],
+  };
+
+  try {
+    await repository.save(first);
+    await repository.save(second);
+    await expect(repository.load({ type: "new_session" })).resolves.toEqual(second);
+
+    const draftsRoot = join(testRoot, "drafts", "b".repeat(64));
+    const entries = await readdir(draftsRoot);
+    expect(entries).toEqual(["new-session.json"]);
+    expect((await stat(draftsRoot)).mode & 0o777).toBe(0o700);
+    expect((await stat(join(draftsRoot, "new-session.json"))).mode & 0o777).toBe(0o600);
+
+    await repository.delete({ type: "new_session" });
+    await expect(repository.load({ type: "new_session" })).resolves.toBeNull();
+    await expect(readdir(draftsRoot)).resolves.toEqual([]);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/agent/src/recoverable-turn-draft.ts
+++ b/packages/agent/src/recoverable-turn-draft.ts
@@ -1,0 +1,317 @@
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { chmod, mkdir, open, rename, unlink } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+import { z } from "zod";
+
+const maximumManifestBytes = 1024 * 1024;
+const projectIdPattern = /^sha256:([0-9a-f]{64})$/u;
+
+export type TurnDraftScopeV1 =
+  | { readonly type: "new_session" }
+  | { readonly type: "session"; readonly sessionId: string };
+
+export type RecoverableTurnDraftV1 = {
+  readonly schemaVersion: 1;
+  readonly scope:
+    | { readonly type: "new_session"; readonly targetId: string }
+    | { readonly type: "session"; readonly sessionId: string };
+  readonly nextOrdinal: number;
+  readonly elements: readonly (
+    | { readonly elementId: string; readonly type: "text"; readonly text: string }
+    | {
+        readonly elementId: string;
+        readonly type: "resource";
+        readonly kind: "file" | "image";
+        readonly ordinal: number;
+        readonly resourceId: string;
+      }
+  )[];
+  readonly resources: readonly {
+    readonly id: string;
+    readonly elementId: string;
+    readonly displayName: string;
+    readonly kind: "file" | "image";
+    readonly ordinal: number;
+    readonly state: "failed" | "ready";
+    readonly byteCount: number | null;
+    readonly mediaHint: "binary" | "image" | "text" | null;
+    readonly support: "image" | "unsupported_binary" | "utf8_text" | null;
+    readonly diagnostic: string | null;
+    readonly selection?:
+      | {
+          readonly type: "staged_artifact";
+          readonly staged: {
+            readonly stagingId: string;
+            readonly id: `sha256:${string}`;
+            readonly mediaType: string;
+            readonly byteCount: number;
+          };
+          readonly displayName: string;
+          readonly digest: `sha256:${string}`;
+          readonly mediaHint: "binary" | "image" | "text";
+          readonly support: "image" | "unsupported_binary" | "utf8_text";
+        }
+      | undefined;
+  }[];
+};
+
+export type RecoverableTurnDraftRepository = {
+  load(scope: TurnDraftScopeV1): Promise<RecoverableTurnDraftV1 | null>;
+  save(draft: RecoverableTurnDraftV1): Promise<void>;
+  delete(scope: TurnDraftScopeV1): Promise<void>;
+};
+
+const digestSchema = z.string().regex(/^sha256:[0-9a-f]{64}$/u) as z.ZodType<`sha256:${string}`>;
+const stagedSelectionSchema = z.strictObject({
+  type: z.literal("staged_artifact"),
+  staged: z.strictObject({
+    stagingId: z.uuid(),
+    id: digestSchema,
+    mediaType: z.enum([
+      "application/octet-stream",
+      "image/jpeg",
+      "image/png",
+      "text/plain; charset=utf-8",
+    ]),
+    byteCount: z
+      .number()
+      .int()
+      .nonnegative()
+      .max(8 * 1024 * 1024),
+  }),
+  displayName: z.string().min(1).max(255),
+  digest: digestSchema,
+  mediaHint: z.enum(["binary", "image", "text"]),
+  support: z.enum(["image", "unsupported_binary", "utf8_text"]),
+});
+const draftSchema: z.ZodType<RecoverableTurnDraftV1> = z
+  .strictObject({
+    schemaVersion: z.literal(1),
+    scope: z.discriminatedUnion("type", [
+      z.strictObject({
+        type: z.literal("new_session"),
+        targetId: z
+          .string()
+          .min(1)
+          .max(512)
+          .refine((value) => !value.includes("\0")),
+      }),
+      z.strictObject({ type: z.literal("session"), sessionId: z.uuid() }),
+    ]),
+    nextOrdinal: z.number().int().positive().safe(),
+    elements: z
+      .array(
+        z.discriminatedUnion("type", [
+          z.strictObject({
+            elementId: z.string().min(1).max(256),
+            type: z.literal("text"),
+            text: z
+              .string()
+              .min(1)
+              .max(512 * 1024),
+          }),
+          z.strictObject({
+            elementId: z.string().min(1).max(256),
+            type: z.literal("resource"),
+            kind: z.enum(["file", "image"]),
+            ordinal: z.number().int().positive().safe(),
+            resourceId: z.string().min(1).max(256),
+          }),
+        ]),
+      )
+      .max(17),
+    resources: z
+      .array(
+        z.strictObject({
+          id: z.string().min(1).max(256),
+          elementId: z.string().min(1).max(256),
+          displayName: z.string().min(1).max(255),
+          kind: z.enum(["file", "image"]),
+          ordinal: z.number().int().positive().safe(),
+          state: z.enum(["failed", "ready"]),
+          byteCount: z
+            .number()
+            .int()
+            .nonnegative()
+            .max(8 * 1024 * 1024)
+            .nullable(),
+          mediaHint: z.enum(["binary", "image", "text"]).nullable(),
+          support: z.enum(["image", "unsupported_binary", "utf8_text"]).nullable(),
+          diagnostic: z.string().max(1024).nullable(),
+          selection: stagedSelectionSchema.optional(),
+        }),
+      )
+      .max(8),
+  })
+  .superRefine((draft, context) => {
+    const resourceElements = draft.elements.filter((element) => element.type === "resource");
+    if (
+      new Set(draft.elements.map((element) => element.elementId)).size !== draft.elements.length ||
+      new Set(draft.resources.map((resource) => resource.id)).size !== draft.resources.length ||
+      new Set(draft.resources.map((resource) => resource.ordinal)).size !==
+        draft.resources.length ||
+      draft.elements.reduce(
+        (length, element) => length + (element.type === "text" ? element.text.length : 0),
+        0,
+      ) >
+        512 * 1024 ||
+      resourceElements.length !== draft.resources.length ||
+      resourceElements.some((element, index) => {
+        const resource = draft.resources[index];
+        return (
+          resource === undefined ||
+          resource.id !== element.resourceId ||
+          resource.elementId !== element.elementId ||
+          resource.kind !== element.kind ||
+          resource.ordinal !== element.ordinal
+        );
+      }) ||
+      draft.resources.some(
+        (resource) =>
+          (resource.state === "ready") !== (resource.selection !== undefined) ||
+          (resource.selection !== undefined &&
+            (resource.selection.displayName !== resource.displayName ||
+              resource.selection.support !== resource.support ||
+              resource.selection.mediaHint !== resource.mediaHint ||
+              resource.selection.staged.byteCount !== resource.byteCount ||
+              resource.selection.staged.id !== resource.selection.digest ||
+              (resource.kind === "image") !== (resource.selection.support === "image"))),
+      ) ||
+      draft.nextOrdinal <= Math.max(0, ...draft.resources.map((resource) => resource.ordinal))
+    ) {
+      context.addIssue({ code: "custom", message: "The recoverable draft graph is invalid." });
+    }
+  });
+
+export async function createRecoverableTurnDraftRepository(options: {
+  readonly projectId: string;
+  readonly stateRoot: string;
+}): Promise<RecoverableTurnDraftRepository> {
+  const projectMatch = projectIdPattern.exec(options.projectId);
+  if (projectMatch?.[1] === undefined) {
+    throw new TypeError("The recoverable draft project identity is invalid.");
+  }
+  const root = resolve(options.stateRoot, "drafts", projectMatch[1]);
+  await mkdir(root, { recursive: true, mode: 0o700 });
+  await chmod(root, 0o700);
+  let mutationQueue = Promise.resolve();
+  const enqueueMutation = <Result>(operation: () => Promise<Result>): Promise<Result> => {
+    const result = mutationQueue.then(operation);
+    mutationQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+
+  return {
+    delete(scope) {
+      return enqueueMutation(async () => {
+        try {
+          await unlink(join(root, manifestName(scope)));
+        } catch (error) {
+          if (isNodeError(error) && error.code === "ENOENT") {
+            return;
+          }
+          throw error;
+        }
+        await syncDirectory(root);
+      });
+    },
+    async load(scope) {
+      await mutationQueue;
+      const path = join(root, manifestName(scope));
+      let bytes: Buffer;
+      try {
+        const file = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+        try {
+          const stats = await file.stat();
+          if (
+            !stats.isFile() ||
+            stats.size <= 0 ||
+            stats.size > maximumManifestBytes ||
+            (stats.mode & 0o077) !== 0 ||
+            (process.geteuid?.() !== undefined && stats.uid !== process.geteuid())
+          ) {
+            throw new TypeError("The recoverable draft manifest is unsafe.");
+          }
+          bytes = await file.readFile();
+        } finally {
+          await file.close();
+        }
+      } catch (error) {
+        if (isNodeError(error) && error.code === "ENOENT") {
+          return null;
+        }
+        throw error;
+      }
+      const parsed = draftSchema.safeParse(JSON.parse(bytes.toString("utf8")) as unknown);
+      if (!parsed.success || !matchesScope(parsed.data.scope, scope)) {
+        throw new TypeError("The recoverable draft manifest is invalid.");
+      }
+      return parsed.data;
+    },
+    save(draft) {
+      return enqueueMutation(async () => {
+        const validated = draftSchema.parse(draft);
+        const serialized = `${JSON.stringify(validated)}\n`;
+        if (Buffer.byteLength(serialized, "utf8") > maximumManifestBytes) {
+          throw new TypeError("The recoverable draft manifest is too large.");
+        }
+        await replaceOwnerPrivateFile(join(root, manifestName(validated.scope)), serialized);
+        await syncDirectory(root);
+      });
+    },
+  };
+}
+
+async function replaceOwnerPrivateFile(path: string, content: string): Promise<void> {
+  const temporaryPath = `${path}.${randomUUID()}.tmp`;
+  const temporaryFile = await open(temporaryPath, "wx", 0o600);
+  try {
+    try {
+      await temporaryFile.chmod(0o600);
+      await temporaryFile.writeFile(content, "utf8");
+      await temporaryFile.sync();
+    } finally {
+      await temporaryFile.close();
+    }
+    await rename(temporaryPath, path);
+  } finally {
+    await unlink(temporaryPath).catch((error: unknown) => {
+      if (!isNodeError(error) || error.code !== "ENOENT") {
+        throw error;
+      }
+    });
+  }
+}
+
+function manifestName(scope: TurnDraftScopeV1 | RecoverableTurnDraftV1["scope"]): string {
+  return scope.type === "new_session" ? "new-session.json" : `session-${scope.sessionId}.json`;
+}
+
+function matchesScope(
+  draftScope: RecoverableTurnDraftV1["scope"],
+  requested: TurnDraftScopeV1,
+): boolean {
+  return (
+    draftScope.type === requested.type &&
+    (draftScope.type === "new_session" ||
+      (requested.type === "session" && draftScope.sessionId === requested.sessionId))
+  );
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  const directory = await open(path, "r");
+  try {
+    await directory.sync();
+  } finally {
+    await directory.close();
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/packages/agent/src/session-history-replay.ts
+++ b/packages/agent/src/session-history-replay.ts
@@ -5,7 +5,12 @@ import {
   createInputResourceUserMessageV1,
 } from "./input-resources.js";
 import { SessionLifecycleError } from "./session-lifecycle-error.js";
-import type { SessionModelResponseField, SessionRecord } from "./session-store.js";
+import type {
+  SessionLogicalRunStartedRecord,
+  SessionModelResponseField,
+  SessionRecord,
+} from "./session-store.js";
+import { createSessionUserContentMessageV1 } from "./structured-user-content.js";
 
 export function modelMessagesFromCompleteRecords(
   records: readonly SessionRecord[],
@@ -49,9 +54,7 @@ export function modelMessagesFromCanonicalRecords(
   const messages: ModelMessage[] = [];
   for (const record of currentRecords) {
     if (record.record.type === "logical_run_started") {
-      messages.push(
-        createInputResourceUserMessageV1(record.record.userMessage, record.record.inputResources),
-      );
+      messages.push(createLogicalRunUserMessageV1(record.record));
       continue;
     }
     if (record.record.type !== "model_response_completed") {
@@ -95,6 +98,18 @@ export function modelMessagesFromCanonicalRecords(
     }
   }
   return messages;
+}
+
+export function createLogicalRunUserMessageV1(
+  record: SessionLogicalRunStartedRecord["record"],
+): ModelMessage {
+  return record.recordVersion === 2
+    ? createSessionUserContentMessageV1({
+        elements: record.userContent,
+        occurrences: record.inputResources,
+        userMessage: record.userMessage,
+      })
+    : createInputResourceUserMessageV1(record.userMessage, record.inputResources);
 }
 
 export function inlineModelResponseField(field: string | SessionModelResponseField): string {

--- a/packages/agent/src/session-history-validation.ts
+++ b/packages/agent/src/session-history-validation.ts
@@ -63,6 +63,7 @@ import type {
   SessionRecord,
 } from "./session-store.js";
 import { isSkillContextRecordV1Valid } from "./skills.js";
+import { validateSessionUserContentV1 } from "./structured-user-content.js";
 import {
   createTodoMutationV1,
   emptyTodoStoreSnapshotV1,
@@ -2277,15 +2278,15 @@ function areLogicalInputResourcesValid(
 ): boolean {
   const resources = record.inputResources ?? [];
   if (resources.length === 0) {
-    return true;
+    return record.recordVersion !== 2;
   }
-  if (record.recordVersion !== 1) {
+  if (record.recordVersion !== 1 && record.recordVersion !== 2) {
     return false;
   }
   const combined = [...visible.values(), ...resources];
   const occurrenceIds = new Set(combined.map((resource) => resource.occurrenceId));
   const aggregateBytes = combined.reduce((sum, resource) => sum + resource.artifact.byteCount, 0);
-  return (
+  const resourcesAreValid =
     occurrenceIds.size === combined.length &&
     combined.length <= inputResourceLimitsV1.maximumOccurrencesPerLineage &&
     Number.isSafeInteger(aggregateBytes) &&
@@ -2304,8 +2305,23 @@ function areLogicalInputResourcesValid(
             resource.mediaHint === "image" &&
             (resource.artifact.mediaType === "image/jpeg" ||
               resource.artifact.mediaType === "image/png"))),
-    )
-  );
+    );
+  if (!resourcesAreValid) {
+    return false;
+  }
+  if (record.recordVersion !== 2) {
+    return true;
+  }
+  try {
+    validateSessionUserContentV1({
+      elements: record.userContent,
+      occurrences: resources,
+      userMessage: record.userMessage,
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function isMatchingStartedAttempt(

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -31,7 +31,6 @@ import {
   withInternalExtensionSkillSourcesCurrent,
 } from "./extension-host.js";
 import {
-  createInputResourceUserMessageV1,
   InputResourceError,
   type InputResourceOccurrenceV1,
   type InputResourceSelectionV1,
@@ -140,6 +139,7 @@ import {
   snapshotFromRecords,
 } from "./session-history-folds.js";
 import {
+  createLogicalRunUserMessageV1,
   inlineModelResponseField,
   modelMessagesFromCompleteRecords,
 } from "./session-history-replay.js";
@@ -180,6 +180,10 @@ import {
   type SkillResourceManifestV1,
   skillContextSnapshot,
 } from "./skills.js";
+import {
+  materializeSessionUserContentV1,
+  type StagedUserContentElementV1,
+} from "./structured-user-content.js";
 import {
   resolveThinkingPolicy,
   ThinkingPolicyError,
@@ -533,6 +537,7 @@ export type SessionCommand =
       readonly signal?: AbortSignal;
       readonly thinkingSelection?: ThinkingPolicySelectionV1;
       readonly resourceSelections?: readonly InputResourceSelectionV1[];
+      readonly structuredContent?: readonly StagedUserContentElementV1[];
       readonly planRevision?: {
         readonly cycleId: string;
         readonly revision: number;
@@ -570,6 +575,7 @@ export interface SessionLifecycle {
     readonly signal?: AbortSignal;
     readonly thinkingSelection?: ThinkingPolicySelectionV1;
     readonly resourceSelections?: readonly InputResourceSelectionV1[];
+    readonly structuredContent?: readonly StagedUserContentElementV1[];
     readonly onAdmitted?: (receipt: SessionAdmissionReceipt) => void;
   }): Promise<SessionContinueResult>;
   branch(input: SessionBranchInput): Promise<CurrentSessionSnapshot>;
@@ -582,6 +588,7 @@ export interface SessionLifecycle {
     readonly signal?: AbortSignal;
     readonly thinkingSelection?: ThinkingPolicySelectionV1;
     readonly resourceSelections?: readonly InputResourceSelectionV1[];
+    readonly structuredContent?: readonly StagedUserContentElementV1[];
     readonly planRevision?: {
       readonly cycleId: string;
       readonly revision: number;
@@ -2069,6 +2076,9 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           ...(input.resourceSelections === undefined
             ? {}
             : { resourceSelections: input.resourceSelections }),
+          ...(input.structuredContent === undefined
+            ? {}
+            : { structuredContent: input.structuredContent }),
           ...(input.thinkingSelection === undefined
             ? {}
             : { thinkingSelection: input.thinkingSelection }),
@@ -2548,8 +2558,11 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             input.runId !== undefined ||
             input.planRevision !== undefined ||
             input.resourceSelections !== undefined ||
+            input.structuredContent !== undefined ||
             input.thinkingSelection !== undefined)) ||
         (input.resourceSelections !== undefined && input.input === undefined) ||
+        (input.structuredContent !== undefined &&
+          (input.input === undefined || input.resourceSelections === undefined)) ||
         input.input?.inputResources !== undefined
       ) {
         throw new SessionLifecycleError("session_invalid");
@@ -3085,7 +3098,19 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         const runInput =
           effectiveInput === undefined || inputResources.length === 0
             ? effectiveInput
-            : { ...effectiveInput, inputResources };
+            : {
+                ...effectiveInput,
+                inputResources,
+                ...(input.structuredContent === undefined
+                  ? {}
+                  : {
+                      userContent: materializeSessionUserContentV1({
+                        elements: input.structuredContent,
+                        occurrences: inputResources,
+                        userMessage: effectiveInput.text,
+                      }),
+                    }),
+              };
         const runtimeInputResources = [...visibleInputResources, ...inputResources];
         if (runtimeInputResources.length > inputResourceLimitsV1.maximumOccurrencesPerLineage) {
           throw new InputResourceError(
@@ -6011,9 +6036,7 @@ function createAgentResumeState(
           : record.sequence < run.sequence,
       ),
     ),
-    ...(checkpointIncludesCurrentRun
-      ? []
-      : [createInputResourceUserMessageV1(run.record.userMessage, run.record.inputResources)]),
+    ...(checkpointIncludesCurrentRun ? [] : [createLogicalRunUserMessageV1(run.record)]),
   ];
   const toolResults: Array<
     NonNullable<AgentSessionDurableContext["resume"]>["toolResults"][number]

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -44,6 +44,11 @@ import {
 } from "./prompt-assembly.js";
 import { normalizedSessionTitle, sessionTitleFallback } from "./session-naming.js";
 import { type SkillContextRecordV1, skillContextRecordV1Schema } from "./skills.js";
+import {
+  type SessionUserContentElementV1,
+  sessionUserContentV1Schema,
+  validateSessionUserContentV1,
+} from "./structured-user-content.js";
 import type { ThinkingPolicySnapshotV1 } from "./thinking-policy.js";
 import { type TodoItemV1, todoItemV1Schema, todoPolicyVersionV1 } from "./todo.js";
 import type { PermissionSubject, ToolCall, ToolEffect, ToolReplayClass } from "./tool-runtime.js";
@@ -274,31 +279,43 @@ export type SessionMcpCatalogStateChangedRecord = {
       };
 };
 
+type SessionLogicalRunStartedBase = {
+  readonly type: "logical_run_started";
+  readonly runId: string;
+  readonly userMessage: string;
+  readonly planKickoff?: PlanApprovalIntentV1;
+  readonly planRevision?: PlanRevisionIntentV1;
+  readonly naming?: {
+    readonly profileVersion: 1;
+    readonly fallbackTitle: string;
+  };
+  readonly skills?: readonly {
+    readonly selection: string;
+    readonly requestId: string;
+  }[];
+  readonly limits?: {
+    readonly maxTurns?: number;
+    readonly maxTokens?: number;
+  };
+  readonly thinkingPolicy?: ThinkingPolicySnapshotV1;
+};
+
 export type SessionLogicalRunStartedRecord = {
   readonly schemaVersion: 3;
   readonly sequence: number;
-  readonly record: {
-    readonly type: "logical_run_started";
-    readonly recordVersion?: 1;
-    readonly runId: string;
-    readonly userMessage: string;
-    readonly planKickoff?: PlanApprovalIntentV1;
-    readonly planRevision?: PlanRevisionIntentV1;
-    readonly naming?: {
-      readonly profileVersion: 1;
-      readonly fallbackTitle: string;
-    };
-    readonly skills?: readonly {
-      readonly selection: string;
-      readonly requestId: string;
-    }[];
-    readonly limits?: {
-      readonly maxTurns?: number;
-      readonly maxTokens?: number;
-    };
-    readonly thinkingPolicy?: ThinkingPolicySnapshotV1;
-    readonly inputResources?: readonly InputResourceOccurrenceV1[];
-  };
+  readonly record: SessionLogicalRunStartedBase &
+    (
+      | {
+          readonly recordVersion?: 1;
+          readonly inputResources?: readonly InputResourceOccurrenceV1[];
+          readonly userContent?: never;
+        }
+      | {
+          readonly recordVersion: 2;
+          readonly inputResources: readonly InputResourceOccurrenceV1[];
+          readonly userContent: readonly SessionUserContentElementV1[];
+        }
+    );
 };
 
 export type SessionManualNameSetRecord = {
@@ -1934,6 +1951,80 @@ const planGitAttestationV1Schema: z.ZodType<PlanGitAttestationV1> = z.strictObje
   gitPolicyDigest: sha256DigestSchema,
   digest: sha256DigestSchema,
 });
+const logicalRunStartedV2Schema = z
+  .strictObject({
+    type: z.literal("logical_run_started"),
+    recordVersion: z.literal(2),
+    runId: z.uuid(),
+    userMessage: z.string().max(512 * 1024),
+    planRevision: z
+      .strictObject({
+        cycleId: z.uuid(),
+        fromRevision: z.number().int().positive(),
+        toRevision: z.number().int().positive(),
+        planId: z.uuid(),
+        contentDigest: sha256DigestSchema,
+      })
+      .refine((intent) => intent.toRevision === intent.fromRevision + 1)
+      .optional(),
+    planKickoff: z
+      .strictObject({
+        sessionId: z.uuid(),
+        commandId: z.uuid(),
+        kickoffRunId: z.uuid(),
+        cycleId: z.uuid(),
+        revision: z.number().int().positive(),
+        planId: z.uuid(),
+        contentDigest: sha256DigestSchema,
+        policyVersion: z.enum(["plan-policy.read-v1", "plan-policy.hybrid-v1"]),
+        toolProfileDigest: sha256DigestSchema,
+      })
+      .optional(),
+    naming: z
+      .strictObject({
+        profileVersion: z.literal(1),
+        fallbackTitle: z
+          .string()
+          .min(1)
+          .max(1_024)
+          .refine((value) => sessionTitleFallback(value) === value),
+      })
+      .optional(),
+    skills: z
+      .array(
+        z.strictObject({
+          selection: z
+            .string()
+            .min(1)
+            .max(16_384)
+            .refine((value) => /^[\x20-\x7e]+$/u.test(value)),
+          requestId: z.string().min(1).max(256),
+        }),
+      )
+      .max(8)
+      .optional(),
+    limits: sessionRunLimitsSchema.optional(),
+    thinkingPolicy: thinkingPolicySnapshotV1Schema.optional(),
+    inputResources: z
+      .array(inputResourceOccurrenceV1Schema)
+      .min(1)
+      .max(inputResourceLimitsV1.maximumOccurrencesPerRun),
+    userContent: sessionUserContentV1Schema,
+  })
+  .superRefine((record, context) => {
+    try {
+      validateSessionUserContentV1({
+        elements: record.userContent,
+        occurrences: record.inputResources,
+        userMessage: record.userMessage,
+      });
+    } catch {
+      context.addIssue({
+        code: "custom",
+        message: "Structured user content must exactly reference the durable input resources.",
+      });
+    }
+  });
 const sessionV3RecordSchema = z.union([
   sessionGenesisV1RecordSchema,
   sessionGenesisV2RecordSchema,
@@ -2162,6 +2253,7 @@ const sessionV3RecordSchema = z.union([
       .max(inputResourceLimitsV1.maximumOccurrencesPerRun)
       .optional(),
   }),
+  logicalRunStartedV2Schema,
   z
     .strictObject({
       type: z.literal("plan_cycle_entered"),

--- a/packages/agent/src/structured-user-content.ts
+++ b/packages/agent/src/structured-user-content.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+import type { ModelMessage } from "./agent-session-contracts.js";
+import {
+  createInputResourceUserMessageV1,
+  type InputResourceOccurrenceV1,
+  inputResourceLimitsV1,
+  inputResourceOccurrenceV1Schema,
+} from "./input-resources.js";
+
+export type StagedUserContentElementV1 =
+  | { readonly type: "text"; readonly text: string }
+  | {
+      readonly type: "input_resource";
+      readonly selectionIndex: number;
+      readonly draftOrdinal: number;
+    };
+
+export type SessionUserContentElementV1 =
+  | { readonly type: "text"; readonly text: string }
+  | {
+      readonly type: "input_resource";
+      readonly occurrenceId: string;
+      readonly draftOrdinal: number;
+    };
+
+export const sessionUserContentElementV1Schema: z.ZodType<SessionUserContentElementV1> =
+  z.discriminatedUnion("type", [
+    z.strictObject({
+      type: z.literal("text"),
+      text: z
+        .string()
+        .min(1)
+        .max(512 * 1024),
+    }),
+    z.strictObject({
+      type: z.literal("input_resource"),
+      occurrenceId: z.string().min(1).max(256),
+      draftOrdinal: z.number().int().positive().safe(),
+    }),
+  ]);
+
+export const sessionUserContentV1Schema = z
+  .array(sessionUserContentElementV1Schema)
+  .min(1)
+  .max(inputResourceLimitsV1.maximumOccurrencesPerRun * 2 + 1)
+  .refine(
+    (elements) =>
+      elements.every(
+        (element, index) => element.type !== "text" || elements[index - 1]?.type !== "text",
+      ),
+    "Adjacent structured user text elements must be normalized.",
+  )
+  .refine((elements) => {
+    const ordinals = elements.flatMap((element) =>
+      element.type === "input_resource" ? [element.draftOrdinal] : [],
+    );
+    return new Set(ordinals).size === ordinals.length;
+  }, "Structured input-resource ordinals must be unique.");
+
+export function materializeSessionUserContentV1(input: {
+  readonly elements: readonly StagedUserContentElementV1[];
+  readonly occurrences: readonly InputResourceOccurrenceV1[];
+  readonly userMessage: string;
+}): readonly SessionUserContentElementV1[] {
+  const elements = input.elements.map((element): SessionUserContentElementV1 => {
+    if (element.type === "text") {
+      return element;
+    }
+    const occurrence = input.occurrences[element.selectionIndex];
+    if (occurrence === undefined) {
+      throw new TypeError("The structured draft references an unavailable input resource.");
+    }
+    return {
+      type: "input_resource",
+      occurrenceId: occurrence.occurrenceId,
+      draftOrdinal: element.draftOrdinal,
+    };
+  });
+  if (!sessionUserContentV1Schema.safeParse(elements).success) {
+    throw new TypeError("The structured user content is invalid.");
+  }
+  validateSessionUserContentV1({
+    elements,
+    occurrences: input.occurrences,
+    userMessage: input.userMessage,
+  });
+  return elements;
+}
+
+export function validateSessionUserContentV1(input: {
+  readonly elements: readonly SessionUserContentElementV1[];
+  readonly occurrences: readonly InputResourceOccurrenceV1[];
+  readonly userMessage: string;
+}): void {
+  if (
+    !sessionUserContentV1Schema.safeParse(input.elements).success ||
+    !inputResourceOccurrenceV1Schema.array().safeParse(input.occurrences).success
+  ) {
+    throw new TypeError("The structured user content is invalid.");
+  }
+  const literalText = input.elements
+    .flatMap((element) => (element.type === "text" ? [element.text] : []))
+    .join("");
+  const referenced = input.elements.flatMap((element) =>
+    element.type === "input_resource" ? [element.occurrenceId] : [],
+  );
+  const expected = input.occurrences.map((occurrence) => occurrence.occurrenceId);
+  if (
+    literalText !== input.userMessage ||
+    referenced.length !== expected.length ||
+    referenced.some((occurrenceId, index) => occurrenceId !== expected[index]) ||
+    new Set(referenced).size !== referenced.length
+  ) {
+    throw new TypeError("The structured user content does not match its immutable occurrences.");
+  }
+}
+
+export function projectSessionUserContentTextV1(input: {
+  readonly elements: readonly SessionUserContentElementV1[];
+  readonly occurrences: readonly InputResourceOccurrenceV1[];
+}): string {
+  const occurrences = new Map(
+    input.occurrences.map((occurrence) => [occurrence.occurrenceId, occurrence]),
+  );
+  return input.elements
+    .map((element) => {
+      if (element.type === "text") {
+        return element.text;
+      }
+      const occurrence = occurrences.get(element.occurrenceId);
+      if (occurrence === undefined) {
+        throw new TypeError("The structured user content occurrence is unavailable.");
+      }
+      return `[${occurrence.support === "image" ? "Image" : "File"} #${element.draftOrdinal}]`;
+    })
+    .join("");
+}
+
+export function createSessionUserContentMessageV1(input: {
+  readonly elements: readonly SessionUserContentElementV1[];
+  readonly occurrences: readonly InputResourceOccurrenceV1[];
+  readonly userMessage: string;
+}): ModelMessage {
+  validateSessionUserContentV1(input);
+  return createInputResourceUserMessageV1(
+    projectSessionUserContentTextV1({
+      elements: input.elements,
+      occurrences: input.occurrences,
+    }),
+    input.occurrences,
+  );
+}

--- a/packages/agent/src/turn-composer.test.ts
+++ b/packages/agent/src/turn-composer.test.ts
@@ -1,0 +1,545 @@
+import { expect, test } from "vitest";
+
+import type { TurnComposerResourceStager } from "./input-resource-staging.js";
+import { createTurnComposer } from "./turn-composer.js";
+
+const digest = `sha256:${"a".repeat(64)}` as const;
+
+test("TurnComposer does not publish or retain text when its recoverable commit fails", async () => {
+  let publications = 0;
+  const stager: TurnComposerResourceStager = {
+    async stage() {
+      throw new Error("No resource should be staged in this test.");
+    },
+    async retain() {},
+    async discard() {},
+    async close() {},
+  };
+  const composer = await createTurnComposer({
+    onChange() {
+      publications += 1;
+    },
+    stager,
+  });
+
+  try {
+    await expect(
+      composer.commitText("must stay hidden", async () => {
+        throw new Error("simulated manifest failure");
+      }),
+    ).rejects.toThrow("simulated manifest failure");
+    expect(composer.snapshot()).toMatchObject({
+      elements: [],
+      renderedText: "",
+      revision: 0,
+    });
+    expect(publications).toBe(0);
+  } finally {
+    await composer.close();
+  }
+});
+
+test("TurnComposer withdraws a newly staged resource when its recoverable commit fails", async () => {
+  const publications: string[] = [];
+  const stager: TurnComposerResourceStager = {
+    async stage(input) {
+      return {
+        type: "staged_artifact",
+        staged: {
+          stagingId: input.id,
+          id: digest,
+          mediaType: "text/plain; charset=utf-8",
+          byteCount: 5,
+        },
+        displayName: "notes.txt",
+        digest,
+        mediaHint: "text",
+        support: "utf8_text",
+      };
+    },
+    async retain() {},
+    async discard() {},
+    async close() {},
+  };
+  let composer: Awaited<ReturnType<typeof createTurnComposer>>;
+  composer = await createTurnComposer({
+    onChange() {
+      publications.push(composer.snapshot().renderedText);
+    },
+    stager,
+  });
+
+  try {
+    await expect(
+      composer.stage("/selected/notes.txt", undefined, async () => {
+        throw new Error("simulated manifest failure");
+      }),
+    ).rejects.toThrow("simulated manifest failure");
+    expect(composer.snapshot()).toMatchObject({
+      elements: [],
+      renderedText: "",
+      resources: [],
+      revision: 0,
+    });
+    expect(publications.at(-1)).toBe("");
+  } finally {
+    await composer.close();
+  }
+});
+
+test("TurnComposer restores a ready resource when its removal commit fails", async () => {
+  let publications = 0;
+  const stager: TurnComposerResourceStager = {
+    async stage(input) {
+      return {
+        type: "staged_artifact",
+        staged: {
+          stagingId: input.id,
+          id: digest,
+          mediaType: "text/plain; charset=utf-8",
+          byteCount: 5,
+        },
+        displayName: "notes.txt",
+        digest,
+        mediaHint: "text",
+        support: "utf8_text",
+      };
+    },
+    async retain() {},
+    async discard() {},
+    async close() {},
+  };
+  const composer = await createTurnComposer({
+    onChange() {
+      publications += 1;
+    },
+    stager,
+  });
+
+  try {
+    const resourceId = await composer.stage("/selected/notes.txt");
+    const before = composer.snapshot();
+    const publicationsBeforeRemoval = publications;
+    await expect(
+      composer.remove(resourceId, async () => {
+        throw new Error("simulated manifest failure");
+      }),
+    ).rejects.toThrow("simulated manifest failure");
+    expect(composer.snapshot()).toEqual(before);
+    expect(publications).toBe(publicationsBeforeRemoval);
+  } finally {
+    await composer.close();
+  }
+});
+
+test("TurnComposer inserts one staged file at an exact text point without flattening the draft", async () => {
+  const stager: TurnComposerResourceStager = {
+    async stage(input) {
+      return {
+        type: "staged_artifact",
+        staged: {
+          stagingId: input.id,
+          id: digest,
+          mediaType: "text/plain; charset=utf-8",
+          byteCount: 5,
+        },
+        displayName: "notes.txt",
+        digest,
+        mediaHint: "text",
+        support: "utf8_text",
+      };
+    },
+    async retain() {},
+    async discard() {},
+    async close() {},
+  };
+  const composer = await createTurnComposer({ onChange() {}, stager });
+
+  try {
+    composer.setText("beforeafter");
+    const before = composer.snapshot();
+    const textElement = before.elements[0];
+    expect(textElement).toMatchObject({ type: "text", text: "beforeafter" });
+    if (textElement?.type !== "text") {
+      throw new Error("Expected one canonical text element before staging.");
+    }
+
+    await composer.stage("/selected/notes.txt", {
+      at: { elementId: textElement.elementId, offset: 6 },
+      baseRevision: before.revision,
+    });
+
+    expect(composer.snapshot()).toMatchObject({
+      elements: [
+        { elementId: textElement.elementId, type: "text", text: "before" },
+        { type: "resource", kind: "file", ordinal: 1 },
+        { type: "text", text: "after" },
+      ],
+      renderedText: "before[File #1]after",
+      resources: [
+        {
+          displayName: "notes.txt",
+          kind: "file",
+          ordinal: 1,
+          state: "ready",
+          token: "[File #1]",
+        },
+      ],
+    });
+  } finally {
+    await composer.close();
+  }
+});
+
+test("TurnComposer removes one atomic resource without renumbering and undo restores its identity", async () => {
+  const stager: TurnComposerResourceStager = {
+    async stage(input) {
+      return {
+        type: "staged_artifact",
+        staged: {
+          stagingId: input.id,
+          id: digest,
+          mediaType: "text/plain; charset=utf-8",
+          byteCount: 5,
+        },
+        displayName: "notes.txt",
+        digest,
+        mediaHint: "text",
+        support: "utf8_text",
+      };
+    },
+    async retain() {},
+    async discard() {},
+    async close() {},
+  };
+  const composer = await createTurnComposer({ onChange() {}, stager });
+
+  try {
+    const firstId = await composer.stage("/selected/first.txt");
+    await composer.stage("/selected/second.txt");
+
+    await expect(composer.remove(firstId)).resolves.toBe(true);
+    expect(composer.snapshot()).toMatchObject({
+      renderedText: "[File #2]",
+      resources: [{ ordinal: 2, token: "[File #2]" }],
+    });
+
+    const removed = composer.snapshot();
+    await expect(composer.undo(removed.revision)).resolves.toBe(true);
+    expect(composer.snapshot()).toMatchObject({
+      renderedText: "[File #1][File #2]",
+      resources: [
+        { id: firstId, ordinal: 1, token: "[File #1]" },
+        { ordinal: 2, token: "[File #2]" },
+      ],
+    });
+  } finally {
+    await composer.close();
+  }
+});
+
+test("TurnComposer reserves cancellation for unsettled resource staging", async () => {
+  const stager: TurnComposerResourceStager = {
+    async stage(input) {
+      return {
+        type: "staged_artifact",
+        staged: {
+          stagingId: input.id,
+          id: digest,
+          mediaType: "text/plain; charset=utf-8",
+          byteCount: 5,
+        },
+        displayName: "notes.txt",
+        digest,
+        mediaHint: "text",
+        support: "utf8_text",
+      };
+    },
+    async retain() {},
+    async discard() {},
+    async close() {},
+  };
+  const composer = await createTurnComposer({ onChange() {}, stager });
+
+  try {
+    const resourceId = await composer.stage("/selected/notes.txt");
+    await expect(composer.cancel(resourceId)).resolves.toBe(false);
+    expect(composer.snapshot().resources).toMatchObject([{ id: resourceId, state: "ready" }]);
+  } finally {
+    await composer.close();
+  }
+});
+
+test("TurnComposer never reuses an ordinal until the draft is explicitly cleared", async () => {
+  const stager: TurnComposerResourceStager = {
+    async stage(input) {
+      return {
+        type: "staged_artifact",
+        staged: {
+          stagingId: input.id,
+          id: digest,
+          mediaType: "text/plain; charset=utf-8",
+          byteCount: 5,
+        },
+        displayName: "notes.txt",
+        digest,
+        mediaHint: "text",
+        support: "utf8_text",
+      };
+    },
+    async retain() {},
+    async discard() {},
+    async close() {},
+  };
+  const composer = await createTurnComposer({ onChange() {}, stager });
+
+  try {
+    const firstId = await composer.stage("/selected/first.txt");
+    await composer.stage("/selected/second.txt");
+    await composer.remove(firstId);
+    await composer.stage("/selected/third.txt");
+    expect(composer.snapshot()).toMatchObject({
+      renderedText: "[File #2][File #3]",
+      resources: [{ ordinal: 2 }, { ordinal: 3 }],
+    });
+
+    await composer.clear();
+    await composer.stage("/selected/fresh.txt");
+    expect(composer.snapshot()).toMatchObject({
+      renderedText: "[File #1]",
+      resources: [{ ordinal: 1 }],
+    });
+  } finally {
+    await composer.close();
+  }
+});
+
+test("TurnComposer edits one text span without changing an adjacent resource identity", async () => {
+  const stager: TurnComposerResourceStager = {
+    async stage(input) {
+      return {
+        type: "staged_artifact",
+        staged: {
+          stagingId: input.id,
+          id: digest,
+          mediaType: "text/plain; charset=utf-8",
+          byteCount: 5,
+        },
+        displayName: "notes.txt",
+        digest,
+        mediaHint: "text",
+        support: "utf8_text",
+      };
+    },
+    async retain() {},
+    async discard() {},
+    async close() {},
+  };
+  const composer = await createTurnComposer({ onChange() {}, stager });
+
+  try {
+    composer.setText("beforeafter");
+    const initial = composer.snapshot();
+    const initialText = initial.elements[0];
+    if (initialText?.type !== "text") {
+      throw new Error("Expected one canonical text element before staging.");
+    }
+    await composer.stage("/selected/notes.txt", {
+      at: { elementId: initialText.elementId, offset: 6 },
+      baseRevision: initial.revision,
+    });
+    const staged = composer.snapshot();
+    const resource = staged.elements[1];
+    const trailingText = staged.elements[2];
+    if (resource?.type !== "resource" || trailingText?.type !== "text") {
+      throw new Error("Expected text, resource, text after staging.");
+    }
+
+    await expect(
+      composer.replaceText({
+        baseRevision: staged.revision,
+        document: [
+          { type: "text", text: "before" },
+          { type: "resource", elementId: resource.elementId },
+          { type: "text", text: "new after" },
+        ],
+      }),
+    ).resolves.toBe(true);
+    expect(composer.snapshot()).toMatchObject({
+      elements: [
+        { type: "text", text: "before" },
+        { elementId: resource.elementId, type: "resource", resourceId: resource.resourceId },
+        { elementId: trailingText.elementId, type: "text", text: "new after" },
+      ],
+      renderedText: "before[File #1]new after",
+    });
+  } finally {
+    await composer.close();
+  }
+});
+
+test("TurnComposer bounds structured undo history without losing the newest edits", async () => {
+  const stager: TurnComposerResourceStager = {
+    async stage(input) {
+      return {
+        type: "staged_artifact",
+        staged: {
+          stagingId: input.id,
+          id: digest,
+          mediaType: "text/plain; charset=utf-8",
+          byteCount: 5,
+        },
+        displayName: "notes.txt",
+        digest,
+        mediaHint: "text",
+        support: "utf8_text",
+      };
+    },
+    async retain() {},
+    async discard() {},
+    async close() {},
+  };
+  const composer = await createTurnComposer({ onChange() {}, stager });
+
+  try {
+    await composer.stage("/selected/notes.txt");
+    const resource = composer.snapshot().elements[0];
+    if (resource?.type !== "resource") {
+      throw new Error("Expected one canonical resource element.");
+    }
+    for (let edit = 1; edit <= 101; edit += 1) {
+      const snapshot = composer.snapshot();
+      await expect(
+        composer.replaceText({
+          baseRevision: snapshot.revision,
+          document: [
+            { type: "resource", elementId: resource.elementId },
+            { type: "text", text: `edit-${edit}` },
+          ],
+        }),
+      ).resolves.toBe(true);
+    }
+    for (let undo = 0; undo < 100; undo += 1) {
+      await expect(composer.undo(composer.snapshot().revision)).resolves.toBe(true);
+    }
+    expect(composer.snapshot().renderedText).toBe("[File #1]edit-1");
+    await expect(composer.undo(composer.snapshot().revision)).resolves.toBe(false);
+  } finally {
+    await composer.close();
+  }
+});
+
+test("TurnComposer seals the exact ordered draft without turning resource tokens into text authority", async () => {
+  const stager: TurnComposerResourceStager = {
+    async stage(input) {
+      return {
+        type: "staged_artifact",
+        staged: {
+          stagingId: input.id,
+          id: digest,
+          mediaType: "text/plain; charset=utf-8",
+          byteCount: 5,
+        },
+        displayName: "notes.txt",
+        digest,
+        mediaHint: "text",
+        support: "utf8_text",
+      };
+    },
+    async retain() {},
+    async discard() {},
+    async close() {},
+  };
+  const composer = await createTurnComposer({ onChange() {}, stager });
+
+  try {
+    composer.setText("beforeafter");
+    const initial = composer.snapshot();
+    const initialText = initial.elements[0];
+    if (initialText?.type !== "text") {
+      throw new Error("Expected one canonical text element before staging.");
+    }
+    await composer.stage("/selected/notes.txt", {
+      at: { elementId: initialText.elementId, offset: 6 },
+      baseRevision: initial.revision,
+    });
+
+    const sealed = await composer.seal(new AbortController().signal);
+    expect(sealed).toMatchObject({
+      renderedText: "before[File #1]after",
+      elements: [
+        { type: "text", text: "before" },
+        {
+          type: "resource",
+          kind: "file",
+          ordinal: 1,
+          token: "[File #1]",
+          selection: { displayName: "notes.txt", support: "utf8_text" },
+        },
+        { type: "text", text: "after" },
+      ],
+    });
+  } finally {
+    await composer.close();
+  }
+});
+
+test("TurnComposer captures and restores one recoverable ordered draft through retained artifacts", async () => {
+  const retained: string[] = [];
+  const stager: TurnComposerResourceStager = {
+    async stage(input) {
+      return {
+        type: "staged_artifact",
+        staged: {
+          stagingId: input.id,
+          id: digest,
+          mediaType: "text/plain; charset=utf-8",
+          byteCount: 5,
+        },
+        displayName: "notes.txt",
+        digest,
+        mediaHint: "text",
+        support: "utf8_text",
+      };
+    },
+    async retain(input) {
+      retained.push(input.resourceId);
+    },
+    async discard() {},
+    async close() {},
+  };
+  const composer = await createTurnComposer({ onChange() {}, stager });
+  const recovered = await createTurnComposer({ onChange() {}, stager });
+
+  try {
+    composer.setText("beforeafter");
+    const initial = composer.snapshot();
+    const initialText = initial.elements[0];
+    if (initialText?.type !== "text") {
+      throw new Error("Expected one canonical text element before staging.");
+    }
+    await composer.stage("/selected/notes.txt", {
+      at: { elementId: initialText.elementId, offset: 6 },
+      baseRevision: initial.revision,
+    });
+
+    const draft = await composer.captureDraft({
+      type: "new_session",
+      targetId: "deepseek-v4-flash.direct",
+    });
+    expect(retained).toHaveLength(1);
+    await recovered.restoreDraft(draft);
+    expect(recovered.snapshot()).toMatchObject({
+      elements: [
+        { type: "text", text: "before" },
+        { type: "resource", ordinal: 1 },
+        { type: "text", text: "after" },
+      ],
+      renderedText: "before[File #1]after",
+      resources: [{ displayName: "notes.txt", ordinal: 1, state: "ready" }],
+    });
+  } finally {
+    await recovered.close();
+    await composer.close();
+  }
+});

--- a/packages/agent/src/turn-composer.ts
+++ b/packages/agent/src/turn-composer.ts
@@ -6,6 +6,8 @@ import {
   type StagedInputResourceSelectionV1,
   safeInputResourceDisplayNameV1,
 } from "./input-resources.js";
+import type { RecoverableTurnDraftV1 } from "./recoverable-turn-draft.js";
+import type { StagedUserContentElementV1 } from "./structured-user-content.js";
 
 export {
   type TurnComposerStageBarrier,
@@ -14,22 +16,59 @@ export {
 
 export type TurnComposerResourceSnapshot = {
   readonly id: string;
+  readonly elementId: string;
   readonly displayName: string;
   readonly state: "queued" | "copying" | "ready" | "failed" | "cancelled" | "removed";
   readonly byteCount: number | null;
+  readonly kind: "file" | "image";
+  readonly mediaHint: "binary" | "image" | "text" | null;
+  readonly ordinal: number;
+  readonly origin: "selected_file";
   readonly support: InputResourceOccurrenceV1["support"] | null;
+  readonly token: string;
   readonly diagnostic: string | null;
 };
 
+export type TurnComposerDraftPoint =
+  | { readonly edge: "start" | "end" }
+  | { readonly elementId: string; readonly edge: "before" | "after" }
+  | { readonly elementId: string; readonly offset: number };
+
+export type TurnComposerElementSnapshot =
+  | { readonly elementId: string; readonly type: "text"; readonly text: string }
+  | {
+      readonly elementId: string;
+      readonly type: "resource";
+      readonly kind: "file" | "image";
+      readonly ordinal: number;
+      readonly resourceId: string;
+    };
+
+export type TurnComposerSealedElement =
+  | { readonly type: "text"; readonly text: string }
+  | {
+      readonly type: "resource";
+      readonly kind: "file" | "image";
+      readonly ordinal: number;
+      readonly token: string;
+      readonly selection: StagedInputResourceSelectionV1;
+    };
+
 type TurnComposerResource = {
   readonly id: string;
+  readonly elementId: string;
   displayName: string;
   state: TurnComposerResourceSnapshot["state"];
   byteCount: number | null;
+  kind: "file" | "image";
+  mediaHint: "binary" | "image" | "text" | null;
+  readonly ordinal: number;
+  readonly origin: "selected_file";
   support: InputResourceOccurrenceV1["support"] | null;
   diagnostic: string | null;
   readonly controller: AbortController;
   staged: StagedInputResourceSelectionV1 | null;
+  retained: boolean;
   settlement: Promise<void> | null;
 };
 
@@ -44,18 +83,43 @@ export class TurnComposerError extends Error {
 }
 
 export type TurnComposer = {
-  stage(path: string): Promise<string>;
+  stage(
+    path: string,
+    mutation?: { readonly at: TurnComposerDraftPoint; readonly baseRevision: number },
+    commit?: () => Promise<void>,
+  ): Promise<string>;
+  replaceText(
+    input: {
+      readonly baseRevision: number;
+      readonly document: readonly (
+        | { readonly type: "text"; readonly text: string }
+        | { readonly type: "resource"; readonly elementId: string }
+      )[];
+    },
+    commit?: () => Promise<void>,
+  ): Promise<boolean>;
+  captureDraft(scope: RecoverableTurnDraftV1["scope"]): Promise<RecoverableTurnDraftV1>;
+  restoreDraft(draft: RecoverableTurnDraftV1): Promise<void>;
+  undo(baseRevision: number, commit?: () => Promise<void>): Promise<boolean>;
   cancel(id: string): Promise<boolean>;
-  remove(id: string): Promise<boolean>;
+  remove(id: string, commit?: () => Promise<void>): Promise<boolean>;
   setText(text: string): void;
+  commitText(text: string, commit: () => Promise<void>): Promise<void>;
   seal(signal: AbortSignal): Promise<{
+    readonly elements: readonly TurnComposerSealedElement[];
+    readonly renderedText: string;
+    readonly structuredContent: readonly StagedUserContentElementV1[];
     readonly text: string;
     readonly selections: readonly StagedInputResourceSelectionV1[];
   }>;
   unseal(): void;
-  clear(): Promise<void>;
+  reset(baseRevision: number, commit: () => Promise<void>): Promise<boolean>;
+  clear(options?: { readonly preserveRetained?: boolean }): Promise<void>;
   close(): Promise<void>;
   snapshot(): {
+    readonly elements: readonly TurnComposerElementSnapshot[];
+    readonly renderedText: string;
+    readonly revision: number;
     readonly sealed: boolean;
     readonly resources: readonly TurnComposerResourceSnapshot[];
   };
@@ -66,6 +130,19 @@ export async function createTurnComposer(options: {
   readonly stager: TurnComposerResourceStager;
 }): Promise<TurnComposer> {
   const resources = new Map<string, TurnComposerResource>();
+  let elements: TurnComposerElementSnapshot[] = [];
+  let nextOrdinal = 1;
+  let revision = 0;
+  const undoStack: Array<{
+    readonly previousElements: readonly TurnComposerElementSnapshot[];
+    readonly restoredResourceId?: string;
+  }> = [];
+  const pushUndo = (entry: (typeof undoStack)[number]): void => {
+    if (undoStack.length >= 100) {
+      undoStack.splice(0, undoStack.length - 99);
+    }
+    undoStack.push(entry);
+  };
   let text = "";
   let sealed = false;
   let closed = false;
@@ -84,17 +161,351 @@ export async function createTurnComposer(options: {
     }
   };
 
+  const resourceToken = (kind: "file" | "image", ordinal: number): string =>
+    `[${kind === "image" ? "Image" : "File"} #${ordinal}]`;
+
+  const renderedText = (): string =>
+    elements
+      .map((element) =>
+        element.type === "text" ? element.text : resourceToken(element.kind, element.ordinal),
+      )
+      .join("");
+
+  const literalText = (): string =>
+    elements.flatMap((element) => (element.type === "text" ? [element.text] : [])).join("");
+
+  const resolvePoint = (
+    point: TurnComposerDraftPoint,
+  ): { readonly index: number; readonly offset: number } | undefined => {
+    if ("elementId" in point && "edge" in point) {
+      const index = elements.findIndex((element) => element.elementId === point.elementId);
+      if (index < 0 || elements[index]?.type !== "resource") {
+        return undefined;
+      }
+      return { index: point.edge === "before" ? index : index + 1, offset: 0 };
+    }
+    if ("edge" in point) {
+      if (point.edge === "start") {
+        return { index: 0, offset: 0 };
+      }
+      const last = elements.at(-1);
+      return last?.type === "text"
+        ? { index: elements.length - 1, offset: last.text.length }
+        : { index: elements.length, offset: 0 };
+    }
+    const index = elements.findIndex((element) => element.elementId === point.elementId);
+    const element = elements[index];
+    if (
+      index < 0 ||
+      element?.type !== "text" ||
+      !Number.isSafeInteger(point.offset) ||
+      point.offset < 0 ||
+      point.offset > element.text.length
+    ) {
+      return undefined;
+    }
+    return { index, offset: point.offset };
+  };
+
+  const normalizeTextElements = (
+    source: readonly TurnComposerElementSnapshot[],
+  ): TurnComposerElementSnapshot[] => {
+    const normalized: TurnComposerElementSnapshot[] = [];
+    for (const element of source) {
+      if (element.type !== "text") {
+        normalized.push(element);
+        continue;
+      }
+      if (element.text.length === 0) {
+        continue;
+      }
+      const previous = normalized.at(-1);
+      if (previous?.type === "text") {
+        normalized[normalized.length - 1] = {
+          ...previous,
+          text: `${previous.text}${element.text}`,
+        };
+      } else {
+        normalized.push(element);
+      }
+    }
+    return normalized;
+  };
+
+  const replaceAggregateText = (nextText: string): void => {
+    const textElements = elements.flatMap((element, index) =>
+      element.type === "text" ? [{ element, index }] : [],
+    );
+    if (!elements.some((element) => element.type === "resource")) {
+      elements =
+        nextText.length === 0 ? [] : [{ elementId: randomUUID(), type: "text", text: nextText }];
+      return;
+    }
+    if (textElements.length === 0) {
+      if (nextText.length > 0) {
+        elements = [...elements, { elementId: randomUUID(), type: "text", text: nextText }];
+      }
+      return;
+    }
+    if (textElements.length !== 1) {
+      throw new TypeError(
+        "A mixed structured draft must be changed through an exact text element edit.",
+      );
+    }
+    const textEntry = textElements[0];
+    if (textEntry === undefined) {
+      throw new TypeError("The structured draft text element is unavailable.");
+    }
+    const { element, index } = textEntry;
+    elements =
+      nextText.length === 0
+        ? [...elements.slice(0, index), ...elements.slice(index + 1)]
+        : elements.map((candidate, candidateIndex) =>
+            candidateIndex === index ? { ...element, text: nextText } : candidate,
+          );
+  };
+
+  const insertResource = (
+    element: Extract<TurnComposerElementSnapshot, { readonly type: "resource" }>,
+    mutation: { readonly at: TurnComposerDraftPoint; readonly baseRevision: number } | undefined,
+  ): void => {
+    if (mutation === undefined) {
+      elements = [...elements, element];
+      return;
+    }
+    if (mutation.baseRevision !== revision) {
+      throw new TypeError("The turn composer draft point is stale.");
+    }
+    const point = resolvePoint(mutation.at);
+    if (point === undefined) {
+      throw new TypeError("The turn composer draft point is invalid.");
+    }
+    const current = elements[point.index];
+    if (current?.type !== "text") {
+      elements = [...elements.slice(0, point.index), element, ...elements.slice(point.index)];
+      return;
+    }
+    const before = current.text.slice(0, point.offset);
+    const after = current.text.slice(point.offset);
+    elements = [
+      ...elements.slice(0, point.index),
+      ...(before.length === 0 ? [] : [{ ...current, text: before }]),
+      element,
+      ...(after.length === 0
+        ? []
+        : [{ elementId: randomUUID(), type: "text" as const, text: after }]),
+      ...elements.slice(point.index + 1),
+    ];
+  };
+
+  const removeResourceElement = (
+    id: string,
+  ):
+    | {
+        readonly element: Extract<TurnComposerElementSnapshot, { readonly type: "resource" }>;
+        readonly previousElements: readonly TurnComposerElementSnapshot[];
+      }
+    | undefined => {
+    const previousElements = elements;
+    const index = previousElements.findIndex(
+      (element) => element.type === "resource" && element.resourceId === id,
+    );
+    const element = previousElements[index];
+    if (index < 0 || element?.type !== "resource") {
+      return undefined;
+    }
+    elements = normalizeTextElements([
+      ...previousElements.slice(0, index),
+      ...previousElements.slice(index + 1),
+    ]);
+    revision += 1;
+    return { element, previousElements };
+  };
+
   return {
+    async captureDraft(scope) {
+      const orderedResources = elements.flatMap((element) => {
+        if (element.type !== "resource") {
+          return [];
+        }
+        const resource = resources.get(element.resourceId);
+        return resource === undefined ? [] : [resource];
+      });
+      if (
+        orderedResources.some(
+          (resource) => resource.state !== "ready" && resource.state !== "failed",
+        )
+      ) {
+        throw new TurnComposerError(
+          "failed",
+          "Only settled input resources can enter a recoverable draft.",
+        );
+      }
+      for (const resource of orderedResources) {
+        if (resource.state === "ready" && resource.staged !== null && !resource.retained) {
+          await options.stager.retain({ resourceId: resource.id, selection: resource.staged });
+          resource.retained = true;
+        }
+      }
+      return {
+        schemaVersion: 1,
+        scope,
+        nextOrdinal,
+        elements: elements.map((element) => ({ ...element })),
+        resources: orderedResources.map((resource) => ({
+          id: resource.id,
+          elementId: resource.elementId,
+          displayName: resource.displayName,
+          kind: resource.kind,
+          ordinal: resource.ordinal,
+          state: resource.state as "failed" | "ready",
+          byteCount: resource.byteCount,
+          mediaHint: resource.mediaHint,
+          support: resource.support,
+          diagnostic: resource.diagnostic,
+          ...(resource.staged === null ? {} : { selection: resource.staged }),
+        })),
+      };
+    },
+    async restoreDraft(draft) {
+      if (closed || sealed || elements.length > 0 || resources.size > 0) {
+        throw new TypeError("The turn composer cannot replace a nonempty draft.");
+      }
+      const recoveredResources = new Map(
+        draft.resources.map((resource) => [resource.id, resource]),
+      );
+      if (
+        draft.elements.some(
+          (element) => element.type === "resource" && !recoveredResources.has(element.resourceId),
+        )
+      ) {
+        throw new TypeError("The recoverable turn draft is incomplete.");
+      }
+      elements = draft.elements.map((element) => ({ ...element }));
+      nextOrdinal = draft.nextOrdinal;
+      text = elements
+        .flatMap((element) => (element.type === "text" ? [element.text] : []))
+        .join("");
+      for (const recovered of draft.resources) {
+        resources.set(recovered.id, {
+          id: recovered.id,
+          elementId: recovered.elementId,
+          displayName: recovered.displayName,
+          state: recovered.state,
+          byteCount: recovered.byteCount,
+          kind: recovered.kind,
+          mediaHint: recovered.mediaHint,
+          ordinal: recovered.ordinal,
+          origin: "selected_file",
+          support: recovered.support,
+          diagnostic: recovered.diagnostic,
+          controller: new AbortController(),
+          staged: recovered.selection ?? null,
+          retained: recovered.selection !== undefined,
+          settlement: Promise.resolve(),
+        });
+      }
+      revision += 1;
+      publish();
+    },
+    async replaceText(input, commit) {
+      if (
+        closed ||
+        sealed ||
+        input.baseRevision !== revision ||
+        input.document.length > inputResourceLimitsV1.maximumOccurrencesPerRun * 2 + 1
+      ) {
+        return false;
+      }
+      const currentResources = elements.filter(
+        (element): element is Extract<TurnComposerElementSnapshot, { readonly type: "resource" }> =>
+          element.type === "resource",
+      );
+      const projectedResourceIds = input.document.flatMap((part) =>
+        part.type === "resource" ? [part.elementId] : [],
+      );
+      if (
+        projectedResourceIds.length !== currentResources.length ||
+        projectedResourceIds.some(
+          (elementId, index) => currentResources[index]?.elementId !== elementId,
+        )
+      ) {
+        return false;
+      }
+      const currentTextIdByGap = new Map<number, string>();
+      let gap = 0;
+      for (const element of elements) {
+        if (element.type === "resource") {
+          gap += 1;
+        } else if (!currentTextIdByGap.has(gap)) {
+          currentTextIdByGap.set(gap, element.elementId);
+        }
+      }
+      const resourcesByElementId = new Map(
+        currentResources.map((resource) => [resource.elementId, resource]),
+      );
+      const nextElements: TurnComposerElementSnapshot[] = [];
+      gap = 0;
+      for (const part of input.document) {
+        if (part.type === "resource") {
+          const resource = resourcesByElementId.get(part.elementId);
+          if (resource === undefined) {
+            return false;
+          }
+          nextElements.push(resource);
+          gap += 1;
+          continue;
+        }
+        if (part.text.length === 0) {
+          continue;
+        }
+        const previous = nextElements.at(-1);
+        if (previous?.type === "text") {
+          nextElements[nextElements.length - 1] = {
+            ...previous,
+            text: `${previous.text}${part.text}`,
+          };
+        } else {
+          nextElements.push({
+            elementId: currentTextIdByGap.get(gap) ?? randomUUID(),
+            type: "text",
+            text: part.text,
+          });
+        }
+      }
+      const nextText = nextElements
+        .flatMap((element) => (element.type === "text" ? [element.text] : []))
+        .join("");
+      if (nextText.length > 512 * 1024) {
+        throw new TypeError("The structured draft text exceeds the C0 limit.");
+      }
+      const previousElements = elements;
+      const previousText = text;
+      const previousRevision = revision;
+      const previousUndoStack = [...undoStack];
+      elements = nextElements;
+      text = nextText;
+      pushUndo({ previousElements });
+      revision += 1;
+      try {
+        await commit?.();
+      } catch (error) {
+        elements = previousElements;
+        text = previousText;
+        revision = previousRevision;
+        undoStack.length = 0;
+        undoStack.push(...previousUndoStack);
+        throw error;
+      }
+      publish();
+      return true;
+    },
     async cancel(id) {
       if (closed || sealed) {
         return false;
       }
       const resource = resources.get(id);
-      if (
-        resource === undefined ||
-        resource.state === "cancelled" ||
-        resource.state === "removed"
-      ) {
+      if (resource === undefined || (resource.state !== "queued" && resource.state !== "copying")) {
         return false;
       }
       resource.state = "cancelled";
@@ -103,26 +514,101 @@ export async function createTurnComposer(options: {
       publish();
       await resource.settlement;
       await discardStaging(resource);
-      return true;
-    },
-    async remove(id) {
-      if (closed || sealed) {
-        return false;
-      }
-      const resource = resources.get(id);
-      if (resource === undefined) {
-        return false;
-      }
-      resource.state = "removed";
-      resource.controller.abort();
-      publish();
-      await resource.settlement;
-      await discardStaging(resource);
+      removeResourceElement(id);
+      text = literalText();
+      undoStack.length = 0;
       resources.delete(id);
       publish();
       return true;
     },
-    async stage(path) {
+    async remove(id, commit) {
+      if (closed || sealed) {
+        return false;
+      }
+      const resource = resources.get(id);
+      if (resource === undefined || resource.state === "removed") {
+        return false;
+      }
+      const previousElements = elements;
+      const previousText = text;
+      const previousRevision = revision;
+      const previousState = resource.state;
+      const previousDiagnostic = resource.diagnostic;
+      const previousUndoStack = [...undoStack];
+      resource.state = "removed";
+      resource.controller.abort();
+      await resource.settlement;
+      const removed = removeResourceElement(id);
+      if (removed !== undefined && resource.staged !== null) {
+        pushUndo({
+          previousElements: removed.previousElements,
+          restoredResourceId: removed.element.resourceId,
+        });
+      }
+      text = literalText();
+      try {
+        await commit?.();
+      } catch (error) {
+        elements = previousElements;
+        text = previousText;
+        revision = previousRevision;
+        resource.state = previousState;
+        resource.diagnostic = previousDiagnostic;
+        undoStack.length = 0;
+        undoStack.push(...previousUndoStack);
+        throw error;
+      }
+      if (removed === undefined || resource.staged === null) {
+        await discardStaging(resource);
+        resources.delete(id);
+      }
+      publish();
+      return true;
+    },
+    async undo(baseRevision, commit) {
+      if (closed || sealed || baseRevision !== revision) {
+        return false;
+      }
+      const entry = undoStack.pop();
+      if (entry === undefined) {
+        return false;
+      }
+      const resource =
+        entry.restoredResourceId === undefined
+          ? undefined
+          : resources.get(entry.restoredResourceId);
+      if (
+        entry.restoredResourceId !== undefined &&
+        (resource?.state !== "removed" || resource.staged === null)
+      ) {
+        undoStack.push(entry);
+        return false;
+      }
+      const previousElements = elements;
+      const previousText = text;
+      const previousRevision = revision;
+      elements = entry.previousElements.map((element) => ({ ...element }));
+      text = literalText();
+      if (resource !== undefined) {
+        resource.state = "ready";
+      }
+      revision += 1;
+      try {
+        await commit?.();
+      } catch (error) {
+        elements = previousElements;
+        text = previousText;
+        revision = previousRevision;
+        if (resource !== undefined) {
+          resource.state = "removed";
+        }
+        undoStack.push(entry);
+        throw error;
+      }
+      publish();
+      return true;
+    },
+    async stage(path, mutation, commit) {
       if (closed || sealed) {
         throw new TypeError("The turn composer is not accepting input resources.");
       }
@@ -133,38 +619,48 @@ export async function createTurnComposer(options: {
         throw new TypeError("The turn composer input-resource count exceeds the v1 run limit.");
       }
       const id = randomUUID();
+      const elementId = randomUUID();
+      const ordinal = nextOrdinal;
+      const previousElements = elements;
+      const previousNextOrdinal = nextOrdinal;
+      const previousRevision = revision;
+      const previousUndoStack = [...undoStack];
       const resource: TurnComposerResource = {
         id,
+        elementId,
         displayName: safeInputResourceDisplayNameV1(path),
         state: "queued",
         byteCount: null,
+        kind: "file",
+        mediaHint: null,
+        ordinal,
+        origin: "selected_file",
         support: null,
         diagnostic: null,
         controller: new AbortController(),
         staged: null,
+        retained: false,
         settlement: null,
       };
+      insertResource(
+        { elementId, type: "resource", kind: "file", ordinal, resourceId: id },
+        mutation,
+      );
+      nextOrdinal += 1;
+      revision += 1;
+      undoStack.length = 0;
       resources.set(id, resource);
       publish();
       resource.state = "copying";
       publish();
       const settlement = (async () => {
+        let staged: StagedInputResourceSelectionV1;
         try {
-          const staged = await options.stager.stage({
+          staged = await options.stager.stage({
             id,
             path,
             signal: resource.controller.signal,
           });
-          if (closed || resource.state === "cancelled" || !resources.has(id)) {
-            await options.stager.discard(staged);
-            return;
-          }
-          resource.displayName = staged.displayName;
-          resource.byteCount = staged.staged.byteCount;
-          resource.support = staged.support;
-          resource.staged = staged;
-          resource.state = "ready";
-          publish();
         } catch (error) {
           if (resource.state === "cancelled" || closed || !resources.has(id)) {
             return;
@@ -172,12 +668,102 @@ export async function createTurnComposer(options: {
           resource.state = "failed";
           resource.diagnostic =
             error instanceof Error ? error.message : "The selected input resource failed.";
+          try {
+            await commit?.();
+          } catch (commitError) {
+            elements = previousElements;
+            nextOrdinal = previousNextOrdinal;
+            revision = previousRevision;
+            undoStack.push(...previousUndoStack);
+            resources.delete(id);
+            publish();
+            throw commitError;
+          }
           publish();
+          return;
         }
+        if (closed || resource.state === "cancelled" || !resources.has(id)) {
+          await options.stager.discard(staged);
+          return;
+        }
+        resource.displayName = staged.displayName;
+        resource.byteCount = staged.staged.byteCount;
+        resource.mediaHint = staged.mediaHint;
+        resource.support = staged.support;
+        resource.kind = staged.support === "image" ? "image" : "file";
+        elements = elements.map((element) =>
+          element.type === "resource" && element.resourceId === id
+            ? { ...element, kind: resource.kind }
+            : element,
+        );
+        resource.staged = staged;
+        resource.state = "ready";
+        try {
+          await commit?.();
+        } catch (error) {
+          elements = previousElements;
+          nextOrdinal = previousNextOrdinal;
+          revision = previousRevision;
+          undoStack.push(...previousUndoStack);
+          resources.delete(id);
+          await discardStaging(resource);
+          publish();
+          throw error;
+        }
+        publish();
       })();
       resource.settlement = settlement;
       await settlement;
       return id;
+    },
+    async reset(baseRevision, commit) {
+      if (
+        closed ||
+        sealed ||
+        baseRevision !== revision ||
+        [...resources.values()].some(
+          (resource) => resource.state === "queued" || resource.state === "copying",
+        )
+      ) {
+        return false;
+      }
+      const previousElements = elements;
+      const previousNextOrdinal = nextOrdinal;
+      const previousRevision = revision;
+      const previousText = text;
+      const previousUndoStack = [...undoStack];
+      const previousResourceStates = new Map(
+        [...resources].map(([id, resource]) => [id, resource.state] as const),
+      );
+      elements = [];
+      nextOrdinal = 1;
+      text = "";
+      undoStack.length = 0;
+      for (const resource of resources.values()) {
+        resource.state = "removed";
+      }
+      revision += 1;
+      try {
+        await commit();
+      } catch (error) {
+        elements = previousElements;
+        nextOrdinal = previousNextOrdinal;
+        revision = previousRevision;
+        text = previousText;
+        undoStack.push(...previousUndoStack);
+        for (const [id, state] of previousResourceStates) {
+          const resource = resources.get(id);
+          if (resource !== undefined) {
+            resource.state = state;
+          }
+        }
+        throw error;
+      }
+      const retained = [...resources.values()];
+      resources.clear();
+      await Promise.allSettled(retained.map(discardStaging));
+      publish();
+      return true;
     },
     async seal(signal) {
       if (closed || sealed) {
@@ -242,12 +828,53 @@ export async function createTurnComposer(options: {
           "Every retained input resource must have supported immutable content.",
         );
       }
+      const resourceById = new Map(retained.map((resource) => [resource.id, resource]));
+      const selectionIndexById = new Map(
+        retained.map((resource, index) => [resource.id, index] as const),
+      );
       return {
+        elements: elements.map((element): TurnComposerSealedElement => {
+          if (element.type === "text") {
+            return { type: "text", text: element.text };
+          }
+          const resource = resourceById.get(element.resourceId);
+          if (resource?.staged === null || resource?.staged === undefined) {
+            throw new TurnComposerError(
+              "failed",
+              "Every retained input resource must be ready before send.",
+            );
+          }
+          return {
+            type: "resource",
+            kind: element.kind,
+            ordinal: element.ordinal,
+            token: resourceToken(element.kind, element.ordinal),
+            selection: resource.staged,
+          };
+        }),
+        renderedText: renderedText(),
+        structuredContent: elements.map((element): StagedUserContentElementV1 => {
+          if (element.type === "text") {
+            return { type: "text", text: element.text };
+          }
+          const selectionIndex = selectionIndexById.get(element.resourceId);
+          if (selectionIndex === undefined) {
+            throw new TurnComposerError(
+              "failed",
+              "Every retained input resource must be ready before send.",
+            );
+          }
+          return {
+            type: "input_resource",
+            selectionIndex,
+            draftOrdinal: element.ordinal,
+          };
+        }),
         text,
         selections: retained.map((resource) => resource.staged as StagedInputResourceSelectionV1),
       };
     },
-    async clear() {
+    async clear(options = {}) {
       const retained = [...resources.values()];
       sealed = false;
       for (const resource of retained) {
@@ -259,9 +886,44 @@ export async function createTurnComposer(options: {
       }
       await Promise.allSettled(retained.map((resource) => resource.settlement));
       resources.clear();
-      await Promise.all(retained.map(discardStaging));
+      await Promise.all(
+        retained.map((resource) =>
+          options.preserveRetained === true && resource.retained
+            ? Promise.resolve()
+            : discardStaging(resource),
+        ),
+      );
       text = "";
+      elements = [];
+      nextOrdinal = 1;
+      undoStack.length = 0;
+      revision += 1;
       publish();
+    },
+    async commitText(nextText, commit) {
+      if (closed || sealed) {
+        throw new TypeError("The sealed turn composer cannot change draft text.");
+      }
+      if (text !== nextText) {
+        const previousText = text;
+        const previousElements = elements;
+        const previousRevision = revision;
+        const previousUndoStack = [...undoStack];
+        text = nextText;
+        replaceAggregateText(nextText);
+        undoStack.length = 0;
+        revision += 1;
+        try {
+          await commit();
+        } catch (error) {
+          text = previousText;
+          elements = previousElements;
+          revision = previousRevision;
+          undoStack.push(...previousUndoStack);
+          throw error;
+        }
+        publish();
+      }
     },
     setText(nextText) {
       if (closed || sealed) {
@@ -269,6 +931,9 @@ export async function createTurnComposer(options: {
       }
       if (text !== nextText) {
         text = nextText;
+        replaceAggregateText(nextText);
+        undoStack.length = 0;
+        revision += 1;
         publish();
       }
     },
@@ -292,10 +957,24 @@ export async function createTurnComposer(options: {
     },
     snapshot() {
       return {
+        elements: elements.map((element) => ({ ...element })),
+        renderedText: renderedText(),
+        revision,
         sealed,
-        resources: [...resources.values()].map(
-          ({ controller: _controller, settlement: _settlement, staged: _staged, ...item }) => item,
-        ),
+        resources: [...resources.values()]
+          .filter((resource) => resource.state !== "removed")
+          .map(
+            ({
+              controller: _controller,
+              retained: _retained,
+              settlement: _settlement,
+              staged: _staged,
+              ...item
+            }) => ({
+              ...item,
+              token: resourceToken(item.kind, item.ordinal),
+            }),
+          ),
       };
     },
   };

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -747,8 +747,29 @@ export type NewSessionDraftDisplay = {
   readonly projectPaths: ProjectPathCatalogDisplay;
 };
 
+export type DraftPoint =
+  | { readonly edge: "start" | "end" }
+  | { readonly elementId: string; readonly edge: "before" | "after" }
+  | { readonly elementId: string; readonly offset: number };
+
+export type DraftTextDocumentPart =
+  | { readonly type: "text"; readonly text: string }
+  | { readonly type: "resource"; readonly elementId: string };
+
 export type TurnComposerDisplay = {
   readonly attachmentAvailable: boolean;
+  readonly draftRevision: number;
+  readonly elements: readonly (
+    | { readonly elementId: string; readonly type: "text"; readonly text: string }
+    | {
+        readonly elementId: string;
+        readonly type: "resource";
+        readonly kind: "file" | "image";
+        readonly ordinal: number;
+        readonly resourceId: string;
+      }
+  )[];
+  readonly renderedText: string;
   readonly unavailableReason: string | null;
   readonly sealed: boolean;
   readonly revisionIntent: {
@@ -760,11 +781,17 @@ export type TurnComposerDisplay = {
   } | null;
   readonly resources: readonly {
     readonly id: string;
+    readonly elementId: string;
     readonly displayName: string;
     readonly state: "queued" | "copying" | "ready" | "failed" | "cancelled" | "removed";
     readonly byteCount: number | null;
+    readonly kind: "file" | "image";
+    readonly mediaHint: "binary" | "image" | "text" | null;
+    readonly ordinal: number;
+    readonly origin: "selected_file";
     readonly support: "image" | "unsupported_binary" | "utf8_text" | null;
     readonly diagnostic: string | null;
+    readonly token: string;
   }[];
 };
 
@@ -1064,6 +1091,28 @@ export type PresentationCommand =
   | {
       readonly type: "stage_input_resource";
       readonly path: string;
+      readonly mutation?: {
+        readonly at: DraftPoint;
+        readonly baseRevision: number;
+      };
+    }
+  | {
+      readonly type: "replace_draft_text";
+      readonly baseRevision: number;
+      readonly document: readonly DraftTextDocumentPart[];
+    }
+  | {
+      readonly type: "remove_draft_element";
+      readonly baseRevision: number;
+      readonly elementId: string;
+    }
+  | {
+      readonly type: "undo_draft";
+      readonly baseRevision: number;
+    }
+  | {
+      readonly type: "clear_draft";
+      readonly baseRevision: number;
     }
   | {
       readonly type: "update_draft_text";

--- a/packages/presentation/src/presentation.test.ts
+++ b/packages/presentation/src/presentation.test.ts
@@ -65,6 +65,9 @@ const emptySnapshot: AuthoritativePresentationSnapshot = {
 
 const emptyComposer = {
   attachmentAvailable: false,
+  draftRevision: 0,
+  elements: [],
+  renderedText: "",
   unavailableReason: "New session required for attachments",
   sealed: false,
   revisionIntent: null,

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -1004,6 +1004,9 @@ test("PresentationSession opens an empty project catalog without creating a sess
       draft: null,
       composer: {
         attachmentAvailable: false,
+        draftRevision: 0,
+        elements: [],
+        renderedText: "",
         unavailableReason: "New session required for attachments",
         sealed: false,
         resources: [],
@@ -1212,6 +1215,16 @@ test("PresentationSession creates Plan revision intent without changing durable 
       planId: submitted.plan.submission.planId,
       contentDigest: submitted.plan.submission.contentDigest,
     });
+    await expect(
+      presentation.dispatch({
+        type: "replace_draft_text",
+        baseRevision: presentation.getState().composer.draftRevision,
+        document: [{ type: "text", text: "Keep the first step and add rollback verification." }],
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    expect(presentation.getState().composer.renderedText).toBe(
+      "Keep the first step and add rollback verification.",
+    );
     await expect(lifecycle.inspect({ sessionId: created.sessionId })).resolves.toEqual(before);
     await expect(
       presentation.dispatch({
@@ -2259,9 +2272,10 @@ test("PresentationSession publishes Reachable after one successful target connec
   };
   const harness = createInMemorySessionLifecycleHarness();
   const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  let presentation: Awaited<ReturnType<typeof createPresentationSession>> | undefined;
 
   try {
-    const presentation = await createPresentationSession({
+    presentation = await createPresentationSession({
       lifecycle,
       modelTargets,
       openProject: true,
@@ -2557,7 +2571,7 @@ test("PresentationSession stages one draft resource before sealing the admitted 
       },
     },
   });
-  const presentation = await createPresentationSession({
+  let presentation = await createPresentationSession({
     lifecycle,
     modelTargets,
     openProject: true,
@@ -2575,7 +2589,20 @@ test("PresentationSession stages one draft resource before sealing the admitted 
 
   try {
     await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
-    const stage = presentation.dispatch({ type: "stage_input_resource", path: selectedPath });
+    await presentation.dispatch({ type: "update_draft_text", text: "beforeafter" });
+    const initialDraft = presentation.getState().composer;
+    const initialText = initialDraft.elements[0];
+    if (initialText?.type !== "text") {
+      throw new Error("Expected one canonical Presentation draft text element.");
+    }
+    const stage = presentation.dispatch({
+      type: "stage_input_resource",
+      path: selectedPath,
+      mutation: {
+        at: { elementId: initialText.elementId, offset: 6 },
+        baseRevision: initialDraft.draftRevision,
+      },
+    });
     await expect(
       Promise.race([
         copying.promise.then(() => "copying" as const),
@@ -2584,9 +2611,23 @@ test("PresentationSession stages one draft resource before sealing the admitted 
     ).resolves.toBe("copying");
     expect(presentation.getState().composer).toMatchObject({
       attachmentAvailable: true,
+      elements: [
+        { elementId: initialText.elementId, type: "text", text: "before" },
+        { type: "resource", kind: "file", ordinal: 1 },
+        { type: "text", text: "after" },
+      ],
+      renderedText: "before[File #1]after",
       sealed: false,
-      resources: [{ displayName: "outside notes.txt", state: "copying" }],
+      resources: [
+        {
+          displayName: "outside notes.txt",
+          ordinal: 1,
+          state: "copying",
+          token: "[File #1]",
+        },
+      ],
     });
+    expect(presentation.getState().composer.resources[0]).not.toHaveProperty("retained");
 
     releaseCopy.resolve();
     await expect(stage).resolves.toMatchObject({ status: "admitted" });
@@ -2607,7 +2648,7 @@ test("PresentationSession stages one draft resource before sealing the admitted 
     await expect(
       presentation.dispatch({
         type: "submit_draft_prompt",
-        text: "Read the linked notes only if needed.",
+        text: "beforeafter",
         skills: [],
         thinkingSelection: null,
       }),
@@ -2617,11 +2658,85 @@ test("PresentationSession stages one draft resource before sealing the admitted 
       expect.arrayContaining([
         expect.objectContaining({
           role: "user",
-          content: expect.stringContaining('"displayName":"outside notes.txt"'),
+          content: expect.stringMatching(
+            /^before\[File #1\]after[\s\S]*"displayName":"outside notes.txt"/u,
+          ),
         }),
       ]),
     );
+    const sessionId = presentation.getState().authoritative.active?.session.id;
+    if (sessionId === undefined) {
+      throw new Error("Expected one admitted session for the structured draft.");
+    }
+    const logicalRun = (await readInMemoryPresentationRecords(harness.sessions)(sessionId)).find(
+      (record) => record.schemaVersion === 3 && record.record.type === "logical_run_started",
+    );
+    expect(logicalRun).toMatchObject({
+      record: {
+        recordVersion: 2,
+        userMessage: "beforeafter",
+        userContent: [
+          { type: "text", text: "before" },
+          { type: "input_resource", occurrenceId: expect.any(String), draftOrdinal: 1 },
+          { type: "text", text: "after" },
+        ],
+      },
+    });
     expect(presentation.getState().composer.resources).toEqual([]);
+    await waitForAssistantMessage(presentation, "Composer fixture answer.");
+    await presentation.close();
+    await lifecycle.continue({
+      sessionId,
+      input: { text: "Continue from the structured history." },
+    });
+    const replayedRequest = requests.findLast((request) =>
+      request.messages.some(
+        (message) =>
+          message.role === "user" &&
+          typeof message.content === "string" &&
+          message.content.includes("Continue from the structured history."),
+      ),
+    );
+    expect(replayedRequest?.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "user",
+          content: expect.stringMatching(
+            /^before\[File #1\]after[\s\S]*"displayName":"outside notes.txt"/u,
+          ),
+        }),
+      ]),
+    );
+    presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      projectLabel: "workspace",
+      sessionId,
+      stateRoot,
+      workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    });
+    expect(presentation.getState().authoritative.active?.transcript.items).toContainEqual(
+      expect.objectContaining({ type: "user_message", text: "before[File #1]after" }),
+    );
+    await presentation.close();
+    presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      openProject: true,
+      projectLabel: "workspace",
+      stateRoot,
+      workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    });
+    await expect(
+      presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId }),
+    ).resolves.toEqual({ status: "admitted", commandId: expect.any(String), resource: null });
+    expect(presentation.getState().composer).toMatchObject({
+      elements: [],
+      renderedText: "",
+      resources: [],
+    });
   } finally {
     releaseCopy.resolve();
     await presentation.close();
@@ -2676,17 +2791,75 @@ test("PresentationSession removes a ready resource before sealing the draft", as
   try {
     await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
     await expect(
-      presentation.dispatch({ type: "stage_input_resource", path: selectedPath }),
+      presentation.dispatch({
+        type: "replace_draft_text",
+        baseRevision: presentation.getState().composer.draftRevision,
+        document: [{ type: "text", text: "draft text" }],
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    await expect(
+      presentation.dispatch({
+        type: "stage_input_resource",
+        path: selectedPath,
+        mutation: {
+          at: { edge: "end" },
+          baseRevision: presentation.getState().composer.draftRevision,
+        },
+      }),
     ).resolves.toMatchObject({ status: "admitted" });
     const resourceId = presentation.getState().composer.resources[0]?.id;
-    if (resourceId === undefined) {
+    const resourceElement = presentation
+      .getState()
+      .composer.elements.find((element) => element.type === "resource");
+    if (resourceId === undefined || resourceElement?.type !== "resource") {
       throw new Error("Expected one ready resource in the composer.");
     }
 
     await expect(
-      presentation.dispatch({ type: "remove_input_resource", resourceId }),
+      presentation.dispatch({
+        type: "remove_draft_element",
+        baseRevision: presentation.getState().composer.draftRevision,
+        elementId: resourceElement.elementId,
+      }),
     ).resolves.toMatchObject({ status: "admitted" });
     expect(presentation.getState().composer.resources).toEqual([]);
+
+    await expect(
+      presentation.dispatch({
+        type: "undo_draft",
+        baseRevision: presentation.getState().composer.draftRevision,
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    expect(presentation.getState().composer).toMatchObject({
+      renderedText: "draft text[File #1]",
+      resources: [{ id: resourceId, ordinal: 1, state: "ready" }],
+    });
+
+    await expect(
+      presentation.dispatch({ type: "remove_input_resource", resourceId }),
+    ).resolves.toMatchObject({ status: "admitted" });
+
+    await expect(
+      presentation.dispatch({
+        type: "clear_draft",
+        baseRevision: presentation.getState().composer.draftRevision,
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    expect(presentation.getState().composer).toMatchObject({
+      elements: [],
+      renderedText: "",
+      resources: [],
+    });
+
+    await expect(
+      presentation.dispatch({ type: "stage_input_resource", path: selectedPath }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    const freshResource = presentation.getState().composer.resources[0];
+    expect(freshResource).toMatchObject({ ordinal: 1, token: "[File #1]" });
+    if (freshResource === undefined) {
+      throw new Error("Expected one fresh resource after clearing the draft.");
+    }
+    await presentation.dispatch({ type: "remove_input_resource", resourceId: freshResource.id });
 
     await presentation.dispatch({
       type: "submit_draft_prompt",
@@ -2753,6 +2926,7 @@ test("PresentationSession cancels a copying resource and excludes it from seal",
     releaseCopy.resolve();
     await expect(cancellation).resolves.toMatchObject({ status: "admitted" });
     await stage;
+    expect(presentation.getState().composer.resources).toEqual([]);
 
     await expect(
       presentation.dispatch({
@@ -3096,7 +3270,7 @@ test("PresentationSession cancels resource staging while a turn is sealing", asy
   }
 });
 
-test("PresentationSession clears staged resources when selecting another session", async () => {
+test("PresentationSession scopes recoverable resources to their selected session", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-select-resource-"));
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
@@ -3134,6 +3308,23 @@ test("PresentationSession clears staged resources when selecting another session
       presentation.dispatch({ type: "select_session", sessionId: second.sessionId }),
     ).resolves.toMatchObject({ status: "admitted" });
     expect(presentation.getState().composer.resources).toEqual([]);
+
+    await expect(
+      presentation.dispatch({ type: "select_session", sessionId: first.sessionId }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    expect(presentation.getState().composer).toMatchObject({
+      renderedText: "[File #1]",
+      resources: [{ displayName: "session-local-notes.txt", ordinal: 1, state: "ready" }],
+    });
+    await expect(
+      presentation.dispatch({
+        type: "submit_prompt",
+        sessionId: first.sessionId,
+        text: "Use the recovered session-local notes.",
+        skills: [],
+        thinkingSelection: null,
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
   } finally {
     await presentation.close();
     await lifecycle.close();
@@ -3956,9 +4147,10 @@ test("PresentationSession admits the first non-empty draft prompt as one durable
   };
   const harness = createInMemorySessionLifecycleHarness();
   const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  let presentation: Awaited<ReturnType<typeof createPresentationSession>> | undefined;
 
   try {
-    const presentation = await createPresentationSession({
+    presentation = await createPresentationSession({
       lifecycle,
       modelTargets,
       openProject: true,
@@ -3970,7 +4162,7 @@ test("PresentationSession admits the first non-empty draft prompt as one durable
     await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
     const completed = Promise.withResolvers<void>();
     const unsubscribe = presentation.subscribe(() => {
-      const items = presentation.getState().authoritative.active?.transcript.items ?? [];
+      const items = presentation?.getState().authoritative.active?.transcript.items ?? [];
       if (
         items.some((item) => item.type === "assistant_message" && item.text === "Draft admitted.")
       ) {
@@ -4010,7 +4202,22 @@ test("PresentationSession admits the first non-empty draft prompt as one durable
     });
 
     await presentation.close();
+    presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      projectLabel: "workspace",
+      stateRoot,
+      targetIdentity,
+      workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    });
+    expect(presentation.getState().composer).toMatchObject({
+      elements: [],
+      renderedText: "",
+      resources: [],
+    });
   } finally {
+    await presentation?.close();
     await lifecycle.close();
     await rm(testRoot, { recursive: true, force: true });
   }
@@ -4494,7 +4701,7 @@ test("PresentationSession begins a draft only from an exact available launch tar
   }
 });
 
-test("PresentationSession opens an exact target as a process-local draft", async () => {
+test("PresentationSession opens an exact target as a recoverable draft", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-open-"));
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
@@ -4557,6 +4764,9 @@ test("PresentationSession opens an exact target as a process-local draft", async
       },
       composer: {
         attachmentAvailable: true,
+        draftRevision: 0,
+        elements: [],
+        renderedText: "",
         unavailableReason: null,
         sealed: false,
         resources: [],
@@ -4569,6 +4779,131 @@ test("PresentationSession opens an exact target as a process-local draft", async
 
     await presentation.close();
   } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession recovers the default new-session draft after a clean restart", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-draft-recovery-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const selectedPath = join(workspaceRoot, "notes.txt");
+  await writeFile(selectedPath, "notes", "utf8");
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      throw new Error("Draft recovery must not resolve a model driver.");
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  let presentation: Awaited<ReturnType<typeof createProductPresentationSession>> | undefined;
+
+  try {
+    presentation = await createProductPresentationSession({
+      lifecycle,
+      modelTargets,
+      projectLabel: "workspace",
+      stateRoot,
+      targetIdentity,
+      workspaceRoot,
+    });
+    await expect(
+      presentation.dispatch({ type: "update_draft_text", text: "beforeafter" }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    const beforeStage = presentation.getState().composer;
+    const textElement = beforeStage.elements[0];
+    if (textElement?.type !== "text") {
+      throw new Error("Expected one recoverable text element before staging.");
+    }
+    await expect(
+      presentation.dispatch({
+        type: "stage_input_resource",
+        path: selectedPath,
+        mutation: {
+          at: { elementId: textElement.elementId, offset: 6 },
+          baseRevision: beforeStage.draftRevision,
+        },
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    await presentation.close();
+
+    presentation = await createProductPresentationSession({
+      lifecycle,
+      modelTargets,
+      projectLabel: "workspace",
+      stateRoot,
+      targetIdentity,
+      workspaceRoot,
+    });
+    expect(presentation.getState().composer).toMatchObject({
+      elements: [
+        { type: "text", text: "before" },
+        { type: "resource", kind: "file", ordinal: 1 },
+        { type: "text", text: "after" },
+      ],
+      renderedText: "before[File #1]after",
+      resources: [{ displayName: "notes.txt", ordinal: 1, state: "ready" }],
+    });
+    await expect(lifecycle.listProjectSessions()).resolves.toMatchObject({ items: [] });
+  } finally {
+    await presentation?.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession discards an explicit process-only draft on close", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-process-only-draft-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const modelTargets = settledModelTargets("Process-only drafts do not reach the model.");
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  let presentation: Awaited<ReturnType<typeof createPresentationSession>> | undefined;
+
+  try {
+    presentation = await createPresentationSession({
+      draftPersistencePolicy: "process_only",
+      lifecycle,
+      modelTargets,
+      projectLabel: "workspace",
+      stateRoot,
+      targetIdentity,
+      workspaceRoot,
+    });
+    await expect(
+      presentation.dispatch({ type: "update_draft_text", text: "do not recover me" }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    await presentation.close();
+
+    presentation = await createPresentationSession({
+      draftPersistencePolicy: "process_only",
+      lifecycle,
+      modelTargets,
+      projectLabel: "workspace",
+      stateRoot,
+      targetIdentity,
+      workspaceRoot,
+    });
+    expect(presentation.getState().composer).toMatchObject({
+      elements: [],
+      renderedText: "",
+      resources: [],
+    });
+  } finally {
+    await presentation?.close();
     await lifecycle.close();
     await rm(testRoot, { recursive: true, force: true });
   }

--- a/packages/testkit/src/public-product-contract.test.ts
+++ b/packages/testkit/src/public-product-contract.test.ts
@@ -1145,13 +1145,18 @@ test("PresentationSession transcript projection has one package-internal owner",
 
   expect.soft(actualOwners).toEqual(expectedOwners);
   expect.soft(projectionConsumers).toEqual(["presentation-session.ts"]);
-  expect.soft(projectionRuntimeImports).toEqual([]);
   expect
     .soft(projectionTypeImports)
     .toEqual(["./agent-session-contracts.js", "./session-store.js", "@adam-agent/presentation"]);
+  expect.soft(projectionRuntimeImports).toEqual(["./structured-user-content.js"]);
   expect
     .soft(projectionDependencies)
-    .toEqual(["./agent-session-contracts.js", "./session-store.js", "@adam-agent/presentation"]);
+    .toEqual([
+      "./agent-session-contracts.js",
+      "./session-store.js",
+      "./structured-user-content.js",
+      "@adam-agent/presentation",
+    ]);
   const packageInternalSymbols = Object.keys(expectedOwners);
   for (const facadeSource of [publicFacadeSource, testingFacadeSource]) {
     expect

--- a/patches/@earendil-works__pi-tui@0.84.2.patch
+++ b/patches/@earendil-works__pi-tui@0.84.2.patch
@@ -1,3 +1,518 @@
+diff --git a/dist/components/editor.d.ts b/dist/components/editor.d.ts
+index a6fedc9e3b36d066e34860d040db6df47d88c432..fc00b23987ad376bcd60096ceff0e6d329404cd1 100644
+--- a/dist/components/editor.d.ts
++++ b/dist/components/editor.d.ts
+@@ -30,6 +30,37 @@ export interface EditorOptions {
+     paddingX?: number;
+     autocompleteMaxVisible?: number;
+ }
++export type EditorDocumentPart = {
++    readonly type: "text";
++    readonly id: string;
++    readonly text: string;
++} | {
++    readonly type: "atom";
++    readonly id: string;
++    readonly label: string;
++};
++export type EditorDocumentPoint = {
++    readonly partId: string;
++    readonly offset: number;
++} | {
++    readonly partId: string;
++    readonly edge: "before" | "after";
++};
++export type EditorEditIntent = {
++    readonly type: "replace";
++    readonly range: {
++        readonly anchor: EditorDocumentPoint;
++        readonly focus: EditorDocumentPoint;
++    };
++    readonly text: string;
++    readonly document: readonly EditorDocumentPart[];
++} | {
++    readonly type: "remove_atom";
++    readonly atomId: string;
++    readonly direction: "backward" | "forward";
++} | {
++    readonly type: "undo";
++};
+ export declare class Editor implements Component, Focusable {
+     private state;
+     /** Focusable interface - set by TUI when focus changes */
+@@ -68,6 +99,7 @@ export declare class Editor implements Component, Focusable {
+     private undoStack;
+     onSubmit?: (text: string) => void;
+     onChange?: (text: string) => void;
++    onEditIntent?: (intent: EditorEditIntent) => void;
+     disableSubmit: boolean;
+     constructor(tui: TUI, theme: EditorTheme, options?: EditorOptions);
+     /** Set of currently valid paste IDs, for marker-aware segmentation. */
+@@ -107,6 +139,8 @@ export declare class Editor implements Component, Focusable {
+         line: number;
+         col: number;
+     };
++    getDocumentCursor(): EditorDocumentPoint;
++    setDocument(parts: readonly EditorDocumentPart[], cursor?: EditorDocumentPoint): void;
+     setText(text: string): void;
+     /**
+      * Insert text at the current cursor position.
+diff --git a/dist/components/editor.js b/dist/components/editor.js
+index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f5f21f7b6 100644
+--- a/dist/components/editor.js
++++ b/dist/components/editor.js
+@@ -246,6 +246,11 @@ export class Editor {
+     undoStack = new UndoStack();
+     onSubmit;
+     onChange;
++    onEditIntent;
++    structuredDocument = null;
++    structuredAtoms = [];
++    structuredCursorPoint = null;
++    structuredPartCounter = 0;
+     disableSubmit = false;
+     constructor(tui, theme, options = {}) {
+         this.tui = tui;
+@@ -527,6 +532,26 @@ export class Editor {
+             this.undo();
+             return;
+         }
++        if (this.structuredDocument !== null &&
++            (kb.matches(data, "tui.input.tab") ||
++                kb.matches(data, "tui.editor.deleteToLineEnd") ||
++                kb.matches(data, "tui.editor.deleteToLineStart") ||
++                kb.matches(data, "tui.editor.deleteWordBackward") ||
++                kb.matches(data, "tui.editor.deleteWordForward") ||
++                kb.matches(data, "tui.editor.yank") ||
++                kb.matches(data, "tui.editor.yankPop") ||
++                kb.matches(data, "tui.editor.historyPrevious") ||
++                kb.matches(data, "tui.editor.historyNext") ||
++                kb.matches(data, "tui.editor.cursorWordLeft") ||
++                kb.matches(data, "tui.editor.cursorWordRight") ||
++                kb.matches(data, "tui.editor.cursorUp") ||
++                kb.matches(data, "tui.editor.cursorDown") ||
++                kb.matches(data, "tui.editor.pageUp") ||
++                kb.matches(data, "tui.editor.pageDown") ||
++                kb.matches(data, "tui.editor.jumpForward") ||
++                kb.matches(data, "tui.editor.jumpBackward"))) {
++            return;
++        }
+         // Handle autocomplete mode
+         if (this.autocompleteState && this.autocompleteList) {
+             if (kb.matches(data, "tui.select.cancel")) {
+@@ -847,6 +872,256 @@ export class Editor {
+     getCursor() {
+         return { line: this.state.cursorLine, col: this.state.cursorCol };
+     }
++    cursorOffset() {
++        let offset = 0;
++        for (let line = 0; line < this.state.cursorLine; line++) {
++            offset += (this.state.lines[line] || "").length + 1;
++        }
++        return offset + this.state.cursorCol;
++    }
++    setCursorFromOffset(offset) {
++        let remaining = offset;
++        for (let line = 0; line < this.state.lines.length; line++) {
++            const lineLength = (this.state.lines[line] || "").length;
++            if (remaining <= lineLength || line === this.state.lines.length - 1) {
++                this.state.cursorLine = line;
++                this.setCursorCol(Math.max(0, Math.min(remaining, lineLength)));
++                return;
++            }
++            remaining -= lineLength + 1;
++        }
++    }
++    resolveDocumentPoint(point) {
++        let offset = 0;
++        for (const part of this.structuredDocument || []) {
++            const content = part.type === "text" ? part.text : part.label;
++            if (part.id === point.partId) {
++                if (part.type === "text" && "offset" in point &&
++                    Number.isSafeInteger(point.offset) && point.offset >= 0 && point.offset <= content.length) {
++                    return offset + point.offset;
++                }
++                if (part.type === "atom" && "edge" in point) {
++                    return offset + (point.edge === "after" ? content.length : 0);
++                }
++                throw new RangeError("Editor document point does not match its part");
++            }
++            offset += content.length;
++        }
++        throw new RangeError("Editor document point names an unknown part");
++    }
++    documentPointAtOffset(targetOffset) {
++        let offset = 0;
++        for (const part of this.structuredDocument || []) {
++            const content = part.type === "text" ? part.text : part.label;
++            const end = offset + content.length;
++            if (part.type === "atom" && targetOffset === offset) {
++                return { partId: part.id, edge: "before" };
++            }
++            if (part.type === "atom" && targetOffset === end) {
++                return { partId: part.id, edge: "after" };
++            }
++            if (part.type === "text" && targetOffset >= offset && targetOffset <= end) {
++                return { partId: part.id, offset: targetOffset - offset };
++            }
++            offset = end;
++        }
++        throw new RangeError("Editor cursor is outside the structured document");
++    }
++    documentTextPointAtOffset(targetOffset) {
++        let offset = 0;
++        for (const part of this.structuredDocument || []) {
++            const content = part.type === "text" ? part.text : part.label;
++            const end = offset + content.length;
++            if (part.type === "text" && targetOffset >= offset && targetOffset <= end) {
++                return { partId: part.id, offset: targetOffset - offset };
++            }
++            offset = end;
++        }
++        throw new RangeError("Editor text point is outside the structured document");
++    }
++    getDocumentCursor() {
++        if (this.structuredDocument === null) {
++            throw new Error("Editor does not have a structured document");
++        }
++        if (this.structuredCursorPoint !== null &&
++            this.resolveDocumentPoint(this.structuredCursorPoint) === this.cursorOffset()) {
++            return { ...this.structuredCursorPoint };
++        }
++        return this.documentPointAtOffset(this.cursorOffset());
++    }
++    nextStructuredTextId() {
++        const existing = new Set((this.structuredDocument || []).map((part) => part.id));
++        let id;
++        do {
++            id = `pi-editor-text-${++this.structuredPartCounter}`;
++        } while (existing.has(id));
++        return id;
++    }
++    normalizeStructuredParts(parts) {
++        const normalized = [];
++        for (const part of parts) {
++            if (part.type === "text" && part.text.length === 0)
++                continue;
++            const previous = normalized.at(-1);
++            if (part.type === "text" && previous?.type === "text") {
++                normalized[normalized.length - 1] = { ...previous, text: previous.text + part.text };
++            }
++            else {
++                normalized.push({ ...part });
++            }
++        }
++        return normalized;
++    }
++    applyStructuredReplace(range, text) {
++        if (this.structuredDocument === null)
++            throw new Error("Editor does not have a structured document");
++        const parts = this.structuredDocument.map((part) => ({ ...part }));
++        let cursor;
++        if ("offset" in range.anchor && "offset" in range.focus && range.anchor.partId === range.focus.partId) {
++            const index = parts.findIndex((part) => part.id === range.anchor.partId);
++            const part = parts[index];
++            if (part?.type !== "text")
++                throw new RangeError("Editor text replacement names an unavailable text part");
++            const start = Math.min(range.anchor.offset, range.focus.offset);
++            const end = Math.max(range.anchor.offset, range.focus.offset);
++            if (start < 0 || end > part.text.length)
++                throw new RangeError("Editor text replacement is outside its text part");
++            parts[index] = { ...part, text: part.text.slice(0, start) + text + part.text.slice(end) };
++            cursor = { partId: part.id, offset: start + text.length };
++        }
++        else if ("edge" in range.anchor && "edge" in range.focus && range.anchor.partId === range.focus.partId && range.anchor.edge === range.focus.edge) {
++            const atomIndex = parts.findIndex((part) => part.id === range.anchor.partId);
++            if (parts[atomIndex]?.type !== "atom")
++                throw new RangeError("Editor insertion edge names an unavailable atom");
++            const insertIndex = range.anchor.edge === "before" ? atomIndex : atomIndex + 1;
++            const textPart = { type: "text", id: this.nextStructuredTextId(), text };
++            parts.splice(insertIndex, 0, textPart);
++            cursor = { partId: textPart.id, offset: text.length };
++            this.structuredDocument = parts;
++            this.setDocument(this.structuredDocument, cursor);
++            return { cursor, document: this.structuredDocument.map((part) => ({ ...part })) };
++        }
++        else {
++            throw new RangeError("Editor structured replacement must stay within one text part or atom edge");
++        }
++        let normalized = this.normalizeStructuredParts(parts);
++        if (!normalized.some((candidate) => candidate.id === cursor.partId)) {
++            const originalIndex = parts.findIndex((candidate) => candidate.id === cursor.partId);
++            const previous = normalized[originalIndex - 1];
++            const next = normalized[originalIndex];
++            if (previous?.type === "text")
++                cursor = { partId: previous.id, offset: previous.text.length };
++            else if (previous?.type === "atom")
++                cursor = { partId: previous.id, edge: "after" };
++            else if (next?.type === "text")
++                cursor = { partId: next.id, offset: 0 };
++            else if (next?.type === "atom")
++                cursor = { partId: next.id, edge: "before" };
++            else {
++                const empty = { type: "text", id: cursor.partId, text: "" };
++                normalized = [empty];
++                cursor = { partId: empty.id, offset: 0 };
++            }
++        }
++        this.structuredDocument = normalized;
++        this.setDocument(this.structuredDocument, cursor);
++        return { cursor, document: this.structuredDocument.map((part) => ({ ...part })) };
++    }
++    emitInsertionIntent(text) {
++        const point = this.getDocumentCursor();
++        const range = { anchor: point, focus: point };
++        const replacement = this.applyStructuredReplace(range, text);
++        this.onEditIntent?.({
++            type: "replace",
++            range,
++            text,
++            document: replacement.document,
++        });
++    }
++    emitAtomRemovalIntent(atomId, direction) {
++        if (this.structuredDocument === null)
++            throw new Error("Editor does not have a structured document");
++        const parts = this.structuredDocument.map((part) => ({ ...part }));
++        const atomIndex = parts.findIndex((part) => part.type === "atom" && part.id === atomId);
++        if (atomIndex < 0)
++            throw new RangeError("Editor atom removal names an unavailable atom");
++        parts.splice(atomIndex, 1);
++        let previous = parts[atomIndex - 1];
++        let next = parts[atomIndex];
++        if (parts.length === 0) {
++            const empty = { type: "text", id: this.nextStructuredTextId(), text: "" };
++            parts.push(empty);
++            previous = undefined;
++            next = empty;
++        }
++        const cursor = previous?.type === "text"
++            ? { partId: previous.id, offset: previous.text.length }
++            : previous?.type === "atom"
++                ? { partId: previous.id, edge: "after" }
++                : next?.type === "text"
++                    ? { partId: next.id, offset: 0 }
++                    : { partId: next.id, edge: "before" };
++        this.setDocument(parts, cursor);
++        this.onEditIntent?.({ type: "remove_atom", atomId, direction });
++    }
++    emitAdjacentReplaceIntent(direction) {
++        const cursor = this.cursorOffset();
++        const segments = [...graphemeSegmenter.segment(this.getText())];
++        const segment = direction === "backward"
++            ? segments.findLast((candidate) => candidate.index + candidate.segment.length === cursor)
++            : segments.find((candidate) => candidate.index === cursor);
++        if (segment === undefined)
++            return;
++        const range = {
++            anchor: this.documentTextPointAtOffset(segment.index),
++            focus: this.documentTextPointAtOffset(segment.index + segment.segment.length),
++        };
++        const replacement = this.applyStructuredReplace(range, "");
++        this.onEditIntent?.({
++            type: "replace",
++            range,
++            text: "",
++            document: replacement.document,
++        });
++    }
++    setDocument(parts, cursor) {
++        if (parts.length === 0) {
++            throw new TypeError("Editor structured documents require at least one identified part");
++        }
++        const ids = new Set();
++        const atoms = [];
++        let visibleText = "";
++        for (const part of parts) {
++            if (typeof part.id !== "string" || part.id.length === 0 || ids.has(part.id)) {
++                throw new TypeError("Editor document part IDs must be unique non-empty strings");
++            }
++            ids.add(part.id);
++            if (part.type === "text") {
++                visibleText += part.text;
++                continue;
++            }
++            if (part.type !== "atom" || part.label.length === 0 || /[\r\n]/.test(part.label)) {
++                throw new TypeError("Editor atoms require one non-empty visible line");
++            }
++            const start = visibleText.length;
++            visibleText += part.label;
++            atoms.push({ id: part.id, start, end: visibleText.length });
++        }
++        this.cancelAutocomplete();
++        this.lastAction = null;
++        this.exitHistoryBrowsing();
++        this.pastes.clear();
++        this.pasteCounter = 0;
++        this.structuredDocument = parts.map((part) => ({ ...part }));
++        this.structuredAtoms = atoms;
++        this.state.lines = visibleText.split("\n");
++        if (this.state.lines.length === 0)
++            this.state.lines = [""];
++        const cursorOffset = cursor === undefined ? visibleText.length : this.resolveDocumentPoint(cursor);
++        this.setCursorFromOffset(cursorOffset);
++        this.structuredCursorPoint = cursor === undefined ? this.documentPointAtOffset(cursorOffset) : { ...cursor };
++        this.scrollOffset = 0;
++    }
+     setText(text) {
+         this.cancelAutocomplete();
+         this.lastAction = null;
+@@ -858,6 +1133,9 @@ export class Editor {
+         }
+         this.pastes.clear();
+         this.pasteCounter = 0;
++        this.structuredDocument = null;
++        this.structuredAtoms = [];
++        this.structuredCursorPoint = null;
+         this.setTextInternal(normalized);
+     }
+     /**
+@@ -868,6 +1146,10 @@ export class Editor {
+     insertTextAtCursor(text) {
+         if (!text)
+             return;
++        if (this.structuredDocument !== null) {
++            this.emitInsertionIntent(this.normalizeText(text));
++            return;
++        }
+         this.cancelAutocomplete();
+         this.pushUndoSnapshot();
+         this.lastAction = null;
+@@ -890,6 +1172,10 @@ export class Editor {
+     insertTextAtCursorInternal(text) {
+         if (!text)
+             return;
++        if (this.structuredDocument !== null) {
++            this.emitInsertionIntent(this.normalizeText(text));
++            return;
++        }
+         // Normalize line endings and tabs
+         const normalized = this.normalizeText(text);
+         const insertedLines = normalized.split("\n");
+@@ -925,6 +1211,10 @@ export class Editor {
+     // All the editor methods from before...
+     insertCharacter(char, skipUndoCoalescing) {
+         this.exitHistoryBrowsing();
++        if (this.structuredDocument !== null) {
++            this.emitInsertionIntent(char);
++            return;
++        }
+         // Undo coalescing (fish-style):
+         // - Consecutive word chars coalesce into one undo unit
+         // - Space captures state before itself (so undo removes space+following word together)
+@@ -1011,6 +1301,10 @@ export class Editor {
+                 filteredText = ` ${filteredText}`;
+             }
+         }
++        if (this.structuredDocument !== null) {
++            this.emitInsertionIntent(filteredText);
++            return;
++        }
+         // Split into lines to check for large paste
+         const pastedLines = filteredText.split("\n");
+         // Check if this is a large paste (> 10 lines or > 1000 characters)
+@@ -1036,6 +1330,10 @@ export class Editor {
+         this.insertTextAtCursorInternal(filteredText);
+     }
+     addNewLine() {
++        if (this.structuredDocument !== null) {
++            this.emitInsertionIntent("\n");
++            return;
++        }
+         this.cancelAutocomplete();
+         this.exitHistoryBrowsing();
+         this.lastAction = null;
+@@ -1068,6 +1366,11 @@ export class Editor {
+     submitValue() {
+         this.cancelAutocomplete();
+         const result = this.expandPasteMarkers(this.state.lines.join("\n")).trim();
++        if (this.structuredDocument !== null) {
++            if (this.onSubmit)
++                this.onSubmit(result);
++            return;
++        }
+         this.state = { lines: [""], cursorLine: 0, cursorCol: 0 };
+         this.pastes.clear();
+         this.pasteCounter = 0;
+@@ -1083,6 +1386,16 @@ export class Editor {
+     handleBackspace() {
+         this.exitHistoryBrowsing();
+         this.lastAction = null;
++        if (this.structuredDocument !== null) {
++            const atom = this.structuredAtoms.find((candidate) => candidate.end === this.cursorOffset());
++            if (atom !== undefined) {
++                this.emitAtomRemovalIntent(atom.id, "backward");
++            }
++            else {
++                this.emitAdjacentReplaceIntent("backward");
++            }
++            return;
++        }
+         if (this.state.cursorCol > 0) {
+             this.pushUndoSnapshot();
+             // Delete grapheme before cursor (handles emojis, combining characters, etc.)
+@@ -1157,6 +1470,7 @@ export class Editor {
+      */
+     setCursorCol(col) {
+         this.state.cursorCol = col;
++        this.structuredCursorPoint = null;
+         this.preferredVisualCol = null;
+         this.snappedFromCursorCol = null;
+     }
+@@ -1410,6 +1724,16 @@ export class Editor {
+     handleForwardDelete() {
+         this.exitHistoryBrowsing();
+         this.lastAction = null;
++        if (this.structuredDocument !== null) {
++            const atom = this.structuredAtoms.find((candidate) => candidate.start === this.cursorOffset());
++            if (atom !== undefined) {
++                this.emitAtomRemovalIntent(atom.id, "forward");
++            }
++            else {
++                this.emitAdjacentReplaceIntent("forward");
++            }
++            return;
++        }
+         const currentLine = this.state.lines[this.state.cursorLine] || "";
+         if (this.state.cursorCol < currentLine.length) {
+             this.pushUndoSnapshot();
+@@ -1520,6 +1844,12 @@ export class Editor {
+         if (deltaCol !== 0) {
+             const currentLine = this.state.lines[this.state.cursorLine] || "";
+             if (deltaCol > 0) {
++                const atom = this.structuredAtoms.find((candidate) => candidate.start === this.cursorOffset());
++                if (atom !== undefined) {
++                    this.setCursorFromOffset(atom.end);
++                    this.structuredCursorPoint = { partId: atom.id, edge: "after" };
++                    return;
++                }
+                 // Moving right - move by one grapheme (handles emojis, combining characters, etc.)
+                 if (this.state.cursorCol < currentLine.length) {
+                     const afterCursor = currentLine.slice(this.state.cursorCol);
+@@ -1541,6 +1871,12 @@ export class Editor {
+                 }
+             }
+             else {
++                const atom = this.structuredAtoms.find((candidate) => candidate.end === this.cursorOffset());
++                if (atom !== undefined) {
++                    this.setCursorFromOffset(atom.start);
++                    this.structuredCursorPoint = { partId: atom.id, edge: "before" };
++                    return;
++                }
+                 // Moving left - move by one grapheme (handles emojis, combining characters, etc.)
+                 if (this.state.cursorCol > 0) {
+                     const beforeCursor = currentLine.slice(0, this.state.cursorCol);
+@@ -1704,6 +2040,10 @@ export class Editor {
+     }
+     undo() {
+         this.exitHistoryBrowsing();
++        if (this.structuredDocument !== null) {
++            this.onEditIntent?.({ type: "undo" });
++            return;
++        }
+         const snapshot = this.undoStack.pop();
+         if (!snapshot)
+             return;
 diff --git a/dist/components/select-list.js b/dist/components/select-list.js
 index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..0b8964d09635714a7e5872c653883e064f59df14 100644
 --- a/dist/components/select-list.js
@@ -11,8 +526,48 @@ index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..0b8964d09635714a7e5872c653883e06
          const prefixWidth = visibleWidth(prefix);
          if (descriptionSingleLine && width > 40) {
              const effectivePrimaryColumnWidth = Math.max(1, Math.min(primaryColumnWidth, width - prefixWidth - 4));
+diff --git a/dist/editor-component.d.ts b/dist/editor-component.d.ts
+index b598c4d291ace5f04b83161252b3ab8cdd4ccbdf..4e776071dab430ab4dc18c589fd15d22c8858586 100644
+--- a/dist/editor-component.d.ts
++++ b/dist/editor-component.d.ts
+@@ -1,4 +1,5 @@
+ import type { AutocompleteProvider } from "./autocomplete.ts";
++import type { EditorDocumentPart, EditorDocumentPoint, EditorEditIntent } from "./components/editor.ts";
+ import type { Component } from "./tui.ts";
+ /**
+  * Interface for custom editor components.
+@@ -18,10 +19,16 @@ export interface EditorComponent extends Component {
+     onSubmit?: (text: string) => void;
+     /** Called when text changes */
+     onChange?: (text: string) => void;
++    /** Called instead of mutating a host-authoritative structured document. */
++    onEditIntent?: (intent: EditorEditIntent) => void;
+     /** Add text to history for up/down navigation */
+     addToHistory?(text: string): void;
+     /** Insert text at current cursor position */
+     insertTextAtCursor?(text: string): void;
++    /** Reconcile a host-authoritative structured document and optional cursor receipt. */
++    setDocument?(parts: readonly EditorDocumentPart[], cursor?: EditorDocumentPoint): void;
++    /** Return the exact structured cursor point, including shared atom/text edges. */
++    getDocumentCursor?(): EditorDocumentPoint;
+     /**
+      * Get text with any markers expanded (e.g., paste markers).
+      * Falls back to getText() if not implemented.
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index 50b5aeb61f12011642978bc2c31d8a2eb36d17d3..86a7fd77af0a5b812f0cb12cd62508b17b1d06d8 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -2,7 +2,7 @@ export { Marked, type Token, type Tokens } from "marked";
+ export { type AutocompleteItem, type AutocompleteProvider, type AutocompleteSuggestions, CombinedAutocompleteProvider, type SlashCommand, } from "./autocomplete.ts";
+ export { Box } from "./components/box.ts";
+ export { CancellableLoader } from "./components/cancellable-loader.ts";
+-export { Editor, type EditorOptions, type EditorTheme } from "./components/editor.ts";
++export { Editor, type EditorDocumentPart, type EditorDocumentPoint, type EditorEditIntent, type EditorOptions, type EditorTheme } from "./components/editor.ts";
+ export { HStack } from "./components/h-stack.ts";
+ export { Image, type ImageOptions, type ImageTheme } from "./components/image.ts";
+ export { Input } from "./components/input.ts";
 diff --git a/dist/tui-alt-screen.d.ts b/dist/tui-alt-screen.d.ts
-index 848119411c1ff2885b8d1efe97f2f297bd4cd470..9acf1cd67d25554e9e4986f5ac738f2dac1b10ea 100644
+index 848119411c1ff2885b8d1efe97f2f297bd4cd470..c49053c1e2060b5e2ebb11210debde0beb79f127 100644
 --- a/dist/tui-alt-screen.d.ts
 +++ b/dist/tui-alt-screen.d.ts
 @@ -5,6 +5,8 @@ export interface TuiAltScreenOptions {
@@ -33,7 +588,7 @@ index 848119411c1ff2885b8d1efe97f2f297bd4cd470..9acf1cd67d25554e9e4986f5ac738f2d
      private readonly searchCurrentMatchStyle;
      private readonly openUrl?;
 diff --git a/dist/tui-alt-screen.js b/dist/tui-alt-screen.js
-index 4edcf845ba7866782a8ec7219508a2dce0073a91..3aecee4ed79adc5a0586fb6d8a95364e31966f09 100644
+index 4edcf845ba7866782a8ec7219508a2dce0073a91..dfa6559c1ceb9f944cc9095bed75c86823ba67bd 100644
 --- a/dist/tui-alt-screen.js
 +++ b/dist/tui-alt-screen.js
 @@ -59,6 +59,7 @@ export class TuiAltScreen extends TuiBase {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@earendil-works/pi-tui@0.84.2': 18a5c3b8651757b10d3ad14bbe6db95f4506c3974331a7543d4340af77d48999
+  '@earendil-works/pi-tui@0.84.2': 923877ec5b8c46ce6c8d651ac110b49d4560a45868910caf7a24c846a0196595
 
 importers:
 
@@ -52,10 +52,13 @@ importers:
         version: link:../../packages/presentation
       '@earendil-works/pi-tui':
         specifier: 0.84.2
-        version: 0.84.2(patch_hash=18a5c3b8651757b10d3ad14bbe6db95f4506c3974331a7543d4340af77d48999)
+        version: 0.84.2(patch_hash=923877ec5b8c46ce6c8d651ac110b49d4560a45868910caf7a24c846a0196595)
       highlight.js:
         specifier: 11.11.1
         version: 11.11.1
+      p-queue:
+        specifier: 9.3.3
+        version: 9.3.3
 
   packages/agent:
     dependencies:
@@ -685,6 +688,9 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   eventsource-parser@3.1.1:
     resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
     engines: {node: '>=18.0.0'}
@@ -1090,6 +1096,14 @@ packages:
       zod:
         optional: true
 
+  p-queue@9.3.3:
+    resolution: {integrity: sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==}
+    engines: {node: '>=20'}
+
+  p-timeout@7.0.1:
+    resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
+    engines: {node: '>=20'}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
@@ -1404,7 +1418,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.8':
     optional: true
 
-  '@earendil-works/pi-tui@0.84.2(patch_hash=18a5c3b8651757b10d3ad14bbe6db95f4506c3974331a7543d4340af77d48999)':
+  '@earendil-works/pi-tui@0.84.2(patch_hash=923877ec5b8c46ce6c8d651ac110b49d4560a45868910caf7a24c846a0196595)':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5
@@ -1735,6 +1749,8 @@ snapshots:
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
+
+  eventemitter3@5.0.4: {}
 
   eventsource-parser@3.1.1: {}
 
@@ -2119,6 +2135,13 @@ snapshots:
   openai@7.4.0(zod@4.4.3):
     optionalDependencies:
       zod: 4.4.3
+
+  p-queue@9.3.3:
+    dependencies:
+      eventemitter3: 5.0.4
+      p-timeout: 7.0.1
+
+  p-timeout@7.0.1: {}
 
   parse-entities@4.0.2:
     dependencies:


### PR DESCRIPTION
Summary
- make text spans and file references an ordered canonical draft with stable atomic tokens
- persist owner-private project/session drafts and retain existing B11 staged artifacts without a second resource store
- preserve ordered content through durable history, replay, compaction, Presentation, and the production Pi TUI
- serialize TUI draft intents with p-queue and prove graceful SIGTERM/SIGHUP closure

Evidence
- pnpm quality:check: 1571 passed, 18 skipped
- pnpm test:tui:behavior: 213 passed
- pnpm test:tui:os: 28 passed
- focused recoverable draft, retained artifact, structured replay, Pi atom, and session-switch contracts passed