### PR TITLE
feat(tui): polish structured composer presentation

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -6,6 +6,8 @@ Adam Agent uses the terminal mechanics package
 [`@earendil-works/pi-tui`](https://github.com/earendil-works/pi/tree/914cf1472e715297caa30db4b9535d534a9eb718/packages/tui),
 licensed under the MIT License.
 
+Adam Agent also adapts Pi TUI's bounded CSI, OSC, and APC terminal-sequence stripping behavior into the browser-safe Presentation text projection used by the Turn Composer and TUI renderer.
+
 Adam Agent's bounded tool-preview interaction and syntax-projection strategy is independently adapted from [`badlogic/pi-mono`](https://github.com/badlogic/pi-mono/tree/dcd461925db2edf69a43c8135db1180d418afd54/packages/coding-agent), also licensed under the MIT License.
 
 Copyright (c) Mario Zechner and contributors

--- a/apps/tui/src/command-autocomplete.test.ts
+++ b/apps/tui/src/command-autocomplete.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "vitest";
+import { AdamAutocompleteProvider } from "./command-autocomplete.js";
+
+test("Skill mention rows expose deterministic source labels without qualified IDs", async () => {
+  const provider = new AdamAutocompleteProvider({
+    getProjectPaths: () => [],
+    getRunActive: () => false,
+    getSkills: () => [
+      {
+        description: "Project procedure.",
+        name: "shared",
+        qualifiedId: "skill:v1:project:packages/app:shared",
+        source: { type: "project", scope: "packages/app" },
+      },
+      {
+        description: "User procedure.",
+        name: "shared",
+        qualifiedId: "skill:v1:user:shared",
+        source: { type: "user" },
+      },
+      {
+        description: "Extension procedure.",
+        name: "shared",
+        qualifiedId: "skill:v1:extension:eve:shared",
+        source: { type: "extension", extensionId: "eve", packageVersion: "0.3.0" },
+      },
+    ],
+  });
+
+  const suggestions = await provider.getSuggestions(["Use $sha"], 0, 8, {
+    signal: new AbortController().signal,
+  });
+  expect(suggestions?.items).toEqual([
+    {
+      value: "$shared",
+      label: "$shared",
+      description: "project:packages/app · Project procedure.",
+    },
+    { value: "$shared", label: "$shared", description: "user · User procedure." },
+    {
+      value: "$shared",
+      label: "$shared",
+      description: "extension:eve@0.3.0 · Extension procedure.",
+    },
+  ]);
+});
+
+test("forced project-path rows use the caller's Text semantic slot", async () => {
+  const provider = new AdamAutocompleteProvider({
+    getProjectPaths: () => ["src/alpha.ts"],
+    getRunActive: () => false,
+    getSkills: () => [],
+    path: (value) => `<text>${value}</text>`,
+  });
+
+  await expect(
+    provider.getSuggestions(["src/a"], 0, 5, {
+      force: true,
+      signal: new AbortController().signal,
+    }),
+  ).resolves.toEqual({
+    items: [{ value: "src/alpha.ts", label: "<text>src/alpha.ts</text>" }],
+    prefix: "src/a",
+  });
+});

--- a/apps/tui/src/command-autocomplete.ts
+++ b/apps/tui/src/command-autocomplete.ts
@@ -11,6 +11,10 @@ type SkillCompletion = {
   readonly description: string;
   readonly name: string;
   readonly qualifiedId: string;
+  readonly source:
+    | { readonly type: "project"; readonly scope: string }
+    | { readonly type: "user" }
+    | { readonly type: "extension"; readonly extensionId: string; readonly packageVersion: string };
 };
 
 export class AdamAutocompleteProvider implements AutocompleteProvider {
@@ -21,6 +25,8 @@ export class AdamAutocompleteProvider implements AutocompleteProvider {
   readonly #getSkills: () => readonly SkillCompletion[];
   readonly #getThinkingLevelIds: () => readonly string[];
   readonly #keyword: (text: string) => string;
+  readonly #path: (text: string) => string;
+  readonly #skill: (text: string) => string;
   readonly #registry: AdamCommandRegistry;
 
   constructor(options: {
@@ -30,6 +36,8 @@ export class AdamAutocompleteProvider implements AutocompleteProvider {
     readonly getSkills: () => readonly SkillCompletion[];
     readonly getThinkingLevelIds?: () => readonly string[];
     readonly keyword?: (text: string) => string;
+    readonly path?: (text: string) => string;
+    readonly skill?: (text: string) => string;
     readonly registry?: AdamCommandRegistry;
   }) {
     this.#getAttachmentsAvailable = options.getAttachmentsAvailable ?? (() => true);
@@ -38,6 +46,8 @@ export class AdamAutocompleteProvider implements AutocompleteProvider {
     this.#getSkills = options.getSkills;
     this.#getThinkingLevelIds = options.getThinkingLevelIds ?? (() => []);
     this.#keyword = options.keyword ?? ((text) => text);
+    this.#path = options.path ?? ((text) => text);
+    this.#skill = options.skill ?? ((text) => text);
     this.#registry = options.registry ?? adamCommandRegistry;
   }
 
@@ -145,8 +155,8 @@ export class AdamAutocompleteProvider implements AutocompleteProvider {
         .filter((skill) => skill.name.startsWith(mentionNamePrefix))
         .map<AutocompleteItem>((skill) => ({
           value: `$${skill.name}`,
-          label: `$${skill.name}`,
-          description: safeTerminalText(`${skill.qualifiedId} · ${skill.description}`),
+          label: this.#skill(`$${skill.name}`),
+          description: safeTerminalText(`${skillSourceLabel(skill.source)} · ${skill.description}`),
         }));
       return Promise.resolve(
         skillItems.length === 0 ? null : { items: skillItems, prefix: mentionPrefix },
@@ -161,7 +171,7 @@ export class AdamAutocompleteProvider implements AutocompleteProvider {
       .filter((path) => path.toLocaleLowerCase().startsWith(normalizedPrefix))
       .map<AutocompleteItem>((path) => {
         const safePath = safeTerminalText(path);
-        return { value: safePath, label: safePath };
+        return { value: safePath, label: this.#path(safePath) };
       });
     return Promise.resolve(pathItems.length === 0 ? null : { items: pathItems, prefix });
   }
@@ -179,4 +189,14 @@ export class AdamAutocompleteProvider implements AutocompleteProvider {
     completed[cursorLine] = `${line.slice(0, start)}${item.value}${line.slice(cursorCol)}`;
     return { lines: completed, cursorLine, cursorCol: start + item.value.length };
   }
+}
+
+function skillSourceLabel(source: SkillCompletion["source"]): string {
+  if (source.type === "user") {
+    return "user";
+  }
+  if (source.type === "project") {
+    return `project:${source.scope}`;
+  }
+  return `extension:${source.extensionId}@${source.packageVersion}`;
 }

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -603,7 +603,16 @@ test("Skill completion restores Green and Overlay roles when Mauve selection mov
     let output = fixture.output().slice(beforeCompletion);
     expect(output).toContain("\u001b[38;2;203;166;247m> $alpha");
     expect(output).toContain("\u001b[38;2;166;227;161m$beta\u001b[39m");
-    expect(stripTerminalSequences(output)).toContain("project:. · beta completion procedure.");
+    expectSemanticCompletionRow(output, {
+      description: "project:. · alpha completion procedure.",
+      label: "$alpha",
+      selected: true,
+    });
+    expectSemanticCompletionRow(output, {
+      description: "project:. · beta completion procedure.",
+      label: "$beta",
+      selected: false,
+    });
 
     const beforeMove = fixture.output().length;
     fixture.write("\u001b[B");
@@ -611,12 +620,40 @@ test("Skill completion restores Green and Overlay roles when Mauve selection mov
     output = fixture.output().slice(beforeMove);
     expect(output).toContain("\u001b[38;2;166;227;161m$alpha\u001b[39m");
     expect(output).toContain("\u001b[38;2;203;166;247m> $beta");
+    expectSemanticCompletionRow(output, {
+      description: "project:. · alpha completion procedure.",
+      label: "$alpha",
+      selected: false,
+    });
+    expectSemanticCompletionRow(output, {
+      description: "project:. · beta completion procedure.",
+      label: "$beta",
+      selected: true,
+    });
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }
 });
+
+function expectSemanticCompletionRow(
+  output: string,
+  input: { readonly description: string; readonly label: string; readonly selected: boolean },
+): void {
+  if (input.selected) {
+    const start = output.indexOf(`\u001b[38;2;203;166;247m> ${input.label}`);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const end = output.indexOf("\u001b[39m", start);
+    expect(output.slice(start, end)).toContain(input.description);
+    return;
+  }
+  const labelEnd = output.indexOf(`\u001b[38;2;166;227;161m${input.label}\u001b[39m`);
+  expect(labelEnd).toBeGreaterThanOrEqual(0);
+  const descriptionStart = output.indexOf("\u001b[38;2;108;112;134m", labelEnd);
+  const descriptionEnd = output.indexOf("\u001b[39m", descriptionStart);
+  expect(output.slice(descriptionStart, descriptionEnd)).toContain(input.description);
+}
 
 test("NO_COLOR Skill completion retains marker, order, columns, and source labels", async () => {
   const { fixture, testRoot } = await startPastedTextAtomFixture({

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -648,9 +648,9 @@ function expectSemanticCompletionRow(
     expect(output.slice(start, end)).toContain(input.description);
     return;
   }
-  const labelEnd = output.indexOf(`\u001b[38;2;166;227;161m${input.label}\u001b[39m`);
-  expect(labelEnd).toBeGreaterThanOrEqual(0);
-  const descriptionStart = output.indexOf("\u001b[38;2;108;112;134m", labelEnd);
+  const labelSpanStart = output.indexOf(`\u001b[38;2;166;227;161m${input.label}\u001b[39m`);
+  expect(labelSpanStart).toBeGreaterThanOrEqual(0);
+  const descriptionStart = output.indexOf("\u001b[38;2;108;112;134m", labelSpanStart);
   const descriptionEnd = output.indexOf("\u001b[39m", descriptionStart);
   expect(output.slice(descriptionStart, descriptionEnd)).toContain(input.description);
 }

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -10,7 +10,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { visibleWidth } from "@earendil-works/pi-tui";
+import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
 import { afterEach, expect, test } from "vitest";
 import { AppliedViewportTerminal } from "./applied-viewport-terminal.test-support.js";
 import { copySelectionToClipboard, selectionCopyMaximumBytes } from "./exit-policy.js";
@@ -509,6 +509,168 @@ test("a chunked large bracketed paste becomes one exact expandable Text atom", a
   }
 });
 
+test("a ready pasted Text presents one bounded content preview", async () => {
+  const { fixture, testRoot } = await startPastedTextAtomFixture({ slug: "ready-preview" });
+  try {
+    const screen = fixture.screen()?.join("\n") ?? "";
+    expect(screen).toContain("[Text #1] · Pasted text · structure... · 11 lines");
+    expect(screen).not.toContain("[Text #1] · Pasted text · ready ·");
+    expect(fixture.output().split("\u001b[38;2;137;220;235m[Text #1]\u001b[39m").length - 1).toBe(
+      2,
+    );
+    expect(fixture.output()).toContain("\u001b[38;2;166;227;161mstructure...\u001b[39m");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a ready pasted Text preview remains stable across responsive layouts", async () => {
+  const { fixture, testRoot } = await startPastedTextAtomFixture({ slug: "preview-responsive" });
+  try {
+    for (const columns of [40, 80, 120]) {
+      const beforeResize = fixture.output().length;
+      await fixture.resize(columns, 24);
+      const frame = latestSynchronizedFrame(fixture.output().slice(beforeResize));
+      expect(frame.every((line) => visibleWidth(line) <= columns)).toBe(true);
+    }
+    expect(stripTerminalSequences(fixture.output())).toContain(
+      "[Text #1] · Pasted text · structure... · 11 lines",
+    );
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a ready pasted Text preview is recomputed after a recoverable restart", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-preview-restart-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  const pasted = Array.from({ length: 11 }, (_, index) => `restart line ${index + 1}`).join("\n");
+
+  try {
+    const first = startFixture({ launch: {}, stateRoot, workspaceRoot });
+    await first.waitFor("Select an exact model target");
+    first.write("\r");
+    await first.waitFor("Adam · New session");
+    first.write(`\u001b[200~${pasted}\u001b[201~`);
+    await first.waitFor("Pasted text staged.");
+    await first.waitFor("restart l...");
+    first.write("\u0011");
+    await expect(first.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+
+    const restarted = startFixture({ launch: {}, stateRoot, workspaceRoot });
+    await restarted.waitFor("Select an exact model target");
+    restarted.write("\r");
+    await restarted.waitFor("restart l...");
+    expect(restarted.screen()?.join("\n") ?? "").not.toContain("Pasted text · ready");
+    restarted.write("\u0011");
+    await expect(restarted.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("NO_COLOR preserves ready pasted Text structure and preview without SGR", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-preview-no-color-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  const pasted = Array.from({ length: 11 }, (_, index) => `colorless line ${index + 1}`).join("\n");
+
+  try {
+    const fixture = startFixture({ noColor: true, stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    const beforePaste = fixture.output().length;
+    fixture.write(`\u001b[200~${pasted}\u001b[201~`);
+    await fixture.waitForCompleteFrameAfter("colorless...", beforePaste);
+    const frame = latestSynchronizedFrame(fixture.output().slice(beforePaste)).join("\n");
+    expect(frame).toContain("[Text #1] · Pasted text · colorless...");
+    expect(frame).not.toContain("\u001b[38;2;");
+    expect(frame).not.toContain("\u001b[48;2;");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a pasted Text preview removes terminal controls and normalizes whitespace before truncation", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-safe-text-preview-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  const pasted = `\u001b[31m\t《红楼梦》\u3000第五回\u001b[0m\u202e\n${Array.from({ length: 10 }, (_, index) => `后文 ${index + 1}`).join("\n")}`;
+  const terminal = new VirtualTerminal();
+  const execution = runTuiFixture({
+    clipboardReader: {
+      async close() {},
+      async readClipboard() {
+        return { status: "text" as const, platform: "linux_x11" as const, text: pasted };
+      },
+    },
+    stateRoot,
+    terminal,
+    workspaceRoot,
+  });
+
+  try {
+    await terminal.whenStarted();
+    terminal.input("\u001bv");
+    await terminal.nextSynchronizedFrameContaining("Pasted text staged.");
+    const output = stripTerminalSequences(terminal.output());
+    const screen = terminal.lines().join("\n");
+    expect(output).toContain("[Text #1] · Pasted text · 《红楼梦》 第五回...");
+    expect(screen).not.toContain("[31m");
+    expect(screen).not.toContain("[0m");
+  } finally {
+    if (terminal.running()) {
+      terminal.input("\u0011");
+    }
+    await execution;
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a pasted Text containing only terminal strings presents the empty-safe preview", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-empty-text-preview-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  const pasted = Array.from({ length: 11 }, () => "\u001b_PRIVATE\u001b\\").join("\n");
+  const terminal = new VirtualTerminal({ columns: 120, rows: 24 });
+  const execution = runTuiFixture({
+    clipboardReader: {
+      async close() {},
+      async readClipboard() {
+        return { status: "text" as const, platform: "linux_x11" as const, text: pasted };
+      },
+    },
+    stateRoot,
+    terminal,
+    workspaceRoot,
+  });
+
+  try {
+    await terminal.whenStarted();
+    terminal.input("\u001bv");
+    await terminal.nextSynchronizedFrameContaining("Pasted text staged.");
+    expect(stripTerminalSequences(terminal.output())).toContain(
+      "[Text #1] · Pasted text · (empty after sanitization)",
+    );
+  } finally {
+    if (terminal.running()) {
+      terminal.input("\u0011");
+    }
+    await execution;
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("Skill completion remains available after one large pasted Text atom", async () => {
   const { fixture, testRoot } = await startPastedTextAtomFixture({
     prepare: prepareFirstStructuredCompletionSkill,
@@ -519,6 +681,10 @@ test("Skill completion remains available after one large pasted Text atom", asyn
     const beforeCompletion = fixture.output().length;
     fixture.write(" Use $fir");
     await fixture.waitForCompleteFrameAfter("$first", beforeCompletion);
+    const completionOutput = fixture.output().slice(beforeCompletion);
+    expect(completionOutput).toContain("\u001b[38;2;203;166;247m> $first");
+    expect(stripTerminalSequences(completionOutput)).toContain("project:. · First structured");
+    expect(completionOutput).not.toContain("skill:v1:project:.:first");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
@@ -4277,7 +4443,7 @@ test("slash completion exposes Registry usage as its argument hint", async () =>
     const beforeCompletion = fixture.output().length;
     fixture.write("/he");
     await fixture.waitForAfter("/help [topic]", beforeCompletion);
-    expect(fixture.output().slice(beforeCompletion)).toContain(keywordLabel("/help"));
+    expect(fixture.output().slice(beforeCompletion)).toContain("\u001b[38;2;203;166;247m> /help");
     fixture.write("\t\r");
     await fixture.waitForAfter("Adam Help", beforeCompletion);
     fixture.write("\u0011");
@@ -4896,7 +5062,7 @@ test("Tab completes a Help topic argument from the Registry", async () => {
     const beforeCompletion = fixture.output().length;
     fixture.write("/help hot");
     await fixture.waitForAfter("Fixed effective keyboard bindings", beforeCompletion);
-    expect(fixture.output().slice(beforeCompletion)).toContain(keywordLabel("hotkeys"));
+    expect(fixture.output().slice(beforeCompletion)).toContain("\u001b[38;2;203;166;247m> hotkeys");
     fixture.write("\t\r");
     const outcome = await Promise.race([
       fixture.waitForAfter("Effective Hotkeys", beforeCompletion).then(() => "hotkeys" as const),

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -545,36 +545,6 @@ test("a ready pasted Text preview remains stable across responsive layouts", asy
   }
 });
 
-test("a ready pasted Text preview is recomputed after a recoverable restart", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-preview-restart-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(workspaceRoot);
-  const pasted = Array.from({ length: 11 }, (_, index) => `restart line ${index + 1}`).join("\n");
-
-  try {
-    const first = startFixture({ launch: {}, stateRoot, workspaceRoot });
-    await first.waitFor("Select an exact model target");
-    first.write("\r");
-    await first.waitFor("Adam · New session");
-    first.write(`\u001b[200~${pasted}\u001b[201~`);
-    await first.waitFor("Pasted text staged.");
-    await first.waitFor("restart l...");
-    first.write("\u0011");
-    await expect(first.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-
-    const restarted = startFixture({ launch: {}, stateRoot, workspaceRoot });
-    await restarted.waitFor("Select an exact model target");
-    restarted.write("\r");
-    await restarted.waitFor("restart l...");
-    expect(restarted.screen()?.join("\n") ?? "").not.toContain("Pasted text · ready");
-    restarted.write("\u0011");
-    await expect(restarted.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-  } finally {
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
 test("NO_COLOR preserves ready pasted Text structure and preview without SGR", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-preview-no-color-"));
   const workspaceRoot = join(testRoot, "workspace");
@@ -599,78 +569,6 @@ test("NO_COLOR preserves ready pasted Text structure and preview without SGR", a
   }
 });
 
-test("a pasted Text preview removes terminal controls and normalizes whitespace before truncation", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-safe-text-preview-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(workspaceRoot);
-  const pasted = `\u001b[31m\t《红楼梦》\u3000第五回\u001b[0m\u202e\n${Array.from({ length: 10 }, (_, index) => `后文 ${index + 1}`).join("\n")}`;
-  const terminal = new VirtualTerminal();
-  const execution = runTuiFixture({
-    clipboardReader: {
-      async close() {},
-      async readClipboard() {
-        return { status: "text" as const, platform: "linux_x11" as const, text: pasted };
-      },
-    },
-    stateRoot,
-    terminal,
-    workspaceRoot,
-  });
-
-  try {
-    await terminal.whenStarted();
-    terminal.input("\u001bv");
-    await terminal.nextSynchronizedFrameContaining("Pasted text staged.");
-    const output = stripTerminalSequences(terminal.output());
-    const screen = terminal.lines().join("\n");
-    expect(output).toContain("[Text #1] · Pasted text · 《红楼梦》 第五回...");
-    expect(screen).not.toContain("[31m");
-    expect(screen).not.toContain("[0m");
-  } finally {
-    if (terminal.running()) {
-      terminal.input("\u0011");
-    }
-    await execution;
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
-test("a pasted Text containing only terminal strings presents the empty-safe preview", async () => {
-  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-empty-text-preview-"));
-  const workspaceRoot = join(testRoot, "workspace");
-  const stateRoot = join(testRoot, "state");
-  await mkdir(workspaceRoot);
-  const pasted = Array.from({ length: 11 }, () => "\u001b_PRIVATE\u001b\\").join("\n");
-  const terminal = new VirtualTerminal({ columns: 120, rows: 24 });
-  const execution = runTuiFixture({
-    clipboardReader: {
-      async close() {},
-      async readClipboard() {
-        return { status: "text" as const, platform: "linux_x11" as const, text: pasted };
-      },
-    },
-    stateRoot,
-    terminal,
-    workspaceRoot,
-  });
-
-  try {
-    await terminal.whenStarted();
-    terminal.input("\u001bv");
-    await terminal.nextSynchronizedFrameContaining("Pasted text staged.");
-    expect(stripTerminalSequences(terminal.output())).toContain(
-      "[Text #1] · Pasted text · (empty after sanitization)",
-    );
-  } finally {
-    if (terminal.running()) {
-      terminal.input("\u0011");
-    }
-    await execution;
-    await rm(testRoot, { recursive: true, force: true });
-  }
-});
-
 test("Skill completion remains available after one large pasted Text atom", async () => {
   const { fixture, testRoot } = await startPastedTextAtomFixture({
     prepare: prepareFirstStructuredCompletionSkill,
@@ -685,6 +583,61 @@ test("Skill completion remains available after one large pasted Text atom", asyn
     expect(completionOutput).toContain("\u001b[38;2;203;166;247m> $first");
     expect(stripTerminalSequences(completionOutput)).toContain("project:. · First structured");
     expect(completionOutput).not.toContain("skill:v1:project:.:first");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("Skill completion restores Green and Overlay roles when Mauve selection moves", async () => {
+  const { fixture, testRoot } = await startPastedTextAtomFixture({
+    prepare: prepareTwoStructuredCompletionSkills,
+    scenario: "skill-selection",
+    slug: "skill-row-selection",
+  });
+  try {
+    const beforeCompletion = fixture.output().length;
+    fixture.write(" Use $");
+    await fixture.waitForCompleteFrameAfter("$beta", beforeCompletion);
+    let output = fixture.output().slice(beforeCompletion);
+    expect(output).toContain("\u001b[38;2;203;166;247m> $alpha");
+    expect(output).toContain("\u001b[38;2;166;227;161m$beta\u001b[39m");
+    expect(stripTerminalSequences(output)).toContain("project:. · beta completion procedure.");
+
+    const beforeMove = fixture.output().length;
+    fixture.write("\u001b[B");
+    await fixture.resize(79, 24);
+    output = fixture.output().slice(beforeMove);
+    expect(output).toContain("\u001b[38;2;166;227;161m$alpha\u001b[39m");
+    expect(output).toContain("\u001b[38;2;203;166;247m> $beta");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("NO_COLOR Skill completion retains marker, order, columns, and source labels", async () => {
+  const { fixture, testRoot } = await startPastedTextAtomFixture({
+    noColor: true,
+    prepare: prepareTwoStructuredCompletionSkills,
+    scenario: "skill-selection",
+    slug: "skill-row-no-color",
+  });
+  try {
+    const beforeCompletion = fixture.output().length;
+    fixture.write(" Use $");
+    await fixture.waitForCompleteFrameAfter("$beta", beforeCompletion);
+    const frame = latestSynchronizedFrame(fixture.output().slice(beforeCompletion));
+    const text = frame.join("\n");
+    expect(text).toContain("> $alpha");
+    expect(text).toContain("$beta");
+    expect(text).toContain("project:. · alpha completion procedure.");
+    expect(text.indexOf("$alpha")).toBeLessThan(text.indexOf("$beta"));
+    expect(frame.every((line) => visibleWidth(line) <= 80)).toBe(true);
+    expect(text).not.toContain("\u001b[38;2;");
+    expect(text).not.toContain("\u001b[48;2;");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
@@ -775,6 +728,7 @@ test("the existing at path picker remains atom-safe after one pasted Text atom",
 });
 
 async function startPastedTextAtomFixture(input: {
+  readonly noColor?: boolean;
   readonly prepare?: (workspaceRoot: string) => Promise<void>;
   readonly scenario?: "skill-selection";
   readonly slug: string;
@@ -786,6 +740,7 @@ async function startPastedTextAtomFixture(input: {
     await mkdir(workspaceRoot, { recursive: true });
     await input.prepare?.(workspaceRoot);
     const fixture = startFixture({
+      ...(input.noColor === undefined ? {} : { noColor: input.noColor }),
       ...(input.scenario === undefined ? {} : { scenario: input.scenario }),
       stateRoot,
       workspaceRoot,
@@ -812,6 +767,18 @@ async function prepareFirstStructuredCompletionSkill(workspaceRoot: string): Pro
     "---\nname: first\ndescription: First structured completion procedure.\n---\nFirst body.\n",
     "utf8",
   );
+}
+
+async function prepareTwoStructuredCompletionSkills(workspaceRoot: string): Promise<void> {
+  for (const name of ["alpha", "beta"]) {
+    const skillDirectory = join(workspaceRoot, ".agents", "skills", name);
+    await mkdir(skillDirectory, { recursive: true });
+    await writeFile(
+      join(skillDirectory, "SKILL.md"),
+      `---\nname: ${name}\ndescription: ${name} completion procedure.\n---\n${name} body.\n`,
+      "utf8",
+    );
+  }
 }
 
 test("a 1000-scalar paste stays ordinary text even when UTF-16 length is larger", async () => {

--- a/apps/tui/src/pi-editor-atoms.test.ts
+++ b/apps/tui/src/pi-editor-atoms.test.ts
@@ -70,6 +70,25 @@ test("Pi Editor treats one host-owned resource label as an atomic navigable part
   ]);
 });
 
+test("Pi Editor styles only structural atom ranges without changing visible text", () => {
+  const editor = new Editor(
+    { requestRender() {}, terminal: { rows: 24 } } as never,
+    createAdamTuiTheme(false).editor,
+  ) as AtomEditor;
+  editor.setDocument(
+    [
+      { type: "text", id: "literal", text: "literal [File #1] " },
+      { type: "atom", id: "resource", label: "[File #1]" },
+    ],
+    { partId: "resource", edge: "after" },
+  );
+
+  const rendered = editor.render(80).join("\n");
+  expect(rendered).toContain("literal [File #1] ");
+  expect(rendered.split("\u001b[38;2;137;220;235m[File #1]\u001b[39m").length - 1).toBe(1);
+  expect(editor.getText()).toBe("literal [File #1] [File #1]");
+});
+
 test("Pi Editor rejects unsupported structured mutations without changing its document", () => {
   const editor = new Editor(
     { requestRender() {} } as never,

--- a/apps/tui/src/safe-terminal-text.ts
+++ b/apps/tui/src/safe-terminal-text.ts
@@ -33,4 +33,4 @@ function isBidirectionalControl(codePoint: number): boolean {
   );
 }
 
-import { stripTerminalSequences } from "@earendil-works/pi-tui";
+import { stripTerminalSequences } from "@adam-agent/presentation";

--- a/apps/tui/src/safe-terminal-text.ts
+++ b/apps/tui/src/safe-terminal-text.ts
@@ -12,25 +12,11 @@ export function safeTerminalText(value: string): string {
       result += "\n";
     } else if (character === "\t") {
       result += "  ";
-    } else if (
-      codePoint >= 0x20 &&
-      !(codePoint >= 0x7f && codePoint <= 0x9f) &&
-      !isBidirectionalControl(codePoint)
-    ) {
+    } else if (!isUnsafePresentationControl(codePoint)) {
       result += character;
     }
   }
   return result;
 }
 
-function isBidirectionalControl(codePoint: number): boolean {
-  return (
-    codePoint === 0x061c ||
-    codePoint === 0x200e ||
-    codePoint === 0x200f ||
-    (codePoint >= 0x202a && codePoint <= 0x202e) ||
-    (codePoint >= 0x2066 && codePoint <= 0x2069)
-  );
-}
-
-import { stripTerminalSequences } from "@adam-agent/presentation";
+import { isUnsafePresentationControl, stripTerminalSequences } from "@adam-agent/presentation";

--- a/apps/tui/src/theme.test.ts
+++ b/apps/tui/src/theme.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "vitest";
+import { createAdamTuiTheme } from "./theme.js";
+
+test("Catppuccin semantic slots retain the frozen completion and reference colors", () => {
+  const theme = createAdamTuiTheme(false);
+  expect(theme.text("text")).toBe("\u001b[38;2;205;214;244mtext\u001b[39m");
+  expect(theme.green("green")).toBe("\u001b[38;2;166;227;161mgreen\u001b[39m");
+  expect(theme.overlay("overlay")).toBe("\u001b[38;2;108;112;134moverlay\u001b[39m");
+  expect(theme.editor.selectList.selectedText("selected")).toBe(
+    "\u001b[38;2;203;166;247mselected\u001b[39m",
+  );
+  expect(theme.reference("reference")).toBe("\u001b[38;2;137;220;235mreference\u001b[39m");
+});
+
+test("NO_COLOR preserves semantic content without SGR", () => {
+  const theme = createAdamTuiTheme(true);
+  expect([
+    theme.text("text"),
+    theme.green("green"),
+    theme.overlay("overlay"),
+    theme.editor.selectList.selectedText("> selected"),
+    theme.reference("reference"),
+  ]).toEqual(["text", "green", "overlay", "> selected", "reference"]);
+});

--- a/apps/tui/src/theme.ts
+++ b/apps/tui/src/theme.ts
@@ -22,6 +22,11 @@ export type AdamTuiTheme = {
   readonly markdown: MarkdownTheme;
   readonly muted: (text: string) => string;
   readonly primary: (text: string) => string;
+  readonly text: (text: string) => string;
+  readonly green: (text: string) => string;
+  readonly overlay: (text: string) => string;
+  readonly mauve: (text: string) => string;
+  readonly reference: (text: string) => string;
   readonly statusError: (text: string) => string;
   readonly statusInfo: (text: string) => string;
   readonly statusSuccess: (text: string) => string;
@@ -68,6 +73,11 @@ export function createAdamTuiTheme(noColor = noColorRequested()): AdamTuiTheme {
 
   return {
     primary: text,
+    text,
+    green,
+    overlay,
+    mauve,
+    reference: color(137, 220, 235),
     brand: bold(mauve),
     muted,
     statusError: red,
@@ -117,11 +127,12 @@ export function createAdamTuiTheme(noColor = noColorRequested()): AdamTuiTheme {
     toolTitle: bold(mauve),
     toolOutput: subtext,
     editor: {
+      atom: color(137, 220, 235),
       borderColor: overlay,
       selectList: {
         selectedPrefix: mauve,
-        selectedText: text,
-        description: muted,
+        selectedText: mauve,
+        description: overlay,
         scrollInfo: muted,
         noMatch: muted,
       },

--- a/apps/tui/src/theme.ts
+++ b/apps/tui/src/theme.ts
@@ -25,7 +25,6 @@ export type AdamTuiTheme = {
   readonly text: (text: string) => string;
   readonly green: (text: string) => string;
   readonly overlay: (text: string) => string;
-  readonly mauve: (text: string) => string;
   readonly reference: (text: string) => string;
   readonly statusError: (text: string) => string;
   readonly statusInfo: (text: string) => string;
@@ -76,7 +75,6 @@ export function createAdamTuiTheme(noColor = noColorRequested()): AdamTuiTheme {
     text,
     green,
     overlay,
-    mauve,
     reference: color(137, 220, 235),
     brand: bold(mauve),
     muted,

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -297,8 +297,11 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
             description: skill.description,
             name: skill.name,
             qualifiedId: skill.qualifiedId,
+            source: skill.source,
           })),
-        keyword: theme.keyword,
+        keyword: theme.text,
+        path: theme.text,
+        skill: theme.green,
         registry: commandRegistry,
       }),
     );
@@ -719,13 +722,13 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         if (pastedText === undefined) {
           continue;
         }
-        resources.addChild(
-          new ResponsiveLine(
-            theme.toolOutput(
-              `${pastedText.token} · Pasted text · ${pastedText.state} · ${pastedText.lineCount} lines · ${pastedText.scalarCount} scalars · ${pastedText.byteCount} bytes`,
-            ),
-          ),
-        );
+        const pastedTextLine =
+          pastedText.state === "ready"
+            ? `${theme.reference(pastedText.token)} · ${theme.text("Pasted text")} · ${theme.green(pastedText.preview)} · ${theme.overlay(`${pastedText.lineCount} lines · ${pastedText.scalarCount} scalars · ${pastedText.byteCount} bytes`)}`
+            : theme.toolOutput(
+                `${pastedText.token} · Pasted text · ${pastedText.state} · ${pastedText.lineCount} lines · ${pastedText.scalarCount} scalars · ${pastedText.byteCount} bytes`,
+              );
+        resources.addChild(new ResponsiveLine(pastedTextLine));
         if (pastedText.diagnostic !== null) {
           resources.addChild(
             new ResponsiveLine(theme.muted(safeTerminalText(pastedText.diagnostic))),
@@ -750,11 +753,11 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
             : "Selected file";
       resources.addChild(
         new ResponsiveLine(
-          theme.toolOutput(
+          `${theme.reference(resource.token)} · ${theme.text(origin)} · ${theme.overlay(
             safeTerminalText(
-              `${resource.token} · ${origin} · ${resource.state} · ${resource.displayName} · ${size} · ${media} · ${support}`,
+              `${resource.state} · ${resource.displayName} · ${size} · ${media} · ${support}`,
             ),
-          ),
+          )}`,
         ),
       );
       if (resource.diagnostic !== null) {

--- a/packages/agent/src/session-naming.ts
+++ b/packages/agent/src/session-naming.ts
@@ -23,7 +23,7 @@ export function normalizedSessionTitle(input: string): string | null {
     .trim();
 }
 
-export function stripTerminalSequences(input: string): string {
+function stripTerminalSequences(input: string): string {
   let output = "";
   for (let index = 0; index < input.length; index += 1) {
     const code = input.charCodeAt(index);
@@ -43,7 +43,7 @@ export function stripTerminalSequences(input: string): string {
       }
       continue;
     }
-    if (introducer === 0x5d || introducer === 0x5f) {
+    if (introducer === 0x5d) {
       index += 2;
       while (index < input.length) {
         if (input.charCodeAt(index) === 0x07) {

--- a/packages/agent/src/session-naming.ts
+++ b/packages/agent/src/session-naming.ts
@@ -23,7 +23,7 @@ export function normalizedSessionTitle(input: string): string | null {
     .trim();
 }
 
-function stripTerminalSequences(input: string): string {
+export function stripTerminalSequences(input: string): string {
   let output = "";
   for (let index = 0; index < input.length; index += 1) {
     const code = input.charCodeAt(index);
@@ -43,7 +43,7 @@ function stripTerminalSequences(input: string): string {
       }
       continue;
     }
-    if (introducer === 0x5d) {
+    if (introducer === 0x5d || introducer === 0x5f) {
       index += 2;
       while (index < input.length) {
         if (input.charCodeAt(index) === 0x07) {

--- a/packages/agent/src/turn-composer.test.ts
+++ b/packages/agent/src/turn-composer.test.ts
@@ -5,6 +5,97 @@ import { createTurnComposer } from "./turn-composer.js";
 
 const digest = `sha256:${"a".repeat(64)}` as const;
 
+function createPastedTextStager(): TurnComposerResourceStager {
+  const texts = new Map<string, string>();
+  return {
+    async stage() {
+      throw new Error("No file should be staged in this test.");
+    },
+    async stageText(input) {
+      texts.set(input.id, input.text);
+      return {
+        type: "staged_pasted_text",
+        staged: {
+          stagingId: input.id,
+          id: digest,
+          mediaType: "text/plain; charset=utf-8",
+          byteCount: Buffer.byteLength(input.text, "utf8"),
+        },
+        digest,
+        byteCount: Buffer.byteLength(input.text, "utf8"),
+        lineCount: input.text.split("\n").length,
+        scalarCount: Array.from(input.text).length,
+      };
+    },
+    async readText(selection) {
+      const text = texts.get(selection.staged.stagingId);
+      if (text === undefined) {
+        throw new Error("The staged pasted text is unavailable.");
+      }
+      return text;
+    },
+    async retain() {},
+    async discard() {},
+    async close() {},
+  };
+}
+
+test("TurnComposer derives one safe bounded preview from pasted text", async () => {
+  const composer = await createTurnComposer({ onChange() {}, stager: createPastedTextStager() });
+  try {
+    await composer.stagePastedText("\u001b[31m\t《红楼梦》\u3000第五回\u001b[0m\u202e\n后文");
+    expect(composer.snapshot().pastedTexts).toMatchObject([
+      { preview: "《红楼梦》 第五回...", state: "ready" },
+    ]);
+  } finally {
+    await composer.close();
+  }
+});
+
+test("TurnComposer uses the exact empty fallback after terminal-string sanitization", async () => {
+  const composer = await createTurnComposer({ onChange() {}, stager: createPastedTextStager() });
+  try {
+    await composer.stagePastedText("\u001b_PRIVATE\u001b\\");
+    expect(composer.snapshot().pastedTexts).toMatchObject([
+      { preview: "(empty after sanitization)", state: "ready" },
+    ]);
+  } finally {
+    await composer.close();
+  }
+});
+
+test("TurnComposer removes malformed ESC controls without deleting following visible text", async () => {
+  const composer = await createTurnComposer({ onChange() {}, stager: createPastedTextStager() });
+  try {
+    await composer.stagePastedText("A\u001bXB");
+    expect(composer.snapshot().pastedTexts).toMatchObject([{ preview: "AXB", state: "ready" }]);
+  } finally {
+    await composer.close();
+  }
+});
+
+test("TurnComposer restores a derived preview without persisting a second copy", async () => {
+  const stager = createPastedTextStager();
+  const composer = await createTurnComposer({ onChange() {}, stager });
+  const recovered = await createTurnComposer({ onChange() {}, stager });
+  try {
+    const pasted = Array.from({ length: 11 }, (_, index) => `recovered paste ${index + 1}`).join(
+      "\n",
+    );
+    await composer.stagePastedText(pasted);
+    const draft = await composer.captureDraft({ type: "new_session", targetId: "fake.local" });
+    expect(draft).not.toHaveProperty("preview");
+    expect(JSON.stringify(draft)).not.toContain("recovered...");
+    await recovered.restoreDraft(draft);
+    expect(recovered.snapshot().pastedTexts).toMatchObject([
+      { preview: "recovered...", state: "ready" },
+    ]);
+  } finally {
+    await recovered.close();
+    await composer.close();
+  }
+});
+
 test("TurnComposer rejects a malformed pasted image before publishing a draft mutation", async () => {
   let publications = 0;
   let stagingInvoked = false;

--- a/packages/agent/src/turn-composer.ts
+++ b/packages/agent/src/turn-composer.ts
@@ -13,6 +13,7 @@ import {
   type StagedPastedTextSelectionV1,
 } from "./pasted-text.js";
 import type { RecoverableTurnDraftV1 } from "./recoverable-turn-draft.js";
+import { stripTerminalSequences } from "./session-naming.js";
 import type { StagedUserContentElementV1 } from "./structured-user-content.js";
 
 export {
@@ -83,6 +84,7 @@ export type TurnComposerPastedTextSnapshot = {
   readonly lineCount: number;
   readonly scalarCount: number;
   readonly origin: "pasted_text";
+  readonly preview: string;
   readonly diagnostic: string | null;
 };
 
@@ -113,6 +115,7 @@ type TurnComposerPastedText = {
   byteCount: number;
   lineCount: number;
   scalarCount: number;
+  preview: string;
   diagnostic: string | null;
   readonly controller: AbortController;
   staged: StagedPastedTextSelectionV1 | null;
@@ -212,6 +215,35 @@ export async function createTurnComposer(options: {
   let text = "";
   let sealed = false;
   let closed = false;
+  const previewSegmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
+
+  const projectPastedTextPreview = (value: string): string => {
+    let safe = "";
+    for (const character of stripTerminalSequences(value)) {
+      const codePoint = character.codePointAt(0) as number;
+      if (/\p{White_Space}/u.test(character)) {
+        safe += " ";
+      } else if (
+        codePoint < 0x20 ||
+        (codePoint >= 0x7f && codePoint <= 0x9f) ||
+        codePoint === 0x061c ||
+        codePoint === 0x200e ||
+        codePoint === 0x200f ||
+        (codePoint >= 0x202a && codePoint <= 0x202e) ||
+        (codePoint >= 0x2066 && codePoint <= 0x2069)
+      ) {
+      } else {
+        safe += character;
+      }
+    }
+    const normalized = safe.replace(/ +/gu, " ").trim();
+    if (normalized.length === 0) {
+      return "(empty after sanitization)";
+    }
+    const graphemes = [...previewSegmenter.segment(normalized)].map((entry) => entry.segment);
+    const preview = graphemes.slice(0, 9).join("");
+    return graphemes.length > 9 ? `${preview}...` : preview;
+  };
 
   const publish = (): void => {
     if (!closed) {
@@ -589,6 +621,7 @@ export async function createTurnComposer(options: {
           byteCount: recovered.byteCount,
           lineCount: recovered.lineCount,
           scalarCount: recovered.scalarCount,
+          preview: recoveredText === null ? "" : projectPastedTextPreview(recoveredText),
           diagnostic:
             recovered.state === "ready" && recoveredText === null
               ? "The recoverable pasted-text bytes are unavailable."
@@ -1121,6 +1154,7 @@ export async function createTurnComposer(options: {
         byteCount: pastedBytes,
         lineCount: normalizedPastedText.split("\n").length,
         scalarCount: Array.from(normalizedPastedText).length,
+        preview: projectPastedTextPreview(normalizedPastedText),
         diagnostic: null,
         controller: new AbortController(),
         staged: null,

--- a/packages/agent/src/turn-composer.ts
+++ b/packages/agent/src/turn-composer.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { stripTerminalSequences } from "@adam-agent/presentation";
 import { normalizeExplicitUserImageToPngV1 } from "./image-input.js";
 import type { TurnComposerResourceStager } from "./input-resource-staging.js";
 import {
@@ -13,7 +14,6 @@ import {
   type StagedPastedTextSelectionV1,
 } from "./pasted-text.js";
 import type { RecoverableTurnDraftV1 } from "./recoverable-turn-draft.js";
-import { stripTerminalSequences } from "./session-naming.js";
 import type { StagedUserContentElementV1 } from "./structured-user-content.js";
 
 export {

--- a/packages/agent/src/turn-composer.ts
+++ b/packages/agent/src/turn-composer.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { stripTerminalSequences } from "@adam-agent/presentation";
+import { isUnsafePresentationControl, stripTerminalSequences } from "@adam-agent/presentation";
 import { normalizeExplicitUserImageToPngV1 } from "./image-input.js";
 import type { TurnComposerResourceStager } from "./input-resource-staging.js";
 import {
@@ -223,15 +223,7 @@ export async function createTurnComposer(options: {
       const codePoint = character.codePointAt(0) as number;
       if (/\p{White_Space}/u.test(character)) {
         safe += " ";
-      } else if (
-        codePoint < 0x20 ||
-        (codePoint >= 0x7f && codePoint <= 0x9f) ||
-        codePoint === 0x061c ||
-        codePoint === 0x200e ||
-        codePoint === 0x200f ||
-        (codePoint >= 0x202a && codePoint <= 0x202e) ||
-        (codePoint >= 0x2066 && codePoint <= 0x2069)
-      ) {
+      } else if (isUnsafePresentationControl(codePoint)) {
       } else {
         safe += character;
       }

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -810,6 +810,7 @@ export type TurnComposerDisplay = {
     readonly lineCount: number;
     readonly scalarCount: number;
     readonly origin: "pasted_text";
+    readonly preview: string;
     readonly diagnostic: string | null;
   }[];
 };

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -1,3 +1,53 @@
+/**
+ * Removes complete CSI, OSC, and APC terminal sequences while preserving visible text.
+ * Adapted from @earendil-works/pi-tui 0.84.2 utils (MIT); see THIRD_PARTY_NOTICES.md.
+ */
+export function stripTerminalSequences(input: string): string {
+  if (!input.includes("\u001b")) {
+    return input;
+  }
+  let output = "";
+  let index = 0;
+  while (index < input.length) {
+    const sequenceLength = terminalSequenceLength(input, index);
+    if (sequenceLength > 0) {
+      index += sequenceLength;
+    } else {
+      output += input[index] ?? "";
+      index += 1;
+    }
+  }
+  return output;
+}
+
+function terminalSequenceLength(input: string, index: number): number {
+  if (input[index] !== "\u001b") {
+    return 0;
+  }
+  const introducer = input[index + 1];
+  if (introducer === "[") {
+    let cursor = index + 2;
+    while (cursor < input.length && !/[mGKHJ]/u.test(input[cursor] ?? "")) {
+      cursor += 1;
+    }
+    return cursor < input.length ? cursor + 1 - index : 0;
+  }
+  if (introducer !== "]" && introducer !== "_") {
+    return 0;
+  }
+  let cursor = index + 2;
+  while (cursor < input.length) {
+    if (input[cursor] === "\u0007") {
+      return cursor + 1 - index;
+    }
+    if (input[cursor] === "\u001b" && input[cursor + 1] === "\\") {
+      return cursor + 2 - index;
+    }
+    cursor += 1;
+  }
+  return 0;
+}
+
 export type ProjectDisplay = {
   readonly id: string;
   readonly label: string;

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -20,6 +20,18 @@ export function stripTerminalSequences(input: string): string {
   return output;
 }
 
+export function isUnsafePresentationControl(codePoint: number): boolean {
+  return (
+    codePoint < 0x20 ||
+    (codePoint >= 0x7f && codePoint <= 0x9f) ||
+    codePoint === 0x061c ||
+    codePoint === 0x200e ||
+    codePoint === 0x200f ||
+    (codePoint >= 0x202a && codePoint <= 0x202e) ||
+    (codePoint >= 0x2066 && codePoint <= 0x2069)
+  );
+}
+
 function terminalSequenceLength(input: string, index: number): number {
   if (input[index] !== "\u001b") {
     return 0;

--- a/packages/presentation/src/safe-text.test.ts
+++ b/packages/presentation/src/safe-text.test.ts
@@ -1,11 +1,16 @@
 import { expect, test } from "vitest";
 
-import { stripTerminalSequences } from "./index.js";
+import { isUnsafePresentationControl, stripTerminalSequences } from "./index.js";
 
 test("stripTerminalSequences removes complete Pi terminal strings", () => {
   expect(
     stripTerminalSequences("a\u001b[31mred\u001b[0m\u001b]0;title\u0007b\u001b_private\u001b\\c"),
   ).toBe("aredbc");
+});
+
+test("isUnsafePresentationControl centralizes C0, C1, and bidi controls", () => {
+  expect([0x1b, 0x7f, 0x061c, 0x202e, 0x2069].every(isUnsafePresentationControl)).toBe(true);
+  expect([0x20, 0x41, 0x4e2d].some(isUnsafePresentationControl)).toBe(false);
 });
 
 test("stripTerminalSequences preserves visible bytes after unknown or incomplete ESC", () => {

--- a/packages/presentation/src/safe-text.test.ts
+++ b/packages/presentation/src/safe-text.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "vitest";
+
+import { stripTerminalSequences } from "./index.js";
+
+test("stripTerminalSequences removes complete Pi terminal strings", () => {
+  expect(
+    stripTerminalSequences("a\u001b[31mred\u001b[0m\u001b]0;title\u0007b\u001b_private\u001b\\c"),
+  ).toBe("aredbc");
+});
+
+test("stripTerminalSequences preserves visible bytes after unknown or incomplete ESC", () => {
+  expect(stripTerminalSequences("A\u001bXB\u001b[31")).toBe("A\u001bXB\u001b[31");
+});

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -5264,7 +5264,7 @@ test("PresentationSession recovers the default new-session draft after a clean r
       ],
       renderedText: "before[File #1]after[Text #2]",
       resources: [{ displayName: "notes.txt", ordinal: 1, state: "ready" }],
-      pastedTexts: [{ ordinal: 2, state: "ready", lineCount: 11 }],
+      pastedTexts: [{ ordinal: 2, state: "ready", lineCount: 11, preview: "recovered..." }],
     });
     await expect(presentation.dispatch({ type: "read_expanded_draft" })).resolves.toMatchObject({
       draftText: `before[File #1]after${pasted}`,

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -3671,7 +3671,7 @@ test("PresentationSession cancels resource staging while a turn is sealing", asy
   }
 });
 
-test("PresentationSession scopes recoverable resources to their selected session", async () => {
+test("PresentationSession scopes recoverable composer inputs to their selected session", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-select-resource-"));
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
@@ -3703,19 +3703,28 @@ test("PresentationSession scopes recoverable resources to their selected session
 
   try {
     await presentation.dispatch({ type: "stage_input_resource", path: selectedPath });
+    await presentation.dispatch({
+      type: "stage_pasted_text",
+      text: Array.from({ length: 11 }, (_, index) => `session paste ${index + 1}`).join("\n"),
+    });
     expect(presentation.getState().composer.resources).toHaveLength(1);
+    expect(presentation.getState().composer.pastedTexts).toMatchObject([
+      { preview: "session p...", state: "ready" },
+    ]);
 
     await expect(
       presentation.dispatch({ type: "select_session", sessionId: second.sessionId }),
     ).resolves.toMatchObject({ status: "admitted" });
     expect(presentation.getState().composer.resources).toEqual([]);
+    expect(presentation.getState().composer.pastedTexts).toEqual([]);
 
     await expect(
       presentation.dispatch({ type: "select_session", sessionId: first.sessionId }),
     ).resolves.toMatchObject({ status: "admitted" });
     expect(presentation.getState().composer).toMatchObject({
-      renderedText: "[File #1]",
+      renderedText: "[File #1][Text #2]",
       resources: [{ displayName: "session-local-notes.txt", ordinal: 1, state: "ready" }],
+      pastedTexts: [{ ordinal: 2, preview: "session p...", state: "ready" }],
     });
     await expect(
       presentation.dispatch({

--- a/patches/@earendil-works__pi-tui@0.84.2.patch
+++ b/patches/@earendil-works__pi-tui@0.84.2.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/components/editor.d.ts b/dist/components/editor.d.ts
-index a6fedc9e3b36d066e34860d040db6df47d88c432..a6bdba4c8d7168d67210d280400b51bc893ac90f 100644
+index a6fedc9e3b36d066e34860d040db6df47d88c432..ced33ab6fef651b7c9d6fc8834af110f3c4ccae0 100644
 --- a/dist/components/editor.d.ts
 +++ b/dist/components/editor.d.ts
 @@ -1,4 +1,4 @@
@@ -8,7 +8,14 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..a6bdba4c8d7168d67210d280400b51bc
  import { type Component, type Focusable, type TUI } from "../tui.ts";
  import { type SelectListTheme } from "./select-list.ts";
  /**
-@@ -30,6 +30,65 @@ export interface EditorOptions {
+@@ -24,12 +24,72 @@ export interface TextChunk {
+ export declare function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl.SegmentData[]): TextChunk[];
+ export interface EditorTheme {
+     borderColor: (str: string) => string;
++    atom?: (str: string) => string;
+     selectList: SelectListTheme;
+ }
+ export interface EditorOptions {
      paddingX?: number;
      autocompleteMaxVisible?: number;
  }
@@ -74,7 +81,7 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..a6bdba4c8d7168d67210d280400b51bc
  export declare class Editor implements Component, Focusable {
      private state;
      /** Focusable interface - set by TUI when focus changes */
-@@ -53,6 +112,7 @@ export declare class Editor implements Component, Focusable {
+@@ -53,6 +113,7 @@ export declare class Editor implements Component, Focusable {
      private autocompleteRequestTask;
      private autocompleteStartToken;
      private autocompleteRequestId;
@@ -82,7 +89,7 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..a6bdba4c8d7168d67210d280400b51bc
      private pastes;
      private pasteCounter;
      private pasteBuffer;
-@@ -68,6 +128,8 @@ export declare class Editor implements Component, Focusable {
+@@ -68,6 +129,8 @@ export declare class Editor implements Component, Focusable {
      private undoStack;
      onSubmit?: (text: string) => void;
      onChange?: (text: string) => void;
@@ -91,7 +98,7 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..a6bdba4c8d7168d67210d280400b51bc
      disableSubmit: boolean;
      constructor(tui: TUI, theme: EditorTheme, options?: EditorOptions);
      /** Set of currently valid paste IDs, for marker-aware segmentation. */
-@@ -79,6 +141,8 @@ export declare class Editor implements Component, Focusable {
+@@ -79,6 +142,8 @@ export declare class Editor implements Component, Focusable {
      getAutocompleteMaxVisible(): number;
      setAutocompleteMaxVisible(maxVisible: number): void;
      setAutocompleteProvider(provider: AutocompleteProvider): void;
@@ -100,7 +107,7 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..a6bdba4c8d7168d67210d280400b51bc
      /**
       * Add a prompt to history for up/down arrow navigation.
       * Called after successful submission.
-@@ -107,7 +171,10 @@ export declare class Editor implements Component, Focusable {
+@@ -107,7 +172,10 @@ export declare class Editor implements Component, Focusable {
          line: number;
          col: number;
      };
@@ -112,7 +119,7 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..a6bdba4c8d7168d67210d280400b51bc
       * Insert text at the current cursor position.
       * Used for programmatic insertion (e.g., clipboard image markers).
 diff --git a/dist/components/editor.js b/dist/components/editor.js
-index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431ff9e50ba 100644
+index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd2e0575c2 100644
 --- a/dist/components/editor.js
 +++ b/dist/components/editor.js
 @@ -219,6 +219,7 @@ export class Editor {
@@ -151,7 +158,39 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
      /**
       * Add a prompt to history for up/down arrow navigation.
       * Called after successful submission.
-@@ -527,6 +542,25 @@ export class Editor {
+@@ -418,22 +433,25 @@ export class Editor {
+         // autocomplete (e.g. slash-command menu) is visible.
+         const emitCursorMarker = this.focused;
+         for (const layoutLine of visibleLines) {
+-            let displayText = layoutLine.text;
++            let displayText = this.styleDocumentText(layoutLine.text, layoutLine.startOffset);
+             let lineVisibleWidth = visibleWidth(layoutLine.text);
+             let cursorInPadding = false;
+             // Add cursor if this line has it
+             if (layoutLine.hasCursor && layoutLine.cursorPos !== undefined) {
+-                const before = displayText.slice(0, layoutLine.cursorPos);
+-                const after = displayText.slice(layoutLine.cursorPos);
++                const beforeText = layoutLine.text.slice(0, layoutLine.cursorPos);
++                const afterText = layoutLine.text.slice(layoutLine.cursorPos);
++                const before = this.styleDocumentText(beforeText, layoutLine.startOffset);
++                const after = afterText;
+                 // Hardware cursor marker (zero-width, emitted before fake cursor for IME positioning)
+                 const marker = emitCursorMarker ? CURSOR_MARKER : "";
+                 if (after.length > 0) {
+                     // Cursor is on a character (grapheme) - replace it with highlighted version
+                     // Get the first grapheme from 'after'
+-                    const afterGraphemes = [...this.segment(after, "grapheme")];
++                    const afterGraphemes = [...this.segment(afterText, "grapheme")];
+                     const firstGrapheme = afterGraphemes[0]?.segment || "";
+-                    const restAfter = after.slice(firstGrapheme.length);
+-                    const cursor = `\x1b[7m${firstGrapheme}\x1b[0m`;
++                    const styledFirstGrapheme = this.styleDocumentText(firstGrapheme, layoutLine.startOffset + layoutLine.cursorPos);
++                    const restAfter = this.styleDocumentText(afterText.slice(firstGrapheme.length), layoutLine.startOffset + layoutLine.cursorPos + firstGrapheme.length);
++                    const cursor = `\x1b[7m${styledFirstGrapheme}\x1b[27m`;
+                     displayText = before + marker + cursor + restAfter;
+                     // lineVisibleWidth stays the same - we're replacing, not adding
+                 }
+@@ -527,6 +545,25 @@ export class Editor {
              this.undo();
              return;
          }
@@ -177,7 +216,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
          // Handle autocomplete mode
          if (this.autocompleteState && this.autocompleteList) {
              if (kb.matches(data, "tui.select.cancel")) {
-@@ -540,35 +574,21 @@ export class Editor {
+@@ -540,35 +577,21 @@ export class Editor {
              if (kb.matches(data, "tui.input.tab")) {
                  const selected = this.autocompleteList.getSelectedItem();
                  if (selected && this.autocompleteProvider) {
@@ -215,7 +254,77 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
                          return;
                      }
                  }
-@@ -847,6 +867,261 @@ export class Editor {
+@@ -748,10 +771,12 @@ export class Editor {
+                 text: "",
+                 hasCursor: true,
+                 cursorPos: 0,
++                startOffset: 0,
+             });
+             return layoutLines;
+         }
+         // Process each logical line
++        let logicalOffset = 0;
+         for (let i = 0; i < this.state.lines.length; i++) {
+             const line = this.state.lines[i] || "";
+             const isCurrentLine = i === this.state.cursorLine;
+@@ -763,12 +788,14 @@ export class Editor {
+                         text: line,
+                         hasCursor: true,
+                         cursorPos: this.state.cursorCol,
++                        startOffset: logicalOffset,
+                     });
+                 }
+                 else {
+                     layoutLines.push({
+                         text: line,
+                         hasCursor: false,
++                        startOffset: logicalOffset,
+                     });
+                 }
+             }
+@@ -810,19 +837,41 @@ export class Editor {
+                             text: chunk.text,
+                             hasCursor: true,
+                             cursorPos: adjustedCursorPos,
++                            startOffset: logicalOffset + chunk.startIndex,
+                         });
+                     }
+                     else {
+                         layoutLines.push({
+                             text: chunk.text,
+                             hasCursor: false,
++                            startOffset: logicalOffset + chunk.startIndex,
+                         });
+                     }
+                 }
+             }
++            logicalOffset += line.length + 1;
+         }
+         return layoutLines;
+     }
++    styleDocumentText(text, startOffset) {
++        if (text.length === 0 || this.theme.atom === undefined || this.structuredAtoms.length === 0)
++            return text;
++        const endOffset = startOffset + text.length;
++        let output = "";
++        let localOffset = 0;
++        for (const atom of this.structuredAtoms) {
++            const overlapStart = Math.max(startOffset, atom.start);
++            const overlapEnd = Math.min(endOffset, atom.end);
++            if (overlapStart >= overlapEnd)
++                continue;
++            const localStart = overlapStart - startOffset;
++            const localEnd = overlapEnd - startOffset;
++            output += text.slice(localOffset, localStart);
++            output += this.theme.atom(text.slice(localStart, localEnd));
++            localOffset = localEnd;
++        }
++        return output + text.slice(localOffset);
++    }
+     getText() {
+         return this.state.lines.join("\n");
+     }
+@@ -847,6 +896,261 @@ export class Editor {
      getCursor() {
          return { line: this.state.cursorLine, col: this.state.cursorCol };
      }
@@ -477,7 +586,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
      setText(text) {
          this.cancelAutocomplete();
          this.lastAction = null;
-@@ -858,8 +1133,16 @@ export class Editor {
+@@ -858,8 +1162,16 @@ export class Editor {
          }
          this.pastes.clear();
          this.pasteCounter = 0;
@@ -494,7 +603,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
      /**
       * Insert text at the current cursor position.
       * Used for programmatic insertion (e.g., clipboard image markers).
-@@ -868,6 +1151,10 @@ export class Editor {
+@@ -868,6 +1180,10 @@ export class Editor {
      insertTextAtCursor(text) {
          if (!text)
              return;
@@ -505,7 +614,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
          this.cancelAutocomplete();
          this.pushUndoSnapshot();
          this.lastAction = null;
-@@ -890,6 +1177,10 @@ export class Editor {
+@@ -890,6 +1206,10 @@ export class Editor {
      insertTextAtCursorInternal(text) {
          if (!text)
              return;
@@ -516,7 +625,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
          // Normalize line endings and tabs
          const normalized = this.normalizeText(text);
          const insertedLines = normalized.split("\n");
-@@ -925,6 +1216,10 @@ export class Editor {
+@@ -925,6 +1245,10 @@ export class Editor {
      // All the editor methods from before...
      insertCharacter(char, skipUndoCoalescing) {
          this.exitHistoryBrowsing();
@@ -527,7 +636,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
          // Undo coalescing (fish-style):
          // - Consecutive word chars coalesce into one undo unit
          // - Space captures state before itself (so undo removes space+following word together)
-@@ -1011,11 +1306,22 @@ export class Editor {
+@@ -1011,11 +1335,22 @@ export class Editor {
                  filteredText = ` ${filteredText}`;
              }
          }
@@ -551,7 +660,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
              // Store the paste and insert a marker
              this.pasteCounter++;
              const pasteId = this.pasteCounter;
-@@ -1036,6 +1342,10 @@ export class Editor {
+@@ -1036,6 +1371,10 @@ export class Editor {
          this.insertTextAtCursorInternal(filteredText);
      }
      addNewLine() {
@@ -562,7 +671,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
          this.cancelAutocomplete();
          this.exitHistoryBrowsing();
          this.lastAction = null;
-@@ -1068,6 +1378,11 @@ export class Editor {
+@@ -1068,6 +1407,11 @@ export class Editor {
      submitValue() {
          this.cancelAutocomplete();
          const result = this.expandPasteMarkers(this.state.lines.join("\n")).trim();
@@ -574,7 +683,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
          this.state = { lines: [""], cursorLine: 0, cursorCol: 0 };
          this.pastes.clear();
          this.pasteCounter = 0;
-@@ -1083,6 +1398,16 @@ export class Editor {
+@@ -1083,6 +1427,16 @@ export class Editor {
      handleBackspace() {
          this.exitHistoryBrowsing();
          this.lastAction = null;
@@ -591,7 +700,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
          if (this.state.cursorCol > 0) {
              this.pushUndoSnapshot();
              // Delete grapheme before cursor (handles emojis, combining characters, etc.)
-@@ -1157,6 +1482,7 @@ export class Editor {
+@@ -1157,6 +1511,7 @@ export class Editor {
       */
      setCursorCol(col) {
          this.state.cursorCol = col;
@@ -599,7 +708,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
          this.preferredVisualCol = null;
          this.snappedFromCursorCol = null;
      }
-@@ -1410,6 +1736,16 @@ export class Editor {
+@@ -1410,6 +1765,16 @@ export class Editor {
      handleForwardDelete() {
          this.exitHistoryBrowsing();
          this.lastAction = null;
@@ -616,7 +725,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
          const currentLine = this.state.lines[this.state.cursorLine] || "";
          if (this.state.cursorCol < currentLine.length) {
              this.pushUndoSnapshot();
-@@ -1520,6 +1856,12 @@ export class Editor {
+@@ -1520,6 +1885,12 @@ export class Editor {
          if (deltaCol !== 0) {
              const currentLine = this.state.lines[this.state.cursorLine] || "";
              if (deltaCol > 0) {
@@ -629,7 +738,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
                  // Moving right - move by one grapheme (handles emojis, combining characters, etc.)
                  if (this.state.cursorCol < currentLine.length) {
                      const afterCursor = currentLine.slice(this.state.cursorCol);
-@@ -1541,6 +1883,12 @@ export class Editor {
+@@ -1541,6 +1912,12 @@ export class Editor {
                  }
              }
              else {
@@ -642,7 +751,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
                  // Moving left - move by one grapheme (handles emojis, combining characters, etc.)
                  if (this.state.cursorCol > 0) {
                      const beforeCursor = currentLine.slice(0, this.state.cursorCol);
-@@ -1704,6 +2052,10 @@ export class Editor {
+@@ -1704,6 +2081,10 @@ export class Editor {
      }
      undo() {
          this.exitHistoryBrowsing();
@@ -653,7 +762,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
          const snapshot = this.undoStack.pop();
          if (!snapshot)
              return;
-@@ -1806,14 +2158,67 @@ export class Editor {
+@@ -1806,14 +2187,67 @@ export class Editor {
          const layout = prefix.startsWith("/") ? SLASH_COMMAND_SELECT_LIST_LAYOUT : undefined;
          return new SelectList(items, this.autocompleteMaxVisible, this.theme.selectList, layout);
      }
@@ -723,7 +832,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
          if (this.isInSlashCommandContext(beforeCursor) && !beforeCursor.trimStart().includes(" ")) {
              this.handleSlashCommandCompletion();
          }
-@@ -1830,9 +2235,12 @@ export class Editor {
+@@ -1830,9 +2264,12 @@ export class Editor {
      requestAutocomplete(options) {
          if (!this.autocompleteProvider)
              return;
@@ -737,7 +846,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
              if (!shouldTrigger) {
                  return;
              }
-@@ -1882,14 +2290,20 @@ export class Editor {
+@@ -1882,14 +2319,20 @@ export class Editor {
          if (options.explicitTab || options.force) {
              return 0;
          }
@@ -761,7 +870,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
          if (!this.isAutocompleteRequestCurrent(requestId, controller, snapshotText, snapshotLine, snapshotCol)) {
              return;
          }
-@@ -1901,14 +2315,7 @@ export class Editor {
+@@ -1901,14 +2344,7 @@ export class Editor {
          }
          if (options.force && options.explicitTab && suggestions.items.length === 1) {
              const item = suggestions.items[0];
@@ -778,9 +887,16 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..c52a3f9e2e9b73db91818142b60fe431
              return;
          }
 diff --git a/dist/components/select-list.js b/dist/components/select-list.js
-index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..0b8964d09635714a7e5872c653883e064f59df14 100644
+index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..7a00d54915cd1f58837c549e29ac30f38254d1c6 100644
 --- a/dist/components/select-list.js
 +++ b/dist/components/select-list.js
+@@ -1,5 +1,5 @@
+ import { getKeybindings } from "../keybindings.js";
+-import { truncateToWidth, visibleWidth } from "../utils.js";
++import { stripTerminalSequences, truncateToWidth, visibleWidth } from "../utils.js";
+ const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
+ const PRIMARY_COLUMN_GAP = 2;
+ const MIN_DESCRIPTION_WIDTH = 10;
 @@ -88,7 +88,7 @@ export class SelectList {
          }
      }
@@ -790,8 +906,26 @@ index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..0b8964d09635714a7e5872c653883e06
          const prefixWidth = visibleWidth(prefix);
          if (descriptionSingleLine && width > 40) {
              const effectivePrimaryColumnWidth = Math.max(1, Math.min(primaryColumnWidth, width - prefixWidth - 4));
+@@ -101,7 +101,7 @@ export class SelectList {
+             if (remainingWidth > MIN_DESCRIPTION_WIDTH) {
+                 const truncatedDesc = truncateToWidth(descriptionSingleLine, remainingWidth, "");
+                 if (isSelected) {
+-                    return this.theme.selectedText(`${prefix}${truncatedValue}${spacing}${truncatedDesc}`);
++                    return this.theme.selectedText(stripTerminalSequences(`${prefix}${truncatedValue}${spacing}${truncatedDesc}`));
+                 }
+                 const descText = this.theme.description(spacing + truncatedDesc);
+                 return prefix + truncatedValue + descText;
+@@ -110,7 +110,7 @@ export class SelectList {
+         const maxWidth = width - prefixWidth - 2;
+         const truncatedValue = this.truncatePrimary(item, isSelected, maxWidth, maxWidth);
+         if (isSelected) {
+-            return this.theme.selectedText(`${prefix}${truncatedValue}`);
++            return this.theme.selectedText(stripTerminalSequences(`${prefix}${truncatedValue}`));
+         }
+         return prefix + truncatedValue;
+     }
 diff --git a/dist/editor-component.d.ts b/dist/editor-component.d.ts
-index b598c4d291ace5f04b83161252b3ab8cdd4ccbdf..b340488d9187e399681a005db69b54c1e2bcff0b 100644
+index b598c4d291ace5f04b83161252b3ab8cdd4ccbdf..72dbe3a909e3cd28ad21d2c956a783036033e7bf 100644
 --- a/dist/editor-component.d.ts
 +++ b/dist/editor-component.d.ts
 @@ -1,4 +1,5 @@

--- a/patches/@earendil-works__pi-tui@0.84.2.patch
+++ b/patches/@earendil-works__pi-tui@0.84.2.patch
@@ -119,7 +119,7 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..ced33ab6fef651b7c9d6fc8834af110f
       * Insert text at the current cursor position.
       * Used for programmatic insertion (e.g., clipboard image markers).
 diff --git a/dist/components/editor.js b/dist/components/editor.js
-index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd2e0575c2 100644
+index 4786b46932b65785cfbd2304610ca77ccead910a..29d2fa6ea0d5b0c4934f3ce150e331a37405d073 100644
 --- a/dist/components/editor.js
 +++ b/dist/components/editor.js
 @@ -219,6 +219,7 @@ export class Editor {
@@ -190,7 +190,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
                      displayText = before + marker + cursor + restAfter;
                      // lineVisibleWidth stays the same - we're replacing, not adding
                  }
-@@ -527,6 +545,25 @@ export class Editor {
+@@ -527,6 +545,26 @@ export class Editor {
              this.undo();
              return;
          }
@@ -205,8 +205,9 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
 +                kb.matches(data, "tui.editor.historyNext") ||
 +                kb.matches(data, "tui.editor.cursorWordLeft") ||
 +                kb.matches(data, "tui.editor.cursorWordRight") ||
-+                kb.matches(data, "tui.editor.cursorUp") ||
-+                kb.matches(data, "tui.editor.cursorDown") ||
++                (this.autocompleteState === null &&
++                    (kb.matches(data, "tui.editor.cursorUp") ||
++                        kb.matches(data, "tui.editor.cursorDown"))) ||
 +                kb.matches(data, "tui.editor.pageUp") ||
 +                kb.matches(data, "tui.editor.pageDown") ||
 +                kb.matches(data, "tui.editor.jumpForward") ||
@@ -216,7 +217,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
          // Handle autocomplete mode
          if (this.autocompleteState && this.autocompleteList) {
              if (kb.matches(data, "tui.select.cancel")) {
-@@ -540,35 +577,21 @@ export class Editor {
+@@ -540,35 +578,21 @@ export class Editor {
              if (kb.matches(data, "tui.input.tab")) {
                  const selected = this.autocompleteList.getSelectedItem();
                  if (selected && this.autocompleteProvider) {
@@ -254,7 +255,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
                          return;
                      }
                  }
-@@ -748,10 +771,12 @@ export class Editor {
+@@ -748,10 +772,12 @@ export class Editor {
                  text: "",
                  hasCursor: true,
                  cursorPos: 0,
@@ -267,7 +268,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
          for (let i = 0; i < this.state.lines.length; i++) {
              const line = this.state.lines[i] || "";
              const isCurrentLine = i === this.state.cursorLine;
-@@ -763,12 +788,14 @@ export class Editor {
+@@ -763,12 +789,14 @@ export class Editor {
                          text: line,
                          hasCursor: true,
                          cursorPos: this.state.cursorCol,
@@ -282,7 +283,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
                      });
                  }
              }
-@@ -810,19 +837,41 @@ export class Editor {
+@@ -810,19 +838,41 @@ export class Editor {
                              text: chunk.text,
                              hasCursor: true,
                              cursorPos: adjustedCursorPos,
@@ -324,7 +325,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
      getText() {
          return this.state.lines.join("\n");
      }
-@@ -847,6 +896,261 @@ export class Editor {
+@@ -847,6 +897,261 @@ export class Editor {
      getCursor() {
          return { line: this.state.cursorLine, col: this.state.cursorCol };
      }
@@ -586,7 +587,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
      setText(text) {
          this.cancelAutocomplete();
          this.lastAction = null;
-@@ -858,8 +1162,16 @@ export class Editor {
+@@ -858,8 +1163,16 @@ export class Editor {
          }
          this.pastes.clear();
          this.pasteCounter = 0;
@@ -603,7 +604,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
      /**
       * Insert text at the current cursor position.
       * Used for programmatic insertion (e.g., clipboard image markers).
-@@ -868,6 +1180,10 @@ export class Editor {
+@@ -868,6 +1181,10 @@ export class Editor {
      insertTextAtCursor(text) {
          if (!text)
              return;
@@ -614,7 +615,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
          this.cancelAutocomplete();
          this.pushUndoSnapshot();
          this.lastAction = null;
-@@ -890,6 +1206,10 @@ export class Editor {
+@@ -890,6 +1207,10 @@ export class Editor {
      insertTextAtCursorInternal(text) {
          if (!text)
              return;
@@ -625,7 +626,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
          // Normalize line endings and tabs
          const normalized = this.normalizeText(text);
          const insertedLines = normalized.split("\n");
-@@ -925,6 +1245,10 @@ export class Editor {
+@@ -925,6 +1246,10 @@ export class Editor {
      // All the editor methods from before...
      insertCharacter(char, skipUndoCoalescing) {
          this.exitHistoryBrowsing();
@@ -636,7 +637,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
          // Undo coalescing (fish-style):
          // - Consecutive word chars coalesce into one undo unit
          // - Space captures state before itself (so undo removes space+following word together)
-@@ -1011,11 +1335,22 @@ export class Editor {
+@@ -1011,11 +1336,22 @@ export class Editor {
                  filteredText = ` ${filteredText}`;
              }
          }
@@ -660,7 +661,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
              // Store the paste and insert a marker
              this.pasteCounter++;
              const pasteId = this.pasteCounter;
-@@ -1036,6 +1371,10 @@ export class Editor {
+@@ -1036,6 +1372,10 @@ export class Editor {
          this.insertTextAtCursorInternal(filteredText);
      }
      addNewLine() {
@@ -671,7 +672,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
          this.cancelAutocomplete();
          this.exitHistoryBrowsing();
          this.lastAction = null;
-@@ -1068,6 +1407,11 @@ export class Editor {
+@@ -1068,6 +1408,11 @@ export class Editor {
      submitValue() {
          this.cancelAutocomplete();
          const result = this.expandPasteMarkers(this.state.lines.join("\n")).trim();
@@ -683,7 +684,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
          this.state = { lines: [""], cursorLine: 0, cursorCol: 0 };
          this.pastes.clear();
          this.pasteCounter = 0;
-@@ -1083,6 +1427,16 @@ export class Editor {
+@@ -1083,6 +1428,16 @@ export class Editor {
      handleBackspace() {
          this.exitHistoryBrowsing();
          this.lastAction = null;
@@ -700,7 +701,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
          if (this.state.cursorCol > 0) {
              this.pushUndoSnapshot();
              // Delete grapheme before cursor (handles emojis, combining characters, etc.)
-@@ -1157,6 +1511,7 @@ export class Editor {
+@@ -1157,6 +1512,7 @@ export class Editor {
       */
      setCursorCol(col) {
          this.state.cursorCol = col;
@@ -708,7 +709,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
          this.preferredVisualCol = null;
          this.snappedFromCursorCol = null;
      }
-@@ -1410,6 +1765,16 @@ export class Editor {
+@@ -1410,6 +1766,16 @@ export class Editor {
      handleForwardDelete() {
          this.exitHistoryBrowsing();
          this.lastAction = null;
@@ -725,7 +726,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
          const currentLine = this.state.lines[this.state.cursorLine] || "";
          if (this.state.cursorCol < currentLine.length) {
              this.pushUndoSnapshot();
-@@ -1520,6 +1885,12 @@ export class Editor {
+@@ -1520,6 +1886,12 @@ export class Editor {
          if (deltaCol !== 0) {
              const currentLine = this.state.lines[this.state.cursorLine] || "";
              if (deltaCol > 0) {
@@ -738,7 +739,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
                  // Moving right - move by one grapheme (handles emojis, combining characters, etc.)
                  if (this.state.cursorCol < currentLine.length) {
                      const afterCursor = currentLine.slice(this.state.cursorCol);
-@@ -1541,6 +1912,12 @@ export class Editor {
+@@ -1541,6 +1913,12 @@ export class Editor {
                  }
              }
              else {
@@ -751,7 +752,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
                  // Moving left - move by one grapheme (handles emojis, combining characters, etc.)
                  if (this.state.cursorCol > 0) {
                      const beforeCursor = currentLine.slice(0, this.state.cursorCol);
-@@ -1704,6 +2081,10 @@ export class Editor {
+@@ -1704,6 +2082,10 @@ export class Editor {
      }
      undo() {
          this.exitHistoryBrowsing();
@@ -762,7 +763,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
          const snapshot = this.undoStack.pop();
          if (!snapshot)
              return;
-@@ -1806,14 +2187,67 @@ export class Editor {
+@@ -1806,14 +2188,67 @@ export class Editor {
          const layout = prefix.startsWith("/") ? SLASH_COMMAND_SELECT_LIST_LAYOUT : undefined;
          return new SelectList(items, this.autocompleteMaxVisible, this.theme.selectList, layout);
      }
@@ -832,7 +833,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
          if (this.isInSlashCommandContext(beforeCursor) && !beforeCursor.trimStart().includes(" ")) {
              this.handleSlashCommandCompletion();
          }
-@@ -1830,9 +2264,12 @@ export class Editor {
+@@ -1830,9 +2265,12 @@ export class Editor {
      requestAutocomplete(options) {
          if (!this.autocompleteProvider)
              return;
@@ -846,7 +847,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
              if (!shouldTrigger) {
                  return;
              }
-@@ -1882,14 +2319,20 @@ export class Editor {
+@@ -1882,14 +2320,20 @@ export class Editor {
          if (options.explicitTab || options.force) {
              return 0;
          }
@@ -870,7 +871,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
          if (!this.isAutocompleteRequestCurrent(requestId, controller, snapshotText, snapshotLine, snapshotCol)) {
              return;
          }
-@@ -1901,14 +2344,7 @@ export class Editor {
+@@ -1901,14 +2345,7 @@ export class Editor {
          }
          if (options.force && options.explicitTab && suggestions.items.length === 1) {
              const item = suggestions.items[0];
@@ -887,7 +888,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..9c6e2a056f300d598b693af3e55717bd
              return;
          }
 diff --git a/dist/components/select-list.js b/dist/components/select-list.js
-index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..7a00d54915cd1f58837c549e29ac30f38254d1c6 100644
+index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..443ce1d5c09d3ad4afd892509d3af448074cec13 100644
 --- a/dist/components/select-list.js
 +++ b/dist/components/select-list.js
 @@ -1,5 +1,5 @@

--- a/patches/@earendil-works__pi-tui@0.84.2.patch
+++ b/patches/@earendil-works__pi-tui@0.84.2.patch
@@ -119,7 +119,7 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..ced33ab6fef651b7c9d6fc8834af110f
       * Insert text at the current cursor position.
       * Used for programmatic insertion (e.g., clipboard image markers).
 diff --git a/dist/components/editor.js b/dist/components/editor.js
-index 4786b46932b65785cfbd2304610ca77ccead910a..29d2fa6ea0d5b0c4934f3ce150e331a37405d073 100644
+index 4786b46932b65785cfbd2304610ca77ccead910a..5c1a37538dbad8250622417fe235b9c68a163b81 100644
 --- a/dist/components/editor.js
 +++ b/dist/components/editor.js
 @@ -219,6 +219,7 @@ export class Editor {
@@ -763,8 +763,15 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..29d2fa6ea0d5b0c4934f3ce150e331a3
          const snapshot = this.undoStack.pop();
          if (!snapshot)
              return;
-@@ -1806,14 +2188,67 @@ export class Editor {
-         const layout = prefix.startsWith("/") ? SLASH_COMMAND_SELECT_LIST_LAYOUT : undefined;
+@@ -1803,17 +2185,73 @@ export class Editor {
+         return firstPrefixIndex;
+     }
+     createAutocompleteList(prefix, items) {
+-        const layout = prefix.startsWith("/") ? SLASH_COMMAND_SELECT_LIST_LAYOUT : undefined;
++        const layout = {
++            ...(prefix.startsWith("/") ? SLASH_COMMAND_SELECT_LIST_LAYOUT : {}),
++            overrideSelectedStyles: true,
++        };
          return new SelectList(items, this.autocompleteMaxVisible, this.theme.selectList, layout);
      }
 +    autocompleteInput() {
@@ -833,7 +840,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..29d2fa6ea0d5b0c4934f3ce150e331a3
          if (this.isInSlashCommandContext(beforeCursor) && !beforeCursor.trimStart().includes(" ")) {
              this.handleSlashCommandCompletion();
          }
-@@ -1830,9 +2265,12 @@ export class Editor {
+@@ -1830,9 +2268,12 @@ export class Editor {
      requestAutocomplete(options) {
          if (!this.autocompleteProvider)
              return;
@@ -847,7 +854,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..29d2fa6ea0d5b0c4934f3ce150e331a3
              if (!shouldTrigger) {
                  return;
              }
-@@ -1882,14 +2320,20 @@ export class Editor {
+@@ -1882,14 +2323,20 @@ export class Editor {
          if (options.explicitTab || options.force) {
              return 0;
          }
@@ -871,7 +878,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..29d2fa6ea0d5b0c4934f3ce150e331a3
          if (!this.isAutocompleteRequestCurrent(requestId, controller, snapshotText, snapshotLine, snapshotCol)) {
              return;
          }
-@@ -1901,14 +2345,7 @@ export class Editor {
+@@ -1901,14 +2348,7 @@ export class Editor {
          }
          if (options.force && options.explicitTab && suggestions.items.length === 1) {
              const item = suggestions.items[0];
@@ -887,8 +894,20 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..29d2fa6ea0d5b0c4934f3ce150e331a3
              this.tui.requestRender();
              return;
          }
+diff --git a/dist/components/select-list.d.ts b/dist/components/select-list.d.ts
+index d507de4ebff8e7fbaacd089677099c63b4dfff6c..f8b6caee7b1651ca1d8f5ce70ee4c2098715ae49 100644
+--- a/dist/components/select-list.d.ts
++++ b/dist/components/select-list.d.ts
+@@ -22,6 +22,7 @@ export interface SelectListLayoutOptions {
+     minPrimaryColumnWidth?: number;
+     maxPrimaryColumnWidth?: number;
+     truncatePrimary?: (context: SelectListTruncatePrimaryContext) => string;
++    overrideSelectedStyles?: boolean;
+ }
+ export declare class SelectList implements Component {
+     private items;
 diff --git a/dist/components/select-list.js b/dist/components/select-list.js
-index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..443ce1d5c09d3ad4afd892509d3af448074cec13 100644
+index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..9d95baaf1e1456bb4ddd09dc00c343ba175403ed 100644
 --- a/dist/components/select-list.js
 +++ b/dist/components/select-list.js
 @@ -1,5 +1,5 @@
@@ -907,21 +926,23 @@ index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..443ce1d5c09d3ad4afd892509d3af448
          const prefixWidth = visibleWidth(prefix);
          if (descriptionSingleLine && width > 40) {
              const effectivePrimaryColumnWidth = Math.max(1, Math.min(primaryColumnWidth, width - prefixWidth - 4));
-@@ -101,7 +101,7 @@ export class SelectList {
+@@ -101,7 +101,8 @@ export class SelectList {
              if (remainingWidth > MIN_DESCRIPTION_WIDTH) {
                  const truncatedDesc = truncateToWidth(descriptionSingleLine, remainingWidth, "");
                  if (isSelected) {
 -                    return this.theme.selectedText(`${prefix}${truncatedValue}${spacing}${truncatedDesc}`);
-+                    return this.theme.selectedText(stripTerminalSequences(`${prefix}${truncatedValue}${spacing}${truncatedDesc}`));
++                    const selected = `${prefix}${truncatedValue}${spacing}${truncatedDesc}`;
++                    return this.theme.selectedText(this.layout.overrideSelectedStyles === true ? stripTerminalSequences(selected) : selected);
                  }
                  const descText = this.theme.description(spacing + truncatedDesc);
                  return prefix + truncatedValue + descText;
-@@ -110,7 +110,7 @@ export class SelectList {
+@@ -110,7 +111,8 @@ export class SelectList {
          const maxWidth = width - prefixWidth - 2;
          const truncatedValue = this.truncatePrimary(item, isSelected, maxWidth, maxWidth);
          if (isSelected) {
 -            return this.theme.selectedText(`${prefix}${truncatedValue}`);
-+            return this.theme.selectedText(stripTerminalSequences(`${prefix}${truncatedValue}`));
++            const selected = `${prefix}${truncatedValue}`;
++            return this.theme.selectedText(this.layout.overrideSelectedStyles === true ? stripTerminalSequences(selected) : selected);
          }
          return prefix + truncatedValue;
      }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@earendil-works/pi-tui@0.84.2': 3df1f597ba04cd5649f84b5460d94ee28cb47ca7d71383875e6ea20700d03d24
+  '@earendil-works/pi-tui@0.84.2': dec9c74d9eac344dd56676697b265b9c9842c80f742097ff1212683edf4e99d5
 
 importers:
 
@@ -52,7 +52,7 @@ importers:
         version: link:../../packages/presentation
       '@earendil-works/pi-tui':
         specifier: 0.84.2
-        version: 0.84.2(patch_hash=3df1f597ba04cd5649f84b5460d94ee28cb47ca7d71383875e6ea20700d03d24)
+        version: 0.84.2(patch_hash=dec9c74d9eac344dd56676697b265b9c9842c80f742097ff1212683edf4e99d5)
       highlight.js:
         specifier: 11.11.1
         version: 11.11.1
@@ -1418,7 +1418,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.8':
     optional: true
 
-  '@earendil-works/pi-tui@0.84.2(patch_hash=3df1f597ba04cd5649f84b5460d94ee28cb47ca7d71383875e6ea20700d03d24)':
+  '@earendil-works/pi-tui@0.84.2(patch_hash=dec9c74d9eac344dd56676697b265b9c9842c80f742097ff1212683edf4e99d5)':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@earendil-works/pi-tui@0.84.2': dec9c74d9eac344dd56676697b265b9c9842c80f742097ff1212683edf4e99d5
+  '@earendil-works/pi-tui@0.84.2': 4f399dc276633108b8533de4838ffce9e9d8311f0062034160a2748a5cd8f485
 
 importers:
 
@@ -52,7 +52,7 @@ importers:
         version: link:../../packages/presentation
       '@earendil-works/pi-tui':
         specifier: 0.84.2
-        version: 0.84.2(patch_hash=dec9c74d9eac344dd56676697b265b9c9842c80f742097ff1212683edf4e99d5)
+        version: 0.84.2(patch_hash=4f399dc276633108b8533de4838ffce9e9d8311f0062034160a2748a5cd8f485)
       highlight.js:
         specifier: 11.11.1
         version: 11.11.1
@@ -1418,7 +1418,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.8':
     optional: true
 
-  '@earendil-works/pi-tui@0.84.2(patch_hash=dec9c74d9eac344dd56676697b265b9c9842c80f742097ff1212683edf4e99d5)':
+  '@earendil-works/pi-tui@0.84.2(patch_hash=4f399dc276633108b8533de4838ffce9e9d8311f0062034160a2748a5cd8f485)':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@earendil-works/pi-tui@0.84.2': 4f399dc276633108b8533de4838ffce9e9d8311f0062034160a2748a5cd8f485
+  '@earendil-works/pi-tui@0.84.2': 2a9614444293ef2af40658d3eaa330f4f8169fc6ab096e30ba7b9bc2fba341a6
 
 importers:
 
@@ -52,7 +52,7 @@ importers:
         version: link:../../packages/presentation
       '@earendil-works/pi-tui':
         specifier: 0.84.2
-        version: 0.84.2(patch_hash=4f399dc276633108b8533de4838ffce9e9d8311f0062034160a2748a5cd8f485)
+        version: 0.84.2(patch_hash=2a9614444293ef2af40658d3eaa330f4f8169fc6ab096e30ba7b9bc2fba341a6)
       highlight.js:
         specifier: 11.11.1
         version: 11.11.1
@@ -1418,7 +1418,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.8':
     optional: true
 
-  '@earendil-works/pi-tui@0.84.2(patch_hash=4f399dc276633108b8533de4838ffce9e9d8311f0062034160a2748a5cd8f485)':
+  '@earendil-works/pi-tui@0.84.2(patch_hash=2a9614444293ef2af40658d3eaa330f4f8169fc6ab096e30ba7b9bc2fba341a6)':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5


### PR DESCRIPTION
## Summary
- derive safe nine-grapheme pasted-Text previews inside the authoritative Turn Composer without persisting a second copy
- add deterministic Skill source labels and Catppuccin Text, Green, Overlay, Mauve, and Sky presentation roles
- add generic Pi Editor atom styling plus scoped structured-autocomplete selection navigation while preserving non-autocomplete semantic colors

## Verification
- final local pnpm quality:check: 78 files passed, 2 opt-in files skipped, 1689 tests passed, 18 skipped
- frozen structural scans passed with no PR5 schema, Runtime, permission, trust, new effect, artifact reread, duplicate store, mock, sleep/polling, timeout, worker, or assertion weakening
- independent Standards and Spec reviews: zero remaining findings