### PR TITLE
feat(tui): persist exact Skill mention atoms

### DIFF
--- a/apps/tui/src/command-autocomplete.test.ts
+++ b/apps/tui/src/command-autocomplete.test.ts
@@ -32,12 +32,25 @@ test("Skill mention rows expose deterministic source labels without qualified ID
   });
   expect(suggestions?.items).toEqual([
     {
+      adamSkill: {
+        name: "shared",
+        qualifiedId: "skill:v1:project:packages/app:shared",
+      },
       value: "$shared",
       label: "$shared",
       description: "project:packages/app · Project procedure.",
     },
-    { value: "$shared", label: "$shared", description: "user · User procedure." },
     {
+      adamSkill: { name: "shared", qualifiedId: "skill:v1:user:shared" },
+      value: "$shared",
+      label: "$shared",
+      description: "user · User procedure.",
+    },
+    {
+      adamSkill: {
+        name: "shared",
+        qualifiedId: "skill:v1:extension:eve:shared",
+      },
       value: "$shared",
       label: "$shared",
       description: "extension:eve@0.3.0 · Extension procedure.",

--- a/apps/tui/src/command-autocomplete.ts
+++ b/apps/tui/src/command-autocomplete.ts
@@ -17,6 +17,24 @@ type SkillCompletion = {
     | { readonly type: "extension"; readonly extensionId: string; readonly packageVersion: string };
 };
 
+export type SkillAutocompleteIdentity = {
+  readonly name: string;
+  readonly qualifiedId: string;
+};
+
+type SkillAutocompleteItem = AutocompleteItem & {
+  readonly adamSkill: SkillAutocompleteIdentity;
+};
+
+export function skillAutocompleteIdentity(
+  item: AutocompleteItem,
+): SkillAutocompleteIdentity | null {
+  const candidate = item as Partial<SkillAutocompleteItem>;
+  return candidate.adamSkill?.name === undefined || candidate.adamSkill.qualifiedId === undefined
+    ? null
+    : candidate.adamSkill;
+}
+
 export class AdamAutocompleteProvider implements AutocompleteProvider {
   readonly triggerCharacters = ["$"];
   readonly #getAttachmentsAvailable: () => boolean;
@@ -153,7 +171,8 @@ export class AdamAutocompleteProvider implements AutocompleteProvider {
     if (mentionPrefix !== undefined && mentionNamePrefix !== undefined) {
       const skillItems = this.#getSkills()
         .filter((skill) => skill.name.startsWith(mentionNamePrefix))
-        .map<AutocompleteItem>((skill) => ({
+        .map<SkillAutocompleteItem>((skill) => ({
+          adamSkill: { name: skill.name, qualifiedId: skill.qualifiedId },
           value: `$${skill.name}`,
           label: this.#skill(`$${skill.name}`),
           description: safeTerminalText(`${skillSourceLabel(skill.source)} · ${skill.description}`),

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -5201,10 +5201,12 @@ test("Delete immediately before a Skill atom removes the whole occurrence", asyn
   }
 });
 
-test("clipboard text paste carries no Skill identity authority", async () => {
+test("copying an accepted Skill atom and pasting those bytes loses identity authority", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-skill-atom-copy-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
+  const pastedStateRoot = join(testRoot, "pasted-state");
+  const controlRoot = join(testRoot, "control");
   const skillDirectory = join(workspaceRoot, ".agents", "skills", "first");
   await mkdir(skillDirectory, { recursive: true });
   await writeFile(
@@ -5212,24 +5214,42 @@ test("clipboard text paste carries no Skill identity authority", async () => {
     "---\nname: first\ndescription: Identity-loss copy procedure.\n---\nCopy body.\n",
     "utf8",
   );
+  await mkdir(controlRoot);
 
   try {
-    const fixture = startFixture({
-      clipboardReader: {
-        async close() {},
-        async readClipboard() {
-          return { status: "text" as const, platform: "linux_x11" as const, text: "$first" };
-        },
-      },
+    const source = startFixture({
+      controlRoot,
+      scenario: "clipboard-success",
       stateRoot,
       workspaceRoot,
     });
-    await fixture.waitFor("Adam · New session");
-    fixture.write("\u001bv");
-    await fixture.waitFor("Clipboard text pasted.");
-    fixture.write("\u0011");
-    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
-    const pastedManifest = await readFilesRecursively(join(stateRoot, "drafts"));
+    await source.waitFor("Adam · New session");
+    source.write("$fir");
+    await source.waitFor("$first");
+    const beforeAccept = source.output().length;
+    source.write("\t");
+    await source.waitForCompleteFrameAfter("$first", beforeAccept);
+    source.write("\u0011");
+    await expect(source.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    const copiedText = await readFile(join(controlRoot, "clipboard.txt"), "utf8");
+    expect(copiedText).toBe("$first");
+
+    const pasted = startFixture({
+      clipboardReader: {
+        async close() {},
+        async readClipboard() {
+          return { status: "text" as const, platform: "linux_x11" as const, text: copiedText };
+        },
+      },
+      stateRoot: pastedStateRoot,
+      workspaceRoot,
+    });
+    await pasted.waitFor("Adam · New session");
+    pasted.write("\u001bv");
+    await pasted.waitFor("Clipboard text pasted.");
+    pasted.write("\u0011");
+    await expect(pasted.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    const pastedManifest = await readFilesRecursively(join(pastedStateRoot, "drafts"));
     expect(pastedManifest).toContain('"type":"text","text":"$first"');
     expect(pastedManifest).not.toContain('"type":"skill"');
     expect(pastedManifest).not.toContain("skill:v1:project:.:first");

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -682,7 +682,7 @@ test("NO_COLOR Skill completion retains marker, order, columns, and source label
   }
 });
 
-test("Tab accepts one literal Skill completion without changing an adjacent Text atom", async () => {
+test("Tab accepts one exact Skill atom without changing an adjacent Text atom", async () => {
   const { fixture, testRoot } = await startPastedTextAtomFixture({
     prepare: prepareFirstStructuredCompletionSkill,
     scenario: "skill-selection",
@@ -702,7 +702,7 @@ test("Tab accepts one literal Skill completion without changing an adjacent Text
   }
 });
 
-test("Enter accepts one literal Skill completion without submitting an adjacent Text atom", async () => {
+test("Enter accepts one exact Skill atom without submitting an adjacent Text atom", async () => {
   const { fixture, stateRoot, testRoot } = await startPastedTextAtomFixture({
     prepare: prepareFirstStructuredCompletionSkill,
     scenario: "skill-selection",
@@ -5049,6 +5049,245 @@ test("Tab completes and admits a Skill mention from the current first-draft cata
     expect(durableState).toContain('"qualifiedId":"skill:v1:project:.:first"');
     expect(durableState).toContain('"reason":"user_explicit"');
     expect(durableState).toContain('"userMessage":"Use $first"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("accepted Skill completion preserves its exact identity across a recoverable restart", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-durable-skill-atom-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const userHome = join(testRoot, "home");
+  const environment = process.env as NodeJS.ProcessEnv & { HOME?: string };
+  const previousHome = environment.HOME;
+  for (const directory of [
+    join(workspaceRoot, ".agents", "skills", "shared-name"),
+    join(userHome, ".agents", "skills", "shared-name"),
+  ]) {
+    await mkdir(directory, { recursive: true });
+    await writeFile(
+      join(directory, "SKILL.md"),
+      "---\nname: shared-name\ndescription: Exact identity restart procedure.\n---\nExact body.\n",
+      "utf8",
+    );
+  }
+  environment.HOME = userHome;
+
+  try {
+    const first = startFixture({
+      launch: {},
+      scenario: "skill-selection",
+      stateRoot,
+      workspaceRoot,
+    });
+    await first.waitFor("Select an exact model target");
+    first.write("\r");
+    await first.waitFor("Adam · New session");
+    const beforeCompletion = first.output().length;
+    first.write("Use $sha");
+    await first.waitForCompleteFrameAfter("$shared-name", beforeCompletion);
+    const selected = (first.screen() ?? []).find((line) => line.includes("> $shared-name"));
+    if (selected !== undefined && !selected.includes("project:.")) {
+      first.write("\u001b[B");
+      await first.resize(79, 24);
+    }
+    first.write("\t");
+    await first.waitFor("Use $shared-name");
+    first.write("\u0011");
+    await expect(first.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+
+    const recoveredManifest = await readFilesRecursively(join(stateRoot, "drafts"));
+    expect(recoveredManifest).toContain('"schemaVersion":2');
+    expect(recoveredManifest).toContain('"type":"skill"');
+    expect(recoveredManifest).toMatch(/"elementId":"adam-skill-[^"]+"/u);
+    expect(recoveredManifest).toContain(
+      '"name":"shared-name","qualifiedId":"skill:v1:project:.:shared-name"',
+    );
+
+    const restarted = startFixture({
+      launch: {},
+      scenario: "skill-selection",
+      stateRoot,
+      workspaceRoot,
+    });
+    await restarted.waitFor("Select an exact model target");
+    restarted.write("\r");
+    await restarted.waitFor("Use $shared-name");
+    restarted.write("\r");
+    await restarted.waitFor("Skill selection complete.");
+    restarted.write("\u0011");
+    await expect(restarted.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    const durable = await readFilesRecursively(stateRoot);
+    expect(durable).toContain('"qualifiedId":"skill:v1:project:.:shared-name"');
+    expect(durable).not.toContain(
+      '"qualifiedId":"skill:v1:user:shared-name","reason":"user_explicit"',
+    );
+  } finally {
+    if (previousHome === undefined) {
+      delete environment.HOME;
+    } else {
+      environment.HOME = previousHome;
+    }
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a Skill atom navigates as one token and Backspace removes its exact occurrence", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-skill-atom-backspace-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "first");
+  await mkdir(skillDirectory, { recursive: true });
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: first\ndescription: Atomic navigation procedure.\n---\nAtomic body.\n",
+    "utf8",
+  );
+
+  try {
+    const fixture = startFixture({ scenario: "skill-selection", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("$fir");
+    await fixture.waitFor("$first");
+    fixture.write("\t");
+    await fixture.waitFor("$first");
+    fixture.write("\u001b[Dx");
+    await fixture.waitFor("x$first");
+    fixture.write("\u001b[Cy");
+    await fixture.waitFor("x$firsty");
+    fixture.write("\u001b[D\u007f");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+
+    const recoveredManifest = await readFilesRecursively(join(stateRoot, "drafts"));
+    expect(recoveredManifest).toContain('"schemaVersion":2');
+    expect(recoveredManifest).toContain('"text":"xy"');
+    expect(recoveredManifest).not.toContain('"type":"skill"');
+    expect(recoveredManifest).not.toContain("skill:v1:project:.:first");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("Delete immediately before a Skill atom removes the whole occurrence", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-skill-atom-delete-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "first");
+  await mkdir(skillDirectory, { recursive: true });
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: first\ndescription: Atomic delete procedure.\n---\nAtomic body.\n",
+    "utf8",
+  );
+
+  try {
+    const fixture = startFixture({ scenario: "skill-selection", stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("$fir");
+    await fixture.waitFor("$first");
+    fixture.write("\ty");
+    await fixture.waitFor("$firsty");
+    fixture.write("\u001b[D\u001b[D\u001b[3~");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+
+    const recoveredManifest = await readFilesRecursively(join(stateRoot, "drafts"));
+    expect(recoveredManifest).toContain('"text":"y"');
+    expect(recoveredManifest).not.toContain('"type":"skill"');
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("clipboard text paste carries no Skill identity authority", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-skill-atom-copy-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "first");
+  await mkdir(skillDirectory, { recursive: true });
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: first\ndescription: Identity-loss copy procedure.\n---\nCopy body.\n",
+    "utf8",
+  );
+
+  try {
+    const fixture = startFixture({
+      clipboardReader: {
+        async close() {},
+        async readClipboard() {
+          return { status: "text" as const, platform: "linux_x11" as const, text: "$first" };
+        },
+      },
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    fixture.write("\u001bv");
+    await fixture.waitFor("Clipboard text pasted.");
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    const pastedManifest = await readFilesRecursively(join(stateRoot, "drafts"));
+    expect(pastedManifest).toContain('"type":"text","text":"$first"');
+    expect(pastedManifest).not.toContain('"type":"skill"');
+    expect(pastedManifest).not.toContain("skill:v1:project:.:first");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("an unavailable recovered Skill atom stays visible and blocks submission without rebinding", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-unavailable-skill-atom-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "first");
+  await mkdir(skillDirectory, { recursive: true });
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: first\ndescription: Recoverable unavailable procedure.\n---\nUnavailable body.\n",
+    "utf8",
+  );
+
+  try {
+    const first = startFixture({
+      launch: {},
+      scenario: "skill-selection",
+      stateRoot,
+      workspaceRoot,
+    });
+    await first.waitFor("Select an exact model target");
+    first.write("\r");
+    await first.waitFor("Adam · New session");
+    first.write("Use $fir");
+    await first.waitFor("$first");
+    const beforeAccept = first.output().length;
+    first.write("\t");
+    await first.waitForCompleteFrameAfter("Use $first", beforeAccept);
+    first.write("\u0011");
+    await expect(first.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    await rm(skillDirectory, { recursive: true, force: true });
+
+    const restarted = startFixture({
+      launch: {},
+      scenario: "skill-selection",
+      stateRoot,
+      workspaceRoot,
+    });
+    await restarted.waitFor("Select an exact model target");
+    restarted.write("\r");
+    await restarted.waitFor("Use $first");
+    const diagnostic = "Skill $first is unavailable; delete it or choose a current Skill.";
+    expect((restarted.screen()?.join("\n") ?? "").replace(/\s+/gu, " ")).toContain(diagnostic);
+    const beforeSubmit = restarted.output().length;
+    restarted.write("\r");
+    await restarted.waitForAfter(diagnostic, beforeSubmit);
+    restarted.write("\u0011");
+    await expect(restarted.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+    const durable = await readFilesRecursively(stateRoot);
+    expect(durable).not.toContain('"reason":"user_explicit"');
+    expect(durable).not.toContain('"type":"session_genesis"');
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }

--- a/apps/tui/src/responsive-root.test.ts
+++ b/apps/tui/src/responsive-root.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+
+import { ResponsiveWrappedText } from "./responsive-root.js";
+
+describe("ResponsiveWrappedText", () => {
+  test("preserves an exact maximum-name Skill diagnostic at minimum width", () => {
+    const diagnostic = `Skill $${"a".repeat(64)} is unavailable; delete it or choose a current Skill.`;
+
+    const lines = new ResponsiveWrappedText(diagnostic).render(40);
+
+    expect(lines.join("").replace(/\s+/gu, "")).toBe(diagnostic.replace(/\s+/gu, ""));
+    expect(lines.every((line) => line.length <= 40)).toBe(true);
+  });
+});

--- a/apps/tui/src/responsive-root.ts
+++ b/apps/tui/src/responsive-root.ts
@@ -1,4 +1,10 @@
-import { type Component, Container, Text, truncateToWidth } from "@earendil-works/pi-tui";
+import {
+  type Component,
+  Container,
+  Text,
+  truncateToWidth,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
 
 export const minimumTerminalColumns = 40;
 export const minimumTerminalRows = 12;
@@ -77,5 +83,19 @@ export class ResponsiveLine implements Component {
   render(width: number): string[] {
     const maximumWidth = width >= 112 ? width : Math.min(width, 52);
     return [truncateToWidth(this.#text, Math.max(0, maximumWidth))];
+  }
+}
+
+export class ResponsiveWrappedText implements Component {
+  readonly #text: string;
+
+  constructor(text: string) {
+    this.#text = text;
+  }
+
+  invalidate(): void {}
+
+  render(width: number): string[] {
+    return wrapTextWithAnsi(this.#text, Math.max(1, width));
   }
 }

--- a/apps/tui/src/structured-editor-completion.test.ts
+++ b/apps/tui/src/structured-editor-completion.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "vitest";
 import { AdamAutocompleteProvider } from "./command-autocomplete.js";
-import { adamStructuredEditorCompletion } from "./structured-editor-completion.js";
+import {
+  adamStructuredEditorCompletion,
+  createAdamStructuredEditorCompletion,
+} from "./structured-editor-completion.js";
 
 const provider = new AdamAutocompleteProvider({
   getProjectPaths: () => [],
@@ -66,6 +69,46 @@ test("structured completion acceptance preserves every atom identity and order",
       anchor: { partId: "right", offset: 4 },
       focus: { partId: "right", offset: 8 },
     },
+    text: "$first",
+  });
+});
+
+test("exact Skill completion promotes one literal range to an identity-bearing atom", () => {
+  let accepted:
+    | { readonly elementId: string; readonly name: string; readonly qualifiedId: string }
+    | undefined;
+  const completion = createAdamStructuredEditorCompletion({
+    onSkillAtom(identity) {
+      accepted = identity;
+    },
+  });
+  const skillItem = {
+    adamSkill: { name: "first", qualifiedId: "skill:v1:project:.:first" },
+    label: "$first",
+    value: "$first",
+  };
+  const result = completion.accept(
+    [
+      { type: "atom", id: "resource", label: "[Text #1]" },
+      { type: "text", id: "right", text: "Use $fir" },
+    ],
+    { partId: "right", offset: 8 },
+    skillItem,
+    "$fir",
+  );
+
+  expect(accepted).toMatchObject({
+    name: "first",
+    qualifiedId: "skill:v1:project:.:first",
+  });
+  expect(accepted?.elementId).toMatch(/^adam-skill-/u);
+  expect(result).toMatchObject({
+    cursor: { partId: accepted?.elementId, edge: "after" },
+    document: [
+      { type: "atom", id: "resource", label: "[Text #1]" },
+      { type: "text", id: "right", text: "Use " },
+      { type: "atom", id: accepted?.elementId, label: "$first" },
+    ],
     text: "$first",
   });
 });

--- a/apps/tui/src/structured-editor-completion.ts
+++ b/apps/tui/src/structured-editor-completion.ts
@@ -1,73 +1,152 @@
+import { randomUUID } from "node:crypto";
 import type {
   EditorDocumentPart,
   EditorDocumentPoint,
   EditorStructuredCompletion,
   EditorStructuredCompletionProjection,
 } from "@earendil-works/pi-tui";
+import {
+  type SkillAutocompleteIdentity,
+  skillAutocompleteIdentity,
+} from "./command-autocomplete.js";
 
-export const adamStructuredEditorCompletion: EditorStructuredCompletion = {
-  project(document, cursor) {
-    const textCursor = textPartAtCursor(document, cursor);
-    if (textCursor === null) {
-      return null;
-    }
-    const beforeCursor = textCursor.part.text.slice(0, textCursor.offset);
-    const earlierLiteralContent = document
-      .slice(0, textCursor.index)
-      .some((part) => part.type === "text" && part.text.trim().length > 0);
-    const blockSlash = earlierLiteralContent && beforeCursor.trimStart().startsWith("/");
-    return projectTextPart(
-      blockSlash ? `x${textCursor.part.text}` : textCursor.part.text,
-      textCursor.offset + (blockSlash ? 1 : 0),
-    );
-  },
-  accept(document, cursor, item, prefix) {
-    const textCursor = textPartAtCursor(document, cursor);
-    if (textCursor === null) {
-      if (prefix.length === 0 && "edge" in cursor && item.value.length > 0) {
-        const atomIndex = document.findIndex(
-          (part) => part.type === "atom" && part.id === cursor.partId,
-        );
-        if (atomIndex < 0) {
-          return null;
-        }
-        const textPart = {
-          type: "text" as const,
-          id: nextTextPartId(document),
-          text: item.value,
-        };
-        const insertIndex = cursor.edge === "before" ? atomIndex : atomIndex + 1;
-        const nextDocument = [...document];
-        nextDocument.splice(insertIndex, 0, textPart);
-        return {
-          cursor: { partId: textPart.id, offset: item.value.length },
-          document: nextDocument,
-          range: { anchor: cursor, focus: cursor },
-          text: item.value,
-        };
+export function createAdamStructuredEditorCompletion(
+  options: {
+    readonly onSkillAtom?: (
+      identity: SkillAutocompleteIdentity & { readonly elementId: string },
+    ) => void;
+  } = {},
+): EditorStructuredCompletion {
+  return {
+    promote(text, cursorOffset, item, prefix) {
+      if (skillAutocompleteIdentity(item) === null) {
+        return null;
       }
-      return null;
-    }
-    const start = textCursor.offset - prefix.length;
-    if (start < 0 || textCursor.part.text.slice(start, textCursor.offset) !== prefix) {
-      return null;
-    }
-    const replacement = `${textCursor.part.text.slice(0, start)}${item.value}${textCursor.part.text.slice(textCursor.offset)}`;
-    const nextDocument = document.map((part) =>
-      part.id === textCursor.part.id ? { ...textCursor.part, text: replacement } : part,
-    );
-    const range = {
+      const document: readonly EditorDocumentPart[] = [
+        { type: "text", id: "adam-editor-text-1", text },
+      ];
+      return acceptSkillAtom(
+        document,
+        { partId: "adam-editor-text-1", offset: cursorOffset },
+        item,
+        prefix,
+        options.onSkillAtom,
+      );
+    },
+    project(document, cursor) {
+      const textCursor = textPartAtCursor(document, cursor);
+      if (textCursor === null) {
+        return null;
+      }
+      const beforeCursor = textCursor.part.text.slice(0, textCursor.offset);
+      const earlierLiteralContent = document
+        .slice(0, textCursor.index)
+        .some((part) => part.type === "text" && part.text.trim().length > 0);
+      const blockSlash = earlierLiteralContent && beforeCursor.trimStart().startsWith("/");
+      return projectTextPart(
+        blockSlash ? `x${textCursor.part.text}` : textCursor.part.text,
+        textCursor.offset + (blockSlash ? 1 : 0),
+      );
+    },
+    accept(document, cursor, item, prefix) {
+      const textCursor = textPartAtCursor(document, cursor);
+      if (textCursor === null) {
+        if (prefix.length === 0 && "edge" in cursor && item.value.length > 0) {
+          const atomIndex = document.findIndex(
+            (part) => part.type === "atom" && part.id === cursor.partId,
+          );
+          if (atomIndex < 0) {
+            return null;
+          }
+          const textPart = {
+            type: "text" as const,
+            id: nextTextPartId(document),
+            text: item.value,
+          };
+          const insertIndex = cursor.edge === "before" ? atomIndex : atomIndex + 1;
+          const nextDocument = [...document];
+          nextDocument.splice(insertIndex, 0, textPart);
+          return {
+            cursor: { partId: textPart.id, offset: item.value.length },
+            document: nextDocument,
+            range: { anchor: cursor, focus: cursor },
+            text: item.value,
+          };
+        }
+        return null;
+      }
+      const start = textCursor.offset - prefix.length;
+      if (start < 0 || textCursor.part.text.slice(start, textCursor.offset) !== prefix) {
+        return null;
+      }
+      const skill = skillAutocompleteIdentity(item);
+      if (skill !== null) {
+        return acceptSkillAtom(document, cursor, item, prefix, options.onSkillAtom);
+      }
+      const replacement = `${textCursor.part.text.slice(0, start)}${item.value}${textCursor.part.text.slice(textCursor.offset)}`;
+      const nextDocument = document.map((part) =>
+        part.id === textCursor.part.id ? { ...textCursor.part, text: replacement } : part,
+      );
+      const range = {
+        anchor: { partId: textCursor.part.id, offset: start },
+        focus: { partId: textCursor.part.id, offset: textCursor.offset },
+      } as const;
+      return {
+        cursor: { partId: textCursor.part.id, offset: start + item.value.length },
+        document: nextDocument,
+        range,
+        text: item.value,
+      };
+    },
+  };
+}
+
+export const adamStructuredEditorCompletion = createAdamStructuredEditorCompletion();
+
+function acceptSkillAtom(
+  document: readonly EditorDocumentPart[],
+  cursor: EditorDocumentPoint,
+  item: Parameters<EditorStructuredCompletion["accept"]>[2],
+  prefix: string,
+  onSkillAtom:
+    | ((identity: SkillAutocompleteIdentity & { readonly elementId: string }) => void)
+    | undefined,
+): ReturnType<EditorStructuredCompletion["accept"]> {
+  const skill = skillAutocompleteIdentity(item);
+  const textCursor = textPartAtCursor(document, cursor);
+  if (skill === null || textCursor === null) {
+    return null;
+  }
+  const start = textCursor.offset - prefix.length;
+  if (start < 0 || textCursor.part.text.slice(start, textCursor.offset) !== prefix) {
+    return null;
+  }
+  const elementId = `adam-skill-${randomUUID()}`;
+  const before = textCursor.part.text.slice(0, start);
+  const after = textCursor.part.text.slice(textCursor.offset);
+  const replacement = [
+    ...(before.length === 0 ? [] : [{ ...textCursor.part, text: before }]),
+    { type: "atom" as const, id: elementId, label: `$${skill.name}` },
+    ...(after.length === 0
+      ? []
+      : [{ type: "text" as const, id: nextTextPartId(document), text: after }]),
+  ];
+  const nextDocument = [
+    ...document.slice(0, textCursor.index),
+    ...replacement,
+    ...document.slice(textCursor.index + 1),
+  ];
+  onSkillAtom?.({ ...skill, elementId });
+  return {
+    cursor: { partId: elementId, edge: "after" },
+    document: nextDocument,
+    range: {
       anchor: { partId: textCursor.part.id, offset: start },
       focus: { partId: textCursor.part.id, offset: textCursor.offset },
-    } as const;
-    return {
-      cursor: { partId: textCursor.part.id, offset: start + item.value.length },
-      document: nextDocument,
-      range,
-      text: item.value,
-    };
-  },
-};
+    },
+    text: item.value,
+  };
+}
 
 function nextTextPartId(document: readonly EditorDocumentPart[]): string {
   const ids = new Set(document.map((part) => part.id));

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -85,6 +85,7 @@ import {
   ResponsiveLine,
   ResponsiveRoot,
   ResponsiveText,
+  ResponsiveWrappedText,
   terminalSizeIsSupported,
 } from "./responsive-root.js";
 import { RightEdgeGuardTerminal } from "./right-edge-guard-terminal.js";
@@ -754,12 +755,11 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       if (element.type === "skill") {
         if (!element.available) {
           resources.addChild(
-            new ResponsiveLine(
-              theme.statusError(`Skill $${safeTerminalText(element.name)} is unavailable;`),
+            new ResponsiveWrappedText(
+              theme.statusError(
+                `Skill $${safeTerminalText(element.name)} is unavailable; delete it or choose a current Skill.`,
+              ),
             ),
-          );
-          resources.addChild(
-            new ResponsiveLine(theme.statusError("delete it or choose a current Skill.")),
           );
         }
         continue;

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -93,7 +93,7 @@ import { safeTerminalText } from "./safe-terminal-text.js";
 import { SessionInspector, type SessionRunStatus } from "./session-inspector.js";
 import { SessionPicker } from "./session-picker.js";
 import { SkillPalette } from "./skill-palette.js";
-import { adamStructuredEditorCompletion } from "./structured-editor-completion.js";
+import { createAdamStructuredEditorCompletion } from "./structured-editor-completion.js";
 import { TargetPicker } from "./target-picker.js";
 import { type AdamTuiTheme, createAdamTuiTheme } from "./theme.js";
 import { ThinkingPicker } from "./thinking-picker.js";
@@ -263,6 +263,15 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   const transcript = transcriptViewport.document;
   const draftInputsSlot = new Container();
   const editorSlot = new Container();
+  const skillAtomIdentities = new Map<
+    string,
+    { readonly name: string; readonly qualifiedId: string }
+  >();
+  const structuredEditorCompletion = createAdamStructuredEditorCompletion({
+    onSkillAtom({ elementId, name, qualifiedId }) {
+      skillAtomIdentities.set(elementId, { name, qualifiedId });
+    },
+  });
   const createEditor = (active: ActiveSessionDisplay | null): Editor => {
     const created = new Editor(tui, theme.editor, { paddingX: 1 });
     created.setAutocompleteProvider(
@@ -305,7 +314,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         registry: commandRegistry,
       }),
     );
-    created.setStructuredCompletion(adamStructuredEditorCompletion);
+    created.setStructuredCompletion(structuredEditorCompletion);
     for (const prompt of authoritativePromptHistory(active)) {
       created.addToHistory(prompt);
     }
@@ -637,7 +646,13 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   ): void => {
     const scopeChanged = scope !== projectedComposerScope;
     projectedComposerScope = scope;
-    const composerKey = `${scope ?? ""}\0${composer.draftRevision}\0${composer.resources
+    const composerKey = `${scope ?? ""}\0${composer.draftRevision}\0${composer.elements
+      .map((element) =>
+        element.type === "skill"
+          ? `${element.elementId}:${element.qualifiedId}:${element.available}`
+          : element.elementId,
+      )
+      .join("|")}\0${composer.resources
       .map((resource) => `${resource.id}:${resource.state}:${resource.kind}`)
       .join("|")}\0${composer.pastedTexts
       .map((pastedText) => `${pastedText.id}:${pastedText.state}`)
@@ -669,6 +684,17 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       return;
     }
     projectedComposerKey = composerKey;
+    if (scopeChanged) {
+      skillAtomIdentities.clear();
+    }
+    for (const element of composer.elements) {
+      if (element.type === "skill") {
+        skillAtomIdentities.set(element.elementId, {
+          name: element.name,
+          qualifiedId: element.qualifiedId,
+        });
+      }
+    }
     if (!composer.elements.some((element) => element.type !== "text")) {
       if (structuredEditorActive && composer.elements.length > 0) {
         editor.setDocument(
@@ -691,6 +717,9 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       if (element.type === "text") {
         return { type: "text", id: element.elementId, text: element.text };
       }
+      if (element.type === "skill") {
+        return { type: "atom", id: element.elementId, label: `$${element.name}` };
+      }
       return {
         type: "atom",
         id: element.elementId,
@@ -706,13 +735,33 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     composer: ReturnType<PresentationSession["getState"]>["composer"],
   ): void => {
     draftInputsSlot.clear();
-    if (composer.resources.length === 0 && composer.pastedTexts.length === 0) {
+    const unavailableSkills = composer.elements.filter(
+      (element) => element.type === "skill" && !element.available,
+    );
+    if (
+      composer.resources.length === 0 &&
+      composer.pastedTexts.length === 0 &&
+      unavailableSkills.length === 0
+    ) {
       return;
     }
     const resources = new Box(1, 1, theme.toolBackground);
     resources.addChild(new ResponsiveLine(theme.toolTitle("Draft inputs")));
     for (const element of composer.elements) {
       if (element.type === "text") {
+        continue;
+      }
+      if (element.type === "skill") {
+        if (!element.available) {
+          resources.addChild(
+            new ResponsiveLine(
+              theme.statusError(`Skill $${safeTerminalText(element.name)} is unavailable;`),
+            ),
+          );
+          resources.addChild(
+            new ResponsiveLine(theme.statusError("delete it or choose a current Skill.")),
+          );
+        }
         continue;
       }
       if (element.type === "pasted_text") {
@@ -2285,7 +2334,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       onSelect(path) {
         const value = `\`${safeTerminalText(path)}\``;
         if (structuredEditorActive && localStructuredDocument !== null) {
-          const edit = adamStructuredEditorCompletion.accept(
+          const edit = structuredEditorCompletion.accept(
             localStructuredDocument,
             editor.getDocumentCursor(),
             { label: value, value },
@@ -2518,14 +2567,21 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           document: intent.document.map((part) =>
             part.type === "text"
               ? { type: "text", text: part.text }
-              : {
-                  type:
-                    composer.elements.find((element) => element.elementId === part.id)?.type ===
-                    "pasted_text"
-                      ? ("pasted_text" as const)
-                      : ("resource" as const),
-                  elementId: part.id,
-                },
+              : skillAtomIdentities.has(part.id)
+                ? {
+                    type: "skill" as const,
+                    elementId: part.id,
+                    name: skillAtomIdentities.get(part.id)?.name ?? "",
+                    qualifiedId: skillAtomIdentities.get(part.id)?.qualifiedId ?? "",
+                  }
+                : {
+                    type:
+                      composer.elements.find((element) => element.elementId === part.id)?.type ===
+                      "pasted_text"
+                        ? ("pasted_text" as const)
+                        : ("resource" as const),
+                    elementId: part.id,
+                  },
           ),
         });
       })
@@ -3582,7 +3638,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           const edit =
             capturedDraft.document === null
               ? null
-              : adamStructuredEditorCompletion.accept(
+              : structuredEditorCompletion.accept(
                   capturedDraft.document,
                   capturedDraft.intent.cursor.point,
                   { label: clipboardResult.text, value: clipboardResult.text },
@@ -3722,7 +3778,11 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   const submitEditorValue = (text: string) => {
     const state = options.presentation.getState();
     const active = state.authoritative.active;
-    if (text.trim().length === 0 && state.composer.pastedTexts.length === 0) {
+    if (
+      text.trim().length === 0 &&
+      state.composer.pastedTexts.length === 0 &&
+      !state.composer.elements.some((element) => element.type === "skill")
+    ) {
       return;
     }
     const earlyParsed = commandRegistry.parse(text);

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -609,16 +609,33 @@ export async function createPresentationSession(
       return true;
     };
     let turnComposer: TurnComposer;
-    const projectTurnComposer = (): PresentationDisplayState["composer"] => {
+    const projectTurnComposer = (
+      skillCatalogOverride?: SkillCatalogDisplay | null,
+    ): PresentationDisplayState["composer"] => {
       const snapshot = turnComposer?.snapshot() ?? {
         sealed: false,
         resources: [],
         pastedTexts: [],
       };
+      const skillCatalog =
+        skillCatalogOverride === undefined
+          ? (state.authoritative.active?.skills ?? state.draft?.skills ?? null)
+          : skillCatalogOverride;
       return {
         attachmentAvailable,
         draftRevision: snapshot.revision,
-        elements: snapshot.elements,
+        elements: snapshot.elements.map((element) =>
+          element.type === "skill"
+            ? {
+                ...element,
+                available:
+                  skillCatalog?.items.some(
+                    (skill) =>
+                      skill.qualifiedId === element.qualifiedId && skill.name === element.name,
+                  ) ?? false,
+              }
+            : element,
+        ),
         renderedText: snapshot.renderedText,
         unavailableReason: attachmentUnavailableReason,
         sealed: snapshot.sealed,
@@ -1162,6 +1179,7 @@ export async function createPresentationSession(
         options,
       );
       const activatedNaming = projectSessionNaming(activatedRecords, snapshot.sessionId);
+      const activatedSkills = projectSkills(snapshot);
       const activatedSummary: SessionSummary = {
         id: snapshot.sessionId,
         label: activatedNaming.displayLabel,
@@ -1239,7 +1257,7 @@ export async function createPresentationSession(
             context: projectSessionContext(snapshot, activatedContextUsage, modelTargetSnapshot),
             pendingInteractions: activatedPendingInteractions,
             repositoryInstructions: projectRepositoryInstructions(snapshot),
-            skills: projectSkills(snapshot),
+            skills: activatedSkills,
             projectPaths,
             mcp: projectMcp(snapshot),
             ...(snapshot.todo === undefined ? {} : { todo: snapshot.todo }),
@@ -1247,7 +1265,7 @@ export async function createPresentationSession(
           },
         },
         draft: null,
-        composer: projectTurnComposer(),
+        composer: projectTurnComposer(activatedSkills),
         transient: null,
       };
       draftTargetIdentity = null;
@@ -2471,7 +2489,9 @@ export async function createPresentationSession(
           const removed =
             element.type === "resource"
               ? await turnComposer.remove(element.resourceId, persistCurrentTurnDraft)
-              : await turnComposer.removePastedText(element.pastedTextId, persistCurrentTurnDraft);
+              : element.type === "pasted_text"
+                ? await turnComposer.removePastedText(element.pastedTextId, persistCurrentTurnDraft)
+                : await turnComposer.removeSkill(element.elementId, persistCurrentTurnDraft);
           return removed
             ? { status: "admitted", commandId: randomUUID(), resource: null }
             : {
@@ -2619,7 +2639,9 @@ export async function createPresentationSession(
       if (command.type === "submit_prompt") {
         if (
           command.sessionId !== state.authoritative.active?.session.id ||
-          (command.text.trim().length === 0 && state.composer.pastedTexts.length === 0)
+          (command.text.trim().length === 0 &&
+            state.composer.pastedTexts.length === 0 &&
+            !state.composer.elements.some((element) => element.type === "skill"))
         ) {
           return {
             status: "rejected",
@@ -2659,13 +2681,23 @@ export async function createPresentationSession(
             };
           }
         }
-        const skillResolution = resolveSkillMentions({
+        const unavailableSkill = state.composer.elements.find(
+          (element) => element.type === "skill" && !element.available,
+        );
+        if (unavailableSkill?.type === "skill") {
+          return {
+            status: "rejected",
+            code: "not_available",
+            message: `Skill $${unavailableSkill.name} is unavailable; delete it or choose a current Skill.`,
+          };
+        }
+        const manualSkillResolution = resolveSkillMentions({
           text: command.text,
           explicitQualifiedIds: command.skills,
           catalog: state.authoritative.active.skills,
         });
-        if (skillResolution.status === "ambiguous") {
-          return ambiguousSkillMentionRejection(skillResolution);
+        if (manualSkillResolution.status === "ambiguous") {
+          return ambiguousSkillMentionRejection(manualSkillResolution);
         }
         if (!draftImagesFitExactTarget()) {
           return {
@@ -2718,6 +2750,12 @@ export async function createPresentationSession(
                 : "The current turn could not be sealed safely.",
           };
         }
+        const resolvedSkillIds = [
+          ...new Set([
+            ...sealedDraft.skillOccurrences.map((occurrence) => occurrence.qualifiedId),
+            ...manualSkillResolution.qualifiedIds,
+          ]),
+        ];
         const admission = Promise.withResolvers<void>();
         const admissionAfterSequence =
           state.authoritative.continuity.status === "current"
@@ -2739,9 +2777,7 @@ export async function createPresentationSession(
           sessionId: command.sessionId,
           input: {
             text: sealedDraft.text,
-            ...(skillResolution.qualifiedIds.length === 0
-              ? {}
-              : { skills: skillResolution.qualifiedIds }),
+            ...(resolvedSkillIds.length === 0 ? {} : { skills: resolvedSkillIds }),
           },
           runId: commandId,
           signal: controller.signal,
@@ -2826,7 +2862,9 @@ export async function createPresentationSession(
         const draft = state.draft;
         if (
           draft === null ||
-          (command.text.trim().length === 0 && state.composer.pastedTexts.length === 0)
+          (command.text.trim().length === 0 &&
+            state.composer.pastedTexts.length === 0 &&
+            !state.composer.elements.some((element) => element.type === "skill"))
         ) {
           return {
             status: "rejected",
@@ -2849,13 +2887,23 @@ export async function createPresentationSession(
             message: "The exact draft target is no longer available.",
           };
         }
-        const skillResolution = resolveSkillMentions({
+        const unavailableSkill = state.composer.elements.find(
+          (element) => element.type === "skill" && !element.available,
+        );
+        if (unavailableSkill?.type === "skill") {
+          return {
+            status: "rejected",
+            code: "not_available",
+            message: `Skill $${unavailableSkill.name} is unavailable; delete it or choose a current Skill.`,
+          };
+        }
+        const manualSkillResolution = resolveSkillMentions({
           text: command.text,
           explicitQualifiedIds: command.skills,
           catalog: draft.skills,
         });
-        if (skillResolution.status === "ambiguous") {
-          return ambiguousSkillMentionRejection(skillResolution);
+        if (manualSkillResolution.status === "ambiguous") {
+          return ambiguousSkillMentionRejection(manualSkillResolution);
         }
         if (!draftImagesFitExactTarget()) {
           return {
@@ -2908,15 +2956,19 @@ export async function createPresentationSession(
                 : "The current turn could not be sealed safely.",
           };
         }
+        const resolvedSkillIds = [
+          ...new Set([
+            ...sealedDraft.skillOccurrences.map((occurrence) => occurrence.qualifiedId),
+            ...manualSkillResolution.qualifiedIds,
+          ]),
+        ];
         const admission = Promise.withResolvers<string>();
         let admittedSessionId: string | null = null;
         const continuation = options.lifecycle.admit({
           targetIdentity,
           input: {
             text: sealedDraft.text,
-            ...(skillResolution.qualifiedIds.length === 0
-              ? {}
-              : { skills: skillResolution.qualifiedIds }),
+            ...(resolvedSkillIds.length === 0 ? {} : { skills: resolvedSkillIds }),
           },
           runId: commandId,
           signal: controller.signal,

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -2681,23 +2681,14 @@ export async function createPresentationSession(
             };
           }
         }
-        const unavailableSkill = state.composer.elements.find(
-          (element) => element.type === "skill" && !element.available,
-        );
-        if (unavailableSkill?.type === "skill") {
-          return {
-            status: "rejected",
-            code: "not_available",
-            message: `Skill $${unavailableSkill.name} is unavailable; delete it or choose a current Skill.`,
-          };
-        }
-        const manualSkillResolution = resolveSkillMentions({
+        const skillResolution = resolveSubmittedSkills({
           text: command.text,
           explicitQualifiedIds: command.skills,
           catalog: state.authoritative.active.skills,
+          elements: state.composer.elements,
         });
-        if (manualSkillResolution.status === "ambiguous") {
-          return ambiguousSkillMentionRejection(manualSkillResolution);
+        if (skillResolution.status === "rejected") {
+          return skillResolution.receipt;
         }
         if (!draftImagesFitExactTarget()) {
           return {
@@ -2750,12 +2741,7 @@ export async function createPresentationSession(
                 : "The current turn could not be sealed safely.",
           };
         }
-        const resolvedSkillIds = [
-          ...new Set([
-            ...sealedDraft.skillOccurrences.map((occurrence) => occurrence.qualifiedId),
-            ...manualSkillResolution.qualifiedIds,
-          ]),
-        ];
+        const resolvedSkillIds = skillResolution.qualifiedIds;
         const admission = Promise.withResolvers<void>();
         const admissionAfterSequence =
           state.authoritative.continuity.status === "current"
@@ -2887,23 +2873,14 @@ export async function createPresentationSession(
             message: "The exact draft target is no longer available.",
           };
         }
-        const unavailableSkill = state.composer.elements.find(
-          (element) => element.type === "skill" && !element.available,
-        );
-        if (unavailableSkill?.type === "skill") {
-          return {
-            status: "rejected",
-            code: "not_available",
-            message: `Skill $${unavailableSkill.name} is unavailable; delete it or choose a current Skill.`,
-          };
-        }
-        const manualSkillResolution = resolveSkillMentions({
+        const skillResolution = resolveSubmittedSkills({
           text: command.text,
           explicitQualifiedIds: command.skills,
           catalog: draft.skills,
+          elements: state.composer.elements,
         });
-        if (manualSkillResolution.status === "ambiguous") {
-          return ambiguousSkillMentionRejection(manualSkillResolution);
+        if (skillResolution.status === "rejected") {
+          return skillResolution.receipt;
         }
         if (!draftImagesFitExactTarget()) {
           return {
@@ -2956,12 +2933,7 @@ export async function createPresentationSession(
                 : "The current turn could not be sealed safely.",
           };
         }
-        const resolvedSkillIds = [
-          ...new Set([
-            ...sealedDraft.skillOccurrences.map((occurrence) => occurrence.qualifiedId),
-            ...manualSkillResolution.qualifiedIds,
-          ]),
-        ];
+        const resolvedSkillIds = skillResolution.qualifiedIds;
         const admission = Promise.withResolvers<string>();
         let admittedSessionId: string | null = null;
         const continuation = options.lifecycle.admit({
@@ -4649,6 +4621,43 @@ function ambiguousSkillMentionRejection(
     code: "invalid_command",
     message: `Skill $${resolution.name} is ambiguous. Select one exact qualified ID with /skills: ${candidates}`,
   };
+}
+
+function resolveSubmittedSkills(input: {
+  readonly text: string;
+  readonly explicitQualifiedIds: readonly string[];
+  readonly catalog: SkillCatalogDisplay | null;
+  readonly elements: PresentationDisplayState["composer"]["elements"];
+}):
+  | { readonly status: "resolved"; readonly qualifiedIds: readonly string[] }
+  | {
+      readonly status: "rejected";
+      readonly receipt: Extract<CommandReceipt, { readonly status: "rejected" }>;
+    } {
+  const unavailableSkill = input.elements.find(
+    (element) => element.type === "skill" && !element.available,
+  );
+  if (unavailableSkill?.type === "skill") {
+    return {
+      status: "rejected",
+      receipt: {
+        status: "rejected",
+        code: "not_available",
+        message: `Skill $${unavailableSkill.name} is unavailable; delete it or choose a current Skill.`,
+      },
+    };
+  }
+  const exactQualifiedIds = input.elements.flatMap((element) =>
+    element.type === "skill" ? [element.qualifiedId] : [],
+  );
+  const resolution = resolveSkillMentions({
+    text: input.text,
+    explicitQualifiedIds: [...exactQualifiedIds, ...input.explicitQualifiedIds],
+    catalog: input.catalog,
+  });
+  return resolution.status === "ambiguous"
+    ? { status: "rejected", receipt: ambiguousSkillMentionRejection(resolution) }
+    : { status: "resolved", qualifiedIds: resolution.qualifiedIds };
 }
 
 function draftAdmissionRejection(

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -2681,7 +2681,7 @@ export async function createPresentationSession(
             };
           }
         }
-        const skillResolution = resolveSubmittedSkills({
+        const skillResolution = preflightSubmittedSkills({
           text: command.text,
           explicitQualifiedIds: command.skills,
           catalog: state.authoritative.active.skills,
@@ -2741,7 +2741,12 @@ export async function createPresentationSession(
                 : "The current turn could not be sealed safely.",
           };
         }
-        const resolvedSkillIds = skillResolution.qualifiedIds;
+        const resolvedSkillIds = [
+          ...new Set([
+            ...sealedDraft.skillOccurrences.map((occurrence) => occurrence.qualifiedId),
+            ...skillResolution.compatibilityQualifiedIds,
+          ]),
+        ];
         const admission = Promise.withResolvers<void>();
         const admissionAfterSequence =
           state.authoritative.continuity.status === "current"
@@ -2873,7 +2878,7 @@ export async function createPresentationSession(
             message: "The exact draft target is no longer available.",
           };
         }
-        const skillResolution = resolveSubmittedSkills({
+        const skillResolution = preflightSubmittedSkills({
           text: command.text,
           explicitQualifiedIds: command.skills,
           catalog: draft.skills,
@@ -2933,7 +2938,12 @@ export async function createPresentationSession(
                 : "The current turn could not be sealed safely.",
           };
         }
-        const resolvedSkillIds = skillResolution.qualifiedIds;
+        const resolvedSkillIds = [
+          ...new Set([
+            ...sealedDraft.skillOccurrences.map((occurrence) => occurrence.qualifiedId),
+            ...skillResolution.compatibilityQualifiedIds,
+          ]),
+        ];
         const admission = Promise.withResolvers<string>();
         let admittedSessionId: string | null = null;
         const continuation = options.lifecycle.admit({
@@ -4623,13 +4633,13 @@ function ambiguousSkillMentionRejection(
   };
 }
 
-function resolveSubmittedSkills(input: {
+function preflightSubmittedSkills(input: {
   readonly text: string;
   readonly explicitQualifiedIds: readonly string[];
   readonly catalog: SkillCatalogDisplay | null;
   readonly elements: PresentationDisplayState["composer"]["elements"];
 }):
-  | { readonly status: "resolved"; readonly qualifiedIds: readonly string[] }
+  | { readonly status: "resolved"; readonly compatibilityQualifiedIds: readonly string[] }
   | {
       readonly status: "rejected";
       readonly receipt: Extract<CommandReceipt, { readonly status: "rejected" }>;
@@ -4657,7 +4667,12 @@ function resolveSubmittedSkills(input: {
   });
   return resolution.status === "ambiguous"
     ? { status: "rejected", receipt: ambiguousSkillMentionRejection(resolution) }
-    : { status: "resolved", qualifiedIds: resolution.qualifiedIds };
+    : {
+        status: "resolved",
+        compatibilityQualifiedIds: resolution.qualifiedIds.filter(
+          (qualifiedId) => !exactQualifiedIds.includes(qualifiedId),
+        ),
+      };
 }
 
 function draftAdmissionRejection(

--- a/packages/agent/src/recoverable-turn-draft.os.test.ts
+++ b/packages/agent/src/recoverable-turn-draft.os.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readdir, rm, stat } from "node:fs/promises";
+import { mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -15,7 +15,7 @@ test("recoverable turn draft atomically replaces one owner-private project manif
     stateRoot: testRoot,
   });
   const first = {
-    schemaVersion: 1 as const,
+    schemaVersion: 2 as const,
     scope: { type: "new_session" as const, targetId: "deepseek-v4-flash.direct" },
     nextOrdinal: 1,
     elements: [{ elementId: "text-1", type: "text" as const, text: "first" }],
@@ -40,6 +40,13 @@ test("recoverable turn draft atomically replaces one owner-private project manif
     await repository.delete({ type: "new_session" });
     await expect(repository.load({ type: "new_session" })).resolves.toBeNull();
     await expect(readdir(draftsRoot)).resolves.toEqual([]);
+
+    const legacy = { ...first, schemaVersion: 1 as const };
+    await writeFile(join(draftsRoot, "new-session.json"), `${JSON.stringify(legacy)}\n`, {
+      mode: 0o600,
+    });
+    await expect(repository.load({ type: "new_session" })).resolves.toEqual(legacy);
+    await repository.delete({ type: "new_session" });
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }

--- a/packages/agent/src/recoverable-turn-draft.os.test.ts
+++ b/packages/agent/src/recoverable-turn-draft.os.test.ts
@@ -51,3 +51,59 @@ test("recoverable turn draft atomically replaces one owner-private project manif
     await rm(testRoot, { recursive: true, force: true });
   }
 });
+
+test("recoverable turn draft rejects a V2 graph whose Skill text exceeds the payload limit", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-recoverable-turn-draft-limit-"));
+  const repository = await createRecoverableTurnDraftRepository({ projectId, stateRoot: testRoot });
+  const manifestPath = join(testRoot, "drafts", "b".repeat(64), "new-session.json");
+  const pastedTextId = "pasted-text-1";
+  const pastedTextElementId = "pasted-text-element-1";
+  const draft = {
+    schemaVersion: 2,
+    scope: { type: "new_session", targetId: "deepseek-v4-flash.direct" },
+    nextOrdinal: 2,
+    elements: [
+      {
+        elementId: pastedTextElementId,
+        type: "pasted_text",
+        ordinal: 1,
+        pastedTextId,
+      },
+      {
+        elementId: "skill-1",
+        type: "skill",
+        name: "a".repeat(64),
+        qualifiedId: "skill:v1:project:.:maximum-name-skill",
+      },
+    ],
+    resources: [],
+    pastedTexts: [
+      {
+        id: pastedTextId,
+        elementId: pastedTextElementId,
+        ordinal: 1,
+        state: "failed",
+        byteCount: 1024 * 1024 - 64,
+        lineCount: 1,
+        scalarCount: 1024 * 1024 - 64,
+        diagnostic: "Unavailable test payload.",
+      },
+    ],
+  };
+
+  try {
+    await repository.save({
+      schemaVersion: 2,
+      scope: { type: "new_session", targetId: "deepseek-v4-flash.direct" },
+      nextOrdinal: 1,
+      elements: [],
+      resources: [],
+    });
+    await writeFile(manifestPath, `${JSON.stringify(draft)}\n`, "utf8");
+    await expect(repository.load({ type: "new_session" })).rejects.toThrow(
+      "The recoverable draft manifest is invalid.",
+    );
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/agent/src/recoverable-turn-draft.ts
+++ b/packages/agent/src/recoverable-turn-draft.ts
@@ -79,9 +79,24 @@ export type RecoverableTurnDraftV1 = {
     | undefined;
 };
 
+export type RecoverableTurnDraftV2 = Omit<RecoverableTurnDraftV1, "elements" | "schemaVersion"> & {
+  readonly schemaVersion: 2;
+  readonly elements: readonly (
+    | RecoverableTurnDraftV1["elements"][number]
+    | {
+        readonly type: "skill";
+        readonly elementId: string;
+        readonly name: string;
+        readonly qualifiedId: string;
+      }
+  )[];
+};
+
+export type RecoverableTurnDraft = RecoverableTurnDraftV1 | RecoverableTurnDraftV2;
+
 export type RecoverableTurnDraftRepository = {
-  load(scope: TurnDraftScopeV1): Promise<RecoverableTurnDraftV1 | null>;
-  save(draft: RecoverableTurnDraftV1): Promise<void>;
+  load(scope: TurnDraftScopeV1): Promise<RecoverableTurnDraft | null>;
+  save(draft: RecoverableTurnDraftV2): Promise<void>;
   delete(scope: TurnDraftScopeV1): Promise<void>;
 };
 
@@ -130,7 +145,7 @@ const stagedPastedTextSelectionSchema: z.ZodType<StagedPastedTextSelectionV1> = 
   lineCount: z.number().int().positive().safe(),
   scalarCount: z.number().int().positive().safe(),
 });
-const draftSchema: z.ZodType<RecoverableTurnDraftV1> = z
+const draftV1Schema = z
   .strictObject({
     schemaVersion: z.literal(1),
     scope: z.discriminatedUnion("type", [
@@ -216,78 +231,148 @@ const draftSchema: z.ZodType<RecoverableTurnDraftV1> = z
       .max(8)
       .optional(),
   })
-  .superRefine((draft, context) => {
-    const resourceElements = draft.elements.filter((element) => element.type === "resource");
-    const pastedTextElements = draft.elements.filter((element) => element.type === "pasted_text");
-    const pastedTexts = draft.pastedTexts ?? [];
-    if (
-      new Set(draft.elements.map((element) => element.elementId)).size !== draft.elements.length ||
-      new Set(draft.resources.map((resource) => resource.id)).size !== draft.resources.length ||
-      new Set(draft.resources.map((resource) => resource.ordinal)).size !==
-        draft.resources.length ||
-      new Set(pastedTexts.map((pastedText) => pastedText.id)).size !== pastedTexts.length ||
-      new Set(pastedTexts.map((pastedText) => pastedText.ordinal)).size !== pastedTexts.length ||
-      draft.elements.reduce(
-        (length, element) =>
-          length + (element.type === "text" ? Buffer.byteLength(element.text, "utf8") : 0),
+  .superRefine((draft, context) => validateDraftGraph(draft, context));
+
+const draftV2Schema = z
+  .strictObject({
+    schemaVersion: z.literal(2),
+    scope: draftV1Schema.shape.scope,
+    nextOrdinal: draftV1Schema.shape.nextOrdinal,
+    elements: z
+      .array(
+        z.discriminatedUnion("type", [
+          z.strictObject({
+            elementId: z.string().min(1).max(256),
+            type: z.literal("text"),
+            text: z
+              .string()
+              .min(1)
+              .max(512 * 1024),
+          }),
+          z.strictObject({
+            elementId: z.string().min(1).max(256),
+            type: z.literal("resource"),
+            kind: z.enum(["file", "image"]),
+            ordinal: z.number().int().positive().safe(),
+            resourceId: z.string().min(1).max(256),
+          }),
+          z.strictObject({
+            elementId: z.string().min(1).max(256),
+            type: z.literal("pasted_text"),
+            ordinal: z.number().int().positive().safe(),
+            pastedTextId: z.string().min(1).max(256),
+          }),
+          z.strictObject({
+            elementId: z.string().min(1).max(256),
+            type: z.literal("skill"),
+            name: z
+              .string()
+              .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/u)
+              .max(64),
+            qualifiedId: z
+              .string()
+              .min(1)
+              .max(16_384)
+              .refine(
+                (value) =>
+                  /^[\x20-\x7e]+$/u.test(value) && Buffer.byteLength(value, "utf8") <= 16_384,
+              ),
+          }),
+        ]),
+      )
+      .max(17),
+    resources: draftV1Schema.shape.resources,
+    pastedTexts: draftV1Schema.shape.pastedTexts,
+  })
+  .superRefine((draft, context) => validateDraftGraph(draft, context));
+
+const recoverableDraftSchema = z.discriminatedUnion("schemaVersion", [
+  draftV1Schema,
+  draftV2Schema,
+]);
+
+function validateDraftGraph(draft: RecoverableTurnDraft, context: z.RefinementCtx): void {
+  const allElements: readonly RecoverableTurnDraftV2["elements"][number][] = draft.elements;
+  const resourceElements = allElements.filter(
+    (
+      element,
+    ): element is Extract<RecoverableTurnDraftV2["elements"][number], { type: "resource" }> =>
+      element.type === "resource",
+  );
+  const pastedTextElements = allElements.filter(
+    (
+      element,
+    ): element is Extract<RecoverableTurnDraftV2["elements"][number], { type: "pasted_text" }> =>
+      element.type === "pasted_text",
+  );
+  const pastedTexts = draft.pastedTexts ?? [];
+  if (
+    new Set(draft.elements.map((element) => element.elementId)).size !== draft.elements.length ||
+    new Set(draft.resources.map((resource) => resource.id)).size !== draft.resources.length ||
+    new Set(draft.resources.map((resource) => resource.ordinal)).size !== draft.resources.length ||
+    new Set(pastedTexts.map((pastedText) => pastedText.id)).size !== pastedTexts.length ||
+    new Set(pastedTexts.map((pastedText) => pastedText.ordinal)).size !== pastedTexts.length ||
+    draft.elements.reduce(
+      (length, element) =>
+        length + (element.type === "text" ? Buffer.byteLength(element.text, "utf8") : 0),
+      0,
+    ) +
+      pastedTexts.reduce((total, pastedText) => total + pastedText.byteCount, 0) >
+      1024 * 1024 ||
+    resourceElements.length !== draft.resources.length ||
+    pastedTextElements.length !== pastedTexts.length ||
+    resourceElements.some((element, index) => {
+      const resource = draft.resources[index];
+      return (
+        resource === undefined ||
+        resource.id !== element.resourceId ||
+        resource.elementId !== element.elementId ||
+        resource.kind !== element.kind ||
+        resource.ordinal !== element.ordinal
+      );
+    }) ||
+    pastedTextElements.some((element, index) => {
+      const pastedText = pastedTexts[index];
+      return (
+        pastedText === undefined ||
+        pastedText.id !== element.pastedTextId ||
+        pastedText.elementId !== element.elementId ||
+        pastedText.ordinal !== element.ordinal
+      );
+    }) ||
+    draft.resources.some(
+      (resource) =>
+        (resource.state === "ready") !== (resource.selection !== undefined) ||
+        (resource.selection !== undefined &&
+          (resource.selection.displayName !== resource.displayName ||
+            resource.selection.support !== resource.support ||
+            resource.selection.mediaHint !== resource.mediaHint ||
+            (resource.selection.origin ?? "selected_file") !==
+              (resource.origin ?? "selected_file") ||
+            resource.selection.staged.byteCount !== resource.byteCount ||
+            resource.selection.staged.id !== resource.selection.digest ||
+            (resource.kind === "image") !== (resource.selection.support === "image"))),
+    ) ||
+    pastedTexts.some(
+      (pastedText) =>
+        (pastedText.state === "ready") !== (pastedText.selection !== undefined) ||
+        (pastedText.selection !== undefined &&
+          (pastedText.selection.staged.id !== pastedText.selection.digest ||
+            pastedText.selection.byteCount !== pastedText.byteCount ||
+            pastedText.selection.lineCount !== pastedText.lineCount ||
+            pastedText.selection.scalarCount !== pastedText.scalarCount)),
+    ) ||
+    draft.resources.length + pastedTexts.length > 8 ||
+    draft.nextOrdinal <=
+      Math.max(
         0,
-      ) +
-        pastedTexts.reduce((total, pastedText) => total + pastedText.byteCount, 0) >
-        1024 * 1024 ||
-      resourceElements.length !== draft.resources.length ||
-      pastedTextElements.length !== pastedTexts.length ||
-      resourceElements.some((element, index) => {
-        const resource = draft.resources[index];
-        return (
-          resource === undefined ||
-          resource.id !== element.resourceId ||
-          resource.elementId !== element.elementId ||
-          resource.kind !== element.kind ||
-          resource.ordinal !== element.ordinal
-        );
-      }) ||
-      pastedTextElements.some((element, index) => {
-        const pastedText = pastedTexts[index];
-        return (
-          pastedText === undefined ||
-          pastedText.id !== element.pastedTextId ||
-          pastedText.elementId !== element.elementId ||
-          pastedText.ordinal !== element.ordinal
-        );
-      }) ||
-      draft.resources.some(
-        (resource) =>
-          (resource.state === "ready") !== (resource.selection !== undefined) ||
-          (resource.selection !== undefined &&
-            (resource.selection.displayName !== resource.displayName ||
-              resource.selection.support !== resource.support ||
-              resource.selection.mediaHint !== resource.mediaHint ||
-              (resource.selection.origin ?? "selected_file") !==
-                (resource.origin ?? "selected_file") ||
-              resource.selection.staged.byteCount !== resource.byteCount ||
-              resource.selection.staged.id !== resource.selection.digest ||
-              (resource.kind === "image") !== (resource.selection.support === "image"))),
-      ) ||
-      pastedTexts.some(
-        (pastedText) =>
-          (pastedText.state === "ready") !== (pastedText.selection !== undefined) ||
-          (pastedText.selection !== undefined &&
-            (pastedText.selection.staged.id !== pastedText.selection.digest ||
-              pastedText.selection.byteCount !== pastedText.byteCount ||
-              pastedText.selection.lineCount !== pastedText.lineCount ||
-              pastedText.selection.scalarCount !== pastedText.scalarCount)),
-      ) ||
-      draft.resources.length + pastedTexts.length > 8 ||
-      draft.nextOrdinal <=
-        Math.max(
-          0,
-          ...draft.resources.map((resource) => resource.ordinal),
-          ...pastedTexts.map((pastedText) => pastedText.ordinal),
-        )
-    ) {
-      context.addIssue({ code: "custom", message: "The recoverable draft graph is invalid." });
-    }
-  });
+        ...draft.resources.map((resource) => resource.ordinal),
+        ...pastedTexts.map((pastedText) => pastedText.ordinal),
+      )
+  ) {
+    context.addIssue({ code: "custom", message: "The recoverable draft graph is invalid." });
+  }
+}
 
 export async function createRecoverableTurnDraftRepository(options: {
   readonly projectId: string;
@@ -351,7 +436,9 @@ export async function createRecoverableTurnDraftRepository(options: {
         }
         throw error;
       }
-      const parsed = draftSchema.safeParse(JSON.parse(bytes.toString("utf8")) as unknown);
+      const parsed = recoverableDraftSchema.safeParse(
+        JSON.parse(bytes.toString("utf8")) as unknown,
+      );
       if (!parsed.success || !matchesScope(parsed.data.scope, scope)) {
         throw new TypeError("The recoverable draft manifest is invalid.");
       }
@@ -359,7 +446,7 @@ export async function createRecoverableTurnDraftRepository(options: {
     },
     save(draft) {
       return enqueueMutation(async () => {
-        const validated = draftSchema.parse(draft);
+        const validated = draftV2Schema.parse(draft);
         const serialized = `${JSON.stringify(validated)}\n`;
         if (Buffer.byteLength(serialized, "utf8") > maximumManifestBytes) {
           throw new TypeError("The recoverable draft manifest is too large.");
@@ -392,12 +479,12 @@ async function replaceOwnerPrivateFile(path: string, content: string): Promise<v
   }
 }
 
-function manifestName(scope: TurnDraftScopeV1 | RecoverableTurnDraftV1["scope"]): string {
+function manifestName(scope: TurnDraftScopeV1 | RecoverableTurnDraft["scope"]): string {
   return scope.type === "new_session" ? "new-session.json" : `session-${scope.sessionId}.json`;
 }
 
 function matchesScope(
-  draftScope: RecoverableTurnDraftV1["scope"],
+  draftScope: RecoverableTurnDraft["scope"],
   requested: TurnDraftScopeV1,
 ): boolean {
   return (

--- a/packages/agent/src/recoverable-turn-draft.ts
+++ b/packages/agent/src/recoverable-turn-draft.ts
@@ -145,6 +145,40 @@ const stagedPastedTextSelectionSchema: z.ZodType<StagedPastedTextSelectionV1> = 
   lineCount: z.number().int().positive().safe(),
   scalarCount: z.number().int().positive().safe(),
 });
+const textElementSchema = z.strictObject({
+  elementId: z.string().min(1).max(256),
+  type: z.literal("text"),
+  text: z
+    .string()
+    .min(1)
+    .max(512 * 1024),
+});
+const resourceElementSchema = z.strictObject({
+  elementId: z.string().min(1).max(256),
+  type: z.literal("resource"),
+  kind: z.enum(["file", "image"]),
+  ordinal: z.number().int().positive().safe(),
+  resourceId: z.string().min(1).max(256),
+});
+const pastedTextElementSchema = z.strictObject({
+  elementId: z.string().min(1).max(256),
+  type: z.literal("pasted_text"),
+  ordinal: z.number().int().positive().safe(),
+  pastedTextId: z.string().min(1).max(256),
+});
+const skillElementSchema = z.strictObject({
+  elementId: z.string().min(1).max(256),
+  type: z.literal("skill"),
+  name: z
+    .string()
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/u)
+    .max(64),
+  qualifiedId: z
+    .string()
+    .min(1)
+    .max(16_384)
+    .refine((value) => /^[\x20-\x7e]+$/u.test(value) && Buffer.byteLength(value, "utf8") <= 16_384),
+});
 const draftV1Schema = z
   .strictObject({
     schemaVersion: z.literal(1),
@@ -163,27 +197,9 @@ const draftV1Schema = z
     elements: z
       .array(
         z.discriminatedUnion("type", [
-          z.strictObject({
-            elementId: z.string().min(1).max(256),
-            type: z.literal("text"),
-            text: z
-              .string()
-              .min(1)
-              .max(512 * 1024),
-          }),
-          z.strictObject({
-            elementId: z.string().min(1).max(256),
-            type: z.literal("resource"),
-            kind: z.enum(["file", "image"]),
-            ordinal: z.number().int().positive().safe(),
-            resourceId: z.string().min(1).max(256),
-          }),
-          z.strictObject({
-            elementId: z.string().min(1).max(256),
-            type: z.literal("pasted_text"),
-            ordinal: z.number().int().positive().safe(),
-            pastedTextId: z.string().min(1).max(256),
-          }),
+          textElementSchema,
+          resourceElementSchema,
+          pastedTextElementSchema,
         ]),
       )
       .max(17),
@@ -241,43 +257,10 @@ const draftV2Schema = z
     elements: z
       .array(
         z.discriminatedUnion("type", [
-          z.strictObject({
-            elementId: z.string().min(1).max(256),
-            type: z.literal("text"),
-            text: z
-              .string()
-              .min(1)
-              .max(512 * 1024),
-          }),
-          z.strictObject({
-            elementId: z.string().min(1).max(256),
-            type: z.literal("resource"),
-            kind: z.enum(["file", "image"]),
-            ordinal: z.number().int().positive().safe(),
-            resourceId: z.string().min(1).max(256),
-          }),
-          z.strictObject({
-            elementId: z.string().min(1).max(256),
-            type: z.literal("pasted_text"),
-            ordinal: z.number().int().positive().safe(),
-            pastedTextId: z.string().min(1).max(256),
-          }),
-          z.strictObject({
-            elementId: z.string().min(1).max(256),
-            type: z.literal("skill"),
-            name: z
-              .string()
-              .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/u)
-              .max(64),
-            qualifiedId: z
-              .string()
-              .min(1)
-              .max(16_384)
-              .refine(
-                (value) =>
-                  /^[\x20-\x7e]+$/u.test(value) && Buffer.byteLength(value, "utf8") <= 16_384,
-              ),
-          }),
+          textElementSchema,
+          resourceElementSchema,
+          pastedTextElementSchema,
+          skillElementSchema,
         ]),
       )
       .max(17),
@@ -314,7 +297,12 @@ function validateDraftGraph(draft: RecoverableTurnDraft, context: z.RefinementCt
     new Set(pastedTexts.map((pastedText) => pastedText.ordinal)).size !== pastedTexts.length ||
     draft.elements.reduce(
       (length, element) =>
-        length + (element.type === "text" ? Buffer.byteLength(element.text, "utf8") : 0),
+        length +
+        (element.type === "text"
+          ? Buffer.byteLength(element.text, "utf8")
+          : element.type === "skill"
+            ? Buffer.byteLength(`$${element.name}`, "utf8")
+            : 0),
       0,
     ) +
       pastedTexts.reduce((total, pastedText) => total + pastedText.byteCount, 0) >

--- a/packages/agent/src/turn-composer.test.ts
+++ b/packages/agent/src/turn-composer.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 
 import type { TurnComposerResourceStager } from "./input-resource-staging.js";
+import { pastedTextLimitsV1 } from "./pasted-text.js";
 import type { RecoverableTurnDraftV1 } from "./recoverable-turn-draft.js";
 import { createTurnComposer } from "./turn-composer.js";
 
@@ -116,6 +117,36 @@ test("TurnComposer expands a Skill atom to visible text without copying identity
     ).resolves.toBe(true);
     expect(composer.readExpandedText()).toBe("$first");
     expect(composer.readExpandedText()).not.toContain("skill:v1:");
+  } finally {
+    await composer.close();
+  }
+});
+
+test("TurnComposer counts a candidate Skill atom against the structured text byte limit", async () => {
+  const composer = await createTurnComposer({ onChange() {}, stager: createPastedTextStager() });
+  try {
+    await composer.stagePastedText("x".repeat(pastedTextLimitsV1.maximumTextBytesPerTurn - 64));
+    const pastedText = composer
+      .snapshot()
+      .elements.find((element) => element.type === "pasted_text");
+    if (pastedText?.type !== "pasted_text") {
+      throw new Error("Expected one staged Text atom.");
+    }
+
+    await expect(
+      composer.replaceText({
+        baseRevision: composer.snapshot().revision,
+        document: [
+          { type: "pasted_text", elementId: pastedText.elementId },
+          {
+            type: "skill",
+            elementId: "maximum-name-skill",
+            name: "a".repeat(64),
+            qualifiedId: "skill:v1:project:.:maximum-name-skill",
+          },
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "limit_exceeded" });
   } finally {
     await composer.close();
   }

--- a/packages/agent/src/turn-composer.test.ts
+++ b/packages/agent/src/turn-composer.test.ts
@@ -117,6 +117,15 @@ test("TurnComposer expands a Skill atom to visible text without copying identity
     ).resolves.toBe(true);
     expect(composer.readExpandedText()).toBe("$first");
     expect(composer.readExpandedText()).not.toContain("skill:v1:");
+    await expect(composer.seal(new AbortController().signal)).resolves.toMatchObject({
+      text: "$first",
+      skillOccurrences: [
+        {
+          elementId: "skill-occurrence",
+          qualifiedId: "skill:v1:project:.:first",
+        },
+      ],
+    });
   } finally {
     await composer.close();
   }

--- a/packages/agent/src/turn-composer.test.ts
+++ b/packages/agent/src/turn-composer.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 
 import type { TurnComposerResourceStager } from "./input-resource-staging.js";
+import type { RecoverableTurnDraftV1 } from "./recoverable-turn-draft.js";
 import { createTurnComposer } from "./turn-composer.js";
 
 const digest = `sha256:${"a".repeat(64)}` as const;
@@ -92,6 +93,30 @@ test("TurnComposer restores a derived preview without persisting a second copy",
     ]);
   } finally {
     await recovered.close();
+    await composer.close();
+  }
+});
+
+test("TurnComposer expands a Skill atom to visible text without copying identity metadata", async () => {
+  const composer = await createTurnComposer({ onChange() {}, stager: createPastedTextStager() });
+  try {
+    composer.setText("$fir");
+    await expect(
+      composer.replaceText({
+        baseRevision: composer.snapshot().revision,
+        document: [
+          {
+            type: "skill",
+            elementId: "skill-occurrence",
+            name: "first",
+            qualifiedId: "skill:v1:project:.:first",
+          },
+        ],
+      }),
+    ).resolves.toBe(true);
+    expect(composer.readExpandedText()).toBe("$first");
+    expect(composer.readExpandedText()).not.toContain("skill:v1:");
+  } finally {
     await composer.close();
   }
 });
@@ -616,6 +641,7 @@ test("TurnComposer seals the exact ordered draft without turning resource tokens
 
 test("TurnComposer captures and restores one recoverable ordered draft through retained artifacts", async () => {
   const retained: string[] = [];
+  const pastedTexts = new Map<string, string>();
   const stager: TurnComposerResourceStager = {
     async stage(input) {
       return {
@@ -631,6 +657,29 @@ test("TurnComposer captures and restores one recoverable ordered draft through r
         mediaHint: "text",
         support: "utf8_text",
       };
+    },
+    async stageText(input) {
+      pastedTexts.set(input.id, input.text);
+      return {
+        type: "staged_pasted_text",
+        staged: {
+          stagingId: input.id,
+          id: digest,
+          mediaType: "text/plain; charset=utf-8",
+          byteCount: Buffer.byteLength(input.text, "utf8"),
+        },
+        digest,
+        byteCount: Buffer.byteLength(input.text, "utf8"),
+        lineCount: input.text.split("\n").length,
+        scalarCount: Array.from(input.text).length,
+      };
+    },
+    async readText(selection) {
+      const pasted = pastedTexts.get(selection.staged.stagingId);
+      if (pasted === undefined) {
+        throw new Error("Expected retained pasted text.");
+      }
+      return pasted;
     },
     async retain(input) {
       retained.push(input.resourceId);
@@ -652,22 +701,33 @@ test("TurnComposer captures and restores one recoverable ordered draft through r
       at: { elementId: initialText.elementId, offset: 6 },
       baseRevision: initial.revision,
     });
+    const pasted = Array.from({ length: 11 }, (_, index) => `legacy paste ${index + 1}`).join("\n");
+    await composer.stagePastedText(pasted);
 
     const draft = await composer.captureDraft({
       type: "new_session",
       targetId: "deepseek-v4-flash.direct",
     });
-    expect(retained).toHaveLength(1);
-    await recovered.restoreDraft(draft);
+    expect(draft.schemaVersion).toBe(2);
+    expect(retained).toHaveLength(2);
+    const legacyDraft: RecoverableTurnDraftV1 = {
+      ...draft,
+      schemaVersion: 1,
+      elements: draft.elements as RecoverableTurnDraftV1["elements"],
+    };
+    await recovered.restoreDraft(legacyDraft);
     expect(recovered.snapshot()).toMatchObject({
       elements: [
         { type: "text", text: "before" },
         { type: "resource", ordinal: 1 },
         { type: "text", text: "after" },
+        { type: "pasted_text", ordinal: 2 },
       ],
-      renderedText: "before[File #1]after",
+      renderedText: "before[File #1]after[Text #2]",
       resources: [{ displayName: "notes.txt", ordinal: 1, state: "ready" }],
+      pastedTexts: [{ ordinal: 2, state: "ready" }],
     });
+    expect(recovered.readExpandedText()).toBe(`before[File #1]after${pasted}`);
   } finally {
     await recovered.close();
     await composer.close();

--- a/packages/agent/src/turn-composer.ts
+++ b/packages/agent/src/turn-composer.ts
@@ -300,9 +300,12 @@ export async function createTurnComposer(options: {
   const literalText = (): string =>
     elements.flatMap((element) => (element.type === "text" ? [element.text] : [])).join("");
 
-  const textPayloadBytes = (literal = literalText()): number =>
+  const textPayloadBytes = (
+    literal = literalText(),
+    candidateElements: readonly TurnComposerElementSnapshot[] = elements,
+  ): number =>
     Buffer.byteLength(literal, "utf8") +
-    elements
+    candidateElements
       .filter((element) => element.type === "skill")
       .reduce((total, element) => total + Buffer.byteLength(`$${element.name}`, "utf8"), 0) +
     [...pastedTexts.values()]
@@ -767,7 +770,7 @@ export async function createTurnComposer(options: {
         .join("");
       if (
         nextText.length > 512 * 1024 ||
-        textPayloadBytes(nextText) > pastedTextLimitsV1.maximumTextBytesPerTurn
+        textPayloadBytes(nextText, nextElements) > pastedTextLimitsV1.maximumTextBytesPerTurn
       ) {
         throw new TurnComposerError(
           "limit_exceeded",

--- a/packages/agent/src/turn-composer.ts
+++ b/packages/agent/src/turn-composer.ts
@@ -13,7 +13,7 @@ import {
   pastedTextLimitsV1,
   type StagedPastedTextSelectionV1,
 } from "./pasted-text.js";
-import type { RecoverableTurnDraftV1 } from "./recoverable-turn-draft.js";
+import type { RecoverableTurnDraft, RecoverableTurnDraftV2 } from "./recoverable-turn-draft.js";
 import type { StagedUserContentElementV1 } from "./structured-user-content.js";
 
 export {
@@ -55,6 +55,12 @@ export type TurnComposerElementSnapshot =
       readonly type: "pasted_text";
       readonly ordinal: number;
       readonly pastedTextId: string;
+    }
+  | {
+      readonly type: "skill";
+      readonly elementId: string;
+      readonly name: string;
+      readonly qualifiedId: string;
     };
 
 export type TurnComposerSealedElement =
@@ -72,6 +78,13 @@ export type TurnComposerSealedElement =
       readonly token: string;
       readonly text: string;
       readonly selection: StagedPastedTextSelectionV1;
+    }
+  | {
+      readonly type: "skill";
+      readonly elementId: string;
+      readonly name: string;
+      readonly qualifiedId: string;
+      readonly text: string;
     };
 
 export type TurnComposerPastedTextSnapshot = {
@@ -157,16 +170,23 @@ export type TurnComposer = {
         | { readonly type: "text"; readonly text: string }
         | { readonly type: "resource"; readonly elementId: string }
         | { readonly type: "pasted_text"; readonly elementId: string }
+        | {
+            readonly type: "skill";
+            readonly elementId: string;
+            readonly name: string;
+            readonly qualifiedId: string;
+          }
       )[];
     },
     commit?: () => Promise<void>,
   ): Promise<boolean>;
-  captureDraft(scope: RecoverableTurnDraftV1["scope"]): Promise<RecoverableTurnDraftV1>;
-  restoreDraft(draft: RecoverableTurnDraftV1): Promise<void>;
+  captureDraft(scope: RecoverableTurnDraftV2["scope"]): Promise<RecoverableTurnDraftV2>;
+  restoreDraft(draft: RecoverableTurnDraft): Promise<void>;
   undo(baseRevision: number, commit?: () => Promise<void>): Promise<boolean>;
   cancel(id: string): Promise<boolean>;
   remove(id: string, commit?: () => Promise<void>): Promise<boolean>;
   removePastedText(id: string, commit?: () => Promise<void>): Promise<boolean>;
+  removeSkill(elementId: string, commit?: () => Promise<void>): Promise<boolean>;
   setText(text: string): void;
   commitText(text: string, commit: () => Promise<void>): Promise<void>;
   seal(signal: AbortSignal): Promise<{
@@ -176,6 +196,10 @@ export type TurnComposer = {
     readonly text: string;
     readonly selections: readonly StagedInputResourceSelectionV1[];
     readonly pastedTextSelections: readonly StagedPastedTextSelectionV1[];
+    readonly skillOccurrences: readonly {
+      readonly elementId: string;
+      readonly qualifiedId: string;
+    }[];
   }>;
   unseal(): void;
   reset(baseRevision: number, commit: () => Promise<void>): Promise<boolean>;
@@ -267,7 +291,9 @@ export async function createTurnComposer(options: {
       .map((element) =>
         element.type === "text"
           ? element.text
-          : atomToken(element.type === "pasted_text" ? "text" : element.kind, element.ordinal),
+          : element.type === "skill"
+            ? `$${element.name}`
+            : atomToken(element.type === "pasted_text" ? "text" : element.kind, element.ordinal),
       )
       .join("");
 
@@ -276,6 +302,9 @@ export async function createTurnComposer(options: {
 
   const textPayloadBytes = (literal = literalText()): number =>
     Buffer.byteLength(literal, "utf8") +
+    elements
+      .filter((element) => element.type === "skill")
+      .reduce((total, element) => total + Buffer.byteLength(`$${element.name}`, "utf8"), 0) +
     [...pastedTexts.values()]
       .filter((pastedText) => pastedText.state !== "removed")
       .reduce((total, pastedText) => total + pastedText.byteCount, 0);
@@ -452,6 +481,28 @@ export async function createTurnComposer(options: {
     return { element, previousElements };
   };
 
+  const removeSkillElement = (
+    elementId: string,
+  ):
+    | {
+        readonly previousElements: readonly TurnComposerElementSnapshot[];
+      }
+    | undefined => {
+    const previousElements = elements;
+    const index = previousElements.findIndex(
+      (element) => element.type === "skill" && element.elementId === elementId,
+    );
+    if (index < 0) {
+      return undefined;
+    }
+    elements = normalizeTextElements([
+      ...previousElements.slice(0, index),
+      ...previousElements.slice(index + 1),
+    ]);
+    revision += 1;
+    return { previousElements };
+  };
+
   return {
     async captureDraft(scope) {
       const orderedResources = elements.flatMap((element) => {
@@ -504,7 +555,7 @@ export async function createTurnComposer(options: {
         }
       }
       return {
-        schemaVersion: 1,
+        schemaVersion: 2,
         scope,
         nextOrdinal,
         elements: elements.map((element) => ({ ...element })),
@@ -641,15 +692,6 @@ export async function createTurnComposer(options: {
         (element): element is Exclude<TurnComposerElementSnapshot, { readonly type: "text" }> =>
           element.type !== "text",
       );
-      const projectedAtomIds = input.document.flatMap((part) =>
-        part.type === "text" ? [] : [part.elementId],
-      );
-      if (
-        projectedAtomIds.length !== currentAtoms.length ||
-        projectedAtomIds.some((elementId, index) => currentAtoms[index]?.elementId !== elementId)
-      ) {
-        return false;
-      }
       const currentTextIdByGap = new Map<number, string>();
       let gap = 0;
       for (const element of elements) {
@@ -661,14 +703,42 @@ export async function createTurnComposer(options: {
       }
       const atomsByElementId = new Map(currentAtoms.map((atom) => [atom.elementId, atom]));
       const nextElements: TurnComposerElementSnapshot[] = [];
+      const projectedIds = new Set<string>();
+      let currentAtomIndex = 0;
       gap = 0;
       for (const part of input.document) {
         if (part.type !== "text") {
           const atom = atomsByElementId.get(part.elementId);
-          if (atom === undefined || atom.type !== part.type) {
+          if (projectedIds.has(part.elementId)) {
             return false;
           }
-          nextElements.push(atom);
+          projectedIds.add(part.elementId);
+          if (atom !== undefined) {
+            if (
+              currentAtoms[currentAtomIndex]?.elementId !== atom.elementId ||
+              atom.type !== part.type
+            ) {
+              return false;
+            }
+            if (
+              atom.type === "skill" &&
+              (part.type !== "skill" ||
+                atom.name !== part.name ||
+                atom.qualifiedId !== part.qualifiedId)
+            ) {
+              return false;
+            }
+            nextElements.push(atom);
+            currentAtomIndex += 1;
+          } else if (
+            part.type === "skill" &&
+            isValidSkillIdentity(part.name, part.qualifiedId) &&
+            !elements.some((element) => element.elementId === part.elementId)
+          ) {
+            nextElements.push({ ...part });
+          } else {
+            return false;
+          }
           gap += 1;
           continue;
         }
@@ -688,6 +758,9 @@ export async function createTurnComposer(options: {
             text: part.text,
           });
         }
+      }
+      if (currentAtomIndex !== currentAtoms.length) {
+        return false;
       }
       const nextText = nextElements
         .flatMap((element) => (element.type === "text" ? [element.text] : []))
@@ -827,6 +900,33 @@ export async function createTurnComposer(options: {
       if (removed === undefined || pastedText.staged === null || pastedText.text === null) {
         await discardPastedText(pastedText);
         pastedTexts.delete(id);
+      }
+      publish();
+      return true;
+    },
+    async removeSkill(elementId, commit) {
+      if (closed || sealed) {
+        return false;
+      }
+      const previousElements = elements;
+      const previousText = text;
+      const previousRevision = revision;
+      const previousUndoStack = [...undoStack];
+      const removed = removeSkillElement(elementId);
+      if (removed === undefined) {
+        return false;
+      }
+      text = literalText();
+      pushUndo({ previousElements: removed.previousElements });
+      try {
+        await commit?.();
+      } catch (error) {
+        elements = previousElements;
+        text = previousText;
+        revision = previousRevision;
+        undoStack.length = 0;
+        undoStack.push(...previousUndoStack);
+        throw error;
       }
       publish();
       return true;
@@ -1412,6 +1512,9 @@ export async function createTurnComposer(options: {
               selection: pastedText.staged,
             };
           }
+          if (element.type === "skill") {
+            return { ...element, text: `$${element.name}` };
+          }
           const resource = resourceById.get(element.resourceId);
           if (resource?.staged === null || resource?.staged === undefined) {
             throw new TurnComposerError(
@@ -1428,43 +1531,61 @@ export async function createTurnComposer(options: {
           };
         }),
         renderedText: renderedText(),
-        structuredContent: elements.map((element): StagedUserContentElementV1 => {
-          if (element.type === "text") {
-            return { type: "text", text: element.text };
-          }
-          if (element.type === "pasted_text") {
-            const selectionIndex = retainedPastedTexts.findIndex(
-              (pastedText) => pastedText.id === element.pastedTextId,
-            );
-            if (selectionIndex < 0) {
+        structuredContent: normalizeStructuredTextElements(
+          elements.map((element): StagedUserContentElementV1 => {
+            if (element.type === "text") {
+              return { type: "text", text: element.text };
+            }
+            if (element.type === "pasted_text") {
+              const selectionIndex = retainedPastedTexts.findIndex(
+                (pastedText) => pastedText.id === element.pastedTextId,
+              );
+              if (selectionIndex < 0) {
+                throw new TurnComposerError(
+                  "failed",
+                  "Every retained Text atom must be ready before send.",
+                );
+              }
+              return {
+                type: "pasted_text",
+                selectionIndex,
+                draftOrdinal: element.ordinal,
+              };
+            }
+            if (element.type === "skill") {
+              return { type: "text", text: `$${element.name}` };
+            }
+            const selectionIndex = selectionIndexById.get(element.resourceId);
+            if (selectionIndex === undefined) {
               throw new TurnComposerError(
                 "failed",
-                "Every retained Text atom must be ready before send.",
+                "Every retained input resource must be ready before send.",
               );
             }
             return {
-              type: "pasted_text",
+              type: "input_resource",
               selectionIndex,
               draftOrdinal: element.ordinal,
             };
-          }
-          const selectionIndex = selectionIndexById.get(element.resourceId);
-          if (selectionIndex === undefined) {
-            throw new TurnComposerError(
-              "failed",
-              "Every retained input resource must be ready before send.",
-            );
-          }
-          return {
-            type: "input_resource",
-            selectionIndex,
-            draftOrdinal: element.ordinal,
-          };
-        }),
-        text,
+          }),
+        ),
+        text: elements
+          .flatMap((element) =>
+            element.type === "text"
+              ? [element.text]
+              : element.type === "skill"
+                ? [`$${element.name}`]
+                : [],
+          )
+          .join(""),
         selections: retained.map((resource) => resource.staged as StagedInputResourceSelectionV1),
         pastedTextSelections: retainedPastedTexts.map(
           (pastedText) => pastedText.staged as StagedPastedTextSelectionV1,
+        ),
+        skillOccurrences: elements.flatMap((element) =>
+          element.type === "skill"
+            ? [{ elementId: element.elementId, qualifiedId: element.qualifiedId }]
+            : [],
         ),
       };
     },
@@ -1520,6 +1641,9 @@ export async function createTurnComposer(options: {
           }
           if (element.type === "resource") {
             return atomToken(element.kind, element.ordinal);
+          }
+          if (element.type === "skill") {
+            return `$${element.name}`;
           }
           const pastedText = pastedTexts.get(element.pastedTextId);
           if (pastedText?.state !== "ready" || pastedText.text === null) {
@@ -1655,4 +1779,33 @@ export async function createTurnComposer(options: {
       };
     },
   };
+}
+
+function isValidSkillIdentity(name: string, qualifiedId: string): boolean {
+  return (
+    /^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(name) &&
+    name.length <= 64 &&
+    qualifiedId.length > 0 &&
+    qualifiedId.length <= 16_384 &&
+    /^[\x20-\x7e]+$/u.test(qualifiedId) &&
+    Buffer.byteLength(qualifiedId, "utf8") <= 16_384
+  );
+}
+
+function normalizeStructuredTextElements(
+  elements: readonly StagedUserContentElementV1[],
+): readonly StagedUserContentElementV1[] {
+  const normalized: StagedUserContentElementV1[] = [];
+  for (const element of elements) {
+    const previous = normalized.at(-1);
+    if (element.type === "text" && previous?.type === "text") {
+      normalized[normalized.length - 1] = {
+        type: "text",
+        text: `${previous.text}${element.text}`,
+      };
+    } else {
+      normalized.push(element);
+    }
+  }
+  return normalized;
 }

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -817,7 +817,13 @@ export type DraftPoint =
 export type DraftTextDocumentPart =
   | { readonly type: "text"; readonly text: string }
   | { readonly type: "resource"; readonly elementId: string }
-  | { readonly type: "pasted_text"; readonly elementId: string };
+  | { readonly type: "pasted_text"; readonly elementId: string }
+  | {
+      readonly type: "skill";
+      readonly elementId: string;
+      readonly name: string;
+      readonly qualifiedId: string;
+    };
 
 export type TurnComposerDisplay = {
   readonly attachmentAvailable: boolean;
@@ -836,6 +842,13 @@ export type TurnComposerDisplay = {
         readonly type: "pasted_text";
         readonly ordinal: number;
         readonly pastedTextId: string;
+      }
+    | {
+        readonly type: "skill";
+        readonly elementId: string;
+        readonly name: string;
+        readonly qualifiedId: string;
+        readonly available: boolean;
       }
   )[];
   readonly renderedText: string;

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -4486,14 +4486,16 @@ test("PresentationSession preserves duplicate and same-name exact Skill atom occ
   const workspaceRoot = join(testRoot, "workspace");
   const userHome = join(testRoot, "home");
   const previousHome = testEnvironment.HOME;
-  for (const directory of [
-    join(workspaceRoot, ".agents", "skills", "shared-name"),
-    join(userHome, ".agents", "skills", "shared-name"),
+  for (const [directory, name] of [
+    [join(workspaceRoot, ".agents", "skills", "shared-name"), "shared-name"] as const,
+    [join(userHome, ".agents", "skills", "shared-name"), "shared-name"] as const,
+    [join(workspaceRoot, ".agents", "skills", "manual-name"), "manual-name"] as const,
+    [join(userHome, ".agents", "skills", "manual-name"), "manual-name"] as const,
   ]) {
     await mkdir(directory, { recursive: true });
     await writeFile(
       join(directory, "SKILL.md"),
-      "---\nname: shared-name\ndescription: Exact atom collision procedure.\n---\nExact body.\n",
+      `---\nname: ${name}\ndescription: Exact atom collision procedure.\n---\nExact body.\n`,
       "utf8",
     );
   }
@@ -4542,6 +4544,12 @@ test("PresentationSession preserves duplicate and same-name exact Skill atom occ
             name: "shared-name",
             qualifiedId: "skill:v1:user:shared-name",
           },
+          {
+            type: "skill",
+            elementId: "manual-project-fourth",
+            name: "manual-name",
+            qualifiedId: "skill:v1:project:.:manual-name",
+          },
         ],
       }),
     ).resolves.toMatchObject({ status: "admitted" });
@@ -4549,6 +4557,7 @@ test("PresentationSession preserves duplicate and same-name exact Skill atom occ
       { type: "skill", elementId: "project-first", available: true },
       { type: "skill", elementId: "project-second", available: true },
       { type: "skill", elementId: "user-third", available: true },
+      { type: "skill", elementId: "manual-project-fourth", available: true },
     ]);
 
     const completed = Promise.withResolvers<void>();
@@ -4568,7 +4577,7 @@ test("PresentationSession preserves duplicate and same-name exact Skill atom occ
     try {
       const receipt = await presentation.dispatch({
         type: "submit_draft_prompt",
-        text: "",
+        text: "$manual-name",
         skills: [],
         thinkingSelection: null,
       });
@@ -4593,17 +4602,21 @@ test("PresentationSession preserves duplicate and same-name exact Skill atom occ
             outcomes: [
               expect.objectContaining({ qualifiedId: "skill:v1:project:.:shared-name" }),
               expect.objectContaining({ qualifiedId: "skill:v1:user:shared-name" }),
+              expect.objectContaining({ qualifiedId: "skill:v1:project:.:manual-name" }),
             ],
-          }),
-        }),
-        expect.objectContaining({
-          record: expect.objectContaining({
-            type: "logical_run_started",
-            userMessage: "$shared-name$shared-name$shared-name",
           }),
         }),
       ]),
     );
+    const logicalRun = records.find(
+      (entry) => "record" in entry && entry.record.type === "logical_run_started",
+    );
+    expect(
+      logicalRun !== undefined && "record" in logicalRun ? logicalRun.record : undefined,
+    ).toMatchObject({
+      type: "logical_run_started",
+      userMessage: "$shared-name$shared-name$shared-name$manual-name$manual-name",
+    });
     await presentation.close();
   } finally {
     await lifecycle.close();

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -3676,11 +3676,22 @@ test("PresentationSession scopes recoverable composer inputs to their selected s
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   const selectedPath = join(testRoot, "session-local-notes.txt");
-  await mkdir(workspaceRoot);
+  const skillDirectory = join(workspaceRoot, ".agents", "skills", "session-review");
+  await mkdir(skillDirectory, { recursive: true });
   await writeFile(selectedPath, "belongs only to the first session\n", "utf8");
+  await writeFile(
+    join(skillDirectory, "SKILL.md"),
+    "---\nname: session-review\ndescription: Session-switch exact atom procedure.\n---\nSession body.\n",
+    "utf8",
+  );
   const modelTargets = settledModelTargets("Session selection fixture answer.");
   const harness = createInMemorySessionLifecycleHarness();
-  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const lifecycle = harness.createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    stateRoot,
+    workspaceRoot,
+  });
   const first = await lifecycle.create({ targetIdentity });
   const second = await lifecycle.create({ targetIdentity });
   await lifecycle.continue({
@@ -3707,6 +3718,26 @@ test("PresentationSession scopes recoverable composer inputs to their selected s
       type: "stage_pasted_text",
       text: Array.from({ length: 11 }, (_, index) => `session paste ${index + 1}`).join("\n"),
     });
+    const beforeSkill = presentation.getState().composer;
+    await expect(
+      presentation.dispatch({
+        type: "replace_draft_text",
+        baseRevision: beforeSkill.draftRevision,
+        document: [
+          ...beforeSkill.elements.map((element) =>
+            element.type === "resource"
+              ? ({ type: "resource" as const, elementId: element.elementId } as const)
+              : ({ type: "pasted_text" as const, elementId: element.elementId } as const),
+          ),
+          {
+            type: "skill",
+            elementId: "session-skill",
+            name: "session-review",
+            qualifiedId: "skill:v1:project:.:session-review",
+          },
+        ],
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
     expect(presentation.getState().composer.resources).toHaveLength(1);
     expect(presentation.getState().composer.pastedTexts).toMatchObject([
       { preview: "session p...", state: "ready" },
@@ -3717,24 +3748,27 @@ test("PresentationSession scopes recoverable composer inputs to their selected s
     ).resolves.toMatchObject({ status: "admitted" });
     expect(presentation.getState().composer.resources).toEqual([]);
     expect(presentation.getState().composer.pastedTexts).toEqual([]);
+    expect(presentation.getState().composer.elements).toEqual([]);
 
     await expect(
       presentation.dispatch({ type: "select_session", sessionId: first.sessionId }),
     ).resolves.toMatchObject({ status: "admitted" });
-    expect(presentation.getState().composer).toMatchObject({
-      renderedText: "[File #1][Text #2]",
+    const restoredComposer = presentation.getState().composer;
+    expect(restoredComposer).toMatchObject({
+      renderedText: "[File #1][Text #2]$session-review",
       resources: [{ displayName: "session-local-notes.txt", ordinal: 1, state: "ready" }],
       pastedTexts: [{ ordinal: 2, preview: "session p...", state: "ready" }],
     });
-    await expect(
-      presentation.dispatch({
-        type: "submit_prompt",
-        sessionId: first.sessionId,
-        text: "Use the recovered session-local notes.",
-        skills: [],
-        thinkingSelection: null,
-      }),
-    ).resolves.toMatchObject({ status: "admitted" });
+    expect(restoredComposer.elements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "skill",
+          elementId: "session-skill",
+          qualifiedId: "skill:v1:project:.:session-review",
+          available: true,
+        }),
+      ]),
+    );
   } finally {
     await presentation.close();
     await lifecycle.close();
@@ -4434,6 +4468,142 @@ test("PresentationSession keeps an ambiguous first-prompt Skill mention outside 
     expect(presentation.getState()).toMatchObject({ draft: { targetId: targetIdentity.targetId } });
     await expect(lifecycle.listProjectSessions()).resolves.toMatchObject({ items: [] });
     expect(providerResolutions).toBe(0);
+    await presentation.close();
+  } finally {
+    await lifecycle.close();
+    if (previousHome === undefined) {
+      delete testEnvironment.HOME;
+    } else {
+      testEnvironment.HOME = previousHome;
+    }
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession preserves duplicate and same-name exact Skill atom occurrence order", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-exact-skill-atoms-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  const userHome = join(testRoot, "home");
+  const previousHome = testEnvironment.HOME;
+  for (const directory of [
+    join(workspaceRoot, ".agents", "skills", "shared-name"),
+    join(userHome, ".agents", "skills", "shared-name"),
+  ]) {
+    await mkdir(directory, { recursive: true });
+    await writeFile(
+      join(directory, "SKILL.md"),
+      "---\nname: shared-name\ndescription: Exact atom collision procedure.\n---\nExact body.\n",
+      "utf8",
+    );
+  }
+  testEnvironment.HOME = userHome;
+  const modelTargets = settledModelTargets("Exact Skill atom admission complete.");
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    stateRoot,
+    workspaceRoot,
+  });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      openProject: true,
+      projectLabel: "workspace",
+      stateRoot,
+      workspaceRoot,
+      [presentationSessionRecordReader]: readInMemoryPresentationRecords(harness.sessions),
+    });
+    await presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId });
+    const baseRevision = presentation.getState().composer.draftRevision;
+    await expect(
+      presentation.dispatch({
+        type: "replace_draft_text",
+        baseRevision,
+        document: [
+          {
+            type: "skill",
+            elementId: "project-first",
+            name: "shared-name",
+            qualifiedId: "skill:v1:project:.:shared-name",
+          },
+          {
+            type: "skill",
+            elementId: "project-second",
+            name: "shared-name",
+            qualifiedId: "skill:v1:project:.:shared-name",
+          },
+          {
+            type: "skill",
+            elementId: "user-third",
+            name: "shared-name",
+            qualifiedId: "skill:v1:user:shared-name",
+          },
+        ],
+      }),
+    ).resolves.toMatchObject({ status: "admitted" });
+    expect(presentation.getState().composer.elements).toMatchObject([
+      { type: "skill", elementId: "project-first", available: true },
+      { type: "skill", elementId: "project-second", available: true },
+      { type: "skill", elementId: "user-third", available: true },
+    ]);
+
+    const completed = Promise.withResolvers<void>();
+    const unsubscribe = presentation.subscribe(() => {
+      if (
+        presentation
+          .getState()
+          .authoritative.active?.transcript.items.some(
+            (item) =>
+              item.type === "assistant_message" &&
+              item.text === "Exact Skill atom admission complete.",
+          )
+      ) {
+        completed.resolve();
+      }
+    });
+    try {
+      const receipt = await presentation.dispatch({
+        type: "submit_draft_prompt",
+        text: "",
+        skills: [],
+        thinkingSelection: null,
+      });
+      if (receipt.status === "rejected") {
+        throw new Error(`${receipt.code}: ${receipt.message}`);
+      }
+      await completed.promise;
+    } finally {
+      unsubscribe();
+    }
+    const listed = await lifecycle.listProjectSessions();
+    const sessionId = listed.items[0]?.sessionId;
+    if (sessionId === undefined) {
+      throw new Error("Expected one admitted exact-Skill session.");
+    }
+    const records = await readInMemoryPresentationRecords(harness.sessions)(sessionId);
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          record: expect.objectContaining({
+            type: "skill_activation_batch_committed",
+            outcomes: [
+              expect.objectContaining({ qualifiedId: "skill:v1:project:.:shared-name" }),
+              expect.objectContaining({ qualifiedId: "skill:v1:user:shared-name" }),
+            ],
+          }),
+        }),
+        expect.objectContaining({
+          record: expect.objectContaining({
+            type: "logical_run_started",
+            userMessage: "$shared-name$shared-name$shared-name",
+          }),
+        }),
+      ]),
+    );
     await presentation.close();
   } finally {
     await lifecycle.close();

--- a/patches/@earendil-works__pi-tui@0.84.2.patch
+++ b/patches/@earendil-works__pi-tui@0.84.2.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/components/editor.d.ts b/dist/components/editor.d.ts
-index a6fedc9e3b36d066e34860d040db6df47d88c432..ced33ab6fef651b7c9d6fc8834af110f3c4ccae0 100644
+index a6fedc9e3b36d066e34860d040db6df47d88c432..a5886312e10e67795d2cbdd68a2bab23e1c5eb01 100644
 --- a/dist/components/editor.d.ts
 +++ b/dist/components/editor.d.ts
 @@ -1,4 +1,4 @@
@@ -8,7 +8,7 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..ced33ab6fef651b7c9d6fc8834af110f
  import { type Component, type Focusable, type TUI } from "../tui.ts";
  import { type SelectListTheme } from "./select-list.ts";
  /**
-@@ -24,12 +24,72 @@ export interface TextChunk {
+@@ -24,12 +24,73 @@ export interface TextChunk {
  export declare function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl.SegmentData[]): TextChunk[];
  export interface EditorTheme {
      borderColor: (str: string) => string;
@@ -77,11 +77,12 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..ced33ab6fef651b7c9d6fc8834af110f
 +export interface EditorStructuredCompletion {
 +    project(document: readonly EditorDocumentPart[], cursor: EditorDocumentPoint): EditorStructuredCompletionProjection | null;
 +    accept(document: readonly EditorDocumentPart[], cursor: EditorDocumentPoint, item: AutocompleteItem, prefix: string): EditorStructuredCompletionEdit | null;
++    promote?(text: string, cursorOffset: number, item: AutocompleteItem, prefix: string): EditorStructuredCompletionEdit | null;
 +}
  export declare class Editor implements Component, Focusable {
      private state;
      /** Focusable interface - set by TUI when focus changes */
-@@ -53,6 +113,7 @@ export declare class Editor implements Component, Focusable {
+@@ -53,6 +114,7 @@ export declare class Editor implements Component, Focusable {
      private autocompleteRequestTask;
      private autocompleteStartToken;
      private autocompleteRequestId;
@@ -89,7 +90,7 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..ced33ab6fef651b7c9d6fc8834af110f
      private pastes;
      private pasteCounter;
      private pasteBuffer;
-@@ -68,6 +129,8 @@ export declare class Editor implements Component, Focusable {
+@@ -68,6 +130,8 @@ export declare class Editor implements Component, Focusable {
      private undoStack;
      onSubmit?: (text: string) => void;
      onChange?: (text: string) => void;
@@ -98,7 +99,7 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..ced33ab6fef651b7c9d6fc8834af110f
      disableSubmit: boolean;
      constructor(tui: TUI, theme: EditorTheme, options?: EditorOptions);
      /** Set of currently valid paste IDs, for marker-aware segmentation. */
-@@ -79,6 +142,8 @@ export declare class Editor implements Component, Focusable {
+@@ -79,6 +143,8 @@ export declare class Editor implements Component, Focusable {
      getAutocompleteMaxVisible(): number;
      setAutocompleteMaxVisible(maxVisible: number): void;
      setAutocompleteProvider(provider: AutocompleteProvider): void;
@@ -107,7 +108,7 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..ced33ab6fef651b7c9d6fc8834af110f
      /**
       * Add a prompt to history for up/down arrow navigation.
       * Called after successful submission.
-@@ -107,7 +172,10 @@ export declare class Editor implements Component, Focusable {
+@@ -107,7 +173,10 @@ export declare class Editor implements Component, Focusable {
          line: number;
          col: number;
      };
@@ -119,7 +120,7 @@ index a6fedc9e3b36d066e34860d040db6df47d88c432..ced33ab6fef651b7c9d6fc8834af110f
       * Insert text at the current cursor position.
       * Used for programmatic insertion (e.g., clipboard image markers).
 diff --git a/dist/components/editor.js b/dist/components/editor.js
-index 4786b46932b65785cfbd2304610ca77ccead910a..5c1a37538dbad8250622417fe235b9c68a163b81 100644
+index 4786b46932b65785cfbd2304610ca77ccead910a..8035125c53bc01ea849ab57c5fa83fafb540ad51 100644
 --- a/dist/components/editor.js
 +++ b/dist/components/editor.js
 @@ -219,6 +219,7 @@ export class Editor {
@@ -763,7 +764,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..5c1a37538dbad8250622417fe235b9c6
          const snapshot = this.undoStack.pop();
          if (!snapshot)
              return;
-@@ -1803,17 +2185,73 @@ export class Editor {
+@@ -1803,17 +2185,86 @@ export class Editor {
          return firstPrefixIndex;
      }
      createAutocompleteList(prefix, items) {
@@ -787,6 +788,19 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..5c1a37538dbad8250622417fe235b9c6
 +    applyAutocompleteItem(item, prefix) {
 +        if (!this.autocompleteProvider)
 +            return false;
++        if (this.structuredDocument === null && this.structuredCompletion?.promote !== undefined) {
++            const edit = this.structuredCompletion.promote(this.getText(), this.cursorOffset(), item, prefix);
++            if (edit !== null) {
++                this.setDocument(edit.document, edit.cursor);
++                this.onEditIntent?.({
++                    type: "replace",
++                    range: edit.range,
++                    text: edit.text,
++                    document: edit.document,
++                });
++                return true;
++            }
++        }
 +        if (this.structuredDocument !== null && this.structuredCompletion !== undefined) {
 +            const edit = this.structuredCompletion.accept(this.structuredDocument, this.getDocumentCursor(), item, prefix);
 +            if (edit === null)
@@ -840,7 +854,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..5c1a37538dbad8250622417fe235b9c6
          if (this.isInSlashCommandContext(beforeCursor) && !beforeCursor.trimStart().includes(" ")) {
              this.handleSlashCommandCompletion();
          }
-@@ -1830,9 +2268,12 @@ export class Editor {
+@@ -1830,9 +2281,12 @@ export class Editor {
      requestAutocomplete(options) {
          if (!this.autocompleteProvider)
              return;
@@ -854,7 +868,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..5c1a37538dbad8250622417fe235b9c6
              if (!shouldTrigger) {
                  return;
              }
-@@ -1882,14 +2323,20 @@ export class Editor {
+@@ -1882,14 +2336,20 @@ export class Editor {
          if (options.explicitTab || options.force) {
              return 0;
          }
@@ -878,7 +892,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..5c1a37538dbad8250622417fe235b9c6
          if (!this.isAutocompleteRequestCurrent(requestId, controller, snapshotText, snapshotLine, snapshotCol)) {
              return;
          }
-@@ -1901,14 +2348,7 @@ export class Editor {
+@@ -1901,14 +2361,7 @@ export class Editor {
          }
          if (options.force && options.explicitTab && suggestions.items.length === 1) {
              const item = suggestions.items[0];
@@ -895,7 +909,7 @@ index 4786b46932b65785cfbd2304610ca77ccead910a..5c1a37538dbad8250622417fe235b9c6
              return;
          }
 diff --git a/dist/components/select-list.d.ts b/dist/components/select-list.d.ts
-index d507de4ebff8e7fbaacd089677099c63b4dfff6c..f8b6caee7b1651ca1d8f5ce70ee4c2098715ae49 100644
+index d507de4ebff8e7fbaacd089677099c63b4dfff6c..0beb0e9abc13ed7a27cf31c0ca5677df37260f47 100644
 --- a/dist/components/select-list.d.ts
 +++ b/dist/components/select-list.d.ts
 @@ -22,6 +22,7 @@ export interface SelectListLayoutOptions {
@@ -907,7 +921,7 @@ index d507de4ebff8e7fbaacd089677099c63b4dfff6c..f8b6caee7b1651ca1d8f5ce70ee4c209
  export declare class SelectList implements Component {
      private items;
 diff --git a/dist/components/select-list.js b/dist/components/select-list.js
-index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..9d95baaf1e1456bb4ddd09dc00c343ba175403ed 100644
+index 2e9231150951c3d3f3e13ac8ae8d623f06d38d5d..1b8d0171ebb65cdf41a37fb9ea1e104771b70e3c 100644
 --- a/dist/components/select-list.js
 +++ b/dist/components/select-list.js
 @@ -1,5 +1,5 @@

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@earendil-works/pi-tui@0.84.2': 2a9614444293ef2af40658d3eaa330f4f8169fc6ab096e30ba7b9bc2fba341a6
+  '@earendil-works/pi-tui@0.84.2': b5489ac683056876bd592b378b28b41ab0676db8998d8eff30e74196bb01a5ab
 
 importers:
 
@@ -52,7 +52,7 @@ importers:
         version: link:../../packages/presentation
       '@earendil-works/pi-tui':
         specifier: 0.84.2
-        version: 0.84.2(patch_hash=2a9614444293ef2af40658d3eaa330f4f8169fc6ab096e30ba7b9bc2fba341a6)
+        version: 0.84.2(patch_hash=b5489ac683056876bd592b378b28b41ab0676db8998d8eff30e74196bb01a5ab)
       highlight.js:
         specifier: 11.11.1
         version: 11.11.1
@@ -1418,7 +1418,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.8':
     optional: true
 
-  '@earendil-works/pi-tui@0.84.2(patch_hash=2a9614444293ef2af40658d3eaa330f4f8169fc6ab096e30ba7b9bc2fba341a6)':
+  '@earendil-works/pi-tui@0.84.2(patch_hash=b5489ac683056876bd592b378b28b41ab0676db8998d8eff30e74196bb01a5ab)':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5


### PR DESCRIPTION
## Summary
- promote accepted Skill completions into atomic composer elements that preserve exact qualified identity across recoverable restart and session switching
- add additive recoverable draft v2 support, exact-first/manual-later Skill resolution, unavailable-atom blocking, and sealed occurrence authority without expanding Runtime, permission, trust, or effect scope
- preserve whole-atom navigation/deletion and visible-only copy semantics, including a caller-visible copy-to-paste identity-loss contract

## Verification
- final local `pnpm quality:check`: 79 files passed, 2 opt-in files skipped, 1700 tests passed, 18 skipped
- focused owning suite: 9 files and 429 tests passed
- frozen structural scans passed with no persisted Skill body/permission/tool metadata, new session or Runtime schema, duplicate store, Adam-module mock, sleep/polling, timeout, worker, or assertion weakening
- independent Standards and Spec reviews: zero remaining findings