### PR TITLE
C1: promote large pasted text to composer atoms

### DIFF
--- a/apps/tui/src/command-registry.ts
+++ b/apps/tui/src/command-registry.ts
@@ -279,8 +279,8 @@ const builtInCommands: readonly AdamCommandDefinition[] = [
     availability: "always",
     id: "copy",
     name: "copy",
-    summary: "Copy the last assistant response.",
-    usage: "/copy",
+    summary: "Copy the last assistant response or the expanded current draft.",
+    usage: "/copy [draft]",
   },
   {
     aliases: [],

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -1535,7 +1535,7 @@ test("the real terminal delivers Ctrl+C interruption without arming exit", async
     await rm(testRoot, { recursive: true, force: true });
   }
 });
-test("the real terminal preserves one large bracketed multiline paste as editor input", async () => {
+test("the real terminal promotes one large bracketed multiline paste to a Text atom", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-bracketed-paste-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
@@ -1556,11 +1556,13 @@ test("the real terminal preserves one large bracketed multiline paste as editor 
       workspaceRoot,
     });
     await fixture.waitFor("Adam · New session");
+    const beforePaste = fixture.output().length;
     fixture.write(`\u001b[200~${pasted}\u001b[201~`);
-    await fixture.waitFor("[paste #1 +24 lines]");
+    await fixture.waitForCompleteFrameAfter("Pasted text staged.", beforePaste);
+    await fixture.waitForCompleteFrameAfter("[Text #1]", beforePaste);
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe(pasted);
+    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe("[Text #1]");
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -470,7 +470,7 @@ test("Shift+Enter and Ctrl+J preserve one exact multiline draft", async () => {
   }
 });
 
-test("a chunked large bracketed paste remains one exact expandable editor value", async () => {
+test("a chunked large bracketed paste becomes one exact expandable Text atom", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-large-paste-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
@@ -493,7 +493,44 @@ test("a chunked large bracketed paste remains one exact expandable editor value"
     await fixture.waitFor("Adam · New session");
     fixture.write(`\u001b[200~${pasted.slice(0, split)}`);
     fixture.write(`${pasted.slice(split)}\u001b[201~`);
-    await fixture.waitFor("[paste #1 +24 lines]");
+    await fixture.waitFor("Pasted text staged.");
+    await fixture.waitFor("[Text #1]");
+    expect(fixture.screen()?.join("\n") ?? "").toContain("Draft inputs");
+    fixture.write("/copy draft\r");
+    await expect(waitForFileContents(join(controlRoot, "clipboard.txt"), pasted)).resolves.toBe(
+      pasted,
+    );
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe("[Text #1]");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a 1000-scalar paste stays ordinary text even when UTF-16 length is larger", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-scalar-paste-boundary-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+  const pasted = `${"界".repeat(996)}e\u0301👩💻`;
+  expect(Array.from(pasted)).toHaveLength(1_000);
+  expect(pasted.length).toBeGreaterThan(1_000);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      scenario: "clipboard-success",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write(`\u001b[200~${pasted}\u001b[201~`);
+    await fixture.waitFor("é👩💻");
+    expect(fixture.screen()?.join("\n") ?? "").not.toContain("[Text #1]");
+    expect(fixture.screen()?.join("\n") ?? "").not.toContain("[paste #1");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
     await expect(readFile(join(controlRoot, "clipboard.txt"), "utf8")).resolves.toBe(pasted);

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -1,10 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { MessageChannel } from "node:worker_threads";
 
+import { isLargePastedTextV1 } from "@adam-agent/agent";
 import type {
   ActiveSessionDisplay,
   ArtifactReference,
   BranchSourceBoundary,
+  DraftPoint,
   OperationDisplay,
   PresentationSession,
   PresentationTransientState,
@@ -20,6 +22,7 @@ import {
   Container,
   Editor,
   type EditorDocumentPart,
+  type EditorPasteIntent,
   isKeyRelease,
   isKeyRepeat,
   Loader,
@@ -596,6 +599,9 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     if (previousEditor.onEditIntent !== undefined) {
       replacement.onEditIntent = previousEditor.onEditIntent;
     }
+    if (previousEditor.onPaste !== undefined) {
+      replacement.onPaste = previousEditor.onPaste;
+    }
     if (previousEditor.onSubmit !== undefined) {
       replacement.onSubmit = previousEditor.onSubmit;
     }
@@ -623,6 +629,8 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     projectedComposerScope = scope;
     const composerKey = `${scope ?? ""}\0${composer.draftRevision}\0${composer.resources
       .map((resource) => `${resource.id}:${resource.state}:${resource.kind}`)
+      .join("|")}\0${composer.pastedTexts
+      .map((pastedText) => `${pastedText.id}:${pastedText.state}`)
       .join("|")}`;
     if (!scopeChanged && composerKey === projectedComposerKey) {
       return;
@@ -631,11 +639,12 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     if (
       composer.resources.some(
         (resource) => resource.state === "queued" || resource.state === "copying",
-      )
+      ) ||
+      composer.pastedTexts.some((pastedText) => pastedText.state === "copying")
     ) {
       return;
     }
-    if (!composer.elements.some((element) => element.type === "resource")) {
+    if (!composer.elements.some((element) => element.type !== "text")) {
       if (structuredEditorActive && composer.elements.length > 0) {
         editor.setDocument(
           composer.elements.map((element) => ({
@@ -653,15 +662,16 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       }
       return;
     }
-    const parts: readonly EditorDocumentPart[] = composer.elements.map((element) =>
-      element.type === "text"
-        ? { type: "text", id: element.elementId, text: element.text }
-        : {
-            type: "atom",
-            id: element.elementId,
-            label: `[${element.kind === "image" ? "Image" : "File"} #${element.ordinal}]`,
-          },
-    );
+    const parts: readonly EditorDocumentPart[] = composer.elements.map((element) => {
+      if (element.type === "text") {
+        return { type: "text", id: element.elementId, text: element.text };
+      }
+      return {
+        type: "atom",
+        id: element.elementId,
+        label: `[${element.type === "pasted_text" ? "Text" : element.kind === "image" ? "Image" : "File"} #${element.ordinal}]`,
+      };
+    });
     editor.setDocument(parts);
     structuredEditorActive = true;
     localStructuredDocument = parts;
@@ -671,12 +681,42 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     composer: ReturnType<PresentationSession["getState"]>["composer"],
   ): void => {
     draftInputsSlot.clear();
-    if (composer.resources.length === 0) {
+    if (composer.resources.length === 0 && composer.pastedTexts.length === 0) {
       return;
     }
     const resources = new Box(1, 1, theme.toolBackground);
     resources.addChild(new ResponsiveLine(theme.toolTitle("Draft inputs")));
-    for (const resource of composer.resources) {
+    for (const element of composer.elements) {
+      if (element.type === "text") {
+        continue;
+      }
+      if (element.type === "pasted_text") {
+        const pastedText = composer.pastedTexts.find(
+          (candidate) => candidate.elementId === element.elementId,
+        );
+        if (pastedText === undefined) {
+          continue;
+        }
+        resources.addChild(
+          new ResponsiveLine(
+            theme.toolOutput(
+              `${pastedText.token} · Pasted text · ${pastedText.state} · ${pastedText.lineCount} lines · ${pastedText.scalarCount} scalars · ${pastedText.byteCount} bytes`,
+            ),
+          ),
+        );
+        if (pastedText.diagnostic !== null) {
+          resources.addChild(
+            new ResponsiveLine(theme.muted(safeTerminalText(pastedText.diagnostic))),
+          );
+        }
+        continue;
+      }
+      const resource = composer.resources.find(
+        (candidate) => candidate.elementId === element.elementId,
+      );
+      if (resource === undefined) {
+        continue;
+      }
       const size = resource.byteCount === null ? "size pending" : `${resource.byteCount} bytes`;
       const media = resource.mediaHint === null ? "media pending" : resource.mediaHint;
       const support = resource.support === null ? "support pending" : resource.support;
@@ -693,7 +733,11 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         resources.addChild(new ResponsiveLine(theme.muted(safeTerminalText(resource.diagnostic))));
       }
     }
-    resources.addChild(new ResponsiveLine(theme.muted("/detach <index> · /cancelattach <index>")));
+    resources.addChild(
+      new ResponsiveLine(
+        theme.muted("Delete removes the adjacent atom · Undo restores it · /detach for files"),
+      ),
+    );
     draftInputsSlot.addChild(resources);
   };
 
@@ -2243,6 +2287,70 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       pathPicker = { close, hide: () => handle?.hide() };
     }
   };
+  editor.onPaste = (intent: EditorPasteIntent) => {
+    if (!isLargePastedTextV1(intent.text)) {
+      return false;
+    }
+    const visibleTextBeforePaste = editor.getExpandedText();
+    const actionId = showNotice("progress", "Staging pasted text…", "until_replaced");
+    void draftMutationQueue
+      .add(async () => {
+        if (intent.cursor.type === "text") {
+          const persisted = await options.presentation.dispatch({
+            type: "update_draft_text",
+            text: visibleTextBeforePaste,
+          });
+          if (persisted.status === "rejected") {
+            return persisted;
+          }
+        }
+        const composer = options.presentation.getState().composer;
+        let at: DraftPoint;
+        if (intent.cursor.type === "document") {
+          at =
+            "offset" in intent.cursor.point
+              ? {
+                  elementId: intent.cursor.point.partId,
+                  offset: intent.cursor.point.offset,
+                }
+              : {
+                  elementId: intent.cursor.point.partId,
+                  edge: intent.cursor.point.edge,
+                };
+        } else {
+          const textElement = composer.elements.find((element) => element.type === "text");
+          at =
+            textElement === undefined
+              ? { edge: "start" }
+              : {
+                  elementId: textElement.elementId,
+                  offset: Math.min(intent.cursor.offset, textElement.text.length),
+                };
+        }
+        return options.presentation.dispatch({
+          type: "stage_pasted_text",
+          text: intent.text,
+          mutation: { at, baseRevision: composer.draftRevision },
+        });
+      })
+      .then((receipt) => {
+        settleNotice(
+          actionId,
+          receipt?.status === "admitted" ? "success" : "error",
+          receipt?.status === "admitted"
+            ? "Pasted text staged."
+            : (receipt?.message ?? "The pasted text could not be staged."),
+          receipt?.status === "admitted" ? "until_next_action" : "until_edit",
+        );
+        renderState();
+      })
+      .catch(() => {
+        settleNotice(actionId, "error", "The pasted text could not be staged.", "until_edit");
+        renderState();
+      });
+    renderState();
+    return true;
+  };
   editor.onEditIntent = (intent) => {
     if (intent.type === "remove_atom") {
       void draftMutationQueue
@@ -2316,7 +2424,14 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           document: intent.document.map((part) =>
             part.type === "text"
               ? { type: "text", text: part.text }
-              : { type: "resource", elementId: part.id },
+              : {
+                  type:
+                    composer.elements.find((element) => element.elementId === part.id)?.type ===
+                    "pasted_text"
+                      ? ("pasted_text" as const)
+                      : ("resource" as const),
+                  elementId: part.id,
+                },
           ),
         });
       })
@@ -3254,10 +3369,62 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         renderState();
       });
   };
+  const copyExpandedDraft = (sessionId?: string): void => {
+    editor.disableSubmit = false;
+    projectedComposerKey = null;
+    const copyActionId = showNotice(
+      "progress",
+      "Expanding current draft for copy…",
+      "until_replaced",
+      sessionId,
+    );
+    renderState();
+    void options.presentation
+      .dispatch({ type: "read_expanded_draft" })
+      .then(async (receipt) => {
+        if (receipt.status === "rejected" || receipt.draftText === undefined) {
+          return receipt.status === "rejected"
+            ? receipt.message
+            : "The expanded draft is unavailable to copy.";
+        }
+        const copied = await copyTextToClipboard(
+          receipt.draftText,
+          options.clipboard,
+          deadlineScheduler,
+        );
+        return copied === "copied"
+          ? "Copied expanded draft."
+          : copied === "unsupported"
+            ? "Clipboard unavailable; expanded draft was not copied."
+            : "Clipboard copy failed; expanded draft was not copied.";
+      })
+      .then(
+        (message) => {
+          settleNotice(
+            copyActionId,
+            message === "Copied expanded draft." ? "success" : "error",
+            message,
+            message === "Copied expanded draft." ? "until_next_action" : "until_replaced",
+            sessionId,
+          );
+          renderState();
+        },
+        () => {
+          settleNotice(
+            copyActionId,
+            "error",
+            "The expanded draft could not be copied.",
+            "until_replaced",
+            sessionId,
+          );
+          renderState();
+        },
+      );
+  };
   const submitEditorValue = (text: string) => {
     const state = options.presentation.getState();
     const active = state.authoritative.active;
-    if (text.trim().length === 0) {
+    if (text.trim().length === 0 && state.composer.pastedTexts.length === 0) {
       return;
     }
     const earlyParsed = commandRegistry.parse(text);
@@ -3306,6 +3473,14 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       }
       if (parsedDraft.kind === "known" && parsedDraft.command.id === "connection") {
         handleConnectionCommand(parsedDraft.argumentsText, state.draft.targetId);
+        return;
+      }
+      if (
+        parsedDraft.kind === "known" &&
+        parsedDraft.command.id === "copy" &&
+        parsedDraft.argumentsText === "draft"
+      ) {
+        copyExpandedDraft();
         return;
       }
       if (handleAttachmentCommand(parsedDraft)) {
@@ -3686,6 +3861,14 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       );
       editor.disableSubmit = false;
       renderState();
+      return;
+    }
+    if (
+      parsedCommand.kind === "known" &&
+      parsedCommand.command.id === "copy" &&
+      parsedCommand.argumentsText === "draft"
+    ) {
+      copyExpandedDraft(active.session.id);
       return;
     }
     if (

--- a/packages/agent/src/agent-session-contracts.ts
+++ b/packages/agent/src/agent-session-contracts.ts
@@ -2,6 +2,7 @@ import type { ArtifactReference, ChangePreviewArtifactSource } from "./artifact-
 import type { ContextCallUsage } from "./durable-context.js";
 import type { InputResourceOccurrenceV1 } from "./input-resources.js";
 import type { ModelDriverDiagnosticCode, ModelDriverErrorCategory } from "./model-driver-error.js";
+import type { PastedTextOccurrenceV1 } from "./pasted-text.js";
 import type { ApprovedPlanProjectionV1 } from "./plan-mode.js";
 import type { SessionUserContentElementV1 } from "./structured-user-content.js";
 import type { ThinkingPolicySnapshotV1 } from "./thinking-policy.js";
@@ -18,6 +19,8 @@ export type UserInput = {
   readonly skills?: readonly string[];
   readonly inputResources?: readonly InputResourceOccurrenceV1[];
   readonly userContent?: readonly SessionUserContentElementV1[];
+  readonly pastedTexts?: readonly PastedTextOccurrenceV1[];
+  readonly pastedTextContents?: ReadonlyMap<string, string>;
 };
 
 export type RunOptions = {

--- a/packages/agent/src/agent-session.ts
+++ b/packages/agent/src/agent-session.ts
@@ -68,6 +68,11 @@ import {
   projectedContentUsageV1,
 } from "./model-user-content.js";
 import {
+  isLargePastedTextV1,
+  pastedTextMetricsV1,
+  pastedTextOccurrenceV1Schema,
+} from "./pasted-text.js";
+import {
   downgradePlanCommandAssessmentV1,
   type PlanCommandAssessment,
 } from "./plan-command-assessment.js";
@@ -443,6 +448,8 @@ export class AgentSession {
             : createSessionUserContentMessageV1({
                 elements: input.userContent,
                 occurrences: input.inputResources ?? [],
+                pastedTexts: input.pastedTexts ?? [],
+                pastedTextContents: input.pastedTextContents,
                 userMessage: input.text,
               });
         const explicitSkills = (input.skills ?? []).map((selection, index) => ({
@@ -469,11 +476,18 @@ export class AgentSession {
                 ? input.inputResources === undefined || input.inputResources.length === 0
                   ? {}
                   : { recordVersion: 1 as const, inputResources: input.inputResources }
-                : {
-                    recordVersion: 2 as const,
-                    inputResources: input.inputResources ?? [],
-                    userContent: input.userContent,
-                  }),
+                : input.pastedTexts !== undefined && input.pastedTexts.length > 0
+                  ? {
+                      recordVersion: 3 as const,
+                      inputResources: input.inputResources ?? [],
+                      pastedTexts: input.pastedTexts,
+                      userContent: input.userContent,
+                    }
+                  : {
+                      recordVersion: 2 as const,
+                      inputResources: input.inputResources ?? [],
+                      userContent: input.userContent,
+                    }),
               runId: this.#activeRunId,
               userMessage: input.text,
               ...(this.#durableContext.planKickoff === undefined
@@ -4296,7 +4310,8 @@ function findRetainedFromSequence(
       record.type === "logical_run_started" &&
       record.runId === runId &&
       firstRetained.role === "user" &&
-      isDeepStrictEqual(createLogicalRunUserMessageV1(record), firstRetained)
+      (record.recordVersion === 3 ||
+        isDeepStrictEqual(createLogicalRunUserMessageV1(record), firstRetained))
     ) {
       return entry.sequence;
     }
@@ -4662,13 +4677,43 @@ function isStructuredUserContentValid(input: UserInput): boolean {
   if (input.userContent === undefined) {
     return true;
   }
-  if (input.inputResources === undefined || input.inputResources.length === 0) {
+  if (
+    (input.inputResources === undefined || input.inputResources.length === 0) &&
+    (input.pastedTexts === undefined || input.pastedTexts.length === 0)
+  ) {
+    return false;
+  }
+  if (
+    input.pastedTexts !== undefined &&
+    (!Array.isArray(input.pastedTexts) ||
+      input.pastedTexts.length > 8 ||
+      input.pastedTexts.some(
+        (occurrence) => !pastedTextOccurrenceV1Schema.safeParse(occurrence).success,
+      ) ||
+      input.pastedTextContents === undefined ||
+      input.pastedTexts.some((occurrence) => {
+        const text = input.pastedTextContents?.get(occurrence.occurrenceId);
+        if (text === undefined) {
+          return true;
+        }
+        const metrics = pastedTextMetricsV1(text);
+        return (
+          metrics.byteCount !== occurrence.byteCount ||
+          metrics.lineCount !== occurrence.lineCount ||
+          metrics.scalarCount !== occurrence.scalarCount ||
+          `sha256:${createHash("sha256").update(text, "utf8").digest("hex")}` !==
+            occurrence.digest ||
+          !isLargePastedTextV1(text)
+        );
+      }))
+  ) {
     return false;
   }
   try {
     validateSessionUserContentV1({
       elements: input.userContent,
-      occurrences: input.inputResources,
+      occurrences: input.inputResources ?? [],
+      pastedTexts: input.pastedTexts ?? [],
       userMessage: input.text,
     });
     return true;

--- a/packages/agent/src/artifact-store.ts
+++ b/packages/agent/src/artifact-store.ts
@@ -78,6 +78,16 @@ export type InputResourceArtifactSourceV1 = {
   readonly provenance: "user_local_file";
 };
 
+export type PastedTextArtifactSourceV1 = {
+  readonly type: "pasted_text";
+  readonly schemaVersion: 1;
+  readonly projectId: string;
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly occurrenceId: string;
+  readonly provenance: "user_paste";
+};
+
 export type PlanArtifactSourceV1 = {
   readonly type: "plan";
   readonly schemaVersion: 1;
@@ -95,6 +105,7 @@ export type ArtifactSource =
   | InputResourceArtifactSourceV1
   | McpToolResultArtifactSourceV1
   | ModelResponseArtifactSource
+  | PastedTextArtifactSourceV1
   | PlanArtifactSourceV1
   | SkillArtifactSource
   | ToolArtifactSource;
@@ -127,6 +138,7 @@ export type ArtifactStagingStore = {
     readonly bytes: Uint8Array;
     readonly mediaType: string;
   }): Promise<StagedArtifactReference>;
+  read(reference: StagedArtifactReference, maximumBytes: number): Promise<Uint8Array | undefined>;
   retain(reference: StagedArtifactReference): Promise<void>;
   discard(reference: StagedArtifactReference): Promise<void>;
   close(): Promise<void>;
@@ -161,6 +173,46 @@ export async function createFileArtifactStagingStore(options: {
         mediaType: input.mediaType,
         byteCount: bytes.byteLength,
       };
+    },
+    async read(reference, maximumBytes) {
+      requireStagingId(reference.stagingId);
+      if (!Number.isSafeInteger(maximumBytes) || maximumBytes < 0) {
+        throw new TypeError("The provisional artifact read bound is invalid.");
+      }
+      let file: Awaited<ReturnType<typeof open>>;
+      try {
+        file = await open(
+          join(stagingRoot, reference.stagingId),
+          constants.O_RDONLY | constants.O_NOFOLLOW,
+        );
+      } catch (error) {
+        if (isNodeError(error) && error.code === "ENOENT") {
+          return undefined;
+        }
+        throw error;
+      }
+      try {
+        const stats = await file.stat();
+        if (
+          !stats.isFile() ||
+          stats.size !== reference.byteCount ||
+          stats.size > maximumBytes ||
+          (stats.mode & 0o077) !== 0 ||
+          (process.geteuid?.() !== undefined && stats.uid !== process.geteuid())
+        ) {
+          throw new Error("The provisional artifact is unsafe.");
+        }
+        const bytes = await file.readFile();
+        if (
+          bytes.byteLength !== reference.byteCount ||
+          `sha256:${createHash("sha256").update(bytes).digest("hex")}` !== reference.id
+        ) {
+          throw new Error("The provisional artifact does not match its sealed digest.");
+        }
+        return bytes;
+      } finally {
+        await file.close();
+      }
     },
     async discard(reference) {
       requireStagingId(reference.stagingId);

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -115,6 +115,7 @@ export {
   type OperationStore,
   OperationStoreError,
 } from "./operation-store.js";
+export { isLargePastedTextV1, pastedTextLimitsV1 } from "./pasted-text.js";
 export {
   createPresentationPreferences,
   createWorkspaceTrust,

--- a/packages/agent/src/input-resource-staging.ts
+++ b/packages/agent/src/input-resource-staging.ts
@@ -7,6 +7,12 @@ import {
   ingestLocalInputResourcesV1,
   type StagedInputResourceSelectionV1,
 } from "./input-resources.js";
+import {
+  isLargePastedTextV1,
+  pastedTextLimitsV1,
+  pastedTextMetricsV1,
+  type StagedPastedTextSelectionV1,
+} from "./pasted-text.js";
 
 export const turnComposerStageBarrier = Symbol("adam-agent.turn-composer-stage-barrier");
 
@@ -20,11 +26,17 @@ export type TurnComposerResourceStager = {
     readonly path: string;
     readonly signal: AbortSignal;
   }): Promise<StagedInputResourceSelectionV1>;
+  stageText?(input: {
+    readonly id: string;
+    readonly text: string;
+    readonly signal: AbortSignal;
+  }): Promise<StagedPastedTextSelectionV1>;
+  readText?(selection: StagedPastedTextSelectionV1): Promise<string>;
   retain(input: {
     readonly resourceId: string;
-    readonly selection: StagedInputResourceSelectionV1;
+    readonly selection: StagedInputResourceSelectionV1 | StagedPastedTextSelectionV1;
   }): Promise<void>;
-  discard(selection: StagedInputResourceSelectionV1): Promise<void>;
+  discard(selection: StagedInputResourceSelectionV1 | StagedPastedTextSelectionV1): Promise<void>;
   close(): Promise<void>;
 };
 
@@ -79,6 +91,48 @@ export async function createFileTurnComposerResourceStager(options: {
         }
         throw error;
       }
+    },
+    async stageText(input) {
+      input.signal.throwIfAborted();
+      if (!isLargePastedTextV1(input.text)) {
+        throw new TypeError("Only a large normalized paste can become a Text atom.");
+      }
+      const metrics = pastedTextMetricsV1(input.text);
+      if (metrics.byteCount > pastedTextLimitsV1.maximumTextBytesPerTurn) {
+        throw new TypeError("The pasted text exceeds the v1 turn limit.");
+      }
+      const staged = await staging.write({
+        bytes: Buffer.from(input.text, "utf8"),
+        mediaType: "text/plain; charset=utf-8",
+      });
+      input.signal.throwIfAborted();
+      return {
+        type: "staged_pasted_text",
+        staged,
+        digest: staged.id,
+        ...metrics,
+      };
+    },
+    async readText(selection) {
+      const bytes = await staging.read(
+        selection.staged,
+        pastedTextLimitsV1.maximumTextBytesPerTurn,
+      );
+      if (bytes === undefined) {
+        throw new TypeError("The recoverable pasted-text bytes are unavailable.");
+      }
+      const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+      const metrics = pastedTextMetricsV1(text);
+      if (
+        selection.digest !== selection.staged.id ||
+        metrics.byteCount !== selection.byteCount ||
+        metrics.lineCount !== selection.lineCount ||
+        metrics.scalarCount !== selection.scalarCount ||
+        !isLargePastedTextV1(text)
+      ) {
+        throw new TypeError("The recoverable pasted-text bytes are corrupt.");
+      }
+      return text;
     },
     async retain(input) {
       await staging.retain(input.selection.staged);

--- a/packages/agent/src/pasted-text.test.ts
+++ b/packages/agent/src/pasted-text.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "vitest";
+
+import {
+  isLargePastedTextV1,
+  isPastedTextOrphanCleanupEligibleV1,
+  normalizePastedTextV1,
+  pastedTextMetricsV1,
+  pastedTextOrphanRetentionMillisecondsV1,
+} from "./pasted-text.js";
+
+test("pasted-text promotion uses normalized logical-line boundaries", () => {
+  const tenLines = Array.from({ length: 10 }, (_, index) => `line ${index + 1}`).join("\n");
+  const elevenLines = `${tenLines}\nline 11`;
+
+  expect(pastedTextMetricsV1(tenLines).lineCount).toBe(10);
+  expect(isLargePastedTextV1(tenLines)).toBe(false);
+  expect(pastedTextMetricsV1(elevenLines).lineCount).toBe(11);
+  expect(isLargePastedTextV1(elevenLines)).toBe(true);
+});
+
+test("pasted-text normalization freezes CRLF, CR, and tab handling", () => {
+  expect(normalizePastedTextV1("first\r\nsecond\rthird\tfourth")).toBe(
+    "first\nsecond\nthird    fourth",
+  );
+});
+
+test("pasted-text orphan cleanup requires seven days and no canonical draft reference", () => {
+  const now = 1_000_000_000;
+  expect(
+    isPastedTextOrphanCleanupEligibleV1({
+      referenced: true,
+      modifiedAtMilliseconds: now - pastedTextOrphanRetentionMillisecondsV1,
+      nowMilliseconds: now,
+    }),
+  ).toBe(false);
+  expect(
+    isPastedTextOrphanCleanupEligibleV1({
+      referenced: false,
+      modifiedAtMilliseconds: now - pastedTextOrphanRetentionMillisecondsV1 + 1,
+      nowMilliseconds: now,
+    }),
+  ).toBe(false);
+  expect(
+    isPastedTextOrphanCleanupEligibleV1({
+      referenced: false,
+      modifiedAtMilliseconds: now - pastedTextOrphanRetentionMillisecondsV1,
+      nowMilliseconds: now,
+    }),
+  ).toBe(true);
+});
+
+test("pasted-text promotion counts Unicode scalars instead of UTF-16 units or graphemes", () => {
+  const oneThousandScalars = `${"界".repeat(996)}e\u0301👩💻`;
+  const oneThousandOneScalars = `${oneThousandScalars}a`;
+
+  expect(Array.from(oneThousandScalars)).toHaveLength(1_000);
+  expect(oneThousandScalars.length).toBeGreaterThan(1_000);
+  expect(isLargePastedTextV1(oneThousandScalars)).toBe(false);
+  expect(Array.from(oneThousandOneScalars)).toHaveLength(1_001);
+  expect(isLargePastedTextV1(oneThousandOneScalars)).toBe(true);
+});

--- a/packages/agent/src/pasted-text.ts
+++ b/packages/agent/src/pasted-text.ts
@@ -1,0 +1,178 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+import type {
+  ArtifactReference,
+  ArtifactStore,
+  PastedTextArtifactSourceV1,
+  StagedArtifactReference,
+} from "./artifact-store.js";
+import { publishFileArtifactStage } from "./artifact-store.js";
+
+export const pastedTextLimitsV1 = {
+  largeLineThreshold: 10,
+  largeScalarThreshold: 1_000,
+  maximumAtomsPerTurn: 8,
+  maximumTextBytesPerTurn: 1_024 * 1_024,
+} as const;
+
+export const pastedTextOrphanRetentionMillisecondsV1 = 7 * 24 * 60 * 60 * 1_000;
+
+export function isPastedTextOrphanCleanupEligibleV1(input: {
+  readonly referenced: boolean;
+  readonly modifiedAtMilliseconds: number;
+  readonly nowMilliseconds: number;
+}): boolean {
+  return (
+    !input.referenced &&
+    Number.isFinite(input.modifiedAtMilliseconds) &&
+    Number.isFinite(input.nowMilliseconds) &&
+    input.nowMilliseconds - input.modifiedAtMilliseconds >= pastedTextOrphanRetentionMillisecondsV1
+  );
+}
+
+export type StagedPastedTextSelectionV1 = {
+  readonly type: "staged_pasted_text";
+  readonly staged: StagedArtifactReference;
+  readonly digest: `sha256:${string}`;
+  readonly byteCount: number;
+  readonly lineCount: number;
+  readonly scalarCount: number;
+};
+
+export type PastedTextOccurrenceV1 = {
+  readonly occurrenceId: string;
+  readonly artifact: ArtifactReference<PastedTextArtifactSourceV1>;
+  readonly digest: `sha256:${string}`;
+  readonly byteCount: number;
+  readonly lineCount: number;
+  readonly scalarCount: number;
+};
+
+const digestSchema = z.string().regex(/^sha256:[0-9a-f]{64}$/u) as z.ZodType<`sha256:${string}`>;
+
+export const pastedTextOccurrenceV1Schema: z.ZodType<PastedTextOccurrenceV1> = z.strictObject({
+  occurrenceId: z.string().min(1).max(256),
+  artifact: z.strictObject({
+    id: digestSchema,
+    mediaType: z.literal("text/plain; charset=utf-8"),
+    byteCount: z.number().int().positive().max(pastedTextLimitsV1.maximumTextBytesPerTurn),
+    source: z.strictObject({
+      type: z.literal("pasted_text"),
+      schemaVersion: z.literal(1),
+      projectId: digestSchema,
+      sessionId: z.uuid(),
+      runId: z.uuid(),
+      occurrenceId: z.string().min(1).max(256),
+      provenance: z.literal("user_paste"),
+    }),
+  }),
+  digest: digestSchema,
+  byteCount: z.number().int().positive().max(pastedTextLimitsV1.maximumTextBytesPerTurn),
+  lineCount: z.number().int().positive().safe(),
+  scalarCount: z.number().int().positive().safe(),
+});
+
+export function pastedTextMetricsV1(text: string): {
+  readonly byteCount: number;
+  readonly lineCount: number;
+  readonly scalarCount: number;
+} {
+  return {
+    byteCount: Buffer.byteLength(text, "utf8"),
+    lineCount: text.split("\n").length,
+    scalarCount: Array.from(text).length,
+  };
+}
+
+export function normalizePastedTextV1(text: string): string {
+  return text.replace(/\r\n/gu, "\n").replace(/\r/gu, "\n").replace(/\t/gu, "    ");
+}
+
+export function isLargePastedTextV1(text: string): boolean {
+  const metrics = pastedTextMetricsV1(text);
+  return (
+    metrics.lineCount > pastedTextLimitsV1.largeLineThreshold ||
+    metrics.scalarCount > pastedTextLimitsV1.largeScalarThreshold
+  );
+}
+
+export async function promotePastedTextSelectionsV1(input: {
+  readonly artifactRoot: string;
+  readonly artifactStore: ArtifactStore;
+  readonly projectId: string;
+  readonly sessionId: string;
+  readonly runId: string;
+  readonly selections: readonly StagedPastedTextSelectionV1[];
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly occurrences: readonly PastedTextOccurrenceV1[];
+  readonly contents: ReadonlyMap<string, string>;
+}> {
+  if (input.selections.length > pastedTextLimitsV1.maximumAtomsPerTurn) {
+    throw new TypeError("The pasted-text atom count exceeds the v1 turn limit.");
+  }
+  const occurrences: PastedTextOccurrenceV1[] = [];
+  const contents = new Map<string, string>();
+  let aggregateBytes = 0;
+  for (const [index, selection] of input.selections.entries()) {
+    input.signal.throwIfAborted();
+    if (
+      selection.type !== "staged_pasted_text" ||
+      selection.staged.mediaType !== "text/plain; charset=utf-8" ||
+      selection.staged.id !== selection.digest ||
+      selection.staged.byteCount !== selection.byteCount ||
+      selection.byteCount <= 0
+    ) {
+      throw new TypeError("The provisional pasted-text selection is invalid.");
+    }
+    aggregateBytes += selection.byteCount;
+    if (aggregateBytes > pastedTextLimitsV1.maximumTextBytesPerTurn) {
+      throw new TypeError("The pasted-text payload exceeds the v1 turn limit.");
+    }
+    const occurrenceId = `${input.runId}:pasted-text:${index + 1}`;
+    const source: PastedTextArtifactSourceV1 = {
+      type: "pasted_text",
+      schemaVersion: 1,
+      projectId: input.projectId,
+      sessionId: input.sessionId,
+      runId: input.runId,
+      occurrenceId,
+      provenance: "user_paste",
+    };
+    const artifact = await publishFileArtifactStage({
+      artifactStore: input.artifactStore,
+      root: input.artifactRoot,
+      source,
+      staged: selection.staged,
+    });
+    const bytes = await input.artifactStore.read(artifact.id, {
+      maximumBytes: pastedTextLimitsV1.maximumTextBytesPerTurn,
+    });
+    if (
+      bytes === undefined ||
+      bytes.byteLength !== selection.byteCount ||
+      `sha256:${createHash("sha256").update(bytes).digest("hex")}` !== selection.digest
+    ) {
+      throw new TypeError("The immutable pasted-text artifact is unavailable or corrupt.");
+    }
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    const metrics = pastedTextMetricsV1(text);
+    if (
+      metrics.byteCount !== selection.byteCount ||
+      metrics.lineCount !== selection.lineCount ||
+      metrics.scalarCount !== selection.scalarCount ||
+      !isLargePastedTextV1(text)
+    ) {
+      throw new TypeError("The immutable pasted-text artifact does not match its descriptor.");
+    }
+    occurrences.push({
+      occurrenceId,
+      artifact,
+      digest: selection.digest,
+      ...metrics,
+    });
+    contents.set(occurrenceId, text);
+  }
+  return { occurrences, contents };
+}

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -548,6 +548,7 @@ export async function createPresentationSession(
         sealed: false,
         revisionIntent: planRevisionIntent,
         resources: [],
+        pastedTexts: [],
       },
       transient: null,
     };
@@ -609,7 +610,11 @@ export async function createPresentationSession(
     };
     let turnComposer: TurnComposer;
     const projectTurnComposer = (): PresentationDisplayState["composer"] => {
-      const snapshot = turnComposer?.snapshot() ?? { sealed: false, resources: [] };
+      const snapshot = turnComposer?.snapshot() ?? {
+        sealed: false,
+        resources: [],
+        pastedTexts: [],
+      };
       return {
         attachmentAvailable,
         draftRevision: snapshot.revision,
@@ -619,6 +624,7 @@ export async function createPresentationSession(
         sealed: snapshot.sealed,
         revisionIntent: planRevisionIntent,
         resources: snapshot.resources,
+        pastedTexts: snapshot.pastedTexts,
       };
     };
     turnComposer = await createTurnComposer({
@@ -676,7 +682,14 @@ export async function createPresentationSession(
       if (
         turnComposer
           .snapshot()
-          .resources.every((resource) => resource.state === "ready" || resource.state === "failed")
+          .resources.every(
+            (resource) => resource.state === "ready" || resource.state === "failed",
+          ) &&
+        turnComposer
+          .snapshot()
+          .pastedTexts.every(
+            (pastedText) => pastedText.state === "ready" || pastedText.state === "failed",
+          )
       ) {
         await persistCurrentTurnDraft();
       }
@@ -691,6 +704,37 @@ export async function createPresentationSession(
         return null;
       }
       return recovered;
+    };
+    const expandedDraftFitsExactTarget = (commandText: string): boolean => {
+      if (state.composer.pastedTexts.length === 0) {
+        return true;
+      }
+      const active = state.authoritative.active;
+      const targetId = active?.session.targetId ?? state.draft?.targetId;
+      const target = state.authoritative.targets.items.find(
+        (candidate) => candidate.targetId === targetId,
+      );
+      const profile =
+        active?.context?.profile ??
+        target?.context?.effective ??
+        target?.context?.official ??
+        modelTargetSnapshot?.targets.find((candidate) => candidate.identity.targetId === targetId)
+          ?.contextProfile;
+      if (profile === undefined) {
+        return false;
+      }
+      try {
+        const literalText = state.composer.elements
+          .flatMap((element) => (element.type === "text" ? [element.text] : []))
+          .join("");
+        const prospectiveBytes =
+          Buffer.byteLength(turnComposer.readExpandedText(), "utf8") +
+          (literalText === commandText ? 0 : Buffer.byteLength(commandText, "utf8"));
+        const estimatedInputTokens = Math.ceil(prospectiveBytes / 4);
+        return estimatedInputTokens + profile.maximumOutputTokens < profile.contextWindowTokens;
+      } catch {
+        return false;
+      }
     };
     const initialDraftScope = currentDraftScope();
     if (initialDraftScope !== null) {
@@ -2303,6 +2347,32 @@ export async function createPresentationSession(
           };
         }
       }
+      if (command.type === "stage_pasted_text") {
+        if (activeRun !== undefined || state.composer.sealed) {
+          return {
+            status: "rejected",
+            code: "conflict",
+            message: "Pasted text cannot be staged while the current turn is sealed.",
+          };
+        }
+        try {
+          await turnComposer.stagePastedText(
+            command.text,
+            command.mutation,
+            persistCurrentTurnDraft,
+          );
+          return { status: "admitted", commandId: randomUUID(), resource: null };
+        } catch (error) {
+          return {
+            status: "rejected",
+            code: "not_available",
+            message:
+              error instanceof Error
+                ? error.message
+                : "The pasted text could not be staged safely.",
+          };
+        }
+      }
       if (command.type === "replace_draft_text") {
         if (activeRun !== undefined || state.composer.sealed) {
           return {
@@ -2319,11 +2389,14 @@ export async function createPresentationSession(
                 code: "stale_interaction",
                 message: "The structured draft no longer matches the current composer revision.",
               };
-        } catch {
+        } catch (error) {
           return {
             status: "rejected",
-            code: "persistence_failed",
-            message: "The recoverable structured draft could not be saved.",
+            code: error instanceof TurnComposerError ? "not_available" : "persistence_failed",
+            message:
+              error instanceof TurnComposerError
+                ? error.message
+                : "The recoverable structured draft could not be saved.",
           };
         }
       }
@@ -2339,7 +2412,11 @@ export async function createPresentationSession(
         const element = snapshot.elements.find(
           (candidate) => candidate.elementId === command.elementId,
         );
-        if (command.baseRevision !== snapshot.revision || element?.type !== "resource") {
+        if (
+          command.baseRevision !== snapshot.revision ||
+          element?.type === "text" ||
+          element === undefined
+        ) {
           return {
             status: "rejected",
             code: "stale_interaction",
@@ -2347,18 +2424,41 @@ export async function createPresentationSession(
           };
         }
         try {
-          return (await turnComposer.remove(element.resourceId, persistCurrentTurnDraft))
+          const removed =
+            element.type === "resource"
+              ? await turnComposer.remove(element.resourceId, persistCurrentTurnDraft)
+              : await turnComposer.removePastedText(element.pastedTextId, persistCurrentTurnDraft);
+          return removed
             ? { status: "admitted", commandId: randomUUID(), resource: null }
             : {
                 status: "rejected",
                 code: "stale_interaction",
                 message: "The draft element is no longer present in the current composer.",
               };
-        } catch {
+        } catch (error) {
           return {
             status: "rejected",
-            code: "persistence_failed",
-            message: "The recoverable turn draft could not be saved.",
+            code: error instanceof TurnComposerError ? "not_available" : "persistence_failed",
+            message:
+              error instanceof TurnComposerError
+                ? error.message
+                : "The recoverable turn draft could not be saved.",
+          };
+        }
+      }
+      if (command.type === "read_expanded_draft") {
+        try {
+          return {
+            status: "admitted",
+            commandId: randomUUID(),
+            resource: null,
+            draftText: turnComposer.readExpandedText(),
+          };
+        } catch (error) {
+          return {
+            status: "rejected",
+            code: "not_available",
+            message: error instanceof Error ? error.message : "The expanded draft is unavailable.",
           };
         }
       }
@@ -2421,11 +2521,14 @@ export async function createPresentationSession(
         try {
           await turnComposer.commitText(command.text, persistCurrentTurnDraft);
           return { status: "admitted", commandId: randomUUID(), resource: null };
-        } catch {
+        } catch (error) {
           return {
             status: "rejected",
-            code: "persistence_failed",
-            message: "The recoverable turn draft could not be saved.",
+            code: error instanceof TurnComposerError ? "not_available" : "persistence_failed",
+            message:
+              error instanceof TurnComposerError
+                ? error.message
+                : "The recoverable turn draft could not be saved.",
           };
         }
       }
@@ -2472,7 +2575,7 @@ export async function createPresentationSession(
       if (command.type === "submit_prompt") {
         if (
           command.sessionId !== state.authoritative.active?.session.id ||
-          command.text.trim().length === 0
+          (command.text.trim().length === 0 && state.composer.pastedTexts.length === 0)
         ) {
           return {
             status: "rejected",
@@ -2519,6 +2622,14 @@ export async function createPresentationSession(
         });
         if (skillResolution.status === "ambiguous") {
           return ambiguousSkillMentionRejection(skillResolution);
+        }
+        if (!expandedDraftFitsExactTarget(command.text)) {
+          return {
+            status: "rejected",
+            code: "not_available",
+            message:
+              "The expanded draft cannot fit the exact target context. Remove or split Text atoms, or switch targets.",
+          };
         }
         const submittedScope = currentDraftScope();
         const controller = new AbortController();
@@ -2585,7 +2696,10 @@ export async function createPresentationSession(
           ...(sealedDraft.selections.length === 0
             ? {}
             : { resourceSelections: sealedDraft.selections }),
-          ...(sealedDraft.selections.length === 0
+          ...(sealedDraft.pastedTextSelections.length === 0
+            ? {}
+            : { pastedTextSelections: sealedDraft.pastedTextSelections }),
+          ...(sealedDraft.selections.length === 0 && sealedDraft.pastedTextSelections.length === 0
             ? {}
             : { structuredContent: sealedDraft.structuredContent }),
           ...(command.thinkingSelection === null
@@ -2658,7 +2772,10 @@ export async function createPresentationSession(
       }
       if (command.type === "submit_draft_prompt") {
         const draft = state.draft;
-        if (draft === null || command.text.trim().length === 0) {
+        if (
+          draft === null ||
+          (command.text.trim().length === 0 && state.composer.pastedTexts.length === 0)
+        ) {
           return {
             status: "rejected",
             code: "invalid_command",
@@ -2687,6 +2804,14 @@ export async function createPresentationSession(
         });
         if (skillResolution.status === "ambiguous") {
           return ambiguousSkillMentionRejection(skillResolution);
+        }
+        if (!expandedDraftFitsExactTarget(command.text)) {
+          return {
+            status: "rejected",
+            code: "not_available",
+            message:
+              "The expanded draft cannot fit the exact target context. Remove or split Text atoms, or switch targets.",
+          };
         }
         const submittedScope = currentDraftScope();
         const controller = new AbortController();
@@ -2738,7 +2863,10 @@ export async function createPresentationSession(
           ...(sealedDraft.selections.length === 0
             ? {}
             : { resourceSelections: sealedDraft.selections }),
-          ...(sealedDraft.selections.length === 0
+          ...(sealedDraft.pastedTextSelections.length === 0
+            ? {}
+            : { pastedTextSelections: sealedDraft.pastedTextSelections }),
+          ...(sealedDraft.selections.length === 0 && sealedDraft.pastedTextSelections.length === 0
             ? {}
             : { structuredContent: sealedDraft.structuredContent }),
           ...(command.thinkingSelection === null

--- a/packages/agent/src/presentation-transcript-projection.ts
+++ b/packages/agent/src/presentation-transcript-projection.ts
@@ -119,7 +119,7 @@ export function projectTranscript(
         sourceSessionId: sessionId,
         branchBoundary: null,
         text:
-          entry.record.recordVersion === 2
+          entry.record.recordVersion === 2 || entry.record.recordVersion === 3
             ? projectSessionUserContentTextV1({
                 elements: entry.record.userContent,
                 occurrences: entry.record.inputResources,

--- a/packages/agent/src/recoverable-turn-draft.ts
+++ b/packages/agent/src/recoverable-turn-draft.ts
@@ -4,6 +4,7 @@ import { chmod, mkdir, open, rename, unlink } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
 import { z } from "zod";
+import type { StagedPastedTextSelectionV1 } from "./pasted-text.js";
 
 const maximumManifestBytes = 1024 * 1024;
 const projectIdPattern = /^sha256:([0-9a-f]{64})$/u;
@@ -26,6 +27,12 @@ export type RecoverableTurnDraftV1 = {
         readonly kind: "file" | "image";
         readonly ordinal: number;
         readonly resourceId: string;
+      }
+    | {
+        readonly elementId: string;
+        readonly type: "pasted_text";
+        readonly ordinal: number;
+        readonly pastedTextId: string;
       }
   )[];
   readonly resources: readonly {
@@ -55,6 +62,19 @@ export type RecoverableTurnDraftV1 = {
         }
       | undefined;
   }[];
+  readonly pastedTexts?:
+    | readonly {
+        readonly id: string;
+        readonly elementId: string;
+        readonly ordinal: number;
+        readonly state: "failed" | "ready";
+        readonly byteCount: number;
+        readonly lineCount: number;
+        readonly scalarCount: number;
+        readonly diagnostic: string | null;
+        readonly selection?: StagedPastedTextSelectionV1 | undefined;
+      }[]
+    | undefined;
 };
 
 export type RecoverableTurnDraftRepository = {
@@ -85,6 +105,27 @@ const stagedSelectionSchema = z.strictObject({
   digest: digestSchema,
   mediaHint: z.enum(["binary", "image", "text"]),
   support: z.enum(["image", "unsupported_binary", "utf8_text"]),
+});
+const stagedPastedTextSelectionSchema: z.ZodType<StagedPastedTextSelectionV1> = z.strictObject({
+  type: z.literal("staged_pasted_text"),
+  staged: z.strictObject({
+    stagingId: z.uuid(),
+    id: digestSchema,
+    mediaType: z.literal("text/plain; charset=utf-8"),
+    byteCount: z
+      .number()
+      .int()
+      .positive()
+      .max(1024 * 1024),
+  }),
+  digest: digestSchema,
+  byteCount: z
+    .number()
+    .int()
+    .positive()
+    .max(1024 * 1024),
+  lineCount: z.number().int().positive().safe(),
+  scalarCount: z.number().int().positive().safe(),
 });
 const draftSchema: z.ZodType<RecoverableTurnDraftV1> = z
   .strictObject({
@@ -119,6 +160,12 @@ const draftSchema: z.ZodType<RecoverableTurnDraftV1> = z
             ordinal: z.number().int().positive().safe(),
             resourceId: z.string().min(1).max(256),
           }),
+          z.strictObject({
+            elementId: z.string().min(1).max(256),
+            type: z.literal("pasted_text"),
+            ordinal: z.number().int().positive().safe(),
+            pastedTextId: z.string().min(1).max(256),
+          }),
         ]),
       )
       .max(17),
@@ -144,20 +191,47 @@ const draftSchema: z.ZodType<RecoverableTurnDraftV1> = z
         }),
       )
       .max(8),
+    pastedTexts: z
+      .array(
+        z.strictObject({
+          id: z.string().min(1).max(256),
+          elementId: z.string().min(1).max(256),
+          ordinal: z.number().int().positive().safe(),
+          state: z.enum(["failed", "ready"]),
+          byteCount: z
+            .number()
+            .int()
+            .positive()
+            .max(1024 * 1024),
+          lineCount: z.number().int().positive().safe(),
+          scalarCount: z.number().int().positive().safe(),
+          diagnostic: z.string().max(1024).nullable(),
+          selection: stagedPastedTextSelectionSchema.optional(),
+        }),
+      )
+      .max(8)
+      .optional(),
   })
   .superRefine((draft, context) => {
     const resourceElements = draft.elements.filter((element) => element.type === "resource");
+    const pastedTextElements = draft.elements.filter((element) => element.type === "pasted_text");
+    const pastedTexts = draft.pastedTexts ?? [];
     if (
       new Set(draft.elements.map((element) => element.elementId)).size !== draft.elements.length ||
       new Set(draft.resources.map((resource) => resource.id)).size !== draft.resources.length ||
       new Set(draft.resources.map((resource) => resource.ordinal)).size !==
         draft.resources.length ||
+      new Set(pastedTexts.map((pastedText) => pastedText.id)).size !== pastedTexts.length ||
+      new Set(pastedTexts.map((pastedText) => pastedText.ordinal)).size !== pastedTexts.length ||
       draft.elements.reduce(
-        (length, element) => length + (element.type === "text" ? element.text.length : 0),
+        (length, element) =>
+          length + (element.type === "text" ? Buffer.byteLength(element.text, "utf8") : 0),
         0,
-      ) >
-        512 * 1024 ||
+      ) +
+        pastedTexts.reduce((total, pastedText) => total + pastedText.byteCount, 0) >
+        1024 * 1024 ||
       resourceElements.length !== draft.resources.length ||
+      pastedTextElements.length !== pastedTexts.length ||
       resourceElements.some((element, index) => {
         const resource = draft.resources[index];
         return (
@@ -166,6 +240,15 @@ const draftSchema: z.ZodType<RecoverableTurnDraftV1> = z
           resource.elementId !== element.elementId ||
           resource.kind !== element.kind ||
           resource.ordinal !== element.ordinal
+        );
+      }) ||
+      pastedTextElements.some((element, index) => {
+        const pastedText = pastedTexts[index];
+        return (
+          pastedText === undefined ||
+          pastedText.id !== element.pastedTextId ||
+          pastedText.elementId !== element.elementId ||
+          pastedText.ordinal !== element.ordinal
         );
       }) ||
       draft.resources.some(
@@ -179,7 +262,22 @@ const draftSchema: z.ZodType<RecoverableTurnDraftV1> = z
               resource.selection.staged.id !== resource.selection.digest ||
               (resource.kind === "image") !== (resource.selection.support === "image"))),
       ) ||
-      draft.nextOrdinal <= Math.max(0, ...draft.resources.map((resource) => resource.ordinal))
+      pastedTexts.some(
+        (pastedText) =>
+          (pastedText.state === "ready") !== (pastedText.selection !== undefined) ||
+          (pastedText.selection !== undefined &&
+            (pastedText.selection.staged.id !== pastedText.selection.digest ||
+              pastedText.selection.byteCount !== pastedText.byteCount ||
+              pastedText.selection.lineCount !== pastedText.lineCount ||
+              pastedText.selection.scalarCount !== pastedText.scalarCount)),
+      ) ||
+      draft.resources.length + pastedTexts.length > 8 ||
+      draft.nextOrdinal <=
+        Math.max(
+          0,
+          ...draft.resources.map((resource) => resource.ordinal),
+          ...pastedTexts.map((pastedText) => pastedText.ordinal),
+        )
     ) {
       context.addIssue({ code: "custom", message: "The recoverable draft graph is invalid." });
     }

--- a/packages/agent/src/session-history-replay.ts
+++ b/packages/agent/src/session-history-replay.ts
@@ -10,7 +10,10 @@ import type {
   SessionModelResponseField,
   SessionRecord,
 } from "./session-store.js";
-import { createSessionUserContentMessageV1 } from "./structured-user-content.js";
+import {
+  createSessionUserContentMessageV1,
+  pastedTextProjectionContentsFromV1,
+} from "./structured-user-content.js";
 
 export function modelMessagesFromCompleteRecords(
   records: readonly SessionRecord[],
@@ -109,7 +112,15 @@ export function createLogicalRunUserMessageV1(
         occurrences: record.inputResources,
         userMessage: record.userMessage,
       })
-    : createInputResourceUserMessageV1(record.userMessage, record.inputResources);
+    : record.recordVersion === 3
+      ? createSessionUserContentMessageV1({
+          elements: record.userContent,
+          occurrences: record.inputResources,
+          pastedTexts: record.pastedTexts,
+          pastedTextContents: pastedTextProjectionContentsFromV1(record),
+          userMessage: record.userMessage,
+        })
+      : createInputResourceUserMessageV1(record.userMessage, record.inputResources);
 }
 
 export function inlineModelResponseField(field: string | SessionModelResponseField): string {

--- a/packages/agent/src/session-history-validation.ts
+++ b/packages/agent/src/session-history-validation.ts
@@ -20,6 +20,7 @@ import {
 } from "./input-resources.js";
 import { isMcpToolProfileV1Valid } from "./mcp-profile-contracts.js";
 import { sameModelTargetIdentity } from "./model-targets.js";
+import { pastedTextLimitsV1 } from "./pasted-text.js";
 import { assessPlanCommandV1 } from "./plan-command-assessment.js";
 import { isPlanGitAttestationV1Valid, planGitAutomaticPolicyV1 } from "./plan-git-policy.js";
 import { isExactPlanMcpPermissionEventV1 } from "./plan-mcp-permission-validation.js";
@@ -2277,10 +2278,10 @@ function areLogicalInputResourcesValid(
   visible: ReadonlyMap<string, InputResourceOccurrenceV1>,
 ): boolean {
   const resources = record.inputResources ?? [];
-  if (resources.length === 0) {
+  if (resources.length === 0 && record.recordVersion !== 3) {
     return record.recordVersion !== 2;
   }
-  if (record.recordVersion !== 1 && record.recordVersion !== 2) {
+  if (record.recordVersion !== 1 && record.recordVersion !== 2 && record.recordVersion !== 3) {
     return false;
   }
   const combined = [...visible.values(), ...resources];
@@ -2309,13 +2310,34 @@ function areLogicalInputResourcesValid(
   if (!resourcesAreValid) {
     return false;
   }
-  if (record.recordVersion !== 2) {
+  if (record.recordVersion === 1) {
     return true;
+  }
+  if (record.recordVersion !== 2 && record.recordVersion !== 3) {
+    return false;
+  }
+  const pastedTexts = record.recordVersion === 3 ? record.pastedTexts : [];
+  const pastedTextBytes = pastedTexts.reduce(
+    (total, occurrence) => total + occurrence.byteCount,
+    0,
+  );
+  if (
+    pastedTexts.some(
+      (occurrence, index) =>
+        occurrence.occurrenceId !== `${record.runId}:pasted-text:${index + 1}` ||
+        occurrence.artifact.id !== occurrence.digest ||
+        occurrence.artifact.source.runId !== record.runId ||
+        occurrence.artifact.source.occurrenceId !== occurrence.occurrenceId,
+    ) ||
+    pastedTextBytes > pastedTextLimitsV1.maximumTextBytesPerTurn
+  ) {
+    return false;
   }
   try {
     validateSessionUserContentV1({
       elements: record.userContent,
       occurrences: resources,
+      pastedTexts,
       userMessage: record.userMessage,
     });
     return true;

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -68,6 +68,12 @@ import {
   modelTargetUsesContextProfile,
   sameModelTargetIdentity,
 } from "./model-targets.js";
+import {
+  isLargePastedTextV1,
+  pastedTextMetricsV1,
+  promotePastedTextSelectionsV1,
+  type StagedPastedTextSelectionV1,
+} from "./pasted-text.js";
 import { planGitAutomaticPolicyV1 } from "./plan-git-policy.js";
 import {
   type ApprovedPlanProjectionV1,
@@ -181,6 +187,7 @@ import {
   skillContextSnapshot,
 } from "./skills.js";
 import {
+  attachPastedTextProjectionContentsV1,
   materializeSessionUserContentV1,
   type StagedUserContentElementV1,
 } from "./structured-user-content.js";
@@ -537,6 +544,7 @@ export type SessionCommand =
       readonly signal?: AbortSignal;
       readonly thinkingSelection?: ThinkingPolicySelectionV1;
       readonly resourceSelections?: readonly InputResourceSelectionV1[];
+      readonly pastedTextSelections?: readonly StagedPastedTextSelectionV1[];
       readonly structuredContent?: readonly StagedUserContentElementV1[];
       readonly planRevision?: {
         readonly cycleId: string;
@@ -575,6 +583,7 @@ export interface SessionLifecycle {
     readonly signal?: AbortSignal;
     readonly thinkingSelection?: ThinkingPolicySelectionV1;
     readonly resourceSelections?: readonly InputResourceSelectionV1[];
+    readonly pastedTextSelections?: readonly StagedPastedTextSelectionV1[];
     readonly structuredContent?: readonly StagedUserContentElementV1[];
     readonly onAdmitted?: (receipt: SessionAdmissionReceipt) => void;
   }): Promise<SessionContinueResult>;
@@ -588,6 +597,7 @@ export interface SessionLifecycle {
     readonly signal?: AbortSignal;
     readonly thinkingSelection?: ThinkingPolicySelectionV1;
     readonly resourceSelections?: readonly InputResourceSelectionV1[];
+    readonly pastedTextSelections?: readonly StagedPastedTextSelectionV1[];
     readonly structuredContent?: readonly StagedUserContentElementV1[];
     readonly planRevision?: {
       readonly cycleId: string;
@@ -2003,7 +2013,8 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       const runId = input.runId ?? randomUUID();
       if (
         !z.uuid().safeParse(runId).success ||
-        input.input.text.trim().length === 0 ||
+        (input.input.text.trim().length === 0 &&
+          (input.pastedTextSelections === undefined || input.pastedTextSelections.length === 0)) ||
         !draftRunLimitsAreValid(input.limits) ||
         options.modelTargets === undefined
       ) {
@@ -2076,6 +2087,9 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           ...(input.resourceSelections === undefined
             ? {}
             : { resourceSelections: input.resourceSelections }),
+          ...(input.pastedTextSelections === undefined
+            ? {}
+            : { pastedTextSelections: input.pastedTextSelections }),
           ...(input.structuredContent === undefined
             ? {}
             : { structuredContent: input.structuredContent }),
@@ -2558,17 +2572,23 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             input.runId !== undefined ||
             input.planRevision !== undefined ||
             input.resourceSelections !== undefined ||
+            input.pastedTextSelections !== undefined ||
             input.structuredContent !== undefined ||
             input.thinkingSelection !== undefined)) ||
         (input.resourceSelections !== undefined && input.input === undefined) ||
+        (input.pastedTextSelections !== undefined && input.input === undefined) ||
         (input.structuredContent !== undefined &&
-          (input.input === undefined || input.resourceSelections === undefined)) ||
+          (input.input === undefined ||
+            (input.resourceSelections === undefined &&
+              input.pastedTextSelections === undefined))) ||
         input.input?.inputResources !== undefined
       ) {
         throw new SessionLifecycleError("session_invalid");
       }
       let effectiveRunId =
-        input.resourceSelections === undefined ? input.runId : (input.runId ?? randomUUID());
+        input.resourceSelections === undefined && input.pastedTextSelections === undefined
+          ? input.runId
+          : (input.runId ?? randomUUID());
       let effectiveInput = input.input;
       disarmMcpIdle(input.sessionId);
       await waitForMcpIdleOperation(input.sessionId);
@@ -3094,19 +3114,35 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
                 selections: input.resourceSelections,
                 signal: input.signal ?? new AbortController().signal,
               });
+        const pastedTextMaterialization =
+          input.pastedTextSelections === undefined
+            ? { occurrences: [], contents: new Map<string, string>() }
+            : await promotePastedTextSelectionsV1({
+                artifactRoot,
+                artifactStore,
+                projectId: first.record.projectId,
+                sessionId: input.sessionId,
+                runId: effectiveRunId as string,
+                selections: input.pastedTextSelections,
+                signal: input.signal ?? new AbortController().signal,
+              });
         input.signal?.throwIfAborted();
         const runInput =
-          effectiveInput === undefined || inputResources.length === 0
+          effectiveInput === undefined ||
+          (inputResources.length === 0 && pastedTextMaterialization.occurrences.length === 0)
             ? effectiveInput
             : {
                 ...effectiveInput,
                 inputResources,
+                pastedTexts: pastedTextMaterialization.occurrences,
+                pastedTextContents: pastedTextMaterialization.contents,
                 ...(input.structuredContent === undefined
                   ? {}
                   : {
                       userContent: materializeSessionUserContentV1({
                         elements: input.structuredContent,
                         occurrences: inputResources,
+                        pastedTexts: pastedTextMaterialization.occurrences,
                         userMessage: effectiveInput.text,
                       }),
                     }),
@@ -6920,6 +6956,70 @@ async function materializeModelResponseArtifacts(
   let logicalReferencedBytes = 0;
 
   for (const entry of records) {
+    if (
+      entry.schemaVersion === 3 &&
+      entry.record.type === "logical_run_started" &&
+      entry.record.recordVersion === 3
+    ) {
+      const contents = new Map<string, string>();
+      let pastedTextBytes = 0;
+      for (const occurrence of entry.record.pastedTexts) {
+        const source = occurrence.artifact.source;
+        if (
+          source.type !== "pasted_text" ||
+          source.projectId !== genesis.record.projectId ||
+          source.sessionId !== genesis.record.sessionId ||
+          source.runId !== entry.record.runId ||
+          source.occurrenceId !== occurrence.occurrenceId ||
+          occurrence.artifact.id !== occurrence.digest ||
+          occurrence.artifact.byteCount !== occurrence.byteCount
+        ) {
+          throw new SessionLifecycleError("session_invalid");
+        }
+        pastedTextBytes += occurrence.byteCount;
+        if (pastedTextBytes > 1_024 * 1_024) {
+          throw new SessionLifecycleError("session_invalid");
+        }
+        let pendingArtifact = artifactCache.get(occurrence.artifact.id);
+        if (pendingArtifact === undefined) {
+          pendingArtifact = readFileArtifact({
+            root: artifactRoot,
+            id: occurrence.artifact.id,
+            maximumBytes: 1_024 * 1_024,
+          }).then((bytes) =>
+            bytes === undefined
+              ? undefined
+              : {
+                  byteCount: bytes.byteLength,
+                  text: new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+                },
+          );
+          artifactCache.set(occurrence.artifact.id, pendingArtifact);
+        }
+        const resolved = await pendingArtifact;
+        if (
+          resolved === undefined ||
+          resolved.byteCount !== occurrence.byteCount ||
+          Buffer.byteLength(resolved.text, "utf8") !== occurrence.byteCount
+        ) {
+          throw new SessionLifecycleError("session_invalid");
+        }
+        const metrics = pastedTextMetricsV1(resolved.text);
+        if (
+          metrics.lineCount !== occurrence.lineCount ||
+          metrics.scalarCount !== occurrence.scalarCount ||
+          !isLargePastedTextV1(resolved.text)
+        ) {
+          throw new SessionLifecycleError("session_invalid");
+        }
+        contents.set(occurrence.occurrenceId, resolved.text);
+      }
+      materialized.push({
+        ...entry,
+        record: attachPastedTextProjectionContentsV1({ ...entry.record }, contents),
+      });
+      continue;
+    }
     if (entry.schemaVersion !== 3 || entry.record.type !== "model_response_completed") {
       materialized.push(entry);
       continue;

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -23,6 +23,7 @@ import type { McpToolProfileV1 } from "./mcp-profile-contracts.js";
 import { modelDriverDiagnosticCodes, modelDriverErrorCategories } from "./model-driver-error.js";
 import type { ModelTargetIdentity } from "./model-targets.js";
 import { imageInputLimitsV1, type ProjectedContentUsageV1 } from "./model-user-content.js";
+import { type PastedTextOccurrenceV1, pastedTextOccurrenceV1Schema } from "./pasted-text.js";
 import type { PlanShellPolicyVersion } from "./plan-command-assessment.js";
 import type { PlanGitAttestationV1 } from "./plan-git-policy.js";
 import type {
@@ -313,6 +314,13 @@ export type SessionLogicalRunStartedRecord = {
       | {
           readonly recordVersion: 2;
           readonly inputResources: readonly InputResourceOccurrenceV1[];
+          readonly userContent: readonly SessionUserContentElementV1[];
+          readonly pastedTexts?: never;
+        }
+      | {
+          readonly recordVersion: 3;
+          readonly inputResources: readonly InputResourceOccurrenceV1[];
+          readonly pastedTexts: readonly PastedTextOccurrenceV1[];
           readonly userContent: readonly SessionUserContentElementV1[];
         }
     );
@@ -1954,7 +1962,7 @@ const planGitAttestationV1Schema: z.ZodType<PlanGitAttestationV1> = z.strictObje
 const logicalRunStartedV2Schema = z
   .strictObject({
     type: z.literal("logical_run_started"),
-    recordVersion: z.literal(2),
+    recordVersion: z.union([z.literal(2), z.literal(3)]),
     runId: z.uuid(),
     userMessage: z.string().max(512 * 1024),
     planRevision: z
@@ -2007,15 +2015,23 @@ const logicalRunStartedV2Schema = z
     thinkingPolicy: thinkingPolicySnapshotV1Schema.optional(),
     inputResources: z
       .array(inputResourceOccurrenceV1Schema)
-      .min(1)
       .max(inputResourceLimitsV1.maximumOccurrencesPerRun),
+    pastedTexts: z.array(pastedTextOccurrenceV1Schema).min(1).max(8).optional(),
     userContent: sessionUserContentV1Schema,
   })
   .superRefine((record, context) => {
     try {
+      if (
+        (record.recordVersion === 2 &&
+          (record.inputResources.length === 0 || record.pastedTexts !== undefined)) ||
+        (record.recordVersion === 3 && record.pastedTexts === undefined)
+      ) {
+        throw new TypeError("The structured logical-run version is inconsistent.");
+      }
       validateSessionUserContentV1({
         elements: record.userContent,
         occurrences: record.inputResources,
+        pastedTexts: record.pastedTexts ?? [],
         userMessage: record.userMessage,
       });
     } catch {

--- a/packages/agent/src/structured-user-content.ts
+++ b/packages/agent/src/structured-user-content.ts
@@ -6,11 +6,36 @@ import {
   inputResourceLimitsV1,
   inputResourceOccurrenceV1Schema,
 } from "./input-resources.js";
+import { type PastedTextOccurrenceV1, pastedTextLimitsV1 } from "./pasted-text.js";
+
+const pastedTextProjectionContentsV1 = Symbol("adam-agent.pasted-text-projection-contents-v1");
+
+export function attachPastedTextProjectionContentsV1<RecordType extends object>(
+  record: RecordType,
+  contents: ReadonlyMap<string, string>,
+): RecordType {
+  return Object.assign(record, { [pastedTextProjectionContentsV1]: contents });
+}
+
+export function pastedTextProjectionContentsFromV1(
+  record: object,
+): ReadonlyMap<string, string> | undefined {
+  return (
+    record as {
+      readonly [pastedTextProjectionContentsV1]?: ReadonlyMap<string, string>;
+    }
+  )[pastedTextProjectionContentsV1];
+}
 
 export type StagedUserContentElementV1 =
   | { readonly type: "text"; readonly text: string }
   | {
       readonly type: "input_resource";
+      readonly selectionIndex: number;
+      readonly draftOrdinal: number;
+    }
+  | {
+      readonly type: "pasted_text";
       readonly selectionIndex: number;
       readonly draftOrdinal: number;
     };
@@ -19,6 +44,11 @@ export type SessionUserContentElementV1 =
   | { readonly type: "text"; readonly text: string }
   | {
       readonly type: "input_resource";
+      readonly occurrenceId: string;
+      readonly draftOrdinal: number;
+    }
+  | {
+      readonly type: "pasted_text";
       readonly occurrenceId: string;
       readonly draftOrdinal: number;
     };
@@ -37,6 +67,11 @@ export const sessionUserContentElementV1Schema: z.ZodType<SessionUserContentElem
       occurrenceId: z.string().min(1).max(256),
       draftOrdinal: z.number().int().positive().safe(),
     }),
+    z.strictObject({
+      type: z.literal("pasted_text"),
+      occurrenceId: z.string().min(1).max(256),
+      draftOrdinal: z.number().int().positive().safe(),
+    }),
   ]);
 
 export const sessionUserContentV1Schema = z
@@ -52,26 +87,30 @@ export const sessionUserContentV1Schema = z
   )
   .refine((elements) => {
     const ordinals = elements.flatMap((element) =>
-      element.type === "input_resource" ? [element.draftOrdinal] : [],
+      element.type === "text" ? [] : [element.draftOrdinal],
     );
     return new Set(ordinals).size === ordinals.length;
-  }, "Structured input-resource ordinals must be unique.");
+  }, "Structured atom ordinals must be unique.");
 
 export function materializeSessionUserContentV1(input: {
   readonly elements: readonly StagedUserContentElementV1[];
   readonly occurrences: readonly InputResourceOccurrenceV1[];
+  readonly pastedTexts?: readonly PastedTextOccurrenceV1[] | undefined;
   readonly userMessage: string;
 }): readonly SessionUserContentElementV1[] {
   const elements = input.elements.map((element): SessionUserContentElementV1 => {
     if (element.type === "text") {
       return element;
     }
-    const occurrence = input.occurrences[element.selectionIndex];
+    const occurrence =
+      element.type === "input_resource"
+        ? input.occurrences[element.selectionIndex]
+        : input.pastedTexts?.[element.selectionIndex];
     if (occurrence === undefined) {
-      throw new TypeError("The structured draft references an unavailable input resource.");
+      throw new TypeError("The structured draft references unavailable immutable content.");
     }
     return {
-      type: "input_resource",
+      type: element.type,
       occurrenceId: occurrence.occurrenceId,
       draftOrdinal: element.draftOrdinal,
     };
@@ -82,6 +121,7 @@ export function materializeSessionUserContentV1(input: {
   validateSessionUserContentV1({
     elements,
     occurrences: input.occurrences,
+    pastedTexts: input.pastedTexts ?? [],
     userMessage: input.userMessage,
   });
   return elements;
@@ -90,6 +130,7 @@ export function materializeSessionUserContentV1(input: {
 export function validateSessionUserContentV1(input: {
   readonly elements: readonly SessionUserContentElementV1[];
   readonly occurrences: readonly InputResourceOccurrenceV1[];
+  readonly pastedTexts?: readonly PastedTextOccurrenceV1[] | undefined;
   readonly userMessage: string;
 }): void {
   if (
@@ -105,11 +146,25 @@ export function validateSessionUserContentV1(input: {
     element.type === "input_resource" ? [element.occurrenceId] : [],
   );
   const expected = input.occurrences.map((occurrence) => occurrence.occurrenceId);
+  const referencedPastedTexts = input.elements.flatMap((element) =>
+    element.type === "pasted_text" ? [element.occurrenceId] : [],
+  );
+  const expectedPastedTexts = (input.pastedTexts ?? []).map(
+    (occurrence) => occurrence.occurrenceId,
+  );
   if (
     literalText !== input.userMessage ||
     referenced.length !== expected.length ||
     referenced.some((occurrenceId, index) => occurrenceId !== expected[index]) ||
-    new Set(referenced).size !== referenced.length
+    new Set(referenced).size !== referenced.length ||
+    referencedPastedTexts.length !== expectedPastedTexts.length ||
+    referencedPastedTexts.some(
+      (occurrenceId, index) => occurrenceId !== expectedPastedTexts[index],
+    ) ||
+    new Set(referencedPastedTexts).size !== referencedPastedTexts.length ||
+    Buffer.byteLength(literalText, "utf8") +
+      (input.pastedTexts ?? []).reduce((total, occurrence) => total + occurrence.byteCount, 0) >
+      pastedTextLimitsV1.maximumTextBytesPerTurn
   ) {
     throw new TypeError("The structured user content does not match its immutable occurrences.");
   }
@@ -127,6 +182,9 @@ export function projectSessionUserContentTextV1(input: {
       if (element.type === "text") {
         return element.text;
       }
+      if (element.type === "pasted_text") {
+        return `[Text #${element.draftOrdinal}]`;
+      }
       const occurrence = occurrences.get(element.occurrenceId);
       if (occurrence === undefined) {
         throw new TypeError("The structured user content occurrence is unavailable.");
@@ -139,14 +197,32 @@ export function projectSessionUserContentTextV1(input: {
 export function createSessionUserContentMessageV1(input: {
   readonly elements: readonly SessionUserContentElementV1[];
   readonly occurrences: readonly InputResourceOccurrenceV1[];
+  readonly pastedTexts?: readonly PastedTextOccurrenceV1[] | undefined;
+  readonly pastedTextContents?: ReadonlyMap<string, string> | undefined;
   readonly userMessage: string;
 }): ModelMessage {
   validateSessionUserContentV1(input);
-  return createInputResourceUserMessageV1(
-    projectSessionUserContentTextV1({
-      elements: input.elements,
-      occurrences: input.occurrences,
-    }),
-    input.occurrences,
+  const occurrences = new Map(
+    input.occurrences.map((occurrence) => [occurrence.occurrenceId, occurrence]),
   );
+  const expanded = input.elements
+    .map((element) => {
+      if (element.type === "text") {
+        return element.text;
+      }
+      if (element.type === "pasted_text") {
+        const text = input.pastedTextContents?.get(element.occurrenceId);
+        if (text === undefined) {
+          throw new TypeError("The pasted-text projection content is unavailable.");
+        }
+        return text;
+      }
+      const occurrence = occurrences.get(element.occurrenceId);
+      if (occurrence === undefined) {
+        throw new TypeError("The structured user content occurrence is unavailable.");
+      }
+      return `[${occurrence.support === "image" ? "Image" : "File"} #${element.draftOrdinal}]`;
+    })
+    .join("");
+  return createInputResourceUserMessageV1(expanded, input.occurrences);
 }

--- a/packages/agent/src/turn-composer.ts
+++ b/packages/agent/src/turn-composer.ts
@@ -6,6 +6,11 @@ import {
   type StagedInputResourceSelectionV1,
   safeInputResourceDisplayNameV1,
 } from "./input-resources.js";
+import {
+  normalizePastedTextV1,
+  pastedTextLimitsV1,
+  type StagedPastedTextSelectionV1,
+} from "./pasted-text.js";
 import type { RecoverableTurnDraftV1 } from "./recoverable-turn-draft.js";
 import type { StagedUserContentElementV1 } from "./structured-user-content.js";
 
@@ -42,6 +47,12 @@ export type TurnComposerElementSnapshot =
       readonly kind: "file" | "image";
       readonly ordinal: number;
       readonly resourceId: string;
+    }
+  | {
+      readonly elementId: string;
+      readonly type: "pasted_text";
+      readonly ordinal: number;
+      readonly pastedTextId: string;
     };
 
 export type TurnComposerSealedElement =
@@ -52,7 +63,27 @@ export type TurnComposerSealedElement =
       readonly ordinal: number;
       readonly token: string;
       readonly selection: StagedInputResourceSelectionV1;
+    }
+  | {
+      readonly type: "pasted_text";
+      readonly ordinal: number;
+      readonly token: string;
+      readonly text: string;
+      readonly selection: StagedPastedTextSelectionV1;
     };
+
+export type TurnComposerPastedTextSnapshot = {
+  readonly id: string;
+  readonly elementId: string;
+  readonly ordinal: number;
+  readonly token: string;
+  readonly state: "copying" | "ready" | "failed" | "removed";
+  readonly byteCount: number;
+  readonly lineCount: number;
+  readonly scalarCount: number;
+  readonly origin: "pasted_text";
+  readonly diagnostic: string | null;
+};
 
 type TurnComposerResource = {
   readonly id: string;
@@ -68,6 +99,23 @@ type TurnComposerResource = {
   diagnostic: string | null;
   readonly controller: AbortController;
   staged: StagedInputResourceSelectionV1 | null;
+  retained: boolean;
+  settlement: Promise<void> | null;
+};
+
+type TurnComposerPastedText = {
+  readonly id: string;
+  readonly elementId: string;
+  readonly ordinal: number;
+  readonly origin: "pasted_text";
+  state: TurnComposerPastedTextSnapshot["state"];
+  byteCount: number;
+  lineCount: number;
+  scalarCount: number;
+  diagnostic: string | null;
+  readonly controller: AbortController;
+  staged: StagedPastedTextSelectionV1 | null;
+  text: string | null;
   retained: boolean;
   settlement: Promise<void> | null;
 };
@@ -88,12 +136,18 @@ export type TurnComposer = {
     mutation?: { readonly at: TurnComposerDraftPoint; readonly baseRevision: number },
     commit?: () => Promise<void>,
   ): Promise<string>;
+  stagePastedText(
+    text: string,
+    mutation?: { readonly at: TurnComposerDraftPoint; readonly baseRevision: number },
+    commit?: () => Promise<void>,
+  ): Promise<string>;
   replaceText(
     input: {
       readonly baseRevision: number;
       readonly document: readonly (
         | { readonly type: "text"; readonly text: string }
         | { readonly type: "resource"; readonly elementId: string }
+        | { readonly type: "pasted_text"; readonly elementId: string }
       )[];
     },
     commit?: () => Promise<void>,
@@ -103,6 +157,7 @@ export type TurnComposer = {
   undo(baseRevision: number, commit?: () => Promise<void>): Promise<boolean>;
   cancel(id: string): Promise<boolean>;
   remove(id: string, commit?: () => Promise<void>): Promise<boolean>;
+  removePastedText(id: string, commit?: () => Promise<void>): Promise<boolean>;
   setText(text: string): void;
   commitText(text: string, commit: () => Promise<void>): Promise<void>;
   seal(signal: AbortSignal): Promise<{
@@ -111,10 +166,12 @@ export type TurnComposer = {
     readonly structuredContent: readonly StagedUserContentElementV1[];
     readonly text: string;
     readonly selections: readonly StagedInputResourceSelectionV1[];
+    readonly pastedTextSelections: readonly StagedPastedTextSelectionV1[];
   }>;
   unseal(): void;
   reset(baseRevision: number, commit: () => Promise<void>): Promise<boolean>;
   clear(options?: { readonly preserveRetained?: boolean }): Promise<void>;
+  readExpandedText(): string;
   close(): Promise<void>;
   snapshot(): {
     readonly elements: readonly TurnComposerElementSnapshot[];
@@ -122,6 +179,7 @@ export type TurnComposer = {
     readonly revision: number;
     readonly sealed: boolean;
     readonly resources: readonly TurnComposerResourceSnapshot[];
+    readonly pastedTexts: readonly TurnComposerPastedTextSnapshot[];
   };
 };
 
@@ -130,12 +188,14 @@ export async function createTurnComposer(options: {
   readonly stager: TurnComposerResourceStager;
 }): Promise<TurnComposer> {
   const resources = new Map<string, TurnComposerResource>();
+  const pastedTexts = new Map<string, TurnComposerPastedText>();
   let elements: TurnComposerElementSnapshot[] = [];
   let nextOrdinal = 1;
   let revision = 0;
   const undoStack: Array<{
     readonly previousElements: readonly TurnComposerElementSnapshot[];
     readonly restoredResourceId?: string;
+    readonly restoredPastedTextId?: string;
   }> = [];
   const pushUndo = (entry: (typeof undoStack)[number]): void => {
     if (undoStack.length >= 100) {
@@ -161,25 +221,41 @@ export async function createTurnComposer(options: {
     }
   };
 
-  const resourceToken = (kind: "file" | "image", ordinal: number): string =>
-    `[${kind === "image" ? "Image" : "File"} #${ordinal}]`;
+  const discardPastedText = async (pastedText: TurnComposerPastedText): Promise<void> => {
+    if (pastedText.staged !== null) {
+      const staged = pastedText.staged;
+      pastedText.staged = null;
+      await options.stager.discard(staged);
+    }
+  };
+
+  const atomToken = (kind: "file" | "image" | "text", ordinal: number): string =>
+    `[${kind === "image" ? "Image" : kind === "text" ? "Text" : "File"} #${ordinal}]`;
 
   const renderedText = (): string =>
     elements
       .map((element) =>
-        element.type === "text" ? element.text : resourceToken(element.kind, element.ordinal),
+        element.type === "text"
+          ? element.text
+          : atomToken(element.type === "pasted_text" ? "text" : element.kind, element.ordinal),
       )
       .join("");
 
   const literalText = (): string =>
     elements.flatMap((element) => (element.type === "text" ? [element.text] : [])).join("");
 
+  const textPayloadBytes = (literal = literalText()): number =>
+    Buffer.byteLength(literal, "utf8") +
+    [...pastedTexts.values()]
+      .filter((pastedText) => pastedText.state !== "removed")
+      .reduce((total, pastedText) => total + pastedText.byteCount, 0);
+
   const resolvePoint = (
     point: TurnComposerDraftPoint,
   ): { readonly index: number; readonly offset: number } | undefined => {
     if ("elementId" in point && "edge" in point) {
       const index = elements.findIndex((element) => element.elementId === point.elementId);
-      if (index < 0 || elements[index]?.type !== "resource") {
+      if (index < 0 || elements[index]?.type === "text") {
         return undefined;
       }
       return { index: point.edge === "before" ? index : index + 1, offset: 0 };
@@ -236,7 +312,7 @@ export async function createTurnComposer(options: {
     const textElements = elements.flatMap((element, index) =>
       element.type === "text" ? [{ element, index }] : [],
     );
-    if (!elements.some((element) => element.type === "resource")) {
+    if (!elements.some((element) => element.type !== "text")) {
       elements =
         nextText.length === 0 ? [] : [{ elementId: randomUUID(), type: "text", text: nextText }];
       return;
@@ -265,8 +341,8 @@ export async function createTurnComposer(options: {
           );
   };
 
-  const insertResource = (
-    element: Extract<TurnComposerElementSnapshot, { readonly type: "resource" }>,
+  const insertAtomicElement = (
+    element: Exclude<TurnComposerElementSnapshot, { readonly type: "text" }>,
     mutation: { readonly at: TurnComposerDraftPoint; readonly baseRevision: number } | undefined,
   ): void => {
     if (mutation === undefined) {
@@ -322,6 +398,30 @@ export async function createTurnComposer(options: {
     return { element, previousElements };
   };
 
+  const removePastedTextElement = (
+    id: string,
+  ):
+    | {
+        readonly element: Extract<TurnComposerElementSnapshot, { readonly type: "pasted_text" }>;
+        readonly previousElements: readonly TurnComposerElementSnapshot[];
+      }
+    | undefined => {
+    const previousElements = elements;
+    const index = previousElements.findIndex(
+      (element) => element.type === "pasted_text" && element.pastedTextId === id,
+    );
+    const element = previousElements[index];
+    if (index < 0 || element?.type !== "pasted_text") {
+      return undefined;
+    }
+    elements = normalizeTextElements([
+      ...previousElements.slice(0, index),
+      ...previousElements.slice(index + 1),
+    ]);
+    revision += 1;
+    return { element, previousElements };
+  };
+
   return {
     async captureDraft(scope) {
       const orderedResources = elements.flatMap((element) => {
@@ -330,6 +430,13 @@ export async function createTurnComposer(options: {
         }
         const resource = resources.get(element.resourceId);
         return resource === undefined ? [] : [resource];
+      });
+      const orderedPastedTexts = elements.flatMap((element) => {
+        if (element.type !== "pasted_text") {
+          return [];
+        }
+        const pastedText = pastedTexts.get(element.pastedTextId);
+        return pastedText === undefined ? [] : [pastedText];
       });
       if (
         orderedResources.some(
@@ -341,10 +448,29 @@ export async function createTurnComposer(options: {
           "Only settled input resources can enter a recoverable draft.",
         );
       }
+      if (
+        orderedPastedTexts.some(
+          (pastedText) => pastedText.state !== "ready" && pastedText.state !== "failed",
+        )
+      ) {
+        throw new TurnComposerError(
+          "failed",
+          "Only settled Text atoms can enter a recoverable draft.",
+        );
+      }
       for (const resource of orderedResources) {
         if (resource.state === "ready" && resource.staged !== null && !resource.retained) {
           await options.stager.retain({ resourceId: resource.id, selection: resource.staged });
           resource.retained = true;
+        }
+      }
+      for (const pastedText of orderedPastedTexts) {
+        if (pastedText.state === "ready" && pastedText.staged !== null && !pastedText.retained) {
+          await options.stager.retain({
+            resourceId: pastedText.id,
+            selection: pastedText.staged,
+          });
+          pastedText.retained = true;
         }
       }
       return {
@@ -365,10 +491,23 @@ export async function createTurnComposer(options: {
           diagnostic: resource.diagnostic,
           ...(resource.staged === null ? {} : { selection: resource.staged }),
         })),
+        pastedTexts: orderedPastedTexts.map((pastedText) => ({
+          id: pastedText.id,
+          elementId: pastedText.elementId,
+          ordinal: pastedText.ordinal,
+          state: pastedText.state as "failed" | "ready",
+          byteCount: pastedText.byteCount,
+          lineCount: pastedText.lineCount,
+          scalarCount: pastedText.scalarCount,
+          diagnostic: pastedText.diagnostic,
+          ...(pastedText.state !== "ready" || pastedText.staged === null
+            ? {}
+            : { selection: pastedText.staged }),
+        })),
       };
     },
     async restoreDraft(draft) {
-      if (closed || sealed || elements.length > 0 || resources.size > 0) {
+      if (closed || sealed || elements.length > 0 || resources.size > 0 || pastedTexts.size > 0) {
         throw new TypeError("The turn composer cannot replace a nonempty draft.");
       }
       const recoveredResources = new Map(
@@ -380,6 +519,33 @@ export async function createTurnComposer(options: {
         )
       ) {
         throw new TypeError("The recoverable turn draft is incomplete.");
+      }
+      const recoveredPastedTexts = new Map(
+        (draft.pastedTexts ?? []).map((item) => [item.id, item]),
+      );
+      if (
+        draft.elements.some(
+          (element) =>
+            element.type === "pasted_text" && !recoveredPastedTexts.has(element.pastedTextId),
+        )
+      ) {
+        throw new TypeError("The recoverable turn draft has incomplete Text atoms.");
+      }
+      if ((draft.pastedTexts?.length ?? 0) > 0 && options.stager.readText === undefined) {
+        throw new TypeError("Recoverable Text atoms are unavailable.");
+      }
+      const recoveredPastedTextContents = new Map<string, string>();
+      for (const recovered of draft.pastedTexts ?? []) {
+        if (recovered.selection !== undefined) {
+          try {
+            recoveredPastedTextContents.set(
+              recovered.id,
+              (await options.stager.readText?.(recovered.selection)) as string,
+            );
+          } catch {
+            // Preserve the atom as failed so the caller can remove it without guessing content.
+          }
+        }
       }
       elements = draft.elements.map((element) => ({ ...element }));
       nextOrdinal = draft.nextOrdinal;
@@ -405,6 +571,28 @@ export async function createTurnComposer(options: {
           settlement: Promise.resolve(),
         });
       }
+      for (const recovered of draft.pastedTexts ?? []) {
+        const recoveredText = recoveredPastedTextContents.get(recovered.id) ?? null;
+        pastedTexts.set(recovered.id, {
+          id: recovered.id,
+          elementId: recovered.elementId,
+          ordinal: recovered.ordinal,
+          origin: "pasted_text",
+          state: recovered.state === "ready" && recoveredText === null ? "failed" : recovered.state,
+          byteCount: recovered.byteCount,
+          lineCount: recovered.lineCount,
+          scalarCount: recovered.scalarCount,
+          diagnostic:
+            recovered.state === "ready" && recoveredText === null
+              ? "The recoverable pasted-text bytes are unavailable."
+              : recovered.diagnostic,
+          controller: new AbortController(),
+          staged: recovered.selection ?? null,
+          text: recoveredText,
+          retained: recovered.selection !== undefined,
+          settlement: Promise.resolve(),
+        });
+      }
       revision += 1;
       publish();
     },
@@ -417,42 +605,38 @@ export async function createTurnComposer(options: {
       ) {
         return false;
       }
-      const currentResources = elements.filter(
-        (element): element is Extract<TurnComposerElementSnapshot, { readonly type: "resource" }> =>
-          element.type === "resource",
+      const currentAtoms = elements.filter(
+        (element): element is Exclude<TurnComposerElementSnapshot, { readonly type: "text" }> =>
+          element.type !== "text",
       );
-      const projectedResourceIds = input.document.flatMap((part) =>
-        part.type === "resource" ? [part.elementId] : [],
+      const projectedAtomIds = input.document.flatMap((part) =>
+        part.type === "text" ? [] : [part.elementId],
       );
       if (
-        projectedResourceIds.length !== currentResources.length ||
-        projectedResourceIds.some(
-          (elementId, index) => currentResources[index]?.elementId !== elementId,
-        )
+        projectedAtomIds.length !== currentAtoms.length ||
+        projectedAtomIds.some((elementId, index) => currentAtoms[index]?.elementId !== elementId)
       ) {
         return false;
       }
       const currentTextIdByGap = new Map<number, string>();
       let gap = 0;
       for (const element of elements) {
-        if (element.type === "resource") {
+        if (element.type !== "text") {
           gap += 1;
         } else if (!currentTextIdByGap.has(gap)) {
           currentTextIdByGap.set(gap, element.elementId);
         }
       }
-      const resourcesByElementId = new Map(
-        currentResources.map((resource) => [resource.elementId, resource]),
-      );
+      const atomsByElementId = new Map(currentAtoms.map((atom) => [atom.elementId, atom]));
       const nextElements: TurnComposerElementSnapshot[] = [];
       gap = 0;
       for (const part of input.document) {
-        if (part.type === "resource") {
-          const resource = resourcesByElementId.get(part.elementId);
-          if (resource === undefined) {
+        if (part.type !== "text") {
+          const atom = atomsByElementId.get(part.elementId);
+          if (atom === undefined || atom.type !== part.type) {
             return false;
           }
-          nextElements.push(resource);
+          nextElements.push(atom);
           gap += 1;
           continue;
         }
@@ -476,8 +660,14 @@ export async function createTurnComposer(options: {
       const nextText = nextElements
         .flatMap((element) => (element.type === "text" ? [element.text] : []))
         .join("");
-      if (nextText.length > 512 * 1024) {
-        throw new TypeError("The structured draft text exceeds the C0 limit.");
+      if (
+        nextText.length > 512 * 1024 ||
+        textPayloadBytes(nextText) > pastedTextLimitsV1.maximumTextBytesPerTurn
+      ) {
+        throw new TurnComposerError(
+          "limit_exceeded",
+          "The structured text payload exceeds the v1 turn limit.",
+        );
       }
       const previousElements = elements;
       const previousText = text;
@@ -565,6 +755,50 @@ export async function createTurnComposer(options: {
       publish();
       return true;
     },
+    async removePastedText(id, commit) {
+      if (closed || sealed) {
+        return false;
+      }
+      const pastedText = pastedTexts.get(id);
+      if (pastedText === undefined || pastedText.state === "removed") {
+        return false;
+      }
+      const previousElements = elements;
+      const previousText = text;
+      const previousRevision = revision;
+      const previousState = pastedText.state;
+      const previousDiagnostic = pastedText.diagnostic;
+      const previousUndoStack = [...undoStack];
+      pastedText.state = "removed";
+      pastedText.controller.abort();
+      await pastedText.settlement;
+      const removed = removePastedTextElement(id);
+      if (removed !== undefined && pastedText.staged !== null && pastedText.text !== null) {
+        pushUndo({
+          previousElements: removed.previousElements,
+          restoredPastedTextId: removed.element.pastedTextId,
+        });
+      }
+      text = literalText();
+      try {
+        await commit?.();
+      } catch (error) {
+        elements = previousElements;
+        text = previousText;
+        revision = previousRevision;
+        pastedText.state = previousState;
+        pastedText.diagnostic = previousDiagnostic;
+        undoStack.length = 0;
+        undoStack.push(...previousUndoStack);
+        throw error;
+      }
+      if (removed === undefined || pastedText.staged === null || pastedText.text === null) {
+        await discardPastedText(pastedText);
+        pastedTexts.delete(id);
+      }
+      publish();
+      return true;
+    },
     async undo(baseRevision, commit) {
       if (closed || sealed || baseRevision !== revision) {
         return false;
@@ -577,9 +811,20 @@ export async function createTurnComposer(options: {
         entry.restoredResourceId === undefined
           ? undefined
           : resources.get(entry.restoredResourceId);
+      const pastedText =
+        entry.restoredPastedTextId === undefined
+          ? undefined
+          : pastedTexts.get(entry.restoredPastedTextId);
       if (
         entry.restoredResourceId !== undefined &&
         (resource?.state !== "removed" || resource.staged === null)
+      ) {
+        undoStack.push(entry);
+        return false;
+      }
+      if (
+        entry.restoredPastedTextId !== undefined &&
+        (pastedText?.state !== "removed" || pastedText.staged === null)
       ) {
         undoStack.push(entry);
         return false;
@@ -592,6 +837,9 @@ export async function createTurnComposer(options: {
       if (resource !== undefined) {
         resource.state = "ready";
       }
+      if (pastedText !== undefined) {
+        pastedText.state = "ready";
+      }
       revision += 1;
       try {
         await commit?.();
@@ -601,6 +849,9 @@ export async function createTurnComposer(options: {
         revision = previousRevision;
         if (resource !== undefined) {
           resource.state = "removed";
+        }
+        if (pastedText !== undefined) {
+          pastedText.state = "removed";
         }
         undoStack.push(entry);
         throw error;
@@ -612,9 +863,11 @@ export async function createTurnComposer(options: {
       if (closed || sealed) {
         throw new TypeError("The turn composer is not accepting input resources.");
       }
-      const retainedCount = [...resources.values()].filter(
-        (resource) => resource.state !== "cancelled" && resource.state !== "removed",
-      ).length;
+      const retainedCount =
+        [...resources.values()].filter(
+          (resource) => resource.state !== "cancelled" && resource.state !== "removed",
+        ).length +
+        [...pastedTexts.values()].filter((candidate) => candidate.state !== "removed").length;
       if (retainedCount >= inputResourceLimitsV1.maximumOccurrencesPerRun) {
         throw new TypeError("The turn composer input-resource count exceeds the v1 run limit.");
       }
@@ -642,7 +895,7 @@ export async function createTurnComposer(options: {
         retained: false,
         settlement: null,
       };
-      insertResource(
+      insertAtomicElement(
         { elementId, type: "resource", kind: "file", ordinal, resourceId: id },
         mutation,
       );
@@ -716,6 +969,111 @@ export async function createTurnComposer(options: {
       await settlement;
       return id;
     },
+    async stagePastedText(pastedText, mutation, commit) {
+      if (closed || sealed) {
+        throw new TypeError("The turn composer is not accepting pasted text.");
+      }
+      const activeAtomCount =
+        [...resources.values()].filter(
+          (resource) => resource.state !== "cancelled" && resource.state !== "removed",
+        ).length +
+        [...pastedTexts.values()].filter((candidate) => candidate.state !== "removed").length;
+      if (activeAtomCount >= pastedTextLimitsV1.maximumAtomsPerTurn) {
+        throw new TypeError("The turn composer atom count exceeds the v1 run limit.");
+      }
+      const normalizedPastedText = normalizePastedTextV1(pastedText);
+      const pastedBytes = Buffer.byteLength(normalizedPastedText, "utf8");
+      if (textPayloadBytes() + pastedBytes > pastedTextLimitsV1.maximumTextBytesPerTurn) {
+        throw new TypeError("The structured text payload exceeds the v1 turn limit.");
+      }
+      const id = randomUUID();
+      const elementId = randomUUID();
+      const ordinal = nextOrdinal;
+      const previousElements = elements;
+      const previousNextOrdinal = nextOrdinal;
+      const previousRevision = revision;
+      const previousUndoStack = [...undoStack];
+      const atom: TurnComposerPastedText = {
+        id,
+        elementId,
+        ordinal,
+        origin: "pasted_text",
+        state: "copying",
+        byteCount: pastedBytes,
+        lineCount: normalizedPastedText.split("\n").length,
+        scalarCount: Array.from(normalizedPastedText).length,
+        diagnostic: null,
+        controller: new AbortController(),
+        staged: null,
+        text: normalizedPastedText,
+        retained: false,
+        settlement: null,
+      };
+      insertAtomicElement({ elementId, type: "pasted_text", ordinal, pastedTextId: id }, mutation);
+      nextOrdinal += 1;
+      revision += 1;
+      undoStack.length = 0;
+      pastedTexts.set(id, atom);
+      publish();
+      const settlement = (async () => {
+        let staged: StagedPastedTextSelectionV1;
+        try {
+          if (options.stager.stageText === undefined) {
+            throw new TypeError("Pasted-text staging is unavailable.");
+          }
+          staged = await options.stager.stageText({
+            id,
+            text: normalizedPastedText,
+            signal: atom.controller.signal,
+          });
+        } catch (error) {
+          if (closed || atom.state === "removed" || !pastedTexts.has(id)) {
+            return;
+          }
+          atom.state = "failed";
+          atom.diagnostic =
+            error instanceof Error ? error.message : "The pasted text failed to stage.";
+          try {
+            await commit?.();
+          } catch (commitError) {
+            elements = previousElements;
+            nextOrdinal = previousNextOrdinal;
+            revision = previousRevision;
+            undoStack.push(...previousUndoStack);
+            pastedTexts.delete(id);
+            publish();
+            throw commitError;
+          }
+          publish();
+          return;
+        }
+        if (closed || !pastedTexts.has(id)) {
+          await options.stager.discard(staged);
+          return;
+        }
+        atom.staged = staged;
+        atom.state = "ready";
+        atom.byteCount = staged.byteCount;
+        atom.lineCount = staged.lineCount;
+        atom.scalarCount = staged.scalarCount;
+        try {
+          await commit?.();
+        } catch (error) {
+          elements = previousElements;
+          nextOrdinal = previousNextOrdinal;
+          revision = previousRevision;
+          undoStack.push(...previousUndoStack);
+          pastedTexts.delete(id);
+          await discardPastedText(atom);
+          publish();
+          throw error;
+        }
+        publish();
+      })();
+      atom.settlement = settlement;
+      await settlement;
+      return id;
+    },
     async reset(baseRevision, commit) {
       if (
         closed ||
@@ -723,7 +1081,8 @@ export async function createTurnComposer(options: {
         baseRevision !== revision ||
         [...resources.values()].some(
           (resource) => resource.state === "queued" || resource.state === "copying",
-        )
+        ) ||
+        [...pastedTexts.values()].some((pastedText) => pastedText.state === "copying")
       ) {
         return false;
       }
@@ -735,12 +1094,18 @@ export async function createTurnComposer(options: {
       const previousResourceStates = new Map(
         [...resources].map(([id, resource]) => [id, resource.state] as const),
       );
+      const previousPastedTextStates = new Map(
+        [...pastedTexts].map(([id, pastedText]) => [id, pastedText.state] as const),
+      );
       elements = [];
       nextOrdinal = 1;
       text = "";
       undoStack.length = 0;
       for (const resource of resources.values()) {
         resource.state = "removed";
+      }
+      for (const pastedText of pastedTexts.values()) {
+        pastedText.state = "removed";
       }
       revision += 1;
       try {
@@ -757,11 +1122,22 @@ export async function createTurnComposer(options: {
             resource.state = state;
           }
         }
+        for (const [id, state] of previousPastedTextStates) {
+          const pastedText = pastedTexts.get(id);
+          if (pastedText !== undefined) {
+            pastedText.state = state;
+          }
+        }
         throw error;
       }
       const retained = [...resources.values()];
+      const retainedPastedTexts = [...pastedTexts.values()];
       resources.clear();
-      await Promise.allSettled(retained.map(discardStaging));
+      pastedTexts.clear();
+      await Promise.allSettled([
+        ...retained.map(discardStaging),
+        ...retainedPastedTexts.map(discardPastedText),
+      ]);
       publish();
       return true;
     },
@@ -779,11 +1155,19 @@ export async function createTurnComposer(options: {
             resource.controller.abort();
           }
         }
+        for (const pastedText of pastedTexts.values()) {
+          if (pastedText.state === "copying") {
+            pastedText.controller.abort();
+          }
+        }
         publish();
       };
       signal.addEventListener("abort", cancelStaging, { once: true });
       try {
-        await Promise.all([...resources.values()].map((resource) => resource.settlement));
+        await Promise.all([
+          ...[...resources.values()].map((resource) => resource.settlement),
+          ...[...pastedTexts.values()].map((pastedText) => pastedText.settlement),
+        ]);
       } finally {
         signal.removeEventListener("abort", cancelStaging);
       }
@@ -828,7 +1212,33 @@ export async function createTurnComposer(options: {
           "Every retained input resource must have supported immutable content.",
         );
       }
+      const retainedPastedTexts = [...pastedTexts.values()].filter(
+        (pastedText) => pastedText.state !== "removed",
+      );
+      const failedPastedText = retainedPastedTexts.find(
+        (pastedText) =>
+          pastedText.state !== "ready" || pastedText.staged === null || pastedText.text === null,
+      );
+      if (failedPastedText !== undefined) {
+        sealed = false;
+        publish();
+        throw new TurnComposerError(
+          "failed",
+          "Every retained Text atom must be ready before send.",
+        );
+      }
+      if (textPayloadBytes() > pastedTextLimitsV1.maximumTextBytesPerTurn) {
+        sealed = false;
+        publish();
+        throw new TurnComposerError(
+          "limit_exceeded",
+          "The structured text payload exceeds the v1 turn limit.",
+        );
+      }
       const resourceById = new Map(retained.map((resource) => [resource.id, resource]));
+      const pastedTextById = new Map(
+        retainedPastedTexts.map((pastedText) => [pastedText.id, pastedText]),
+      );
       const selectionIndexById = new Map(
         retained.map((resource, index) => [resource.id, index] as const),
       );
@@ -836,6 +1246,26 @@ export async function createTurnComposer(options: {
         elements: elements.map((element): TurnComposerSealedElement => {
           if (element.type === "text") {
             return { type: "text", text: element.text };
+          }
+          if (element.type === "pasted_text") {
+            const pastedText = pastedTextById.get(element.pastedTextId);
+            if (
+              pastedText?.staged === null ||
+              pastedText?.staged === undefined ||
+              pastedText.text === null
+            ) {
+              throw new TurnComposerError(
+                "failed",
+                "Every retained Text atom must be ready before send.",
+              );
+            }
+            return {
+              type: "pasted_text",
+              ordinal: element.ordinal,
+              token: atomToken("text", element.ordinal),
+              text: pastedText.text,
+              selection: pastedText.staged,
+            };
           }
           const resource = resourceById.get(element.resourceId);
           if (resource?.staged === null || resource?.staged === undefined) {
@@ -848,7 +1278,7 @@ export async function createTurnComposer(options: {
             type: "resource",
             kind: element.kind,
             ordinal: element.ordinal,
-            token: resourceToken(element.kind, element.ordinal),
+            token: atomToken(element.kind, element.ordinal),
             selection: resource.staged,
           };
         }),
@@ -856,6 +1286,22 @@ export async function createTurnComposer(options: {
         structuredContent: elements.map((element): StagedUserContentElementV1 => {
           if (element.type === "text") {
             return { type: "text", text: element.text };
+          }
+          if (element.type === "pasted_text") {
+            const selectionIndex = retainedPastedTexts.findIndex(
+              (pastedText) => pastedText.id === element.pastedTextId,
+            );
+            if (selectionIndex < 0) {
+              throw new TurnComposerError(
+                "failed",
+                "Every retained Text atom must be ready before send.",
+              );
+            }
+            return {
+              type: "pasted_text",
+              selectionIndex,
+              draftOrdinal: element.ordinal,
+            };
           }
           const selectionIndex = selectionIndexById.get(element.resourceId);
           if (selectionIndex === undefined) {
@@ -872,10 +1318,14 @@ export async function createTurnComposer(options: {
         }),
         text,
         selections: retained.map((resource) => resource.staged as StagedInputResourceSelectionV1),
+        pastedTextSelections: retainedPastedTexts.map(
+          (pastedText) => pastedText.staged as StagedPastedTextSelectionV1,
+        ),
       };
     },
     async clear(options = {}) {
       const retained = [...resources.values()];
+      const retainedPastedTexts = [...pastedTexts.values()];
       sealed = false;
       for (const resource of retained) {
         if (resource.state === "queued" || resource.state === "copying") {
@@ -884,13 +1334,30 @@ export async function createTurnComposer(options: {
           resource.controller.abort();
         }
       }
-      await Promise.allSettled(retained.map((resource) => resource.settlement));
+      for (const pastedText of retainedPastedTexts) {
+        if (pastedText.state === "copying") {
+          pastedText.state = "removed";
+          pastedText.controller.abort();
+        }
+      }
+      await Promise.allSettled([
+        ...retained.map((resource) => resource.settlement),
+        ...retainedPastedTexts.map((pastedText) => pastedText.settlement),
+      ]);
       resources.clear();
+      pastedTexts.clear();
       await Promise.all(
         retained.map((resource) =>
-          options.preserveRetained === true && resource.retained
+          options.preserveRetained === true && resource.retained && resource.state !== "removed"
             ? Promise.resolve()
             : discardStaging(resource),
+        ),
+      );
+      await Promise.all(
+        retainedPastedTexts.map((pastedText) =>
+          options.preserveRetained === true && pastedText.retained && pastedText.state !== "removed"
+            ? Promise.resolve()
+            : discardPastedText(pastedText),
         ),
       );
       text = "";
@@ -900,9 +1367,38 @@ export async function createTurnComposer(options: {
       revision += 1;
       publish();
     },
+    readExpandedText() {
+      return elements
+        .map((element) => {
+          if (element.type === "text") {
+            return element.text;
+          }
+          if (element.type === "resource") {
+            return atomToken(element.kind, element.ordinal);
+          }
+          const pastedText = pastedTexts.get(element.pastedTextId);
+          if (pastedText?.state !== "ready" || pastedText.text === null) {
+            throw new TurnComposerError(
+              "failed",
+              "Every retained Text atom must be ready before copy.",
+            );
+          }
+          return pastedText.text;
+        })
+        .join("");
+    },
     async commitText(nextText, commit) {
       if (closed || sealed) {
         throw new TypeError("The sealed turn composer cannot change draft text.");
+      }
+      if (
+        nextText.length > 512 * 1024 ||
+        textPayloadBytes(nextText) > pastedTextLimitsV1.maximumTextBytesPerTurn
+      ) {
+        throw new TurnComposerError(
+          "limit_exceeded",
+          "The structured text payload exceeds the v1 turn limit.",
+        );
       }
       if (text !== nextText) {
         const previousText = text;
@@ -929,6 +1425,15 @@ export async function createTurnComposer(options: {
       if (closed || sealed) {
         throw new TypeError("The sealed turn composer cannot change draft text.");
       }
+      if (
+        nextText.length > 512 * 1024 ||
+        textPayloadBytes(nextText) > pastedTextLimitsV1.maximumTextBytesPerTurn
+      ) {
+        throw new TurnComposerError(
+          "limit_exceeded",
+          "The structured text payload exceeds the v1 turn limit.",
+        );
+      }
       if (text !== nextText) {
         text = nextText;
         replaceAggregateText(nextText);
@@ -951,9 +1456,24 @@ export async function createTurnComposer(options: {
       for (const resource of resources.values()) {
         resource.controller.abort();
       }
-      await Promise.allSettled([...resources.values()].map((resource) => resource.settlement));
+      for (const pastedText of pastedTexts.values()) {
+        pastedText.controller.abort();
+      }
+      await Promise.allSettled([
+        ...[...resources.values()].map((resource) => resource.settlement),
+        ...[...pastedTexts.values()].map((pastedText) => pastedText.settlement),
+      ]);
+      await Promise.all([
+        ...[...resources.values()]
+          .filter((resource) => resource.state === "removed")
+          .map(discardStaging),
+        ...[...pastedTexts.values()]
+          .filter((pastedText) => pastedText.state === "removed")
+          .map(discardPastedText),
+      ]);
       await options.stager.close();
       resources.clear();
+      pastedTexts.clear();
     },
     snapshot() {
       return {
@@ -972,8 +1492,20 @@ export async function createTurnComposer(options: {
               ...item
             }) => ({
               ...item,
-              token: resourceToken(item.kind, item.ordinal),
+              token: atomToken(item.kind, item.ordinal),
             }),
+          ),
+        pastedTexts: [...pastedTexts.values()]
+          .filter((pastedText) => pastedText.state !== "removed")
+          .map(
+            ({
+              controller: _controller,
+              retained: _retained,
+              settlement: _settlement,
+              staged: _staged,
+              text: _text,
+              ...item
+            }) => ({ ...item, token: atomToken("text", item.ordinal) }),
           ),
       };
     },

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -754,7 +754,8 @@ export type DraftPoint =
 
 export type DraftTextDocumentPart =
   | { readonly type: "text"; readonly text: string }
-  | { readonly type: "resource"; readonly elementId: string };
+  | { readonly type: "resource"; readonly elementId: string }
+  | { readonly type: "pasted_text"; readonly elementId: string };
 
 export type TurnComposerDisplay = {
   readonly attachmentAvailable: boolean;
@@ -767,6 +768,12 @@ export type TurnComposerDisplay = {
         readonly kind: "file" | "image";
         readonly ordinal: number;
         readonly resourceId: string;
+      }
+    | {
+        readonly elementId: string;
+        readonly type: "pasted_text";
+        readonly ordinal: number;
+        readonly pastedTextId: string;
       }
   )[];
   readonly renderedText: string;
@@ -792,6 +799,18 @@ export type TurnComposerDisplay = {
     readonly support: "image" | "unsupported_binary" | "utf8_text" | null;
     readonly diagnostic: string | null;
     readonly token: string;
+  }[];
+  readonly pastedTexts: readonly {
+    readonly id: string;
+    readonly elementId: string;
+    readonly ordinal: number;
+    readonly token: string;
+    readonly state: "copying" | "ready" | "failed" | "removed";
+    readonly byteCount: number;
+    readonly lineCount: number;
+    readonly scalarCount: number;
+    readonly origin: "pasted_text";
+    readonly diagnostic: string | null;
   }[];
 };
 
@@ -859,6 +878,7 @@ export type CommandReceipt =
       readonly status: "admitted";
       readonly commandId: string;
       readonly resource: ArtifactChunk | null;
+      readonly draftText?: string;
       readonly todo?: TodoPageResource | TodoEntityResource;
     }
   | {
@@ -1097,6 +1117,14 @@ export type PresentationCommand =
       };
     }
   | {
+      readonly type: "stage_pasted_text";
+      readonly text: string;
+      readonly mutation?: {
+        readonly at: DraftPoint;
+        readonly baseRevision: number;
+      };
+    }
+  | {
       readonly type: "replace_draft_text";
       readonly baseRevision: number;
       readonly document: readonly DraftTextDocumentPart[];
@@ -1114,6 +1142,7 @@ export type PresentationCommand =
       readonly type: "clear_draft";
       readonly baseRevision: number;
     }
+  | { readonly type: "read_expanded_draft" }
   | {
       readonly type: "update_draft_text";
       readonly text: string;

--- a/packages/presentation/src/presentation.test.ts
+++ b/packages/presentation/src/presentation.test.ts
@@ -72,6 +72,7 @@ const emptyComposer = {
   sealed: false,
   revisionIntent: null,
   resources: [],
+  pastedTexts: [],
 } as const;
 
 describe("presentation reconciliation", () => {

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -1010,6 +1010,7 @@ test("PresentationSession opens an empty project catalog without creating a sess
         unavailableReason: "New session required for attachments",
         sealed: false,
         resources: [],
+        pastedTexts: [],
         revisionIntent: null,
       },
       transient: null,
@@ -2739,6 +2740,344 @@ test("PresentationSession stages one draft resource before sealing the admitted 
     });
   } finally {
     releaseCopy.resolve();
+    await presentation.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession expands one pasted Text atom at its exact durable user position", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-pasted-text-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const selectedPath = join(testRoot, "mixed-notes.txt");
+  await writeFile(selectedPath, "mixed notes\n", "utf8");
+  const pasted = Array.from({ length: 11 }, (_, index) => `pasted line ${index + 1}`).join("\n");
+  const requests: Parameters<ModelDriver["stream"]>[0][] = [];
+  const driver = new FakeModelDriver((request) => {
+    requests.push(request);
+    return [
+      { type: "text_delta", text: "Pasted text answer." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const presentation = await createPresentationSession({
+    lifecycle,
+    modelTargets,
+    openProject: true,
+    projectLabel: "workspace",
+    stateRoot,
+    workspaceRoot,
+    [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+  });
+
+  try {
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+    await presentation.dispatch({ type: "update_draft_text", text: "beforeafter" });
+    const draft = presentation.getState().composer;
+    const textElement = draft.elements[0];
+    if (textElement?.type !== "text") {
+      throw new Error("Expected one literal draft span.");
+    }
+    await expect(
+      presentation.dispatch({
+        type: "stage_pasted_text",
+        text: pasted,
+        mutation: {
+          at: { elementId: textElement.elementId, offset: 6 },
+          baseRevision: draft.draftRevision,
+        },
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    expect(presentation.getState().composer).toMatchObject({
+      elements: [
+        { type: "text", text: "before" },
+        { type: "pasted_text", ordinal: 1 },
+        { type: "text", text: "after" },
+      ],
+      renderedText: "before[Text #1]after",
+      pastedTexts: [{ ordinal: 1, state: "ready", lineCount: 11 }],
+    });
+    await expect(
+      presentation.dispatch({ type: "stage_input_resource", path: selectedPath }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    expect(presentation.getState().composer.renderedText).toBe("before[Text #1]after[File #2]");
+
+    await expect(
+      presentation.dispatch({
+        type: "submit_draft_prompt",
+        text: "beforeafter",
+        skills: [],
+        thinkingSelection: null,
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    const ordinaryRequest = requests.find((request) =>
+      request.messages.some(
+        (message) =>
+          message.role === "user" &&
+          typeof message.content === "string" &&
+          message.content.startsWith(`before${pasted}after[File #2]`) &&
+          message.content.includes('"displayName":"mixed-notes.txt"'),
+      ),
+    );
+    expect(ordinaryRequest).toBeDefined();
+    const sessionId = presentation.getState().authoritative.active?.session.id;
+    if (sessionId === undefined) {
+      throw new Error("Expected an admitted pasted-text session.");
+    }
+    const logicalRun = (await readInMemoryPresentationRecords(harness.sessions)(sessionId)).find(
+      (record) => record.schemaVersion === 3 && record.record.type === "logical_run_started",
+    );
+    expect(logicalRun).toMatchObject({
+      record: {
+        recordVersion: 3,
+        userMessage: "beforeafter",
+        pastedTexts: [{ byteCount: Buffer.byteLength(pasted, "utf8") }],
+        inputResources: [{ displayName: "mixed-notes.txt" }],
+        userContent: [
+          { type: "text", text: "before" },
+          { type: "pasted_text", occurrenceId: expect.any(String), draftOrdinal: 1 },
+          { type: "text", text: "after" },
+          { type: "input_resource", occurrenceId: expect.any(String), draftOrdinal: 2 },
+        ],
+      },
+    });
+    await waitForAssistantMessage(presentation, "Pasted text answer.");
+    await presentation.close();
+    await lifecycle.continue({
+      sessionId,
+      input: { text: "Continue after pasted text." },
+    });
+    const replayedRequest = requests.findLast((request) =>
+      request.messages.some(
+        (message) =>
+          message.role === "user" &&
+          typeof message.content === "string" &&
+          message.content.includes("Continue after pasted text."),
+      ),
+    );
+    expect(
+      replayedRequest?.messages.some(
+        (message) =>
+          message.role === "user" &&
+          typeof message.content === "string" &&
+          message.content.startsWith(`before${pasted}after[File #2]`) &&
+          message.content.includes('"displayName":"mixed-notes.txt"'),
+      ),
+    ).toBe(true);
+    const reopened = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      projectLabel: "workspace",
+      sessionId,
+      stateRoot,
+      workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    });
+    expect(reopened.getState().authoritative.active?.transcript.items).toContainEqual(
+      expect.objectContaining({
+        type: "user_message",
+        text: "before[Text #1]after[File #2]",
+      }),
+    );
+    await reopened.close();
+  } finally {
+    await presentation.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession accepts exactly 1 MiB of structured text and rejects one extra byte", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-pasted-text-limit-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const exact = "x".repeat(1_024 * 1_024);
+  const lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+  const presentation = await createPresentationSession({
+    lifecycle,
+    projectLabel: "workspace",
+    stateRoot,
+    targetIdentity,
+    workspaceRoot,
+  });
+
+  try {
+    await expect(
+      presentation.dispatch({ type: "stage_pasted_text", text: exact }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    await expect(presentation.dispatch({ type: "read_expanded_draft" })).resolves.toMatchObject({
+      status: "admitted",
+      draftText: exact,
+    });
+    await expect(presentation.dispatch({ type: "update_draft_text", text: "x" })).resolves.toEqual({
+      status: "rejected",
+      code: "not_available",
+      message: "The structured text payload exceeds the v1 turn limit.",
+    });
+    expect(presentation.getState().composer.renderedText).toBe("[Text #1]");
+    await expect(
+      presentation.dispatch({
+        type: "clear_draft",
+        baseRevision: presentation.getState().composer.draftRevision,
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    await expect(
+      presentation.dispatch({ type: "stage_pasted_text", text: `${exact}x` }),
+    ).resolves.toMatchObject({ status: "rejected", code: "not_available" });
+    expect(presentation.getState().composer.pastedTexts).toEqual([]);
+  } finally {
+    await presentation.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession rejects an oversized Text atom before durable admission or provider work", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-pasted-text-context-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  let providerCalls = 0;
+  const constrainedProfile: ContextProfile = {
+    version: 1,
+    contextWindowTokens: 1_200,
+    maximumOutputTokens: 100,
+    compactAtTokens: 900,
+    postCompactTargetTokens: 400,
+    retainedTargetTokens: 100,
+    estimatorVersion: 1,
+  };
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return {
+        identity: targetIdentity,
+        contextProfile: constrainedProfile,
+        driver: new FakeModelDriver(() => {
+          providerCalls += 1;
+          return [{ type: "finish", reason: "stop" }];
+        }),
+      };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile: constrainedProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const presentation = await createPresentationSession({
+    lifecycle,
+    modelTargets,
+    openProject: true,
+    projectLabel: "workspace",
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+    await presentation.dispatch({ type: "stage_pasted_text", text: "x".repeat(5_000) });
+    await expect(
+      presentation.dispatch({
+        type: "submit_draft_prompt",
+        text: "Send the paste.",
+        skills: [],
+        thinkingSelection: null,
+      }),
+    ).resolves.toEqual({
+      status: "rejected",
+      code: "not_available",
+      message:
+        "The expanded draft cannot fit the exact target context. Remove or split Text atoms, or switch targets.",
+    });
+    expect(providerCalls).toBe(0);
+    await expect(lifecycle.listProjectSessions()).resolves.toMatchObject({ items: [] });
+    expect(presentation.getState().composer.renderedText).toBe("[Text #1]");
+  } finally {
+    await presentation.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession removes and undoes one whole Text atom without renumbering", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-pasted-text-undo-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+  const presentation = await createPresentationSession({
+    lifecycle,
+    projectLabel: "workspace",
+    stateRoot,
+    targetIdentity,
+    workspaceRoot,
+  });
+
+  try {
+    await presentation.dispatch({
+      type: "stage_pasted_text",
+      text: Array.from({ length: 11 }, (_, index) => `undo line ${index + 1}`).join("\n"),
+    });
+    const staged = presentation.getState().composer;
+    const atom = staged.elements[0];
+    if (atom?.type !== "pasted_text") {
+      throw new Error("Expected one Text atom.");
+    }
+    await expect(
+      presentation.dispatch({
+        type: "remove_draft_element",
+        baseRevision: staged.draftRevision,
+        elementId: atom.elementId,
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    expect(presentation.getState().composer).toMatchObject({
+      renderedText: "",
+      pastedTexts: [],
+    });
+    await expect(
+      presentation.dispatch({
+        type: "undo_draft",
+        baseRevision: presentation.getState().composer.draftRevision,
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    expect(presentation.getState().composer).toMatchObject({
+      renderedText: "[Text #1]",
+      pastedTexts: [{ ordinal: 1, state: "ready" }],
+    });
+    await presentation.dispatch({
+      type: "stage_pasted_text",
+      text: "x".repeat(1_001),
+    });
+    expect(presentation.getState().composer.renderedText).toBe("[Text #1][Text #2]");
+  } finally {
     await presentation.close();
     await lifecycle.close();
     await rm(testRoot, { recursive: true, force: true });
@@ -4770,6 +5109,7 @@ test("PresentationSession opens an exact target as a recoverable draft", async (
         unavailableReason: null,
         sealed: false,
         resources: [],
+        pastedTexts: [],
         revisionIntent: null,
       },
       transient: null,
@@ -4790,6 +5130,9 @@ test("PresentationSession recovers the default new-session draft after a clean r
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
   const selectedPath = join(workspaceRoot, "notes.txt");
+  const pasted = Array.from({ length: 11 }, (_, index) => `recovered paste ${index + 1}`).join(
+    "\n",
+  );
   await writeFile(selectedPath, "notes", "utf8");
   const modelTargets: ModelTargets = {
     async resolve() {
@@ -4837,6 +5180,9 @@ test("PresentationSession recovers the default new-session draft after a clean r
         },
       }),
     ).resolves.toMatchObject({ status: "admitted" });
+    await expect(
+      presentation.dispatch({ type: "stage_pasted_text", text: pasted }),
+    ).resolves.toMatchObject({ status: "admitted" });
     await presentation.close();
 
     presentation = await createProductPresentationSession({
@@ -4852,9 +5198,14 @@ test("PresentationSession recovers the default new-session draft after a clean r
         { type: "text", text: "before" },
         { type: "resource", kind: "file", ordinal: 1 },
         { type: "text", text: "after" },
+        { type: "pasted_text", ordinal: 2 },
       ],
-      renderedText: "before[File #1]after",
+      renderedText: "before[File #1]after[Text #2]",
       resources: [{ displayName: "notes.txt", ordinal: 1, state: "ready" }],
+      pastedTexts: [{ ordinal: 2, state: "ready", lineCount: 11 }],
+    });
+    await expect(presentation.dispatch({ type: "read_expanded_draft" })).resolves.toMatchObject({
+      draftText: `before[File #1]after${pasted}`,
     });
     await expect(lifecycle.listProjectSessions()).resolves.toMatchObject({ items: [] });
   } finally {
@@ -4886,6 +5237,9 @@ test("PresentationSession discards an explicit process-only draft on close", asy
     await expect(
       presentation.dispatch({ type: "update_draft_text", text: "do not recover me" }),
     ).resolves.toMatchObject({ status: "admitted" });
+    await expect(
+      presentation.dispatch({ type: "stage_pasted_text", text: "x".repeat(1_001) }),
+    ).resolves.toMatchObject({ status: "admitted" });
     await presentation.close();
 
     presentation = await createPresentationSession({
@@ -4901,6 +5255,7 @@ test("PresentationSession discards an explicit process-only draft on close", asy
       elements: [],
       renderedText: "",
       resources: [],
+      pastedTexts: [],
     });
   } finally {
     await presentation?.close();

--- a/patches/@earendil-works__pi-tui@0.84.2.patch
+++ b/patches/@earendil-works__pi-tui@0.84.2.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/components/editor.d.ts b/dist/components/editor.d.ts
-index a6fedc9e3b36d066e34860d040db6df47d88c432..fc00b23987ad376bcd60096ceff0e6d329404cd1 100644
+index a6fedc9e3b36d066e34860d040db6df47d88c432..26b2fd69ac2dfdbea79ee24125ff5bf2d695d8af 100644
 --- a/dist/components/editor.d.ts
 +++ b/dist/components/editor.d.ts
-@@ -30,6 +30,37 @@ export interface EditorOptions {
+@@ -30,6 +30,47 @@ export interface EditorOptions {
      paddingX?: number;
      autocompleteMaxVisible?: number;
  }
@@ -37,18 +37,29 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..fc00b23987ad376bcd60096ceff0e6d3
 +} | {
 +    readonly type: "undo";
 +};
++export type EditorPasteIntent = {
++    readonly text: string;
++    readonly cursor: {
++        readonly type: "text";
++        readonly offset: number;
++    } | {
++        readonly type: "document";
++        readonly point: EditorDocumentPoint;
++    };
++};
  export declare class Editor implements Component, Focusable {
      private state;
      /** Focusable interface - set by TUI when focus changes */
-@@ -68,6 +99,7 @@ export declare class Editor implements Component, Focusable {
+@@ -68,6 +109,8 @@ export declare class Editor implements Component, Focusable {
      private undoStack;
      onSubmit?: (text: string) => void;
      onChange?: (text: string) => void;
 +    onEditIntent?: (intent: EditorEditIntent) => void;
++    onPaste?: (intent: EditorPasteIntent) => boolean;
      disableSubmit: boolean;
      constructor(tui: TUI, theme: EditorTheme, options?: EditorOptions);
      /** Set of currently valid paste IDs, for marker-aware segmentation. */
-@@ -107,6 +139,8 @@ export declare class Editor implements Component, Focusable {
+@@ -107,6 +150,8 @@ export declare class Editor implements Component, Focusable {
          line: number;
          col: number;
      };
@@ -58,14 +69,15 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..fc00b23987ad376bcd60096ceff0e6d3
      /**
       * Insert text at the current cursor position.
 diff --git a/dist/components/editor.js b/dist/components/editor.js
-index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f5f21f7b6 100644
+index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94d0456dcf 100644
 --- a/dist/components/editor.js
 +++ b/dist/components/editor.js
-@@ -246,6 +246,11 @@ export class Editor {
+@@ -246,6 +246,12 @@ export class Editor {
      undoStack = new UndoStack();
      onSubmit;
      onChange;
 +    onEditIntent;
++    onPaste;
 +    structuredDocument = null;
 +    structuredAtoms = [];
 +    structuredCursorPoint = null;
@@ -73,7 +85,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f
      disableSubmit = false;
      constructor(tui, theme, options = {}) {
          this.tui = tui;
-@@ -527,6 +532,26 @@ export class Editor {
+@@ -527,6 +533,26 @@ export class Editor {
              this.undo();
              return;
          }
@@ -100,7 +112,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f
          // Handle autocomplete mode
          if (this.autocompleteState && this.autocompleteList) {
              if (kb.matches(data, "tui.select.cancel")) {
-@@ -847,6 +872,256 @@ export class Editor {
+@@ -847,6 +873,256 @@ export class Editor {
      getCursor() {
          return { line: this.state.cursorLine, col: this.state.cursorCol };
      }
@@ -357,7 +369,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f
      setText(text) {
          this.cancelAutocomplete();
          this.lastAction = null;
-@@ -858,6 +1133,9 @@ export class Editor {
+@@ -858,6 +1134,9 @@ export class Editor {
          }
          this.pastes.clear();
          this.pasteCounter = 0;
@@ -367,7 +379,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f
          this.setTextInternal(normalized);
      }
      /**
-@@ -868,6 +1146,10 @@ export class Editor {
+@@ -868,6 +1147,10 @@ export class Editor {
      insertTextAtCursor(text) {
          if (!text)
              return;
@@ -378,7 +390,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f
          this.cancelAutocomplete();
          this.pushUndoSnapshot();
          this.lastAction = null;
-@@ -890,6 +1172,10 @@ export class Editor {
+@@ -890,6 +1173,10 @@ export class Editor {
      insertTextAtCursorInternal(text) {
          if (!text)
              return;
@@ -389,7 +401,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f
          // Normalize line endings and tabs
          const normalized = this.normalizeText(text);
          const insertedLines = normalized.split("\n");
-@@ -925,6 +1211,10 @@ export class Editor {
+@@ -925,6 +1212,10 @@ export class Editor {
      // All the editor methods from before...
      insertCharacter(char, skipUndoCoalescing) {
          this.exitHistoryBrowsing();
@@ -400,10 +412,17 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f
          // Undo coalescing (fish-style):
          // - Consecutive word chars coalesce into one undo unit
          // - Space captures state before itself (so undo removes space+following word together)
-@@ -1011,6 +1301,10 @@ export class Editor {
+@@ -1011,11 +1302,22 @@ export class Editor {
                  filteredText = ` ${filteredText}`;
              }
          }
++        const pasteIntent = this.structuredDocument === null
++            ? { text: filteredText, cursor: { type: "text", offset: this.cursorOffset() } }
++            : { text: filteredText, cursor: { type: "document", point: this.getDocumentCursor() } };
++        const hostClassifiedPaste = this.onPaste !== undefined;
++        if (this.onPaste?.(pasteIntent) === true) {
++            return;
++        }
 +        if (this.structuredDocument !== null) {
 +            this.emitInsertionIntent(filteredText);
 +            return;
@@ -411,7 +430,13 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f
          // Split into lines to check for large paste
          const pastedLines = filteredText.split("\n");
          // Check if this is a large paste (> 10 lines or > 1000 characters)
-@@ -1036,6 +1330,10 @@ export class Editor {
+         const totalChars = filteredText.length;
+-        if (pastedLines.length > 10 || totalChars > 1000) {
++        if (!hostClassifiedPaste && (pastedLines.length > 10 || totalChars > 1000)) {
+             // Store the paste and insert a marker
+             this.pasteCounter++;
+             const pasteId = this.pasteCounter;
+@@ -1036,6 +1338,10 @@ export class Editor {
          this.insertTextAtCursorInternal(filteredText);
      }
      addNewLine() {
@@ -422,7 +447,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f
          this.cancelAutocomplete();
          this.exitHistoryBrowsing();
          this.lastAction = null;
-@@ -1068,6 +1366,11 @@ export class Editor {
+@@ -1068,6 +1374,11 @@ export class Editor {
      submitValue() {
          this.cancelAutocomplete();
          const result = this.expandPasteMarkers(this.state.lines.join("\n")).trim();
@@ -434,7 +459,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f
          this.state = { lines: [""], cursorLine: 0, cursorCol: 0 };
          this.pastes.clear();
          this.pasteCounter = 0;
-@@ -1083,6 +1386,16 @@ export class Editor {
+@@ -1083,6 +1394,16 @@ export class Editor {
      handleBackspace() {
          this.exitHistoryBrowsing();
          this.lastAction = null;
@@ -451,7 +476,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f
          if (this.state.cursorCol > 0) {
              this.pushUndoSnapshot();
              // Delete grapheme before cursor (handles emojis, combining characters, etc.)
-@@ -1157,6 +1470,7 @@ export class Editor {
+@@ -1157,6 +1478,7 @@ export class Editor {
       */
      setCursorCol(col) {
          this.state.cursorCol = col;
@@ -459,7 +484,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f
          this.preferredVisualCol = null;
          this.snappedFromCursorCol = null;
      }
-@@ -1410,6 +1724,16 @@ export class Editor {
+@@ -1410,6 +1732,16 @@ export class Editor {
      handleForwardDelete() {
          this.exitHistoryBrowsing();
          this.lastAction = null;
@@ -476,7 +501,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f
          const currentLine = this.state.lines[this.state.cursorLine] || "";
          if (this.state.cursorCol < currentLine.length) {
              this.pushUndoSnapshot();
-@@ -1520,6 +1844,12 @@ export class Editor {
+@@ -1520,6 +1852,12 @@ export class Editor {
          if (deltaCol !== 0) {
              const currentLine = this.state.lines[this.state.cursorLine] || "";
              if (deltaCol > 0) {
@@ -489,7 +514,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f
                  // Moving right - move by one grapheme (handles emojis, combining characters, etc.)
                  if (this.state.cursorCol < currentLine.length) {
                      const afterCursor = currentLine.slice(this.state.cursorCol);
-@@ -1541,6 +1871,12 @@ export class Editor {
+@@ -1541,6 +1879,12 @@ export class Editor {
                  }
              }
              else {
@@ -502,7 +527,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..e479acdeb9ff0800db1ee2e165f2174f
                  // Moving left - move by one grapheme (handles emojis, combining characters, etc.)
                  if (this.state.cursorCol > 0) {
                      const beforeCursor = currentLine.slice(0, this.state.cursorCol);
-@@ -1704,6 +2040,10 @@ export class Editor {
+@@ -1704,6 +2048,10 @@ export class Editor {
      }
      undo() {
          this.exitHistoryBrowsing();
@@ -527,21 +552,22 @@ index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..0b8964d09635714a7e5872c653883e06
          if (descriptionSingleLine && width > 40) {
              const effectivePrimaryColumnWidth = Math.max(1, Math.min(primaryColumnWidth, width - prefixWidth - 4));
 diff --git a/dist/editor-component.d.ts b/dist/editor-component.d.ts
-index b598c4d291ace5f04b83161252b3ab8cdd4ccbdf..4e776071dab430ab4dc18c589fd15d22c8858586 100644
+index b598c4d291ace5f04b83161252b3ab8cdd4ccbdf..734cca4d88ec3615a564caadce0311b0ba20ee4a 100644
 --- a/dist/editor-component.d.ts
 +++ b/dist/editor-component.d.ts
 @@ -1,4 +1,5 @@
  import type { AutocompleteProvider } from "./autocomplete.ts";
-+import type { EditorDocumentPart, EditorDocumentPoint, EditorEditIntent } from "./components/editor.ts";
++import type { EditorDocumentPart, EditorDocumentPoint, EditorEditIntent, EditorPasteIntent } from "./components/editor.ts";
  import type { Component } from "./tui.ts";
  /**
   * Interface for custom editor components.
-@@ -18,10 +19,16 @@ export interface EditorComponent extends Component {
+@@ -18,10 +19,17 @@ export interface EditorComponent extends Component {
      onSubmit?: (text: string) => void;
      /** Called when text changes */
      onChange?: (text: string) => void;
 +    /** Called instead of mutating a host-authoritative structured document. */
 +    onEditIntent?: (intent: EditorEditIntent) => void;
++    onPaste?: (intent: EditorPasteIntent) => boolean;
      /** Add text to history for up/down navigation */
      addToHistory?(text: string): void;
      /** Insert text at current cursor position */
@@ -554,7 +580,7 @@ index b598c4d291ace5f04b83161252b3ab8cdd4ccbdf..4e776071dab430ab4dc18c589fd15d22
       * Get text with any markers expanded (e.g., paste markers).
       * Falls back to getText() if not implemented.
 diff --git a/dist/index.d.ts b/dist/index.d.ts
-index 50b5aeb61f12011642978bc2c31d8a2eb36d17d3..86a7fd77af0a5b812f0cb12cd62508b17b1d06d8 100644
+index 50b5aeb61f12011642978bc2c31d8a2eb36d17d3..5882d0e9bfd60ee3342083ea57fcffacf34e0ef1 100644
 --- a/dist/index.d.ts
 +++ b/dist/index.d.ts
 @@ -2,7 +2,7 @@ export { Marked, type Token, type Tokens } from "marked";
@@ -562,7 +588,7 @@ index 50b5aeb61f12011642978bc2c31d8a2eb36d17d3..86a7fd77af0a5b812f0cb12cd62508b1
  export { Box } from "./components/box.ts";
  export { CancellableLoader } from "./components/cancellable-loader.ts";
 -export { Editor, type EditorOptions, type EditorTheme } from "./components/editor.ts";
-+export { Editor, type EditorDocumentPart, type EditorDocumentPoint, type EditorEditIntent, type EditorOptions, type EditorTheme } from "./components/editor.ts";
++export { Editor, type EditorDocumentPart, type EditorDocumentPoint, type EditorEditIntent, type EditorOptions, type EditorPasteIntent, type EditorTheme } from "./components/editor.ts";
  export { HStack } from "./components/h-stack.ts";
  export { Image, type ImageOptions, type ImageTheme } from "./components/image.ts";
  export { Input } from "./components/input.ts";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@earendil-works/pi-tui@0.84.2': 923877ec5b8c46ce6c8d651ac110b49d4560a45868910caf7a24c846a0196595
+  '@earendil-works/pi-tui@0.84.2': 9e4b660c5123f19b0872b16136448997cd91bf4fa3be8d735fbbdce2643493b7
 
 importers:
 
@@ -52,7 +52,7 @@ importers:
         version: link:../../packages/presentation
       '@earendil-works/pi-tui':
         specifier: 0.84.2
-        version: 0.84.2(patch_hash=923877ec5b8c46ce6c8d651ac110b49d4560a45868910caf7a24c846a0196595)
+        version: 0.84.2(patch_hash=9e4b660c5123f19b0872b16136448997cd91bf4fa3be8d735fbbdce2643493b7)
       highlight.js:
         specifier: 11.11.1
         version: 11.11.1
@@ -1418,7 +1418,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.8':
     optional: true
 
-  '@earendil-works/pi-tui@0.84.2(patch_hash=923877ec5b8c46ce6c8d651ac110b49d4560a45868910caf7a24c846a0196595)':
+  '@earendil-works/pi-tui@0.84.2(patch_hash=9e4b660c5123f19b0872b16136448997cd91bf4fa3be8d735fbbdce2643493b7)':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5


### PR DESCRIPTION
Summary
- promote normalized pastes above 10 logical lines or 1000 Unicode scalars to stable Text atoms
- preserve exact user-text semantics through owner-private draft recovery, immutable artifacts, durable replay, branch history, and transcript projection
- add visible-token copy plus explicit expanded-draft copy, shared File/Text numbering, whole-atom delete and undo
- enforce a 1 MiB UTF-8 structured-text limit and exact-target preflight before durable admission

Evidence
- pnpm quality:check: 1580 passed, 18 skipped
- focused TUI behavior: 214 passed
- real PTY Text promotion passed
- 10/11-line, 1000/1001-scalar, exact 1 MiB plus one-byte rejection, restart, replay, mixed File/Text, copy, delete/undo, process-only, and orphan-eligibility contracts passed