### PR TITLE
fix(tui): harden WSL clipboard image arbitration

### DIFF
--- a/apps/tui/src/linux-clipboard-image.os.test.ts
+++ b/apps/tui/src/linux-clipboard-image.os.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -12,7 +12,7 @@ const onePixelPng = Buffer.from(
   "base64",
 );
 
-test.each([
+const readerFixtures = [
   {
     name: "Wayland wl-paste",
     helper: "wl-paste",
@@ -31,54 +31,148 @@ test.each([
     environment: { WSL_DISTRO_NAME: "Ubuntu" },
     expectedPlatform: "wsl_bridge",
   },
-])("the $name reader returns exact bytes through a real child process", async (fixture) => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-clipboard-image-process-"));
-  const helperPath = join(testRoot, fixture.helper);
-  const sourcePath = join(testRoot, "source.png");
-  await writeFile(helperPath, '#!/bin/sh\n/bin/cat "$ADAM_TEST_IMAGE_SOURCE"\n', {
-    mode: 0o755,
-  });
-  await writeFile(sourcePath, onePixelPng);
+] as const;
 
-  try {
-    const reader = createLinuxClipboardImageReader({
-      environment: {
-        ...process.env,
-        ...fixture.environment,
-        ADAM_TEST_IMAGE_SOURCE: sourcePath,
-        DISPLAY: fixture.environment.DISPLAY,
-        PATH: testRoot,
-        WAYLAND_DISPLAY: fixture.environment.WAYLAND_DISPLAY,
-        WSL_DISTRO_NAME: fixture.environment.WSL_DISTRO_NAME,
-      },
-    });
-    await expect(reader.readImage()).resolves.toEqual({
-      status: "read",
-      bytes: onePixelPng,
-      platform: fixture.expectedPlatform,
-    });
-    await expect(reader.close()).resolves.toBeUndefined();
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
+type ReaderEnvironment = {
+  readonly DISPLAY?: string;
+  readonly WAYLAND_DISPLAY?: string;
+  readonly WSL_DISTRO_NAME?: string;
+};
 
-test("the real clipboard image reader terminates a non-closing helper at its deadline", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-clipboard-image-deadline-"));
-  const helperPath = join(testRoot, "wl-paste");
-  await writeFile(helperPath, "#!/bin/sh\nwhile :; do :; done\n", { mode: 0o755 });
+test.each(readerFixtures)(
+  "the $name reader returns exact bytes through a real child process",
+  async (fixture) => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-clipboard-image-process-"));
+    const helperPath = join(testRoot, fixture.helper);
+    const argumentsPath = join(testRoot, "arguments.txt");
+    const sourcePath = join(testRoot, "source.png");
+    await writeFile(
+      helperPath,
+      '#!/bin/sh\nif [ -n "$ADAM_TEST_ARGUMENTS" ]; then printf "%s\\n" "$@" > "$ADAM_TEST_ARGUMENTS"; fi\n/bin/cat "$ADAM_TEST_IMAGE_SOURCE"\n',
+      { mode: 0o755 },
+    );
+    await writeFile(sourcePath, onePixelPng);
 
-  try {
-    const reader = createLinuxClipboardImageReader({
-      deadlineMilliseconds: 50,
-      environment: { ...process.env, PATH: testRoot, WAYLAND_DISPLAY: "wayland-0" },
-    });
-    await expect(reader.readImage()).resolves.toEqual({
-      status: "failed",
-      message: "Clipboard image acquisition reached its deadline.",
-    });
-    await expect(reader.close()).resolves.toBeUndefined();
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
+    try {
+      const fixtureEnvironment: ReaderEnvironment = fixture.environment;
+      const reader = createLinuxClipboardImageReader({
+        environment: {
+          ...process.env,
+          ...fixtureEnvironment,
+          ADAM_TEST_ARGUMENTS: argumentsPath,
+          ADAM_TEST_IMAGE_SOURCE: sourcePath,
+          DISPLAY: fixtureEnvironment.DISPLAY,
+          PATH: testRoot,
+          WAYLAND_DISPLAY: fixtureEnvironment.WAYLAND_DISPLAY,
+          WSL_DISTRO_NAME: fixtureEnvironment.WSL_DISTRO_NAME,
+        },
+      });
+      await expect(reader.readImage()).resolves.toEqual({
+        status: "read",
+        bytes: onePixelPng,
+        platform: fixture.expectedPlatform,
+      });
+      if (fixture.expectedPlatform === "wsl_bridge") {
+        await expect(readFile(argumentsPath, "utf8")).resolves.toContain("-STA");
+      }
+      await expect(reader.close()).resolves.toBeUndefined();
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test.each(readerFixtures)(
+  "the $name reader reports typed failure through real child close",
+  async (fixture) => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-clipboard-image-failure-"));
+    await writeFile(join(testRoot, fixture.helper), "#!/bin/sh\nexit 2\n", { mode: 0o755 });
+
+    try {
+      const reader = createLinuxClipboardImageReader({
+        environment: readerEnvironment(testRoot, fixture.environment),
+      });
+      await expect(reader.readImage()).resolves.toMatchObject({ status: "unsupported" });
+      await expect(reader.close()).resolves.toBeUndefined();
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test.each(readerFixtures)(
+  "the $name reader bounds real helper output and confirms child close",
+  async (fixture) => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-clipboard-image-output-bound-"));
+    await writeFile(
+      join(testRoot, fixture.helper),
+      "#!/bin/sh\n/usr/bin/head -c 8388609 /dev/zero\n",
+      { mode: 0o755 },
+    );
+
+    try {
+      const reader = createLinuxClipboardImageReader({
+        environment: readerEnvironment(testRoot, fixture.environment),
+      });
+      await expect(reader.readImage()).resolves.toMatchObject({ status: "failed" });
+      await expect(reader.close()).resolves.toBeUndefined();
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test.each(readerFixtures)(
+  "the $name reader escalates TERM to KILL and confirms real child close",
+  async (fixture) => {
+    const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-clipboard-image-deadline-"));
+    const signalPath = join(testRoot, "signals.txt");
+    const startedPath = join(testRoot, "started.txt");
+    await writeFile(
+      join(testRoot, fixture.helper),
+      '#!/bin/sh\nprintf "started\\n" >> "$ADAM_TEST_STARTED"\ntrap \'printf "term\\n" >> "$ADAM_TEST_SIGNALS"\' TERM\nwhile :; do :; done\n',
+      { mode: 0o755 },
+    );
+
+    try {
+      const reader = createLinuxClipboardImageReader({
+        candidateDeadlineMilliseconds: 50,
+        environment: readerEnvironment(testRoot, fixture.environment, {
+          ADAM_TEST_SIGNALS: signalPath,
+          ADAM_TEST_STARTED: startedPath,
+        }),
+        terminationGraceMilliseconds: 25,
+      });
+      await expect(reader.readImage()).resolves.toEqual({
+        status: "failed",
+        message: "Clipboard image acquisition reached its deadline.",
+      });
+      const expectedAttempts = fixture.expectedPlatform === "wsl_bridge" ? 1 : 2;
+      expect((await readFile(startedPath, "utf8")).trim().split("\n")).toHaveLength(
+        expectedAttempts,
+      );
+      expect((await readFile(signalPath, "utf8")).trim().split("\n")).toHaveLength(
+        expectedAttempts,
+      );
+      await expect(reader.close()).resolves.toBeUndefined();
+    } finally {
+      await rm(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+function readerEnvironment(
+  testRoot: string,
+  fixtureEnvironment: ReaderEnvironment,
+  extra: NodeJS.ProcessEnv = {},
+): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    ...fixtureEnvironment,
+    ...extra,
+    DISPLAY: fixtureEnvironment.DISPLAY,
+    PATH: testRoot,
+    WAYLAND_DISPLAY: fixtureEnvironment.WAYLAND_DISPLAY,
+    WSL_DISTRO_NAME: fixtureEnvironment.WSL_DISTRO_NAME,
+  };
+}

--- a/apps/tui/src/linux-clipboard-image.test.ts
+++ b/apps/tui/src/linux-clipboard-image.test.ts
@@ -59,7 +59,7 @@ test.each([
     name: "WSL",
     environment: { WSL_DISTRO_NAME: "Ubuntu" },
     command: "powershell.exe",
-    arguments_: ["-NoProfile", "-NonInteractive", "-Command"],
+    arguments_: ["-NoProfile", "-NonInteractive", "-STA", "-Command"],
     platform: "wsl_bridge",
   },
 ])(
@@ -143,12 +143,165 @@ test("the Linux clipboard image reader falls back from PNG to exact JPEG bytes",
   await reader.close();
 });
 
+test("a mixed WSLg environment cannot let display readers starve the WSL bridge", async () => {
+  const calls: Array<{ readonly child: FakeImageChild; readonly command: string }> = [];
+  const reader = createLinuxClipboardImageReader({
+    environment: {
+      DISPLAY: ":0",
+      WAYLAND_DISPLAY: "wayland-0",
+      WSL_DISTRO_NAME: "Ubuntu",
+    },
+    [linuxClipboardImageSpawn](command) {
+      const child = new FakeImageChild();
+      calls.push({ child, command });
+      return child as LinuxClipboardImageChild;
+    },
+  });
+
+  const result = reader.readImage();
+  expect(calls.map((call) => call.command)).toEqual(["powershell.exe"]);
+  calls[0]?.child.stdout.end(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  calls[0]?.child.emit("close", 0);
+  await expect(result).resolves.toEqual({
+    status: "read",
+    bytes: Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+    platform: "wsl_bridge",
+  });
+  await reader.close();
+});
+
+test("a WSL FileDrop result is terminal and never reads another display selection", async () => {
+  const calls: Array<{ readonly child: FakeImageChild; readonly command: string }> = [];
+  const reader = createLinuxClipboardImageReader({
+    environment: { DISPLAY: ":0", WSL_DISTRO_NAME: "Ubuntu" },
+    [linuxClipboardImageSpawn](command) {
+      const child = new FakeImageChild();
+      calls.push({ child, command });
+      if (command !== "powershell.exe") {
+        queueMicrotask(() => child.emit("close", 2));
+      }
+      return child as LinuxClipboardImageChild;
+    },
+  });
+
+  const result = reader.readImage();
+  calls[0]?.child.emit("close", 4);
+  await expect(result).resolves.toEqual({
+    status: "file_drop",
+    message: "Clipboard files are not supported; attach an admitted project file explicitly.",
+  });
+  expect(calls.map((call) => call.command)).toEqual(["powershell.exe"]);
+  await reader.close();
+});
+
+test("an empty WSL clipboard remains a typed empty result", async () => {
+  const child = new FakeImageChild();
+  const reader = createLinuxClipboardImageReader({
+    environment: { WSL_DISTRO_NAME: "Ubuntu" },
+    [linuxClipboardImageSpawn]() {
+      return child as LinuxClipboardImageChild;
+    },
+  });
+
+  const result = reader.readImage();
+  child.emit("close", 3);
+  await expect(result).resolves.toEqual({
+    status: "empty",
+    message: "The clipboard does not contain image bytes.",
+  });
+  await reader.close();
+});
+
+test("the WSL command distinguishes empty from unsupported non-image formats", async () => {
+  const child = new FakeImageChild();
+  let script = "";
+  const reader = createLinuxClipboardImageReader({
+    environment: { WSL_DISTRO_NAME: "Ubuntu" },
+    [linuxClipboardImageSpawn](_command, arguments_) {
+      script = arguments_.at(-1) ?? "";
+      return child as LinuxClipboardImageChild;
+    },
+  });
+
+  const result = reader.readImage();
+  expect(script).toContain("GetDataObject()");
+  expect(script).toContain("GetFormats()");
+  expect(script).toContain("GetDataPresent($format,$false)");
+  expect(script).toContain("@('PNG','image/png','JFIF','image/jpeg')");
+  expect(script).toContain("CopyTo($stream)");
+  expect(script).toContain("exit 5");
+  child.emit("close", 5);
+  await expect(result).resolves.toEqual({
+    status: "unsupported",
+    message: "The clipboard does not expose PNG or JPEG image bytes.",
+  });
+  await reader.close();
+});
+
+test("one display helper deadline cannot consume the next candidate opportunity", async () => {
+  const scheduler = controlledScheduler();
+  const calls: Array<{ readonly child: FakeImageChild; readonly command: string }> = [];
+  const reader = createLinuxClipboardImageReader({
+    candidateDeadlineMilliseconds: 100,
+    environment: { WAYLAND_DISPLAY: "wayland-0", WSL_DISTRO_NAME: "Ubuntu" },
+    scheduler,
+    [linuxClipboardImageSpawn](command) {
+      const child = new FakeImageChild();
+      calls.push({ child, command });
+      return child as LinuxClipboardImageChild;
+    },
+  });
+  const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xd9]);
+
+  const result = reader.readImage();
+  calls[0]?.child.emit("close", 3);
+  await Promise.resolve();
+  expect(calls.map((call) => call.command)).toEqual(["powershell.exe", "wl-paste"]);
+  scheduler.fire(100);
+  expect(calls[1]?.child.kill).toHaveBeenLastCalledWith("SIGTERM");
+  calls[1]?.child.emit("close", null);
+  await Promise.resolve();
+  expect(calls.map((call) => call.command)).toEqual(["powershell.exe", "wl-paste", "wl-paste"]);
+  calls[2]?.child.stdout.end(jpeg);
+  calls[2]?.child.emit("close", 0);
+  await expect(result).resolves.toEqual({ status: "read", bytes: jpeg, platform: "linux_wayland" });
+  await reader.close();
+});
+
+test("a WSL deadline is terminal and never falls back to another clipboard selection", async () => {
+  const scheduler = controlledScheduler();
+  const calls: Array<{ readonly child: FakeImageChild; readonly command: string }> = [];
+  const reader = createLinuxClipboardImageReader({
+    candidateDeadlineMilliseconds: 100,
+    environment: { DISPLAY: ":0", WSL_DISTRO_NAME: "Ubuntu" },
+    scheduler,
+    [linuxClipboardImageSpawn](command) {
+      const child = new FakeImageChild();
+      calls.push({ child, command });
+      if (command !== "powershell.exe") {
+        queueMicrotask(() => child.emit("close", 2));
+      }
+      return child as LinuxClipboardImageChild;
+    },
+  });
+
+  const result = reader.readImage();
+  scheduler.fire(100);
+  calls[0]?.child.emit("close", null);
+  await expect(result).resolves.toEqual({
+    status: "failed",
+    message: "Clipboard image acquisition reached its deadline.",
+  });
+  expect(calls.map((call) => call.command)).toEqual(["powershell.exe"]);
+  await reader.close();
+});
+
 test("the Linux clipboard image reader terminates and joins a helper after its deadline", async () => {
   const scheduler = controlledScheduler();
   const child = new FakeImageChild();
   const reader = createLinuxClipboardImageReader({
-    deadlineMilliseconds: 100,
-    environment: { DISPLAY: ":1" },
+    candidateDeadlineMilliseconds: 100,
+    environment: { WSL_DISTRO_NAME: "Ubuntu" },
     reclamationMilliseconds: 20,
     scheduler,
     terminationGraceMilliseconds: 10,

--- a/apps/tui/src/linux-clipboard-image.ts
+++ b/apps/tui/src/linux-clipboard-image.ts
@@ -15,7 +15,7 @@ export type ClipboardImageReadResult =
       readonly platform: "linux_wayland" | "linux_x11" | "wsl_bridge";
     }
   | {
-      readonly status: "empty" | "failed" | "unsupported";
+      readonly status: "empty" | "failed" | "file_drop" | "unsupported";
       readonly message: string;
     };
 
@@ -44,18 +44,38 @@ type ActiveImageHelper = {
   readonly settlement: Promise<ClipboardImageReadResult>;
 };
 
-const powershellImageScript =
-  "Add-Type -AssemblyName System.Windows.Forms; Add-Type -AssemblyName System.Drawing; $image=[System.Windows.Forms.Clipboard]::GetImage(); if ($null -eq $image) { exit 3 }; $stream=[Console]::OpenStandardOutput(); try { $image.Save($stream,[System.Drawing.Imaging.ImageFormat]::Png) } finally { $stream.Dispose(); $image.Dispose() }";
+const wslClipboardExit = {
+  empty: 3,
+  fileDrop: 4,
+  unsupported: 5,
+} as const;
+
+const powershellImageScript = [
+  "Add-Type -AssemblyName System.Windows.Forms",
+  "Add-Type -AssemblyName System.Drawing",
+  "$data=[System.Windows.Forms.Clipboard]::GetDataObject()",
+  `if ($null -eq $data) { exit ${wslClipboardExit.empty} }`,
+  `if ([System.Windows.Forms.Clipboard]::ContainsFileDropList()) { exit ${wslClipboardExit.fileDrop} }`,
+  "$registered=$null",
+  "foreach ($format in @('PNG','image/png','JFIF','image/jpeg')) { if ($data.GetDataPresent($format,$false)) { $registered=$data.GetData($format,$false); break } }",
+  `if ($null -ne $registered) { $stream=[Console]::OpenStandardOutput(); try { if ($registered -is [byte[]]) { $stream.Write($registered,0,$registered.Length) } elseif ($registered -is [System.IO.Stream]) { $registered.CopyTo($stream) } else { exit ${wslClipboardExit.unsupported} } } finally { $stream.Dispose(); if ($registered -is [System.IDisposable]) { $registered.Dispose() } }; exit 0 }`,
+  "$image=[System.Windows.Forms.Clipboard]::GetImage()",
+  `if ($null -eq $image) { $formats=$data.GetFormats(); if ($null -eq $formats -or $formats.Length -eq 0) { exit ${wslClipboardExit.empty} }; exit ${wslClipboardExit.unsupported} }`,
+  "$stream=[Console]::OpenStandardOutput()",
+  "$image.Save($stream,[System.Drawing.Imaging.ImageFormat]::Png)",
+  "$stream.Dispose()",
+  "$image.Dispose()",
+].join("; ");
 
 export function createLinuxClipboardImageReader({
-  deadlineMilliseconds = 2_000,
+  candidateDeadlineMilliseconds = 2_000,
   environment = process.env,
   reclamationMilliseconds = 100,
   scheduler = nodeDeadlineScheduler,
   terminationGraceMilliseconds = 50,
   [linuxClipboardImageSpawn]: spawnProcess = nodeImageSpawn,
 }: {
-  readonly deadlineMilliseconds?: number;
+  readonly candidateDeadlineMilliseconds?: number;
   readonly environment?: NodeJS.ProcessEnv;
   readonly reclamationMilliseconds?: number;
   readonly scheduler?: DeadlineScheduler;
@@ -93,41 +113,55 @@ export function createLinuxClipboardImageReader({
           message: "No supported Linux, Wayland, X11, or WSL clipboard image reader is available.",
         };
       }
-      let deadlineExpired = false;
-      let current: ActiveImageHelper | undefined;
-      const deadline = scheduler.schedule(deadlineMilliseconds, () => {
-        deadlineExpired = true;
-        current?.beginTermination();
-      });
       let sawEmpty = false;
+      let sawDeadline = false;
       let sawFailure = false;
-      try {
-        for (const candidate of candidates) {
-          if (closing || deadlineExpired) {
-            return {
-              status: "failed",
-              message: "Clipboard image acquisition reached its deadline.",
-            };
-          }
-          current = startImageHelper({
-            active,
-            candidate,
-            environment,
-            reclamationMilliseconds,
-            scheduler,
-            spawnProcess,
-            terminationGraceMilliseconds,
-          });
-          active.add(current);
-          const result = await current.settlement;
-          current = undefined;
-          if (result.status === "read") {
-            return result;
-          }
-          sawEmpty ||= result.status === "empty";
-          sawFailure ||= result.status === "failed";
+      for (const candidate of candidates) {
+        if (closing) {
+          return { status: "failed", message: "Clipboard image reader is closing." };
         }
-        return sawFailure
+        const current = startImageHelper({
+          active,
+          candidate,
+          environment,
+          reclamationMilliseconds,
+          scheduler,
+          spawnProcess,
+          terminationGraceMilliseconds,
+        });
+        active.add(current);
+        let deadlineExpired = false;
+        const deadline = scheduler.schedule(candidateDeadlineMilliseconds, () => {
+          deadlineExpired = true;
+          current.beginTermination();
+        });
+        let result: ClipboardImageReadResult;
+        try {
+          result = await current.settlement;
+        } finally {
+          deadline.cancel();
+        }
+        if (closing) {
+          return { status: "failed", message: "Clipboard image reader is closing." };
+        }
+        if (result.status === "read") {
+          return result;
+        }
+        if (result.status === "file_drop") {
+          return result;
+        }
+        if (candidate.platform === "wsl_bridge" && result.status === "failed") {
+          return deadlineExpired
+            ? { status: "failed", message: "Clipboard image acquisition reached its deadline." }
+            : result;
+        }
+        sawDeadline ||= deadlineExpired;
+        sawEmpty ||= result.status === "empty";
+        sawFailure ||= result.status === "failed";
+      }
+      return sawDeadline
+        ? { status: "failed", message: "Clipboard image acquisition reached its deadline." }
+        : sawFailure
           ? { status: "failed", message: "Clipboard image acquisition failed." }
           : sawEmpty
             ? { status: "empty", message: "The clipboard does not contain image bytes." }
@@ -135,9 +169,6 @@ export function createLinuxClipboardImageReader({
                 status: "unsupported",
                 message: "The clipboard does not expose PNG or JPEG image bytes.",
               };
-      } finally {
-        deadline.cancel();
-      }
     },
   };
 }
@@ -150,6 +181,16 @@ type ImageReaderCandidate = {
 
 function imageReaderCandidates(environment: NodeJS.ProcessEnv): readonly ImageReaderCandidate[] {
   const candidates: ImageReaderCandidate[] = [];
+  if (
+    hasEnvironmentValue(environment, "WSL_DISTRO_NAME") ||
+    hasEnvironmentValue(environment, "WSL_INTEROP")
+  ) {
+    candidates.push({
+      command: "powershell.exe",
+      arguments_: ["-NoProfile", "-NonInteractive", "-STA", "-Command", powershellImageScript],
+      platform: "wsl_bridge",
+    });
+  }
   if (hasEnvironmentValue(environment, "WAYLAND_DISPLAY")) {
     candidates.push(
       {
@@ -177,16 +218,6 @@ function imageReaderCandidates(environment: NodeJS.ProcessEnv): readonly ImageRe
         platform: "linux_x11",
       },
     );
-  }
-  if (
-    hasEnvironmentValue(environment, "WSL_DISTRO_NAME") ||
-    hasEnvironmentValue(environment, "WSL_INTEROP")
-  ) {
-    candidates.push({
-      command: "powershell.exe",
-      arguments_: ["-NoProfile", "-NonInteractive", "-Command", powershellImageScript],
-      platform: "wsl_bridge",
-    });
   }
   return candidates;
 }
@@ -291,6 +322,17 @@ function startImageHelper(options: {
       return;
     }
     if (code !== 0) {
+      if (options.candidate.platform === "wsl_bridge" && code === wslClipboardExit.empty) {
+        resolveSettlement?.({ status: "empty", message: "The clipboard image is empty." });
+        return;
+      }
+      if (options.candidate.platform === "wsl_bridge" && code === wslClipboardExit.fileDrop) {
+        resolveSettlement?.({
+          status: "file_drop",
+          message: "Clipboard files are not supported; attach an admitted project file explicitly.",
+        });
+        return;
+      }
       resolveSettlement?.({
         status: "unsupported",
         message: "Clipboard image MIME is unavailable.",

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -72,6 +72,63 @@ test("the real TUI process restores the terminal after staging one input resourc
   }
 });
 
+test("the production WSL paste-image path stages one image and restores the terminal", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-wsl-paste-image-process-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const configRoot = join(testRoot, "config");
+  const sourcePath = join(testRoot, "source.png");
+  await mkdir(workspaceRoot);
+  await writeFile(
+    sourcePath,
+    Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+      "base64",
+    ),
+  );
+  await writeFile(
+    join(testRoot, "powershell.exe"),
+    '#!/bin/sh\n/bin/cat "$ADAM_TEST_IMAGE_SOURCE"\n',
+    { mode: 0o755 },
+  );
+  const inheritedProcessPath = Reflect.get(process.env, "PATH");
+
+  try {
+    await trustWorkspace(configRoot, workspaceRoot);
+    const fixture = startFixture({
+      program: {
+        arguments: ["--target", "deepseek-v4-flash.direct", "--state-root", stateRoot],
+        cwd: workspaceRoot,
+        entrypoint: productionPath,
+        environment: {
+          ADAM_TEST_IMAGE_SOURCE: sourcePath,
+          DEEPSEEK_API_KEY: "deterministic-non-network-fixture",
+          PATH: `${testRoot}:${typeof inheritedProcessPath === "string" ? inheritedProcessPath : ""}`,
+          WSL_DISTRO_NAME: "Ubuntu",
+          XDG_CONFIG_HOME: configRoot,
+        },
+      },
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitForCompleteFrameAfter("Adam · New session", 0);
+    const beforePaste = fixture.output().length;
+    fixture.write("/paste-image\r");
+    await fixture.waitForCompleteFrameAfter("Clipboard image staged.", beforePaste);
+    expect(fixture.screen()?.join("\n") ?? "").toContain("[Image #1]");
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).toContain("\u001b[?2004h");
+    expect(result.stdout).toContain("\u001b[?2004l");
+    expect(result.stdout.indexOf("\u001b[?2004h")).toBeLessThan(
+      result.stdout.lastIndexOf("\u001b[?2004l"),
+    );
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 async function trustWorkspace(configRoot: string, workspaceRoot: string): Promise<void> {
   const workspaceTrust = createWorkspaceTrust({
     environment: { XDG_CONFIG_HOME: configRoot },

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -762,6 +762,15 @@ test.each([
     expected: "Clipboard image acquisition reached its deadline.",
   },
   {
+    name: "FileDrop clipboard",
+    result: {
+      status: "file_drop",
+      message: "Clipboard files are not supported; attach an admitted project file explicitly.",
+    } as const,
+    expected: "Clipboard files are not supported",
+    expectedTail: "explicitly.",
+  },
+  {
     name: "malformed bytes",
     result: {
       status: "read",
@@ -798,6 +807,9 @@ test.each([
     const beforePasteImage = terminal.output().length;
     terminal.input("/paste-image\r");
     await terminal.nextSynchronizedFrameContaining(fixture.expected, beforePasteImage);
+    if ("expectedTail" in fixture) {
+      expect(terminal.lines().join("\n")).toContain(fixture.expectedTail);
+    }
     expect(terminal.lines().join("\n")).not.toContain("[Image #");
     terminal.input("\u0011");
     await expect(execution).resolves.toBeUndefined();


### PR DESCRIPTION
## Summary

- prioritize the WSL PowerShell family in mixed WSLg environments and require explicit STA
- distinguish registered PNG/JPEG, Bitmap, empty, FileDrop, unsupported, failure, and deadline outcomes without leaking clipboard content
- give every admitted display candidate an independent deadline while keeping WSL failures and FileDrop terminal
- expand deterministic, real-process, and production PTY evidence without entering unified paste or keybinding scope

## Evidence

- focused final set: 4 files, 25 passed
- full local pnpm quality:check: 71 files passed, 2 skipped; 1,615 tests passed, 18 skipped
- content-free real WSL PowerShell apartment check: STA
- independent Standards review: zero documented-standard violations; naming and private exit protocol repaired
- independent Spec review: WSL terminal failure, registered formats, and OS matrix gaps repaired