### PR TITLE
fix(tui): restore completion after draft atoms

### DIFF
--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -508,6 +508,145 @@ test("a chunked large bracketed paste becomes one exact expandable Text atom", a
   }
 });
 
+test("Skill completion remains available after one large pasted Text atom", async () => {
+  const { fixture, testRoot } = await startPastedTextAtomFixture({
+    prepare: prepareFirstStructuredCompletionSkill,
+    scenario: "skill-selection",
+    slug: "skill-completion",
+  });
+  try {
+    const beforeCompletion = fixture.output().length;
+    fixture.write(" Use $fir");
+    await fixture.waitForCompleteFrameAfter("$first", beforeCompletion);
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("Tab accepts one literal Skill completion without changing an adjacent Text atom", async () => {
+  const { fixture, testRoot } = await startPastedTextAtomFixture({
+    prepare: prepareFirstStructuredCompletionSkill,
+    scenario: "skill-selection",
+    slug: "skill-tab",
+  });
+  try {
+    fixture.write(" Use $fir");
+    await fixture.waitFor("$first");
+    const beforeAccept = fixture.output().length;
+    fixture.write("\t");
+    await fixture.waitForCompleteFrameAfter("Use $first", beforeAccept);
+    expect(fixture.screen()?.join("\n") ?? "").toContain("[Text #1]");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("Enter accepts one literal Skill completion without submitting an adjacent Text atom", async () => {
+  const { fixture, stateRoot, testRoot } = await startPastedTextAtomFixture({
+    prepare: prepareFirstStructuredCompletionSkill,
+    scenario: "skill-selection",
+    slug: "skill-enter",
+  });
+  try {
+    fixture.write(" Use $fir");
+    await fixture.waitFor("$first");
+    const beforeAccept = fixture.output().length;
+    fixture.write("\r");
+    await fixture.waitForCompleteFrameAfter("Use $first", beforeAccept);
+    expect(fixture.screen()?.join("\n") ?? "").toContain("[Text #1]");
+    fixture.write("\r");
+    await fixture.waitFor("Skill selection complete.");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    const durableState = await readFilesRecursively(stateRoot);
+    expect(durableState).toContain("Use $first");
+    expect(durableState).not.toContain('Use $fir"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("slash completion uses the literal text part after one pasted Text atom", async () => {
+  const { fixture, testRoot } = await startPastedTextAtomFixture({ slug: "slash-completion" });
+  try {
+    const beforeCompletion = fixture.output().length;
+    fixture.write("/pl");
+    await fixture.waitForCompleteFrameAfter("/plan", beforeCompletion);
+    expect(fixture.screen()?.join("\n") ?? "").toContain("[Text #1]");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the existing at path picker remains atom-safe after one pasted Text atom", async () => {
+  const { fixture, testRoot } = await startPastedTextAtomFixture({
+    prepare: async (workspaceRoot) => {
+      await mkdir(join(workspaceRoot, "src"), { recursive: true });
+      await writeFile(join(workspaceRoot, "src", "alpha.ts"), "private\n", "utf8");
+    },
+    slug: "at-completion",
+  });
+  try {
+    const beforePicker = fixture.output().length;
+    fixture.write(" Inspect @");
+    await fixture.waitForCompleteFrameAfter("Select a project path", beforePicker);
+    const beforeAccept = fixture.output().length;
+    fixture.write("alpha\r");
+    await fixture.waitForCompleteFrameAfter("Inspect `src/alpha.ts`", beforeAccept);
+    expect(fixture.screen()?.join("\n") ?? "").toContain("[Text #1]");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+async function startPastedTextAtomFixture(input: {
+  readonly prepare?: (workspaceRoot: string) => Promise<void>;
+  readonly scenario?: "skill-selection";
+  readonly slug: string;
+}) {
+  const testRoot = await mkdtemp(join(tmpdir(), `adam-agent-tui-text-atom-${input.slug}-`));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  try {
+    await mkdir(workspaceRoot, { recursive: true });
+    await input.prepare?.(workspaceRoot);
+    const fixture = startFixture({
+      ...(input.scenario === undefined ? {} : { scenario: input.scenario }),
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    const pasted = Array.from({ length: 11 }, (_, index) => `structured line ${index + 1}`).join(
+      "\n",
+    );
+    fixture.write(`\u001b[200~${pasted}\u001b[201~`);
+    await fixture.waitFor("Pasted text staged.");
+    await fixture.waitFor("[Text #1]");
+    return { fixture, stateRoot, testRoot };
+  } catch (error) {
+    await rm(testRoot, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+async function prepareFirstStructuredCompletionSkill(workspaceRoot: string): Promise<void> {
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "first");
+  await mkdir(skillDirectory, { recursive: true });
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: first\ndescription: First structured completion procedure.\n---\nFirst body.\n",
+    "utf8",
+  );
+}
+
 test("a 1000-scalar paste stays ordinary text even when UTF-16 length is larger", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-scalar-paste-boundary-"));
   const workspaceRoot = join(testRoot, "workspace");

--- a/apps/tui/src/structured-editor-completion.test.ts
+++ b/apps/tui/src/structured-editor-completion.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "vitest";
+import { AdamAutocompleteProvider } from "./command-autocomplete.js";
+import { adamStructuredEditorCompletion } from "./structured-editor-completion.js";
+
+const provider = new AdamAutocompleteProvider({
+  getProjectPaths: () => [],
+  getRunActive: () => false,
+  getSkills: () => [],
+});
+
+test("structured completion hides atom labels while preserving earlier literal slash eligibility", async () => {
+  const cursor = { partId: "right", offset: 3 } as const;
+  const afterAtom = [
+    { type: "atom", id: "resource", label: "[Text #1]" },
+    { type: "text", id: "right", text: "/pl" },
+  ] as const;
+  const eligible = adamStructuredEditorCompletion.project(afterAtom, cursor);
+  expect(eligible).not.toBeNull();
+  await expect(
+    provider.getSuggestions(
+      [...(eligible?.lines ?? [])],
+      eligible?.cursorLine ?? 0,
+      eligible?.cursorCol ?? 0,
+      { signal: new AbortController().signal },
+    ),
+  ).resolves.toMatchObject({
+    items: expect.arrayContaining([expect.objectContaining({ value: "/plan" })]),
+  });
+
+  const afterEarlierLiteral = [
+    { type: "text", id: "left", text: "explain" },
+    ...afterAtom,
+  ] as const;
+  const blocked = adamStructuredEditorCompletion.project(afterEarlierLiteral, cursor);
+  expect(blocked).not.toBeNull();
+  await expect(
+    provider.getSuggestions(
+      [...(blocked?.lines ?? [])],
+      blocked?.cursorLine ?? 0,
+      blocked?.cursorCol ?? 0,
+      { signal: new AbortController().signal },
+    ),
+  ).resolves.toBeNull();
+});
+
+test("structured completion acceptance preserves every atom identity and order", () => {
+  const document = [
+    { type: "atom", id: "resource", label: "[Text #1]" },
+    { type: "text", id: "right", text: "Use $fir" },
+  ] as const;
+
+  expect(
+    adamStructuredEditorCompletion.accept(
+      document,
+      { partId: "right", offset: 8 },
+      { label: "$first", value: "$first" },
+      "$fir",
+    ),
+  ).toEqual({
+    cursor: { partId: "right", offset: 10 },
+    document: [
+      { type: "atom", id: "resource", label: "[Text #1]" },
+      { type: "text", id: "right", text: "Use $first" },
+    ],
+    range: {
+      anchor: { partId: "right", offset: 4 },
+      focus: { partId: "right", offset: 8 },
+    },
+    text: "$first",
+  });
+});

--- a/apps/tui/src/structured-editor-completion.ts
+++ b/apps/tui/src/structured-editor-completion.ts
@@ -1,0 +1,77 @@
+import type {
+  EditorDocumentPart,
+  EditorDocumentPoint,
+  EditorStructuredCompletion,
+  EditorStructuredCompletionProjection,
+} from "@earendil-works/pi-tui";
+
+export const adamStructuredEditorCompletion: EditorStructuredCompletion = {
+  project(document, cursor) {
+    const textCursor = textPartAtCursor(document, cursor);
+    if (textCursor === null) {
+      return null;
+    }
+    const beforeCursor = textCursor.part.text.slice(0, textCursor.offset);
+    const earlierLiteralContent = document
+      .slice(0, textCursor.index)
+      .some((part) => part.type === "text" && part.text.trim().length > 0);
+    const blockSlash = earlierLiteralContent && beforeCursor.trimStart().startsWith("/");
+    return projectTextPart(
+      blockSlash ? `x${textCursor.part.text}` : textCursor.part.text,
+      textCursor.offset + (blockSlash ? 1 : 0),
+    );
+  },
+  accept(document, cursor, item, prefix) {
+    const textCursor = textPartAtCursor(document, cursor);
+    if (textCursor === null) {
+      return null;
+    }
+    const start = textCursor.offset - prefix.length;
+    if (start < 0 || textCursor.part.text.slice(start, textCursor.offset) !== prefix) {
+      return null;
+    }
+    const replacement = `${textCursor.part.text.slice(0, start)}${item.value}${textCursor.part.text.slice(textCursor.offset)}`;
+    const nextDocument = document.map((part) =>
+      part.id === textCursor.part.id ? { ...textCursor.part, text: replacement } : part,
+    );
+    const range = {
+      anchor: { partId: textCursor.part.id, offset: start },
+      focus: { partId: textCursor.part.id, offset: textCursor.offset },
+    } as const;
+    return {
+      cursor: { partId: textCursor.part.id, offset: start + item.value.length },
+      document: nextDocument,
+      range,
+      text: item.value,
+    };
+  },
+};
+
+function textPartAtCursor(
+  document: readonly EditorDocumentPart[],
+  cursor: EditorDocumentPoint,
+): {
+  readonly index: number;
+  readonly part: Extract<EditorDocumentPart, { readonly type: "text" }>;
+  readonly offset: number;
+} | null {
+  if (!("offset" in cursor) || !Number.isSafeInteger(cursor.offset) || cursor.offset < 0) {
+    return null;
+  }
+  const index = document.findIndex((candidate) => candidate.id === cursor.partId);
+  const part = document[index];
+  if (part?.type !== "text" || cursor.offset > part.text.length) {
+    return null;
+  }
+  return { index, offset: cursor.offset, part };
+}
+
+function projectTextPart(text: string, cursorOffset: number): EditorStructuredCompletionProjection {
+  const lines = text.split("\n");
+  const beforeCursor = text.slice(0, cursorOffset).split("\n");
+  return {
+    cursorCol: beforeCursor.at(-1)?.length ?? 0,
+    cursorLine: beforeCursor.length - 1,
+    lines,
+  };
+}

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -92,6 +92,7 @@ import { safeTerminalText } from "./safe-terminal-text.js";
 import { SessionInspector, type SessionRunStatus } from "./session-inspector.js";
 import { SessionPicker } from "./session-picker.js";
 import { SkillPalette } from "./skill-palette.js";
+import { adamStructuredEditorCompletion } from "./structured-editor-completion.js";
 import { TargetPicker } from "./target-picker.js";
 import { type AdamTuiTheme, createAdamTuiTheme } from "./theme.js";
 import { ThinkingPicker } from "./thinking-picker.js";
@@ -299,6 +300,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         registry: commandRegistry,
       }),
     );
+    created.setStructuredCompletion(adamStructuredEditorCompletion);
     for (const prompt of authoritativePromptHistory(active)) {
       created.addToHistory(prompt);
     }
@@ -623,6 +625,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   let localStructuredDocument: readonly EditorDocumentPart[] | null = null;
   let projectedComposerKey: string | null = null;
   let projectedComposerScope: string | null = null;
+  let structuredReconcileScheduled = false;
   const synchronizeStructuredComposer = (
     composer: ReturnType<PresentationSession["getState"]>["composer"],
     scope: string | null,
@@ -637,7 +640,6 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     if (!scopeChanged && composerKey === projectedComposerKey) {
       return;
     }
-    projectedComposerKey = composerKey;
     if (
       composer.resources.some(
         (resource) => resource.state === "queued" || resource.state === "copying",
@@ -646,6 +648,22 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     ) {
       return;
     }
+    if (structuredEditorActive && (draftMutationQueue.pending > 0 || draftMutationQueue.size > 0)) {
+      if (!structuredReconcileScheduled) {
+        structuredReconcileScheduled = true;
+        void draftMutationQueue.onIdle().then(
+          () => {
+            structuredReconcileScheduled = false;
+            renderState();
+          },
+          () => {
+            structuredReconcileScheduled = false;
+          },
+        );
+      }
+      return;
+    }
+    projectedComposerKey = composerKey;
     if (!composer.elements.some((element) => element.type !== "text")) {
       if (structuredEditorActive && composer.elements.length > 0) {
         editor.setDocument(
@@ -2230,6 +2248,65 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       });
   };
   let emptyDraftChangeGeneration = 0;
+  const showProjectPathPicker = (): void => {
+    const state = options.presentation.getState();
+    const active = state.authoritative.active;
+    const projectPaths = active?.projectPaths ?? state.draft?.projectPaths;
+    if (
+      pathPicker !== undefined ||
+      projectPaths === undefined ||
+      projectPaths.items.length === 0 ||
+      !isProjectPathTrigger(editor.getExpandedText())
+    ) {
+      return;
+    }
+    let handle: { hide(): void } | undefined;
+    const close = () => {
+      handle?.hide();
+      pathPicker = undefined;
+      tui.setFocus(editor);
+      tui.requestRender();
+    };
+    const picker = new ProjectPathPicker({
+      catalog: projectPaths,
+      onClose: close,
+      onSelect(path) {
+        const value = `\`${safeTerminalText(path)}\``;
+        if (structuredEditorActive && localStructuredDocument !== null) {
+          const edit = adamStructuredEditorCompletion.accept(
+            localStructuredDocument,
+            editor.getDocumentCursor(),
+            { label: value, value },
+            "@",
+          );
+          if (edit !== null) {
+            editor.setDocument(edit.document, edit.cursor);
+            editor.onEditIntent?.({
+              type: "replace",
+              document: edit.document,
+              range: edit.range,
+              text: edit.text,
+            });
+          }
+        } else {
+          const draft = editor.getExpandedText();
+          const trigger = draft.lastIndexOf("@");
+          if (trigger >= 0) {
+            editor.setText(`${draft.slice(0, trigger)}${value}${draft.slice(trigger + 1)}`);
+          }
+        }
+        close();
+      },
+      theme,
+    });
+    handle = showOverlay(picker, {
+      width: "90%",
+      minWidth: 36,
+      maxHeight: "80%",
+      margin: 1,
+    });
+    pathPicker = { close, hide: () => handle?.hide() };
+  };
   editor.onChange = () => {
     const text = editor.getExpandedText();
     emptyDraftChangeGeneration += 1;
@@ -2255,45 +2332,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       clearExitWindow();
       renderState();
     }
-    const state = options.presentation.getState();
-    const active = state.authoritative.active;
-    const projectPaths = active?.projectPaths ?? state.draft?.projectPaths;
-    if (
-      pathPicker === undefined &&
-      projectPaths !== undefined &&
-      projectPaths.items.length > 0 &&
-      isProjectPathTrigger(editor.getExpandedText())
-    ) {
-      let handle: { hide(): void } | undefined;
-      const close = () => {
-        handle?.hide();
-        pathPicker = undefined;
-        tui.setFocus(editor);
-        tui.requestRender();
-      };
-      const picker = new ProjectPathPicker({
-        catalog: projectPaths,
-        onClose: close,
-        onSelect(path) {
-          const draft = editor.getExpandedText();
-          const trigger = draft.lastIndexOf("@");
-          if (trigger >= 0) {
-            editor.setText(
-              `${draft.slice(0, trigger)}\`${safeTerminalText(path)}\`${draft.slice(trigger + 1)}`,
-            );
-          }
-          close();
-        },
-        theme,
-      });
-      handle = showOverlay(picker, {
-        width: "90%",
-        minWidth: 36,
-        maxHeight: "80%",
-        margin: 1,
-      });
-      pathPicker = { close, hide: () => handle?.hide() };
-    }
+    showProjectPathPicker();
   };
   editor.onPaste = (intent: EditorPasteIntent) => {
     if (!isLargePastedTextV1(intent.text)) {
@@ -2419,6 +2458,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     const localLiteralText = intent.document
       .flatMap((part) => (part.type === "text" ? [part.text] : []))
       .join("");
+    showProjectPathPicker();
     if (localLiteralText.startsWith("/")) {
       renderState();
       return;

--- a/patches/@earendil-works__pi-tui@0.84.2.patch
+++ b/patches/@earendil-works__pi-tui@0.84.2.patch
@@ -1,8 +1,14 @@
 diff --git a/dist/components/editor.d.ts b/dist/components/editor.d.ts
-index a6fedc9e3b36d066e34860d040db6df47d88c432..26b2fd69ac2dfdbea79ee24125ff5bf2d695d8af 100644
+index a6fedc9e3b36d066e34860d040db6df47d88c432..8964a0abe9223c856910e1355931300567c6251a 100644
 --- a/dist/components/editor.d.ts
 +++ b/dist/components/editor.d.ts
-@@ -30,6 +30,47 @@ export interface EditorOptions {
+@@ -1,4 +1,4 @@
+-import type { AutocompleteProvider } from "../autocomplete.ts";
++import type { AutocompleteItem, AutocompleteProvider } from "../autocomplete.ts";
+ import { type Component, type Focusable, type TUI } from "../tui.ts";
+ import { type SelectListTheme } from "./select-list.ts";
+ /**
+@@ -30,6 +30,65 @@ export interface EditorOptions {
      paddingX?: number;
      autocompleteMaxVisible?: number;
  }
@@ -47,10 +53,36 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..26b2fd69ac2dfdbea79ee24125ff5bf2
 +        readonly point: EditorDocumentPoint;
 +    };
 +};
++export type EditorStructuredCompletionProjection = {
++    readonly lines: readonly string[];
++    readonly cursorLine: number;
++    readonly cursorCol: number;
++};
++export type EditorStructuredCompletionEdit = {
++    readonly range: {
++        readonly anchor: EditorDocumentPoint;
++        readonly focus: EditorDocumentPoint;
++    };
++    readonly text: string;
++    readonly document: readonly EditorDocumentPart[];
++    readonly cursor: EditorDocumentPoint;
++};
++export interface EditorStructuredCompletion {
++    project(document: readonly EditorDocumentPart[], cursor: EditorDocumentPoint): EditorStructuredCompletionProjection | null;
++    accept(document: readonly EditorDocumentPart[], cursor: EditorDocumentPoint, item: AutocompleteItem, prefix: string): EditorStructuredCompletionEdit | null;
++}
  export declare class Editor implements Component, Focusable {
      private state;
      /** Focusable interface - set by TUI when focus changes */
-@@ -68,6 +109,8 @@ export declare class Editor implements Component, Focusable {
+@@ -53,6 +112,7 @@ export declare class Editor implements Component, Focusable {
+     private autocompleteRequestTask;
+     private autocompleteStartToken;
+     private autocompleteRequestId;
++    private structuredCompletion?;
+     private pastes;
+     private pasteCounter;
+     private pasteBuffer;
+@@ -68,6 +128,8 @@ export declare class Editor implements Component, Focusable {
      private undoStack;
      onSubmit?: (text: string) => void;
      onChange?: (text: string) => void;
@@ -59,7 +91,15 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..26b2fd69ac2dfdbea79ee24125ff5bf2
      disableSubmit: boolean;
      constructor(tui: TUI, theme: EditorTheme, options?: EditorOptions);
      /** Set of currently valid paste IDs, for marker-aware segmentation. */
-@@ -107,6 +150,8 @@ export declare class Editor implements Component, Focusable {
+@@ -79,6 +141,7 @@ export declare class Editor implements Component, Focusable {
+     getAutocompleteMaxVisible(): number;
+     setAutocompleteMaxVisible(maxVisible: number): void;
+     setAutocompleteProvider(provider: AutocompleteProvider): void;
++    setStructuredCompletion(completion: EditorStructuredCompletion): void;
+     /**
+      * Add a prompt to history for up/down arrow navigation.
+      * Called after successful submission.
+@@ -107,6 +170,8 @@ export declare class Editor implements Component, Focusable {
          line: number;
          col: number;
      };
@@ -69,10 +109,18 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..26b2fd69ac2dfdbea79ee24125ff5bf2
      /**
       * Insert text at the current cursor position.
 diff --git a/dist/components/editor.js b/dist/components/editor.js
-index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94d0456dcf 100644
+index 4786b46932b65785cfbd2304610ca77ccead910a..242b66932e24571f55034c1b876ad7a40f876ce9 100644
 --- a/dist/components/editor.js
 +++ b/dist/components/editor.js
-@@ -246,6 +246,12 @@ export class Editor {
+@@ -219,6 +219,7 @@ export class Editor {
+     autocompleteRequestTask = Promise.resolve();
+     autocompleteStartToken = 0;
+     autocompleteRequestId = 0;
++    structuredCompletion;
+     // Paste tracking for large pastes
+     pastes = new Map();
+     pasteCounter = 0;
+@@ -246,6 +247,12 @@ export class Editor {
      undoStack = new UndoStack();
      onSubmit;
      onChange;
@@ -85,13 +133,23 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
      disableSubmit = false;
      constructor(tui, theme, options = {}) {
          this.tui = tui;
-@@ -527,6 +533,26 @@ export class Editor {
+@@ -289,6 +296,10 @@ export class Editor {
+         this.autocompleteProvider = provider;
+         this.setAutocompleteTriggerCharacters(provider.triggerCharacters ?? []);
+     }
++    setStructuredCompletion(completion) {
++        this.cancelAutocomplete();
++        this.structuredCompletion = completion;
++    }
+     /**
+      * Add a prompt to history for up/down arrow navigation.
+      * Called after successful submission.
+@@ -527,6 +538,25 @@ export class Editor {
              this.undo();
              return;
          }
 +        if (this.structuredDocument !== null &&
-+            (kb.matches(data, "tui.input.tab") ||
-+                kb.matches(data, "tui.editor.deleteToLineEnd") ||
++            (kb.matches(data, "tui.editor.deleteToLineEnd") ||
 +                kb.matches(data, "tui.editor.deleteToLineStart") ||
 +                kb.matches(data, "tui.editor.deleteWordBackward") ||
 +                kb.matches(data, "tui.editor.deleteWordForward") ||
@@ -112,7 +170,45 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
          // Handle autocomplete mode
          if (this.autocompleteState && this.autocompleteList) {
              if (kb.matches(data, "tui.select.cancel")) {
-@@ -847,6 +873,256 @@ export class Editor {
+@@ -540,35 +570,21 @@ export class Editor {
+             if (kb.matches(data, "tui.input.tab")) {
+                 const selected = this.autocompleteList.getSelectedItem();
+                 if (selected && this.autocompleteProvider) {
+-                    this.pushUndoSnapshot();
+-                    this.lastAction = null;
+-                    const result = this.autocompleteProvider.applyCompletion(this.state.lines, this.state.cursorLine, this.state.cursorCol, selected, this.autocompletePrefix);
+-                    this.state.lines = result.lines;
+-                    this.state.cursorLine = result.cursorLine;
+-                    this.setCursorCol(result.cursorCol);
++                    this.applyAutocompleteItem(selected, this.autocompletePrefix);
+                     this.cancelAutocomplete();
+-                    if (this.onChange)
+-                        this.onChange(this.getText());
+                 }
+                 return;
+             }
+             if (kb.matches(data, "tui.select.confirm")) {
+                 const selected = this.autocompleteList.getSelectedItem();
+                 if (selected && this.autocompleteProvider) {
+-                    this.pushUndoSnapshot();
+-                    this.lastAction = null;
+-                    const result = this.autocompleteProvider.applyCompletion(this.state.lines, this.state.cursorLine, this.state.cursorCol, selected, this.autocompletePrefix);
+-                    this.state.lines = result.lines;
+-                    this.state.cursorLine = result.cursorLine;
+-                    this.setCursorCol(result.cursorCol);
++                    this.applyAutocompleteItem(selected, this.autocompletePrefix);
+                     if (this.autocompletePrefix.startsWith("/")) {
+                         this.cancelAutocomplete();
+                         // Fall through to submit
+                     }
+                     else {
+                         this.cancelAutocomplete();
+-                        if (this.onChange)
+-                            this.onChange(this.getText());
+                         return;
+                     }
+                 }
+@@ -847,6 +863,261 @@ export class Editor {
      getCursor() {
          return { line: this.state.cursorLine, col: this.state.cursorCol };
      }
@@ -281,6 +377,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
 +            text,
 +            document: replacement.document,
 +        });
++        this.refreshStructuredAutocomplete();
 +    }
 +    emitAtomRemovalIntent(atomId, direction) {
 +        if (this.structuredDocument === null)
@@ -351,7 +448,11 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
 +            visibleText += part.label;
 +            atoms.push({ id: part.id, start, end: visibleText.length });
 +        }
-+        this.cancelAutocomplete();
++        const preserveAutocomplete = this.structuredDocument !== null &&
++            this.structuredCompletion !== undefined &&
++            this.getText() === visibleText;
++        if (!preserveAutocomplete)
++            this.cancelAutocomplete();
 +        this.lastAction = null;
 +        this.exitHistoryBrowsing();
 +        this.pastes.clear();
@@ -369,7 +470,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
      setText(text) {
          this.cancelAutocomplete();
          this.lastAction = null;
-@@ -858,6 +1134,9 @@ export class Editor {
+@@ -858,6 +1129,9 @@ export class Editor {
          }
          this.pastes.clear();
          this.pasteCounter = 0;
@@ -379,7 +480,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
          this.setTextInternal(normalized);
      }
      /**
-@@ -868,6 +1147,10 @@ export class Editor {
+@@ -868,6 +1142,10 @@ export class Editor {
      insertTextAtCursor(text) {
          if (!text)
              return;
@@ -390,7 +491,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
          this.cancelAutocomplete();
          this.pushUndoSnapshot();
          this.lastAction = null;
-@@ -890,6 +1173,10 @@ export class Editor {
+@@ -890,6 +1168,10 @@ export class Editor {
      insertTextAtCursorInternal(text) {
          if (!text)
              return;
@@ -401,7 +502,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
          // Normalize line endings and tabs
          const normalized = this.normalizeText(text);
          const insertedLines = normalized.split("\n");
-@@ -925,6 +1212,10 @@ export class Editor {
+@@ -925,6 +1207,10 @@ export class Editor {
      // All the editor methods from before...
      insertCharacter(char, skipUndoCoalescing) {
          this.exitHistoryBrowsing();
@@ -412,7 +513,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
          // Undo coalescing (fish-style):
          // - Consecutive word chars coalesce into one undo unit
          // - Space captures state before itself (so undo removes space+following word together)
-@@ -1011,11 +1302,22 @@ export class Editor {
+@@ -1011,11 +1297,22 @@ export class Editor {
                  filteredText = ` ${filteredText}`;
              }
          }
@@ -436,7 +537,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
              // Store the paste and insert a marker
              this.pasteCounter++;
              const pasteId = this.pasteCounter;
-@@ -1036,6 +1338,10 @@ export class Editor {
+@@ -1036,6 +1333,10 @@ export class Editor {
          this.insertTextAtCursorInternal(filteredText);
      }
      addNewLine() {
@@ -447,7 +548,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
          this.cancelAutocomplete();
          this.exitHistoryBrowsing();
          this.lastAction = null;
-@@ -1068,6 +1374,11 @@ export class Editor {
+@@ -1068,6 +1369,11 @@ export class Editor {
      submitValue() {
          this.cancelAutocomplete();
          const result = this.expandPasteMarkers(this.state.lines.join("\n")).trim();
@@ -459,7 +560,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
          this.state = { lines: [""], cursorLine: 0, cursorCol: 0 };
          this.pastes.clear();
          this.pasteCounter = 0;
-@@ -1083,6 +1394,16 @@ export class Editor {
+@@ -1083,6 +1389,16 @@ export class Editor {
      handleBackspace() {
          this.exitHistoryBrowsing();
          this.lastAction = null;
@@ -476,7 +577,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
          if (this.state.cursorCol > 0) {
              this.pushUndoSnapshot();
              // Delete grapheme before cursor (handles emojis, combining characters, etc.)
-@@ -1157,6 +1478,7 @@ export class Editor {
+@@ -1157,6 +1473,7 @@ export class Editor {
       */
      setCursorCol(col) {
          this.state.cursorCol = col;
@@ -484,7 +585,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
          this.preferredVisualCol = null;
          this.snappedFromCursorCol = null;
      }
-@@ -1410,6 +1732,16 @@ export class Editor {
+@@ -1410,6 +1727,16 @@ export class Editor {
      handleForwardDelete() {
          this.exitHistoryBrowsing();
          this.lastAction = null;
@@ -501,7 +602,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
          const currentLine = this.state.lines[this.state.cursorLine] || "";
          if (this.state.cursorCol < currentLine.length) {
              this.pushUndoSnapshot();
-@@ -1520,6 +1852,12 @@ export class Editor {
+@@ -1520,6 +1847,12 @@ export class Editor {
          if (deltaCol !== 0) {
              const currentLine = this.state.lines[this.state.cursorLine] || "";
              if (deltaCol > 0) {
@@ -514,7 +615,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
                  // Moving right - move by one grapheme (handles emojis, combining characters, etc.)
                  if (this.state.cursorCol < currentLine.length) {
                      const afterCursor = currentLine.slice(this.state.cursorCol);
-@@ -1541,6 +1879,12 @@ export class Editor {
+@@ -1541,6 +1874,12 @@ export class Editor {
                  }
              }
              else {
@@ -527,7 +628,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
                  // Moving left - move by one grapheme (handles emojis, combining characters, etc.)
                  if (this.state.cursorCol > 0) {
                      const beforeCursor = currentLine.slice(0, this.state.cursorCol);
-@@ -1704,6 +2048,10 @@ export class Editor {
+@@ -1704,6 +2043,10 @@ export class Editor {
      }
      undo() {
          this.exitHistoryBrowsing();
@@ -538,6 +639,130 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..ac2dbd79b7219b33cf1751ff8bb45f94
          const snapshot = this.undoStack.pop();
          if (!snapshot)
              return;
+@@ -1806,14 +2149,67 @@ export class Editor {
+         const layout = prefix.startsWith("/") ? SLASH_COMMAND_SELECT_LIST_LAYOUT : undefined;
+         return new SelectList(items, this.autocompleteMaxVisible, this.theme.selectList, layout);
+     }
++    autocompleteInput() {
++        if (this.structuredDocument !== null && this.structuredCompletion !== undefined) {
++            return this.structuredCompletion.project(this.structuredDocument, this.getDocumentCursor());
++        }
++        return {
++            lines: this.state.lines,
++            cursorLine: this.state.cursorLine,
++            cursorCol: this.state.cursorCol,
++        };
++    }
++    applyAutocompleteItem(item, prefix) {
++        if (!this.autocompleteProvider)
++            return false;
++        if (this.structuredDocument !== null && this.structuredCompletion !== undefined) {
++            const edit = this.structuredCompletion.accept(this.structuredDocument, this.getDocumentCursor(), item, prefix);
++            if (edit === null)
++                return false;
++            this.setDocument(edit.document, edit.cursor);
++            this.onEditIntent?.({
++                type: "replace",
++                range: edit.range,
++                text: edit.text,
++                document: edit.document,
++            });
++            return true;
++        }
++        this.pushUndoSnapshot();
++        this.lastAction = null;
++        const result = this.autocompleteProvider.applyCompletion(this.state.lines, this.state.cursorLine, this.state.cursorCol, item, prefix);
++        this.state.lines = result.lines;
++        this.state.cursorLine = result.cursorLine;
++        this.setCursorCol(result.cursorCol);
++        if (this.onChange)
++            this.onChange(this.getText());
++        return true;
++    }
++    refreshStructuredAutocomplete() {
++        const input = this.autocompleteInput();
++        if (input === null)
++            return;
++        if (this.autocompleteState) {
++            this.updateAutocomplete();
++            return;
++        }
++        const currentLine = input.lines[input.cursorLine] || "";
++        const beforeCursor = currentLine.slice(0, input.cursorCol);
++        if (this.isInSlashCommandContext(beforeCursor) || this.autocompleteTriggerPattern.test(beforeCursor)) {
++            this.tryTriggerAutocomplete();
++        }
++    }
+     tryTriggerAutocomplete(explicitTab = false) {
+         this.requestAutocomplete({ force: false, explicitTab });
+     }
+     handleTabCompletion() {
+         if (!this.autocompleteProvider)
+             return;
+-        const currentLine = this.state.lines[this.state.cursorLine] || "";
+-        const beforeCursor = currentLine.slice(0, this.state.cursorCol);
++        const input = this.autocompleteInput();
++        if (input === null)
++            return;
++        const currentLine = input.lines[input.cursorLine] || "";
++        const beforeCursor = currentLine.slice(0, input.cursorCol);
+         if (this.isInSlashCommandContext(beforeCursor) && !beforeCursor.trimStart().includes(" ")) {
+             this.handleSlashCommandCompletion();
+         }
+@@ -1830,9 +2226,12 @@ export class Editor {
+     requestAutocomplete(options) {
+         if (!this.autocompleteProvider)
+             return;
++        const input = this.autocompleteInput();
++        if (input === null)
++            return;
+         if (options.force) {
+             const shouldTrigger = !this.autocompleteProvider.shouldTriggerFileCompletion ||
+-                this.autocompleteProvider.shouldTriggerFileCompletion(this.state.lines, this.state.cursorLine, this.state.cursorCol);
++                this.autocompleteProvider.shouldTriggerFileCompletion([...input.lines], input.cursorLine, input.cursorCol);
+             if (!shouldTrigger) {
+                 return;
+             }
+@@ -1882,14 +2281,20 @@ export class Editor {
+         if (options.explicitTab || options.force) {
+             return 0;
+         }
+-        const currentLine = this.state.lines[this.state.cursorLine] || "";
+-        const textBeforeCursor = currentLine.slice(0, this.state.cursorCol);
++        const input = this.autocompleteInput();
++        if (input === null)
++            return 0;
++        const currentLine = input.lines[input.cursorLine] || "";
++        const textBeforeCursor = currentLine.slice(0, input.cursorCol);
+         return this.autocompleteDebouncePattern.test(textBeforeCursor) ? ATTACHMENT_AUTOCOMPLETE_DEBOUNCE_MS : 0;
+     }
+     async runAutocompleteRequest(requestId, controller, snapshotText, snapshotLine, snapshotCol, options) {
+         if (!this.autocompleteProvider)
+             return;
+-        const suggestions = await this.autocompleteProvider.getSuggestions(this.state.lines, this.state.cursorLine, this.state.cursorCol, { signal: controller.signal, force: options.force });
++        const input = this.autocompleteInput();
++        if (input === null)
++            return;
++        const suggestions = await this.autocompleteProvider.getSuggestions([...input.lines], input.cursorLine, input.cursorCol, { signal: controller.signal, force: options.force });
+         if (!this.isAutocompleteRequestCurrent(requestId, controller, snapshotText, snapshotLine, snapshotCol)) {
+             return;
+         }
+@@ -1901,14 +2306,7 @@ export class Editor {
+         }
+         if (options.force && options.explicitTab && suggestions.items.length === 1) {
+             const item = suggestions.items[0];
+-            this.pushUndoSnapshot();
+-            this.lastAction = null;
+-            const result = this.autocompleteProvider.applyCompletion(this.state.lines, this.state.cursorLine, this.state.cursorCol, item, suggestions.prefix);
+-            this.state.lines = result.lines;
+-            this.state.cursorLine = result.cursorLine;
+-            this.setCursorCol(result.cursorCol);
+-            if (this.onChange)
+-                this.onChange(this.getText());
++            this.applyAutocompleteItem(item, suggestions.prefix);
+             this.tui.requestRender();
+             return;
+         }
 diff --git a/dist/components/select-list.js b/dist/components/select-list.js
 index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..0b8964d09635714a7e5872c653883e064f59df14 100644
 --- a/dist/components/select-list.js
@@ -552,12 +777,12 @@ index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..0b8964d09635714a7e5872c653883e06
          if (descriptionSingleLine && width > 40) {
              const effectivePrimaryColumnWidth = Math.max(1, Math.min(primaryColumnWidth, width - prefixWidth - 4));
 diff --git a/dist/editor-component.d.ts b/dist/editor-component.d.ts
-index b598c4d291ace5f04b83161252b3ab8cdd4ccbdf..734cca4d88ec3615a564caadce0311b0ba20ee4a 100644
+index b598c4d291ace5f04b83161252b3ab8cdd4ccbdf..fc589d63de74ce745b5d6d9ac6c1fa96fb397003 100644
 --- a/dist/editor-component.d.ts
 +++ b/dist/editor-component.d.ts
 @@ -1,4 +1,5 @@
  import type { AutocompleteProvider } from "./autocomplete.ts";
-+import type { EditorDocumentPart, EditorDocumentPoint, EditorEditIntent, EditorPasteIntent } from "./components/editor.ts";
++import type { EditorDocumentPart, EditorDocumentPoint, EditorEditIntent, EditorPasteIntent, EditorStructuredCompletion } from "./components/editor.ts";
  import type { Component } from "./tui.ts";
  /**
   * Interface for custom editor components.
@@ -579,8 +804,17 @@ index b598c4d291ace5f04b83161252b3ab8cdd4ccbdf..734cca4d88ec3615a564caadce0311b0
      /**
       * Get text with any markers expanded (e.g., paste markers).
       * Falls back to getText() if not implemented.
+@@ -29,6 +37,8 @@ export interface EditorComponent extends Component {
+     getExpandedText?(): string;
+     /** Set the autocomplete provider */
+     setAutocompleteProvider?(provider: AutocompleteProvider): void;
++    /** Supply host-owned structured completion semantics. */
++    setStructuredCompletion?(completion: EditorStructuredCompletion): void;
+     /** Border color function */
+     borderColor?: (str: string) => string;
+     /** Set horizontal padding */
 diff --git a/dist/index.d.ts b/dist/index.d.ts
-index 50b5aeb61f12011642978bc2c31d8a2eb36d17d3..5882d0e9bfd60ee3342083ea57fcffacf34e0ef1 100644
+index 50b5aeb61f12011642978bc2c31d8a2eb36d17d3..cd3ec6f74896a543f4e522a5d86d83da44e64e9e 100644
 --- a/dist/index.d.ts
 +++ b/dist/index.d.ts
 @@ -2,7 +2,7 @@ export { Marked, type Token, type Tokens } from "marked";
@@ -588,7 +822,7 @@ index 50b5aeb61f12011642978bc2c31d8a2eb36d17d3..5882d0e9bfd60ee3342083ea57fcffac
  export { Box } from "./components/box.ts";
  export { CancellableLoader } from "./components/cancellable-loader.ts";
 -export { Editor, type EditorOptions, type EditorTheme } from "./components/editor.ts";
-+export { Editor, type EditorDocumentPart, type EditorDocumentPoint, type EditorEditIntent, type EditorOptions, type EditorPasteIntent, type EditorTheme } from "./components/editor.ts";
++export { Editor, type EditorDocumentPart, type EditorDocumentPoint, type EditorEditIntent, type EditorOptions, type EditorPasteIntent, type EditorStructuredCompletion, type EditorStructuredCompletionEdit, type EditorStructuredCompletionProjection, type EditorTheme } from "./components/editor.ts";
  export { HStack } from "./components/h-stack.ts";
  export { Image, type ImageOptions, type ImageTheme } from "./components/image.ts";
  export { Input } from "./components/input.ts";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@earendil-works/pi-tui@0.84.2': 9e4b660c5123f19b0872b16136448997cd91bf4fa3be8d735fbbdce2643493b7
+  '@earendil-works/pi-tui@0.84.2': 29f4bede400aa94594c99d903c727f2ee908ac5a9af6fa35725a811657d4faa9
 
 importers:
 
@@ -52,7 +52,7 @@ importers:
         version: link:../../packages/presentation
       '@earendil-works/pi-tui':
         specifier: 0.84.2
-        version: 0.84.2(patch_hash=9e4b660c5123f19b0872b16136448997cd91bf4fa3be8d735fbbdce2643493b7)
+        version: 0.84.2(patch_hash=29f4bede400aa94594c99d903c727f2ee908ac5a9af6fa35725a811657d4faa9)
       highlight.js:
         specifier: 11.11.1
         version: 11.11.1
@@ -1418,7 +1418,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.8':
     optional: true
 
-  '@earendil-works/pi-tui@0.84.2(patch_hash=9e4b660c5123f19b0872b16136448997cd91bf4fa3be8d735fbbdce2643493b7)':
+  '@earendil-works/pi-tui@0.84.2(patch_hash=29f4bede400aa94594c99d903c727f2ee908ac5a9af6fa35725a811657d4faa9)':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5


### PR DESCRIPTION
## Summary

- restore command and Skill completion after a structured Draft atom through one Adam-owned project/accept interface
- preserve atom identities and the existing project-path picker while routing its selected replacement atom-safely
- defer full structured-key parity and modal/UI redesign outside this bug PR

## Evidence

- focused completion set: 8 passed
- full local pnpm quality:check: 70 files passed, 2 skipped; 1,607 tests passed, 18 skipped
- independent Standards review: no hard violations; duplicated fixture setup repaired
- independent Spec review: existing path-picker semantics and earlier-literal slash eligibility repaired