### PR TITLE
S4-A0: add project execution domain

### DIFF
--- a/packages/agent/src/extension-host.ts
+++ b/packages/agent/src/extension-host.ts
@@ -234,7 +234,6 @@ export type ExtensionHostSnapshot = {
 
 export interface ExtensionHost {
   readonly operations: OperationHost;
-  readonly [extensionProjectExecutionDomain]: ProjectExecutionDomain;
   disableExtension(extensionId: string): Promise<ExtensionStateSnapshot>;
   enableExtension(extensionId: string): Promise<ExtensionStateSnapshot>;
   listContributions(): readonly ExtensionContributionSummary[];
@@ -242,9 +241,13 @@ export interface ExtensionHost {
   startProjectChanges(options: ExtensionProjectChangesStartOptions): Promise<OperationReference>;
 }
 
-export const extensionProjectExecutionDomain = Symbol(
-  "adam-agent.extension-project-execution-domain",
-);
+const extensionProjectExecutionDomains = new WeakMap<ExtensionHost, ProjectExecutionDomain>();
+
+export function projectExecutionDomainForExtensionHost(
+  host: ExtensionHost,
+): ProjectExecutionDomain | undefined {
+  return extensionProjectExecutionDomains.get(host);
+}
 
 export type ExtensionProjectChangesStartOptions = {
   readonly command: {
@@ -470,7 +473,6 @@ export function createExtensionHost(options: ExtensionHostOptions): ExtensionHos
   });
   let loadInFlight: Promise<ExtensionHostSnapshot> | undefined;
   const host: ExtensionHost = {
-    [extensionProjectExecutionDomain]: projectExecutionDomain,
     operations: operationHost,
     disableExtension(extensionId) {
       return enqueueLifecycleCommand(lifecycleCommandQueues, extensionId, async () => {
@@ -1101,6 +1103,7 @@ export function createExtensionHost(options: ExtensionHostOptions): ExtensionHos
     lifecycleCommandQueues,
     sources: extensionSkillSources,
   });
+  extensionProjectExecutionDomains.set(host, projectExecutionDomain);
   return host;
 }
 

--- a/packages/agent/src/extension-host.ts
+++ b/packages/agent/src/extension-host.ts
@@ -51,9 +51,14 @@ import {
   ProjectChangeMaterializerError,
 } from "./project-change-materializer.js";
 import {
+  createProjectExecutionDomain,
+  type ProjectExecutionDomain,
+  ProjectExecutionDomainError,
+  projectRuntimeRootId,
+} from "./project-execution-domain.js";
+import {
   createProjectLifecycleOwner,
   type ProjectLifecycleOwner,
-  ProjectLifecycleOwnerError,
 } from "./project-lifecycle-owner.js";
 import type { PermissionPolicy } from "./tool-runtime.js";
 
@@ -229,12 +234,17 @@ export type ExtensionHostSnapshot = {
 
 export interface ExtensionHost {
   readonly operations: OperationHost;
+  readonly [extensionProjectExecutionDomain]: ProjectExecutionDomain;
   disableExtension(extensionId: string): Promise<ExtensionStateSnapshot>;
   enableExtension(extensionId: string): Promise<ExtensionStateSnapshot>;
   listContributions(): readonly ExtensionContributionSummary[];
   loadConfiguredExtensions(): Promise<ExtensionHostSnapshot>;
   startProjectChanges(options: ExtensionProjectChangesStartOptions): Promise<OperationReference>;
 }
+
+export const extensionProjectExecutionDomain = Symbol(
+  "adam-agent.extension-project-execution-domain",
+);
 
 export type ExtensionProjectChangesStartOptions = {
   readonly command: {
@@ -439,6 +449,9 @@ export function createExtensionHost(options: ExtensionHostOptions): ExtensionHos
           workspaceRoot: options.projectRoot ?? process.cwd(),
           ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
         }));
+  const projectExecutionDomain = createProjectExecutionDomain({
+    lifecycleOwner: projectLifecycleOwner,
+  });
   const operationHost: OperationHostControl = createOperationHost({
     ...(options.artifactStore === undefined ? {} : { artifactStore: options.artifactStore }),
     ...(options.operationDeadlineMs === undefined
@@ -446,7 +459,7 @@ export function createExtensionHost(options: ExtensionHostOptions): ExtensionHos
       : { defaultDeadlineMs: options.operationDeadlineMs }),
     ...(options.biomeExecution === undefined ? {} : { biomeExecution: options.biomeExecution }),
     projectRoot: options.projectRoot ?? process.cwd(),
-    lifecycleOwner: projectLifecycleOwner,
+    executionDomain: projectExecutionDomain,
     ...(options.operationOriginAuthority === undefined
       ? {}
       : { originAuthority: options.operationOriginAuthority }),
@@ -457,6 +470,7 @@ export function createExtensionHost(options: ExtensionHostOptions): ExtensionHos
   });
   let loadInFlight: Promise<ExtensionHostSnapshot> | undefined;
   const host: ExtensionHost = {
+    [extensionProjectExecutionDomain]: projectExecutionDomain,
     operations: operationHost,
     disableExtension(extensionId) {
       return enqueueLifecycleCommand(lifecycleCommandQueues, extensionId, async () => {
@@ -588,8 +602,8 @@ export function createExtensionHost(options: ExtensionHostOptions): ExtensionHos
       ) {
         return Promise.resolve({ extensions: existing });
       }
-      const operation = projectLifecycleOwner
-        .run(async () => {
+      const operation = projectExecutionDomain
+        .runRoot({ rootId: projectRuntimeRootId }, async () => {
           const availableCapabilities = new Map(
             options.capabilities.map((capability) => [capability.id, capability]),
           );
@@ -1063,8 +1077,13 @@ export function createExtensionHost(options: ExtensionHostOptions): ExtensionHos
           return { extensions };
         })
         .catch((error: unknown) => {
-          if (error instanceof ProjectLifecycleOwnerError) {
-            throw new ExtensionHostError(error.code, { cause: error });
+          if (error instanceof ProjectExecutionDomainError) {
+            throw new ExtensionHostError(
+              error.code === "root_conflict" || error.code === "project_in_use"
+                ? "project_in_use"
+                : "project_owner_unavailable",
+              { cause: error },
+            );
           }
           throw error;
         });

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -62,6 +62,10 @@ export {
   presentationSessionRecordReader,
   resolvePresentationTerminalContext,
 } from "./presentation-session.js";
+export {
+  createProjectExecutionDomain,
+  ProjectExecutionDomainError,
+} from "./project-execution-domain.js";
 export type {
   ProjectLifecycleOwner,
   ProjectLifecycleOwnerLease,

--- a/packages/agent/src/operation-host.ts
+++ b/packages/agent/src/operation-host.ts
@@ -61,9 +61,10 @@ import {
   OperationStoreError,
 } from "./operation-store.js";
 import {
-  type ProjectLifecycleOwner,
-  ProjectLifecycleOwnerError,
-} from "./project-lifecycle-owner.js";
+  type ProjectExecutionDomain,
+  ProjectExecutionDomainError,
+  projectRuntimeRootId,
+} from "./project-execution-domain.js";
 import type { PermissionPolicy } from "./tool-runtime.js";
 
 export type RegisteredOperation = {
@@ -263,7 +264,7 @@ export function createOperationHost(options: {
   readonly artifactStore?: ArtifactStore;
   readonly biomeExecution?: BiomeExecutionAdapter;
   readonly defaultDeadlineMs?: number;
-  readonly lifecycleOwner: ProjectLifecycleOwner;
+  readonly executionDomain: ProjectExecutionDomain;
   readonly originAuthority?: OperationOriginAuthority;
   readonly projectRoot: string;
   readonly permissions?: PermissionPolicy;
@@ -373,13 +374,16 @@ export function createOperationHost(options: {
         decodedInput = decodeInput(registered.registration, normalizedInput.value);
         inputDecoded = true;
       }
-      const lifecycleLease = await options.lifecycleOwner.acquire().catch((error: unknown) => {
-        if (error instanceof ProjectLifecycleOwnerError) {
-          throw new OperationHostError(error.code, { cause: error });
-        }
-        throw error;
-      });
-      let lifecycleLeaseTransferred = false;
+      const operationId = randomUUID();
+      const executionClaim = await options.executionDomain
+        .claimRoot({ rootId: projectRuntimeRootId })
+        .catch((error: unknown) => {
+          if (error instanceof ProjectExecutionDomainError) {
+            throw new OperationHostError(operationOwnerErrorCode(error), { cause: error });
+          }
+          throw error;
+        });
+      let executionClaimTransferred = false;
       try {
         const raced = await store.findByIdempotency(scope);
         const racedReference =
@@ -404,7 +408,6 @@ export function createOperationHost(options: {
         if (normalizedInput === undefined || !inputDecoded) {
           throw new OperationHostError("operation_input_invalid");
         }
-        const operationId = randomUUID();
         const now = Date.now();
         const recordedAt = new Date(now).toISOString();
         const deadlineAt = new Date(now + deadlineMs).toISOString();
@@ -498,7 +501,7 @@ export function createOperationHost(options: {
           terminalPersistenceFailed: false,
         };
         activeOperations.set(operationId, active);
-        lifecycleLeaseTransferred = true;
+        executionClaimTransferred = true;
         queueMicrotask(() => {
           void executeOperation(
             active,
@@ -512,7 +515,7 @@ export function createOperationHost(options: {
           )
             .catch(() => undefined)
             .finally(async () => {
-              await lifecycleLease.release();
+              await executionClaim.release();
               active.ownerDidSettle = true;
               active.signalOwnerSettled();
               releaseActiveOperation(active, activeOperations);
@@ -520,8 +523,8 @@ export function createOperationHost(options: {
         });
         return { operationId };
       } finally {
-        if (!lifecycleLeaseTransferred) {
-          await lifecycleLease.release();
+        if (!executionClaimTransferred) {
+          await executionClaim.release();
         }
       }
     });
@@ -587,8 +590,8 @@ export function createOperationHost(options: {
       if (currentRecovery !== undefined) {
         return currentRecovery;
       }
-      const recovery = options.lifecycleOwner
-        .run(async () => {
+      const recovery = options.executionDomain
+        .runRoot({ rootId: projectRuntimeRootId }, async () => {
           const records = await store.read(operationId);
           if (records.length === 0) {
             throw new OperationHostError("operation_not_found");
@@ -694,8 +697,8 @@ export function createOperationHost(options: {
           return host.query(operationId);
         })
         .catch((error: unknown) => {
-          if (error instanceof ProjectLifecycleOwnerError) {
-            throw new OperationHostError(error.code, { cause: error });
+          if (error instanceof ProjectExecutionDomainError) {
+            throw new OperationHostError(operationOwnerErrorCode(error), { cause: error });
           }
           throw error;
         });
@@ -726,8 +729,8 @@ export function createOperationHost(options: {
       }
       const active = activeOperations.get(operationId);
       if (active === undefined) {
-        return options.lifecycleOwner
-          .run(async () => {
+        return options.executionDomain
+          .runRoot({ rootId: projectRuntimeRootId }, async () => {
             const records = await store.read(operationId);
             const current = createSnapshot(records, false, options.resolveOperation);
             if (
@@ -750,8 +753,8 @@ export function createOperationHost(options: {
             return host.query(operationId);
           })
           .catch((error: unknown) => {
-            if (error instanceof ProjectLifecycleOwnerError) {
-              throw new OperationHostError(error.code, { cause: error });
+            if (error instanceof ProjectExecutionDomainError) {
+              throw new OperationHostError(operationOwnerErrorCode(error), { cause: error });
             }
             throw error;
           });
@@ -2556,6 +2559,14 @@ function isTerminal(event: OperationEventRecord["event"]): event is DurableOpera
     event.type === "operation_failed" ||
     event.type === "operation_inspection_required"
   );
+}
+
+function operationOwnerErrorCode(
+  error: ProjectExecutionDomainError,
+): "project_in_use" | "project_owner_unavailable" {
+  return error.code === "root_conflict" || error.code === "project_in_use"
+    ? "project_in_use"
+    : "project_owner_unavailable";
 }
 
 function operationHostErrorMessage(code: OperationHostError["code"]): string {

--- a/packages/agent/src/project-execution-domain.ts
+++ b/packages/agent/src/project-execution-domain.ts
@@ -1,0 +1,160 @@
+import type {
+  ProjectLifecycleOwner,
+  ProjectLifecycleOwnerLease,
+} from "./project-lifecycle-owner.js";
+import { ProjectLifecycleOwnerError } from "./project-lifecycle-owner.js";
+
+export const projectRuntimeRootId = "project-runtime";
+
+export class ProjectExecutionDomainError extends Error {
+  readonly code:
+    | "domain_closed"
+    | "claim_released"
+    | "project_in_use"
+    | "project_owner_unavailable"
+    | "root_conflict";
+
+  constructor(code: ProjectExecutionDomainError["code"]) {
+    super(
+      code === "claim_released"
+        ? "The project execution claim has already been released."
+        : code === "domain_closed"
+          ? "The project execution domain is closed."
+          : code === "project_owner_unavailable"
+            ? "The OS-backed project lifecycle owner is unavailable."
+            : code === "project_in_use"
+              ? "Another process owns lifecycle mutations for this canonical project."
+              : "Another session or operation cannot start while this parent session owns active background children. Wait for or cancel them first.",
+    );
+    this.name = "ProjectExecutionDomainError";
+    this.code = code;
+  }
+}
+
+export type ProjectExecutionChildClaim = {
+  readonly childId: string;
+  release(): Promise<void>;
+};
+
+export type ProjectExecutionRootClaim = {
+  readonly rootId: string;
+  claimChild(input: { readonly childId: string }): Promise<ProjectExecutionChildClaim>;
+  release(): Promise<void>;
+};
+
+export type ProjectExecutionDomain = {
+  claimRoot(input: { readonly rootId: string }): Promise<ProjectExecutionRootClaim>;
+  runRoot<T>(input: { readonly rootId: string }, operation: () => Promise<T>): Promise<T>;
+  close(): Promise<void>;
+};
+
+export function createProjectExecutionDomain(options: {
+  readonly lifecycleOwner: ProjectLifecycleOwner;
+}): ProjectExecutionDomain {
+  let activeRootId: string | undefined;
+  let ownerLease: ProjectLifecycleOwnerLease | undefined;
+  let acquisitionPromise: Promise<ProjectLifecycleOwnerLease> | undefined;
+  let claimCount = 0;
+  let closed = false;
+  let closePromise: Promise<void> | undefined;
+  let resolveClose: (() => void) | undefined;
+
+  const releaseClaim = async () => {
+    claimCount -= 1;
+    if (claimCount !== 0) {
+      return;
+    }
+    const lease = ownerLease;
+    ownerLease = undefined;
+    activeRootId = undefined;
+    await lease?.release();
+    resolveClose?.();
+  };
+
+  const createRelease = () => {
+    let released = false;
+    return async () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      await releaseClaim();
+    };
+  };
+
+  const domain: ProjectExecutionDomain = {
+    async claimRoot({ rootId }) {
+      if (closed) {
+        throw new ProjectExecutionDomainError("domain_closed");
+      }
+      if (activeRootId !== undefined && activeRootId !== rootId) {
+        throw new ProjectExecutionDomainError("root_conflict");
+      }
+      activeRootId ??= rootId;
+      claimCount += 1;
+      if (ownerLease === undefined) {
+        try {
+          if (acquisitionPromise === undefined) {
+            acquisitionPromise = options.lifecycleOwner.acquire();
+          }
+          const acquisition = acquisitionPromise;
+          ownerLease = await acquisition;
+          if (acquisitionPromise === acquisition) {
+            acquisitionPromise = undefined;
+          }
+        } catch (error) {
+          acquisitionPromise = undefined;
+          await releaseClaim();
+          if (error instanceof ProjectLifecycleOwnerError) {
+            throw new ProjectExecutionDomainError(error.code);
+          }
+          throw error;
+        }
+      }
+      if (closed) {
+        await releaseClaim();
+        throw new ProjectExecutionDomainError("domain_closed");
+      }
+      let rootReleased = false;
+      return {
+        rootId,
+        async claimChild({ childId }) {
+          if (rootReleased || activeRootId !== rootId || ownerLease === undefined) {
+            throw new ProjectExecutionDomainError("claim_released");
+          }
+          if (closed) {
+            throw new ProjectExecutionDomainError("domain_closed");
+          }
+          claimCount += 1;
+          return { childId, release: createRelease() };
+        },
+        async release() {
+          if (rootReleased) {
+            return;
+          }
+          rootReleased = true;
+          await releaseClaim();
+        },
+      };
+    },
+    async runRoot(input, operation) {
+      const claim = await domain.claimRoot(input);
+      try {
+        return await operation();
+      } finally {
+        await claim.release();
+      }
+    },
+    close() {
+      closed = true;
+      closePromise ??=
+        claimCount === 0
+          ? Promise.resolve()
+          : new Promise<void>((resolve) => {
+              resolveClose = resolve;
+            });
+      return closePromise;
+    },
+  };
+  return domain;
+}

--- a/packages/agent/src/project-execution-domain.ts
+++ b/packages/agent/src/project-execution-domain.ts
@@ -54,10 +54,13 @@ export function createProjectExecutionDomain(options: {
   let activeRootId: string | undefined;
   let ownerLease: ProjectLifecycleOwnerLease | undefined;
   let acquisitionPromise: Promise<ProjectLifecycleOwnerLease> | undefined;
+  let finalReleasePromise: Promise<void> | undefined;
+  let finalReleaseFailure: { readonly error: unknown } | undefined;
   let claimCount = 0;
   let closed = false;
   let closePromise: Promise<void> | undefined;
   let resolveClose: (() => void) | undefined;
+  let rejectClose: ((error: unknown) => void) | undefined;
 
   const releaseClaim = async () => {
     claimCount -= 1;
@@ -65,10 +68,23 @@ export function createProjectExecutionDomain(options: {
       return;
     }
     const lease = ownerLease;
-    ownerLease = undefined;
-    activeRootId = undefined;
-    await lease?.release();
-    resolveClose?.();
+    const release = (async () => {
+      try {
+        await lease?.release();
+        ownerLease = undefined;
+        activeRootId = undefined;
+        resolveClose?.();
+      } catch (error) {
+        closed = true;
+        finalReleaseFailure = { error };
+        rejectClose?.(error);
+        throw error;
+      } finally {
+        finalReleasePromise = undefined;
+      }
+    })();
+    finalReleasePromise = release;
+    await release;
   };
 
   const createRelease = () => {
@@ -86,6 +102,9 @@ export function createProjectExecutionDomain(options: {
     async claimRoot({ rootId }) {
       if (closed) {
         throw new ProjectExecutionDomainError("domain_closed");
+      }
+      if (finalReleasePromise !== undefined) {
+        throw new ProjectExecutionDomainError("root_conflict");
       }
       if (activeRootId !== undefined && activeRootId !== rootId) {
         throw new ProjectExecutionDomainError("root_conflict");
@@ -148,11 +167,16 @@ export function createProjectExecutionDomain(options: {
     close() {
       closed = true;
       closePromise ??=
-        claimCount === 0
-          ? Promise.resolve()
-          : new Promise<void>((resolve) => {
-              resolveClose = resolve;
-            });
+        finalReleasePromise !== undefined
+          ? finalReleasePromise
+          : finalReleaseFailure !== undefined
+            ? Promise.reject(finalReleaseFailure.error)
+            : claimCount === 0
+              ? Promise.resolve()
+              : new Promise<void>((resolve, reject) => {
+                  resolveClose = resolve;
+                  rejectClose = reject;
+                });
       return closePromise;
     },
   };

--- a/packages/agent/src/project-execution-domain.ts
+++ b/packages/agent/src/project-execution-domain.ts
@@ -88,13 +88,10 @@ export function createProjectExecutionDomain(options: {
   };
 
   const createRelease = () => {
-    let released = false;
-    return async () => {
-      if (released) {
-        return;
-      }
-      released = true;
-      await releaseClaim();
+    let releasePromise: Promise<void> | undefined;
+    return () => {
+      releasePromise ??= releaseClaim();
+      return releasePromise;
     };
   };
 
@@ -134,11 +131,15 @@ export function createProjectExecutionDomain(options: {
         await releaseClaim();
         throw new ProjectExecutionDomainError("domain_closed");
       }
-      let rootReleased = false;
+      let rootReleasePromise: Promise<void> | undefined;
       return {
         rootId,
         async claimChild({ childId }) {
-          if (rootReleased || activeRootId !== rootId || ownerLease === undefined) {
+          if (
+            rootReleasePromise !== undefined ||
+            activeRootId !== rootId ||
+            ownerLease === undefined
+          ) {
             throw new ProjectExecutionDomainError("claim_released");
           }
           if (closed) {
@@ -147,12 +148,9 @@ export function createProjectExecutionDomain(options: {
           claimCount += 1;
           return { childId, release: createRelease() };
         },
-        async release() {
-          if (rootReleased) {
-            return;
-          }
-          rootReleased = true;
-          await releaseClaim();
+        release() {
+          rootReleasePromise ??= releaseClaim();
+          return rootReleasePromise;
         },
       };
     },

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -27,8 +27,8 @@ import {
 } from "./durable-model-response-policy.js";
 import {
   type ExtensionHost,
-  extensionProjectExecutionDomain,
   loadInternalExtensionSkillSources,
+  projectExecutionDomainForExtensionHost,
   withInternalExtensionSkillSourcesCurrent,
 } from "./extension-host.js";
 import {
@@ -915,9 +915,13 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         .catch(() => undefined);
     }
   };
+  const extensionExecutionDomain =
+    options.extensionHost === undefined
+      ? undefined
+      : projectExecutionDomainForExtensionHost(options.extensionHost);
   const executionDomain =
-    options[sessionProjectLifecycleOwner] === undefined && options.extensionHost !== undefined
-      ? options.extensionHost[extensionProjectExecutionDomain]
+    options[sessionProjectLifecycleOwner] === undefined && extensionExecutionDomain !== undefined
+      ? extensionExecutionDomain
       : createProjectExecutionDomain({
           lifecycleOwner:
             options[sessionProjectLifecycleOwner] ?? createProjectLifecycleOwner(options),

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -27,6 +27,7 @@ import {
 } from "./durable-model-response-policy.js";
 import {
   type ExtensionHost,
+  extensionProjectExecutionDomain,
   loadInternalExtensionSkillSources,
   withInternalExtensionSkillSourcesCurrent,
 } from "./extension-host.js";
@@ -91,9 +92,13 @@ import {
   type PlanShellEnvironmentV1,
 } from "./plan-shell-environment.js";
 import {
+  createProjectExecutionDomain,
+  ProjectExecutionDomainError,
+  projectRuntimeRootId,
+} from "./project-execution-domain.js";
+import {
   createProjectLifecycleOwner,
   type ProjectLifecycleOwner,
-  ProjectLifecycleOwnerError,
 } from "./project-lifecycle-owner.js";
 import {
   assemblePromptMessagesV1,
@@ -910,7 +915,13 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         .catch(() => undefined);
     }
   };
-  const owner = options[sessionProjectLifecycleOwner] ?? createProjectLifecycleOwner(options);
+  const executionDomain =
+    options[sessionProjectLifecycleOwner] === undefined && options.extensionHost !== undefined
+      ? options.extensionHost[extensionProjectExecutionDomain]
+      : createProjectExecutionDomain({
+          lifecycleOwner:
+            options[sessionProjectLifecycleOwner] ?? createProjectLifecycleOwner(options),
+        });
   const pendingMcpCatalogChanges = new Map<
     string,
     {
@@ -1025,7 +1036,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     if (active !== undefined && (kind === "title" || active.kind === "title")) {
       await active.settlement;
     }
-    const operationPromise = owner.run(operation);
+    const operationPromise = executionDomain.runRoot({ rootId: projectRuntimeRootId }, operation);
     const tracked = {
       kind,
       settlement: operationPromise.then(
@@ -1038,8 +1049,12 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     try {
       return await operationPromise;
     } catch (error) {
-      if (error instanceof ProjectLifecycleOwnerError) {
-        throw new SessionLifecycleError(error.code);
+      if (error instanceof ProjectExecutionDomainError) {
+        throw new SessionLifecycleError(
+          error.code === "root_conflict" || error.code === "project_in_use"
+            ? "project_in_use"
+            : "project_owner_unavailable",
+        );
       }
       throw error;
     } finally {
@@ -2546,6 +2561,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         } catch {
           durable = false;
         }
+        await executionDomain.close();
         return {
           status:
             hostResult.status === "closed" && durable

--- a/packages/testkit/src/operation-host.test.ts
+++ b/packages/testkit/src/operation-host.test.ts
@@ -588,6 +588,9 @@ test("ExtensionHost lists only linked operations inside an exact session prefix"
         sourceSequence: 3,
       },
     });
+    for await (const _record of host.operations.events({ operationId: included.operationId })) {
+      // A distinct operation root is eligible only after causal terminal settlement.
+    }
     const secondIncluded = await host.operations.startLinked({
       contributionId: "fixture.review",
       idempotencyKey: "linked-list-included-2",
@@ -598,11 +601,19 @@ test("ExtensionHost lists only linked operations inside an exact session prefix"
         sourceSequence: 5,
       },
     });
-    await host.operations.start({
+    for await (const _record of host.operations.events({
+      operationId: secondIncluded.operationId,
+    })) {
+      // A distinct operation root is eligible only after causal terminal settlement.
+    }
+    const legacy = await host.operations.start({
       contributionId: "fixture.review",
       idempotencyKey: "linked-list-legacy-1",
       input: { revision: "legacy" },
     });
+    for await (const _record of host.operations.events({ operationId: legacy.operationId })) {
+      // A distinct operation root is eligible only after causal terminal settlement.
+    }
     const afterPrefix = await host.operations.startLinked({
       contributionId: "fixture.review",
       idempotencyKey: "linked-list-after-prefix-1",
@@ -613,7 +624,10 @@ test("ExtensionHost lists only linked operations inside an exact session prefix"
         sourceSequence: 8,
       },
     });
-    await host.operations.startLinked({
+    for await (const _record of host.operations.events({ operationId: afterPrefix.operationId })) {
+      // A distinct operation root is eligible only after causal terminal settlement.
+    }
+    const otherSession = await host.operations.startLinked({
       contributionId: "fixture.review",
       idempotencyKey: "linked-list-other-session-1",
       input: { revision: "other" },
@@ -623,6 +637,11 @@ test("ExtensionHost lists only linked operations inside an exact session prefix"
         sourceSequence: 2,
       },
     });
+    for await (const _record of host.operations.events({
+      operationId: otherSession.operationId,
+    })) {
+      // A distinct operation root is eligible only after causal terminal settlement.
+    }
 
     await expect(host.operations.listLinked({ sessionId, throughSequence: 7 })).resolves.toEqual({
       items: [included, secondIncluded],

--- a/packages/testkit/src/project-execution-domain-owner.fixture.ts
+++ b/packages/testkit/src/project-execution-domain-owner.fixture.ts
@@ -1,0 +1,22 @@
+const { createProjectExecutionDomain, createProjectLifecycleOwner } = await import(
+  "@adam-agent/agent/internal-testing"
+);
+
+const workspaceRoot = requiredEnvironment("ADAM_AGENT_FIXTURE_WORKSPACE_ROOT");
+const stateRoot = requiredEnvironment("ADAM_AGENT_FIXTURE_STATE_ROOT");
+const domain = createProjectExecutionDomain({
+  lifecycleOwner: createProjectLifecycleOwner({ stateRoot, workspaceRoot }),
+});
+const root = await domain.claimRoot({ rootId: "parent-session" });
+await root.claimChild({ childId: "child-1" });
+await root.release();
+process.send?.("child-held");
+await new Promise<void>(() => {});
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value.length === 0) {
+    throw new Error(`Missing ${name}.`);
+  }
+  return value;
+}

--- a/packages/testkit/src/project-execution-domain-topology.test.ts
+++ b/packages/testkit/src/project-execution-domain-topology.test.ts
@@ -1,0 +1,16 @@
+import { readFile } from "node:fs/promises";
+
+import { expect, test } from "vitest";
+
+test("ProjectExecutionDomain is the sole production caller of ProjectLifecycleOwner", async () => {
+  const sources = await Promise.all(
+    ["extension-host.ts", "operation-host.ts", "session-lifecycle.ts"].map(async (fileName) => ({
+      fileName,
+      source: await readFile(new URL(`../../agent/src/${fileName}`, import.meta.url), "utf8"),
+    })),
+  );
+
+  for (const { fileName, source } of sources) {
+    expect.soft(source, fileName).not.toMatch(/(?:lifecycleOwner|owner)\.(?:acquire|run)\(/u);
+  }
+});

--- a/packages/testkit/src/project-execution-domain-topology.test.ts
+++ b/packages/testkit/src/project-execution-domain-topology.test.ts
@@ -1,16 +1,60 @@
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { expect, test } from "vitest";
 
+const agentSourceRoot = fileURLToPath(new URL("../../agent/src/", import.meta.url));
+
 test("ProjectExecutionDomain is the sole production caller of ProjectLifecycleOwner", async () => {
-  const sources = await Promise.all(
-    ["extension-host.ts", "operation-host.ts", "session-lifecycle.ts"].map(async (fileName) => ({
-      fileName,
-      source: await readFile(new URL(`../../agent/src/${fileName}`, import.meta.url), "utf8"),
-    })),
+  const sources = await productionAgentSources();
+  const ownerMethodCalls = sources.flatMap(({ path, source }) =>
+    [...source.matchAll(/\b([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\.(acquire|run)\(/gu)].map(
+      (match) => ({ call: `${match[1]}.${match[2]}`, path }),
+    ),
   );
 
-  for (const { fileName, source } of sources) {
-    expect.soft(source, fileName).not.toMatch(/(?:lifecycleOwner|owner)\.(?:acquire|run)\(/u);
-  }
+  expect(ownerMethodCalls).toEqual([
+    { call: "options.lifecycleOwner.acquire", path: "project-execution-domain.ts" },
+    { call: "session.run", path: "session-lifecycle.ts" },
+    { call: "coordinator.run", path: "tool-runtime.ts" },
+  ]);
+  expect(
+    sources.flatMap(({ path, source }) =>
+      /\[["'](?:acquire|run)["']\]/u.test(source) ? [path] : [],
+    ),
+  ).toEqual([]);
 });
+
+test("ProjectExecutionDomain stays out of the public ExtensionHost interface", async () => {
+  const extensionHostSource = await readFile(join(agentSourceRoot, "extension-host.ts"), "utf8");
+  const publicFacadeSource = await readFile(join(agentSourceRoot, "index.ts"), "utf8");
+  const interfaceSource = extensionHostSource.match(
+    /export interface ExtensionHost \{([\s\S]*?)\n\}/u,
+  )?.[1];
+
+  expect(interfaceSource).toBeDefined();
+  expect(interfaceSource).not.toMatch(/ProjectExecutionDomain|extensionProjectExecutionDomain/u);
+  expect(publicFacadeSource).not.toMatch(/ProjectExecutionDomain/u);
+});
+
+async function productionAgentSources(): Promise<readonly { path: string; source: string }[]> {
+  const entries = (await readdir(agentSourceRoot, { recursive: true }))
+    .filter(
+      (entry) =>
+        entry.endsWith(".ts") &&
+        !entry.endsWith(".test.ts") &&
+        !entry.endsWith(".os.test.ts") &&
+        !entry.endsWith(".fixture.ts"),
+    )
+    .sort();
+  return Promise.all(
+    entries.map(async (entry) => {
+      const absolutePath = join(agentSourceRoot, entry);
+      return {
+        path: relative(agentSourceRoot, absolutePath),
+        source: await readFile(absolutePath, "utf8"),
+      };
+    }),
+  );
+}

--- a/packages/testkit/src/project-execution-domain.os.test.ts
+++ b/packages/testkit/src/project-execution-domain.os.test.ts
@@ -1,0 +1,109 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  createProjectExecutionDomain,
+  createProjectLifecycleOwner,
+  ProjectExecutionDomainError,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+
+const ownerFixturePath = fileURLToPath(
+  new URL("../dist/project-execution-domain-owner.fixture.js", import.meta.url),
+);
+
+test("ProjectExecutionDomain keeps the real flock until the final child claim releases", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-project-domain-flock-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const first = createProjectExecutionDomain({
+    lifecycleOwner: createProjectLifecycleOwner({ stateRoot, workspaceRoot }),
+  });
+  const second = createProjectExecutionDomain({
+    lifecycleOwner: createProjectLifecycleOwner({ stateRoot, workspaceRoot }),
+  });
+
+  try {
+    const root = await first.claimRoot({ rootId: "parent-session" });
+    const child = await root.claimChild({ childId: "child-1" });
+    await root.release();
+
+    await expect(second.claimRoot({ rootId: "other-session" })).rejects.toEqual(
+      new ProjectExecutionDomainError("project_in_use"),
+    );
+
+    await child.release();
+    const admitted = await second.claimRoot({ rootId: "other-session" });
+    await admitted.release();
+  } finally {
+    await first.close();
+    await second.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("ProjectExecutionDomain restart loses live claims without retaining the real flock", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-project-domain-restart-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const owner = spawn(process.execPath, [ownerFixturePath], {
+    env: {
+      ...process.env,
+      ADAM_AGENT_FIXTURE_STATE_ROOT: stateRoot,
+      ADAM_AGENT_FIXTURE_WORKSPACE_ROOT: workspaceRoot,
+    },
+    stdio: ["ignore", "ignore", "pipe", "ipc"],
+  });
+
+  try {
+    await waitForMessage(owner, "child-held");
+    owner.kill("SIGKILL");
+    await waitForClose(owner);
+    const restarted = createProjectExecutionDomain({
+      lifecycleOwner: createProjectLifecycleOwner({ stateRoot, workspaceRoot }),
+    });
+
+    const admitted = await restarted.claimRoot({ rootId: "new-session" });
+    await admitted.release();
+    await restarted.close();
+  } finally {
+    if (owner.exitCode === null && owner.signalCode === null) {
+      owner.kill("SIGKILL");
+      await waitForClose(owner);
+    }
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+async function waitForMessage(child: ChildProcess, expected: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onMessage = (message: unknown) => {
+      if (message === expected) {
+        cleanup();
+        resolve();
+      }
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new Error(`Fixture closed before publishing ${expected}.`));
+    };
+    const cleanup = () => {
+      child.off("message", onMessage);
+      child.off("close", onClose);
+    };
+    child.on("message", onMessage);
+    child.once("close", onClose);
+  });
+}
+
+async function waitForClose(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  await new Promise<void>((resolve) => child.once("close", () => resolve()));
+}

--- a/packages/testkit/src/project-execution-domain.test.ts
+++ b/packages/testkit/src/project-execution-domain.test.ts
@@ -246,6 +246,31 @@ test("ProjectExecutionDomain close reports a failed final OS release", async () 
   const root = await domain.claimRoot({ rootId: "parent-session" });
 
   await expect(root.release()).rejects.toBe(releaseFailure);
+  await expect(root.release()).rejects.toBe(releaseFailure);
+  await expect(domain.close()).rejects.toBe(releaseFailure);
+});
+
+test("ProjectExecutionDomain preserves a failed final OS release for child retries", async () => {
+  const releaseFailure = new Error("injected child owner release failure");
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return {
+        async release() {
+          throw releaseFailure;
+        },
+      };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const root = await domain.claimRoot({ rootId: "parent-session" });
+  const child = await root.claimChild({ childId: "child-1" });
+  await root.release();
+
+  await expect(child.release()).rejects.toBe(releaseFailure);
+  await expect(child.release()).rejects.toBe(releaseFailure);
   await expect(domain.close()).rejects.toBe(releaseFailure);
 });
 

--- a/packages/testkit/src/project-execution-domain.test.ts
+++ b/packages/testkit/src/project-execution-domain.test.ts
@@ -192,6 +192,63 @@ test("ProjectExecutionDomain close fences an acquisition already in flight", asy
   expect(releases).toBe(1);
 });
 
+test("ProjectExecutionDomain close waits for a final OS release already in flight", async () => {
+  const ownerReleaseStarted = Promise.withResolvers<void>();
+  const allowOwnerRelease = Promise.withResolvers<void>();
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return {
+        async release() {
+          ownerReleaseStarted.resolve();
+          await allowOwnerRelease.promise;
+        },
+      };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const root = await domain.claimRoot({ rootId: "parent-session" });
+
+  const releasing = root.release();
+  await ownerReleaseStarted.promise;
+  const closing = domain.close().then(() => "closed" as const);
+  const firstSettlement = Promise.race([
+    closing,
+    domain
+      .claimRoot({ rootId: "parent-session" })
+      .catch((error: unknown) => ({ admissionError: error }) as const),
+  ]);
+
+  await expect(firstSettlement).resolves.toEqual({
+    admissionError: new ProjectExecutionDomainError("domain_closed"),
+  });
+  allowOwnerRelease.resolve();
+  await expect(Promise.all([releasing, closing])).resolves.toEqual([undefined, "closed"]);
+});
+
+test("ProjectExecutionDomain close reports a failed final OS release", async () => {
+  const releaseFailure = new Error("injected owner release failure");
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return {
+        async release() {
+          throw releaseFailure;
+        },
+      };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const root = await domain.claimRoot({ rootId: "parent-session" });
+
+  await expect(root.release()).rejects.toBe(releaseFailure);
+  await expect(domain.close()).rejects.toBe(releaseFailure);
+});
+
 test("ProjectExecutionDomain runs one operation under an exact root claim", async () => {
   let releases = 0;
   const owner: ProjectLifecycleOwner = {

--- a/packages/testkit/src/project-execution-domain.test.ts
+++ b/packages/testkit/src/project-execution-domain.test.ts
@@ -1,0 +1,235 @@
+import type {
+  ProjectLifecycleOwner,
+  ProjectLifecycleOwnerLease,
+} from "@adam-agent/agent/internal-testing";
+import {
+  createProjectExecutionDomain,
+  ProjectExecutionDomainError,
+  ProjectLifecycleOwnerError,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+
+test("ProjectExecutionDomain retains one owner for a subordinate claim and the same root", async () => {
+  let acquisitions = 0;
+  let releases = 0;
+  const owner: ProjectLifecycleOwner = {
+    async acquire(): Promise<ProjectLifecycleOwnerLease> {
+      acquisitions += 1;
+      let released = false;
+      return {
+        async release() {
+          if (released) {
+            return;
+          }
+          released = true;
+          releases += 1;
+        },
+      };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const parent = await domain.claimRoot({ rootId: "parent-session" });
+  const child = await parent.claimChild({ childId: "child-1" });
+
+  await parent.release();
+  const reentered = await domain.claimRoot({ rootId: "parent-session" });
+  await expect(domain.claimRoot({ rootId: "different-session" })).rejects.toEqual(
+    new ProjectExecutionDomainError("root_conflict"),
+  );
+  expect({ acquisitions, releases }).toEqual({ acquisitions: 1, releases: 0 });
+
+  await reentered.release();
+  expect(releases).toBe(0);
+  await child.release();
+  expect(releases).toBe(1);
+});
+
+test("ProjectExecutionDomain releases root and child claims idempotently", async () => {
+  let releases = 0;
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return {
+        async release() {
+          releases += 1;
+        },
+      };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const root = await domain.claimRoot({ rootId: "parent-session" });
+  const child = await root.claimChild({ childId: "child-1" });
+
+  await root.release();
+  await root.release();
+  await child.release();
+  await child.release();
+
+  expect(releases).toBe(1);
+});
+
+test("ProjectExecutionDomain close fences admission before draining subordinate claims", async () => {
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return { async release() {} };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const root = await domain.claimRoot({ rootId: "parent-session" });
+  const child = await root.claimChild({ childId: "child-1" });
+  await root.release();
+
+  const closing = domain.close().then(() => "closed" as const);
+  const firstSettlement = Promise.race([
+    closing,
+    domain
+      .claimRoot({ rootId: "parent-session" })
+      .catch((error: unknown) => ({ admissionError: error }) as const),
+  ]);
+
+  await expect(firstSettlement).resolves.toEqual({
+    admissionError: new ProjectExecutionDomainError("domain_closed"),
+  });
+  await child.release();
+  await expect(closing).resolves.toBe("closed");
+});
+
+test("ProjectExecutionDomain maps an unavailable OS owner without publishing a root", async () => {
+  const owner: ProjectLifecycleOwner = {
+    async acquire(): Promise<ProjectLifecycleOwnerLease> {
+      throw new ProjectLifecycleOwnerError("project_owner_unavailable");
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+
+  await expect(domain.claimRoot({ rootId: "parent-session" })).rejects.toEqual(
+    new ProjectExecutionDomainError("project_owner_unavailable"),
+  );
+});
+
+test("ProjectExecutionDomain preserves an external project-in-use rejection", async () => {
+  const owner: ProjectLifecycleOwner = {
+    async acquire(): Promise<ProjectLifecycleOwnerLease> {
+      throw new ProjectLifecycleOwnerError("project_in_use");
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+
+  await expect(domain.claimRoot({ rootId: "parent-session" })).rejects.toEqual(
+    new ProjectExecutionDomainError("project_in_use"),
+  );
+});
+
+test("ProjectExecutionDomain joins concurrent claims for the same root behind one acquisition", async () => {
+  const acquisitionStarted = Promise.withResolvers<void>();
+  const allowAcquisition = Promise.withResolvers<void>();
+  let acquisitions = 0;
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      acquisitions += 1;
+      acquisitionStarted.resolve();
+      await allowAcquisition.promise;
+      return { async release() {} };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+
+  const firstClaim = domain.claimRoot({ rootId: "parent-session" });
+  await acquisitionStarted.promise;
+  const secondClaim = domain.claimRoot({ rootId: "parent-session" });
+  allowAcquisition.resolve();
+  const [first, second] = await Promise.all([firstClaim, secondClaim]);
+
+  expect(acquisitions).toBe(1);
+  await first.release();
+  await second.release();
+});
+
+test("ProjectExecutionDomain close fences an acquisition already in flight", async () => {
+  const acquisitionStarted = Promise.withResolvers<void>();
+  const allowAcquisition = Promise.withResolvers<void>();
+  let releases = 0;
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      acquisitionStarted.resolve();
+      await allowAcquisition.promise;
+      return {
+        async release() {
+          releases += 1;
+        },
+      };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+
+  const claiming = domain.claimRoot({ rootId: "parent-session" });
+  await acquisitionStarted.promise;
+  const closing = domain.close();
+  allowAcquisition.resolve();
+
+  await expect(claiming).rejects.toEqual(new ProjectExecutionDomainError("domain_closed"));
+  await expect(closing).resolves.toBeUndefined();
+  expect(releases).toBe(1);
+});
+
+test("ProjectExecutionDomain runs one operation under an exact root claim", async () => {
+  let releases = 0;
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return {
+        async release() {
+          releases += 1;
+        },
+      };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+
+  await expect(domain.runRoot({ rootId: "parent-session" }, async () => "completed")).resolves.toBe(
+    "completed",
+  );
+  expect(releases).toBe(1);
+});
+
+test("ProjectExecutionDomain rejects a child minted from a released root claim", async () => {
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return { async release() {} };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const stale = await domain.claimRoot({ rootId: "parent-session" });
+  await stale.release();
+  const current = await domain.claimRoot({ rootId: "different-session" });
+
+  await expect(stale.claimChild({ childId: "stale-child" })).rejects.toEqual(
+    new ProjectExecutionDomainError("claim_released"),
+  );
+  await current.release();
+});

--- a/packages/testkit/src/session-lifecycle.test.ts
+++ b/packages/testkit/src/session-lifecycle.test.ts
@@ -38,7 +38,6 @@ import {
   inputResourceIngestBarrier,
   openJsonlSessionStore,
   type ProjectLifecycleOwner,
-  ProjectLifecycleOwnerError,
   planApprovalIntentBarrier,
   preparedDirectDeepSeekV2ContextProfile,
   type SessionRecord,
@@ -2880,47 +2879,23 @@ test("SessionLifecycle close causally joins an admitted naming mutation", async 
   }
 });
 
-test("SessionLifecycle close drains every admitted owner operation after acquisition reorder", async () => {
+test("SessionLifecycle close drains an admitted ProjectExecutionDomain acquisition", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-owner-drain-"));
   const stateRoot = join(testRoot, "state");
   const workspaceRoot = join(testRoot, "workspace");
   await mkdir(workspaceRoot);
-  const firstAcquisitionStarted = Promise.withResolvers<void>();
-  const releaseFirstAcquisition = Promise.withResolvers<void>();
-  const secondAcquisitionStarted = Promise.withResolvers<void>();
-  const releaseSecondAcquisition = Promise.withResolvers<void>();
-  let reorderAcquisitions = false;
-  let reorderedRun = 0;
-  let secondAcquisitionHeld = false;
+  const acquisitionStarted = Promise.withResolvers<void>();
+  const releaseAcquisition = Promise.withResolvers<void>();
+  let holdAcquisition = false;
   const owner: ProjectLifecycleOwner = {
     async acquire() {
+      if (holdAcquisition) {
+        acquisitionStarted.resolve();
+        await releaseAcquisition.promise;
+      }
       return { async release() {} };
     },
     async run(operation) {
-      if (!reorderAcquisitions) {
-        return operation();
-      }
-      reorderedRun += 1;
-      if (reorderedRun === 1) {
-        firstAcquisitionStarted.resolve();
-        await releaseFirstAcquisition.promise;
-        throw new ProjectLifecycleOwnerError("project_in_use");
-      }
-      if (reorderedRun === 2) {
-        secondAcquisitionHeld = true;
-        secondAcquisitionStarted.resolve();
-        try {
-          const result = await operation();
-          await releaseSecondAcquisition.promise;
-          return result;
-        } finally {
-          secondAcquisitionHeld = false;
-        }
-      }
-      if (secondAcquisitionHeld) {
-        releaseSecondAcquisition.resolve();
-        throw new ProjectLifecycleOwnerError("project_in_use");
-      }
       return operation();
     },
   };
@@ -2931,7 +2906,7 @@ test("SessionLifecycle close drains every admitted owner operation after acquisi
     [sessionCloseDrainBarrier]: {
       beforeWait({ activeCount }) {
         drainedCounts.push(activeCount);
-        releaseSecondAcquisition.resolve();
+        releaseAcquisition.resolve();
       },
     },
     [sessionProjectLifecycleOwner]: owner,
@@ -2939,27 +2914,19 @@ test("SessionLifecycle close drains every admitted owner operation after acquisi
 
   try {
     const created = await lifecycle.create({ targetIdentity });
-    reorderAcquisitions = true;
-    const firstNaming = lifecycle.setSessionManualName({
+    holdAcquisition = true;
+    const naming = lifecycle.setSessionManualName({
       sessionId: created.sessionId,
-      name: "Rejected first acquisition",
+      name: "Durable domain acquisition",
     });
-    await firstAcquisitionStarted.promise;
-    const secondNaming = lifecycle.setSessionManualName({
-      sessionId: created.sessionId,
-      name: "Durable reordered acquisition",
-    });
-    await secondAcquisitionStarted.promise;
-    releaseFirstAcquisition.resolve();
-    await expect(firstNaming).rejects.toMatchObject({ code: "project_in_use" });
+    await acquisitionStarted.promise;
     const closing = lifecycle.close();
 
-    await expect(secondNaming).resolves.toMatchObject({ status: "updated" });
+    await expect(naming).resolves.toMatchObject({ status: "updated" });
     await expect(closing).resolves.toEqual({ status: "closed" });
     expect(drainedCounts).toEqual([1]);
   } finally {
-    releaseFirstAcquisition.resolve();
-    releaseSecondAcquisition.resolve();
+    releaseAcquisition.resolve();
     await lifecycle.close();
     await rm(testRoot, { recursive: true, force: true });
   }
@@ -2980,20 +2947,19 @@ test("SessionLifecycle close joins title admission before returning", async () =
   let observeCloseDurability = false;
   const owner: ProjectLifecycleOwner = {
     async acquire() {
-      return { async release() {} };
-    },
-    async run(operation) {
       const hold = holdNextOwnerOperation;
       holdNextOwnerOperation = false;
       if (observeCloseDurability && !hold) {
         closeDurabilityStarted.resolve();
       }
-      const result = await operation();
       if (hold) {
         heldOwnerOperation.resolve();
         await releaseOwnerOperation.promise;
       }
-      return result;
+      return { async release() {} };
+    },
+    async run(operation) {
+      return operation();
     },
   };
   const closeOrder: string[] = [];

--- a/packages/testkit/src/trusted-mcp-host.test.ts
+++ b/packages/testkit/src/trusted-mcp-host.test.ts
@@ -1775,9 +1775,7 @@ test("SessionLifecycle retains its MCP lease while an activation claim precedes 
   };
   const secondActivationLeaseReady = Promise.withResolvers<void>();
   const allowSecondActivation = Promise.withResolvers<void>();
-  const cancellationReachedOwner = Promise.withResolvers<void>();
   let holdNextActivation = false;
-  let observeNextOwnerAcquire = false;
   let leaseAcquisitionCount = 0;
   let leaseReleaseCount = 0;
   const workspaceTrust: WorkspaceTrustController = {
@@ -1802,12 +1800,7 @@ test("SessionLifecycle retains its MCP lease while an activation claim precedes 
     workspaceRoot,
     workspaceTrust,
     [mcpTransportFactory]: peer,
-    [sessionProjectLifecycleOwner]: createQueuedProjectLifecycleOwner(() => {
-      if (observeNextOwnerAcquire) {
-        observeNextOwnerAcquire = false;
-        cancellationReachedOwner.resolve();
-      }
-    }),
+    [sessionProjectLifecycleOwner]: createQueuedProjectLifecycleOwner(),
     [workspaceMcpLeaseTransitionBarrier]: {
       async activationLeaseReady() {
         if (holdNextActivation) {
@@ -1852,7 +1845,6 @@ test("SessionLifecycle retains its MCP lease while an activation claim precedes 
       "The second MCP activation did not acquire its pre-generation lease claim.",
     );
     const firstTransportClosed = peer.nextClose("fixture");
-    observeNextOwnerAcquire = true;
     cancellingFirst = lifecycle.configureMcp({
       type: "cancel_configuration",
       sessionId: first.sessionId,
@@ -1864,9 +1856,9 @@ test("SessionLifecycle retains its MCP lease while an activation claim precedes 
       "The first MCP generation did not close while the second activation held its claim.",
     );
     await withFailureGuard(
-      cancellationReachedOwner.promise,
+      cancellingFirst,
       5_000,
-      "MCP cancellation did not finish its lease-release decision.",
+      "MCP cancellation did not finish under the re-entered project root.",
     );
     expect(leaseAcquisitionCount).toBe(1);
     expect(leaseReleaseCount).toBe(0);


### PR DESCRIPTION
## Summary
- add the package-private, ref-counted ProjectExecutionDomain as the sole ProjectLifecycleOwner caller
- share one project-runtime root across SessionLifecycle and Extension/Operation Host composition
- prove subordinate claims, exact root conflict, idempotent release including failures, close fencing, restart loss, and real flock ownership

## Evidence
- `pnpm quality:check` (82 files passed, 2 opt-in skipped; 1716 tests passed, 18 opt-in skipped)
- focused semantic/OS owner evidence and frozen Slice 4 scans
- independent GPT-5.6 Sol High Standards and Spec re-reviews: clean

Scope is strictly S4-A0. No AgentManager, managed-agent tools, stores, TUI, Web, Skills, mailbox, or later Slice 4 capability is added.