### PR TITLE
S4-A1: add foreground managed scout

### DIFF
--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -312,6 +312,9 @@ function formatPermissionPrompt(
   if (event.subject.type === "input_resource") {
     return `Allow ${event.name} for linked input resource ${quoteForTerminal(event.subject.occurrenceId)} [y/N] `;
   }
+  if (event.subject.type === "managed_agent_spawn") {
+    return `Allow ${event.subject.profile} foreground scout for this exact task (${event.subject.taskDigest}) [y/N] `;
+  }
   return `Allow ${event.name} for ${quoteForTerminal(event.subject.path)} [y/N] `;
 }
 
@@ -549,6 +552,7 @@ async function runCliCommand(activeCommand: CliCommand): Promise<void> {
 async function createRunLifecycle(modelTargets: ModelTargets): Promise<SessionLifecycle> {
   const artifactStore = createLazyFileArtifactStore(join(stateRoot, "artifacts"));
   return createSessionLifecycle({
+    managedAgentTools: "managed-agent-tools.a1.v1",
     modelTargets,
     preferences: createPresentationPreferences({ environment: userConfigurationEnvironment }),
     workspaceTrust: createWorkspaceTrust({
@@ -560,7 +564,7 @@ async function createRunLifecycle(modelTargets: ModelTargets): Promise<SessionLi
     tools: createCodingToolRegistry({ workspaceRoot, stateRoot, artifactStore }),
     permissions: createPermissionPolicy({
       allowedEffects: ["read"],
-      askedEffects: ["write", "execute"],
+      askedEffects: ["write", "execute", "delegate"],
     }),
   });
 }

--- a/apps/tui/src/project-runtime.ts
+++ b/apps/tui/src/project-runtime.ts
@@ -100,6 +100,7 @@ export async function createProductionProjectRuntime(
   const extensionSnapshot = await host.loadConfiguredExtensions();
   lifecycle = createSessionLifecycle({
     extensionHost: host,
+    managedAgentTools: "managed-agent-tools.a1.v1",
     modelTargets: options.modelTargets,
     permissions: options.permissions,
     preferences: options.preferences,

--- a/packages/agent/src/agent-session.ts
+++ b/packages/agent/src/agent-session.ts
@@ -136,6 +136,7 @@ import {
   createSessionUserContentMessageV1,
   validateSessionUserContentV1,
 } from "./structured-user-content.js";
+import type { ThinkingPolicySnapshotV1 } from "./thinking-policy.js";
 import {
   createTodoInputV1Schema,
   createTodoMutationV1,
@@ -178,6 +179,10 @@ type AgentSessionBaseDependencies = {
   readonly store: SessionStore;
 };
 
+export const sessionToolProfileNames = Symbol("adam-agent.session-tool-profile-names");
+export const sessionInitialThinkingPolicy = Symbol("adam-agent.session-initial-thinking-policy");
+export const sessionInitialMessages = Symbol("adam-agent.session-initial-messages");
+
 export type AgentSessionDependencies = AgentSessionBaseDependencies &
   (
     | {
@@ -214,6 +219,8 @@ export class AgentSession {
   readonly #durableOutputLimits: Required<AgentSessionDurableOutputLimits>;
   readonly #contextProfile: ContextProfile | undefined;
   readonly #maximumOutputTokens: number;
+  readonly #thinkingPolicy: ThinkingPolicySnapshotV1 | undefined;
+  readonly #initialMessages: readonly ModelMessage[];
   readonly #store: SessionStore<SessionRecord>;
   #activeAbortController: AbortController | undefined;
   #activeProviderAttempt:
@@ -279,13 +286,33 @@ export class AgentSession {
       throw new RangeError("The model output limit must be a positive safe integer.");
     }
     this.#maximumOutputTokens = maximumOutputTokens;
+    this.#thinkingPolicy =
+      this.#durableContext?.thinkingPolicy ??
+      (
+        dependencies as AgentSessionDependencies & {
+          readonly [sessionInitialThinkingPolicy]?: ThinkingPolicySnapshotV1;
+        }
+      )[sessionInitialThinkingPolicy];
+    this.#initialMessages =
+      this.#durableContext?.initialMessages ??
+      (
+        dependencies as AgentSessionDependencies & {
+          readonly [sessionInitialMessages]?: readonly ModelMessage[];
+        }
+      )[sessionInitialMessages] ??
+      [];
     this.#model = dependencies.model;
     this.#modalityProfile = dependencies.modalityProfile;
     const durablePromptContext = this.#durableContext?.promptContext;
+    const configuredToolNames = (
+      dependencies as AgentSessionDependencies & {
+        readonly [sessionToolProfileNames]?: readonly string[];
+      }
+    )[sessionToolProfileNames];
     const selectedToolNames =
       durablePromptContext === undefined
         ? this.#durableContext === undefined
-          ? [
+          ? (configuredToolNames ?? [
               "read_file",
               "search_repository",
               "write_file",
@@ -295,9 +322,12 @@ export class AgentSession {
               "get_todo",
               "list_todos",
               "update_todo",
-            ]
+            ])
           : ["read_file", "write_file", "edit_file", "run_shell"]
         : durablePromptContext.toolProfile.definitions.map((definition) => definition.name);
+    if (new Set(selectedToolNames).size !== selectedToolNames.length) {
+      throw new TypeError("The initial Tool Profile names must be unique.");
+    }
     this.#todoEnabled = hasTodoToolProfileV1(selectedToolNames.map((name) => ({ name })));
     this.#todo = this.#durableContext?.todo ?? emptyTodoStoreSnapshotV1();
     this.#tools =
@@ -596,7 +626,7 @@ export class AgentSession {
     }
     const messages: ModelMessage[] =
       resume === undefined
-        ? [...(this.#durableContext?.initialMessages ?? []), projectedUserMessage]
+        ? [...this.#initialMessages, projectedUserMessage]
         : resume.messages.map((message) => ({ ...message }));
     const toolResultsById = new Map<
       string,
@@ -863,9 +893,7 @@ export class AgentSession {
           maximumOutputTokens,
           purpose: "ordinary",
           signal,
-          ...(this.#durableContext?.thinkingPolicy === undefined
-            ? {}
-            : { thinkingPolicy: this.#durableContext.thinkingPolicy }),
+          ...(this.#thinkingPolicy === undefined ? {} : { thinkingPolicy: this.#thinkingPolicy }),
         })) {
           if (signal.aborted) {
             break;

--- a/packages/agent/src/agent-session.ts
+++ b/packages/agent/src/agent-session.ts
@@ -180,7 +180,6 @@ type AgentSessionBaseDependencies = {
 };
 
 export const sessionToolProfileNames = Symbol("adam-agent.session-tool-profile-names");
-export const sessionInitialThinkingPolicy = Symbol("adam-agent.session-initial-thinking-policy");
 
 export type AgentSessionDependencies = AgentSessionBaseDependencies &
   (
@@ -284,13 +283,7 @@ export class AgentSession {
       throw new RangeError("The model output limit must be a positive safe integer.");
     }
     this.#maximumOutputTokens = maximumOutputTokens;
-    this.#thinkingPolicy =
-      this.#durableContext?.thinkingPolicy ??
-      (
-        dependencies as AgentSessionDependencies & {
-          readonly [sessionInitialThinkingPolicy]?: ThinkingPolicySnapshotV1;
-        }
-      )[sessionInitialThinkingPolicy];
+    this.#thinkingPolicy = this.#durableContext?.thinkingPolicy;
     this.#model = dependencies.model;
     this.#modalityProfile = dependencies.modalityProfile;
     const durablePromptContext = this.#durableContext?.promptContext;

--- a/packages/agent/src/agent-session.ts
+++ b/packages/agent/src/agent-session.ts
@@ -181,7 +181,6 @@ type AgentSessionBaseDependencies = {
 
 export const sessionToolProfileNames = Symbol("adam-agent.session-tool-profile-names");
 export const sessionInitialThinkingPolicy = Symbol("adam-agent.session-initial-thinking-policy");
-export const sessionInitialMessages = Symbol("adam-agent.session-initial-messages");
 
 export type AgentSessionDependencies = AgentSessionBaseDependencies &
   (
@@ -220,7 +219,6 @@ export class AgentSession {
   readonly #contextProfile: ContextProfile | undefined;
   readonly #maximumOutputTokens: number;
   readonly #thinkingPolicy: ThinkingPolicySnapshotV1 | undefined;
-  readonly #initialMessages: readonly ModelMessage[];
   readonly #store: SessionStore<SessionRecord>;
   #activeAbortController: AbortController | undefined;
   #activeProviderAttempt:
@@ -293,14 +291,6 @@ export class AgentSession {
           readonly [sessionInitialThinkingPolicy]?: ThinkingPolicySnapshotV1;
         }
       )[sessionInitialThinkingPolicy];
-    this.#initialMessages =
-      this.#durableContext?.initialMessages ??
-      (
-        dependencies as AgentSessionDependencies & {
-          readonly [sessionInitialMessages]?: readonly ModelMessage[];
-        }
-      )[sessionInitialMessages] ??
-      [];
     this.#model = dependencies.model;
     this.#modalityProfile = dependencies.modalityProfile;
     const durablePromptContext = this.#durableContext?.promptContext;
@@ -626,7 +616,7 @@ export class AgentSession {
     }
     const messages: ModelMessage[] =
       resume === undefined
-        ? [...this.#initialMessages, projectedUserMessage]
+        ? [...(this.#durableContext?.initialMessages ?? []), projectedUserMessage]
         : resume.messages.map((message) => ({ ...message }));
     const toolResultsById = new Map<
       string,

--- a/packages/agent/src/artifact-store.ts
+++ b/packages/agent/src/artifact-store.ts
@@ -14,6 +14,15 @@ export type ToolArtifactSource = {
   readonly truncated: boolean;
 };
 
+export type ManagedAgentResultArtifactSourceV1 = {
+  readonly type: "managed_agent_result";
+  readonly schemaVersion: 1;
+  readonly agentId: string;
+  readonly attemptId: string;
+  readonly childSessionId: string;
+  readonly totalBytes: number;
+};
+
 export type McpToolResultArtifactSourceV1 = {
   readonly type: "mcp_tool_result";
   readonly schemaVersion: 1;
@@ -103,6 +112,7 @@ export type ArtifactSource =
   | ChangePreviewArtifactSource
   | ExtensionArtifactSource
   | InputResourceArtifactSourceV1
+  | ManagedAgentResultArtifactSourceV1
   | McpToolResultArtifactSourceV1
   | ModelResponseArtifactSource
   | PastedTextArtifactSourceV1

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -1,7 +1,6 @@
 /** Tests only. This internal fault-injection surface has no compatibility promise. */
 
 export {
-  sessionInitialMessages,
   sessionInitialThinkingPolicy,
   sessionToolProfileNames,
 } from "./agent-session.js";
@@ -16,8 +15,6 @@ export { digestContextRecordPrefix } from "./durable-context.js";
 export { createInputResourceUserMessageV1 } from "./input-resources.js";
 export {
   createAgentManager,
-  createInMemoryManagedAgentStore,
-  createJsonlManagedAgentStore,
   createManagedAgentToolRegistry,
   type ManagedAgentDeadlineScheduler,
   type ManagedAgentRecord,
@@ -25,6 +22,11 @@ export {
   ManagedAgentStoreError,
   recoverInterruptedManagedAgents,
 } from "./managed-agent.js";
+export { scoutManagedAgentProfileV1 } from "./managed-agent-profiles.js";
+export {
+  createInMemoryManagedAgentStore,
+  createJsonlManagedAgentStore,
+} from "./managed-agent-store.js";
 export type {
   McpBeforeToolDispatchBarrier,
   McpBootstrapScheduler,

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -1,9 +1,6 @@
 /** Tests only. This internal fault-injection surface has no compatibility promise. */
 
-export {
-  sessionInitialThinkingPolicy,
-  sessionToolProfileNames,
-} from "./agent-session.js";
+export { sessionToolProfileNames } from "./agent-session.js";
 export { AiSdkModelDriver as AiSdkModelDriverForTesting } from "./ai-sdk-model-driver.js";
 export {
   createObservedBiomeExecutionAdapter,

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -1,5 +1,10 @@
 /** Tests only. This internal fault-injection surface has no compatibility promise. */
 
+export {
+  sessionInitialMessages,
+  sessionInitialThinkingPolicy,
+  sessionToolProfileNames,
+} from "./agent-session.js";
 export { AiSdkModelDriver as AiSdkModelDriverForTesting } from "./ai-sdk-model-driver.js";
 export {
   createObservedBiomeExecutionAdapter,
@@ -9,6 +14,17 @@ export type { ContextProfile } from "./context-profile.js";
 export { DirectDeepSeekResponsesModelDriver as DirectDeepSeekResponsesModelDriverForTesting } from "./deepseek-responses-model-driver.js";
 export { digestContextRecordPrefix } from "./durable-context.js";
 export { createInputResourceUserMessageV1 } from "./input-resources.js";
+export {
+  createAgentManager,
+  createInMemoryManagedAgentStore,
+  createJsonlManagedAgentStore,
+  createManagedAgentToolRegistry,
+  type ManagedAgentDeadlineScheduler,
+  type ManagedAgentRecord,
+  type ManagedAgentStore,
+  ManagedAgentStoreError,
+  recoverInterruptedManagedAgents,
+} from "./managed-agent.js";
 export type {
   McpBeforeToolDispatchBarrier,
   McpBootstrapScheduler,
@@ -123,6 +139,7 @@ export {
   workspaceMcpLeaseTransitionBarrier,
 } from "./session-lifecycle.js";
 export {
+  createInMemorySessionStore,
   createInMemorySessionStoreDirectory,
   createJsonlSessionStoreDirectory,
   openJsonlSessionStore,
@@ -130,6 +147,7 @@ export {
   type SessionContextCompactionFailedRecord,
   type SessionContextCompactionInterruptedRecord,
   type SessionContextCompactionStartedRecord,
+  type SessionEventRecord,
   type SessionGenesisRecord,
   type SessionModelResponseCompletedRecord,
   type SessionProviderAttemptInterruptedRecord,

--- a/packages/agent/src/managed-agent-profiles.ts
+++ b/packages/agent/src/managed-agent-profiles.ts
@@ -1,0 +1,20 @@
+export const scoutManagedAgentProfileV1 = {
+  id: "scout.v1",
+  version: 1,
+  toolNames: ["read_file", "search_repository"],
+  allowedEffects: ["read"],
+  limits: {
+    maximumTurnsPerAttempt: 8,
+    maximumCumulativeTokens: 128_000,
+    maximumDeadlineMilliseconds: 10 * 60 * 1_000,
+  },
+  capabilities: {
+    background: false,
+    selectedSkills: false,
+    ambientExtensions: false,
+    parentCoordination: false,
+    nestedAgents: false,
+  },
+} as const;
+
+export type ScoutManagedAgentProfileV1 = typeof scoutManagedAgentProfileV1;

--- a/packages/agent/src/managed-agent-profiles.ts
+++ b/packages/agent/src/managed-agent-profiles.ts
@@ -1,4 +1,6 @@
-export const scoutManagedAgentProfileV1 = {
+import { createHash } from "node:crypto";
+
+const scoutManagedAgentProfileDefinitionV1 = {
   id: "scout.v1",
   version: 1,
   toolNames: ["read_file", "search_repository"],
@@ -6,7 +8,7 @@ export const scoutManagedAgentProfileV1 = {
   limits: {
     maximumTurnsPerAttempt: 8,
     maximumCumulativeTokens: 128_000,
-    maximumDeadlineMilliseconds: 10 * 60 * 1_000,
+    maximumDeadlineMilliseconds: 600_000 as const,
   },
   capabilities: {
     background: false,
@@ -16,5 +18,12 @@ export const scoutManagedAgentProfileV1 = {
     nestedAgents: false,
   },
 } as const;
+
+export const scoutManagedAgentProfileV1 = {
+  ...scoutManagedAgentProfileDefinitionV1,
+  digest: `sha256:${createHash("sha256")
+    .update(JSON.stringify(scoutManagedAgentProfileDefinitionV1))
+    .digest("hex")}` as const,
+};
 
 export type ScoutManagedAgentProfileV1 = typeof scoutManagedAgentProfileV1;

--- a/packages/agent/src/managed-agent-store.ts
+++ b/packages/agent/src/managed-agent-store.ts
@@ -1,0 +1,155 @@
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { chmod, mkdir, open, readFile, realpath } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import {
+  type ManagedAgentRecord,
+  type ManagedAgentStore,
+  ManagedAgentStoreError,
+  validateManagedAgentRecord,
+} from "./managed-agent.js";
+
+const maximumManagedAgentLogBytes = 32 * 1024 * 1024;
+const managedAgentAppendQueues = new Map<string, Promise<void>>();
+
+export function createInMemoryManagedAgentStore(): ManagedAgentStore {
+  const records: ManagedAgentRecord[] = [];
+  return {
+    async append(record) {
+      const validated = validateManagedAgentRecord(record, records);
+      const storedBytes = records.reduce(
+        (total, entry) => total + Buffer.byteLength(JSON.stringify(entry), "utf8") + 1,
+        0,
+      );
+      if (storedBytes + validated.byteLength > maximumManagedAgentLogBytes) {
+        throw new ManagedAgentStoreError("managed_agent_log_too_large");
+      }
+      records.push(validated.record);
+    },
+    async read() {
+      return [...records];
+    },
+  };
+}
+
+export async function createJsonlManagedAgentStore(options: {
+  readonly workspaceRoot: string;
+  readonly stateRoot?: string;
+}): Promise<ManagedAgentStore> {
+  const canonicalWorkspaceRoot = await realpath(options.workspaceRoot);
+  const projectKey = createHash("sha256").update(canonicalWorkspaceRoot).digest("hex");
+  const stateRoot = options.stateRoot ?? defaultManagedAgentStateRoot();
+  const projectsDirectory = join(stateRoot, "projects");
+  const projectDirectory = join(projectsDirectory, projectKey);
+  const managedAgentsDirectory = join(projectDirectory, "managed-agents");
+  for (const directory of [projectsDirectory, projectDirectory, managedAgentsDirectory]) {
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    await chmod(directory, 0o700);
+  }
+  const logPath = join(managedAgentsDirectory, "events-v1.jsonl");
+  await ensureManagedAgentLogFile(logPath);
+  await readManagedAgentLog(logPath);
+  return {
+    append(record) {
+      return enqueueManagedAgentAppend(logPath, async () => {
+        const records = await readManagedAgentLog(logPath);
+        const validated = validateManagedAgentRecord(record, records);
+        const storedBytes = records.reduce(
+          (total, entry) => total + Buffer.byteLength(JSON.stringify(entry), "utf8") + 1,
+          0,
+        );
+        if (storedBytes + validated.byteLength > maximumManagedAgentLogBytes) {
+          throw new ManagedAgentStoreError("managed_agent_log_too_large");
+        }
+        const file = await open(
+          logPath,
+          constants.O_APPEND | constants.O_RDWR | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+          0o600,
+        );
+        try {
+          const stats = await file.stat();
+          if (!stats.isFile()) {
+            throw new ManagedAgentStoreError("managed_agent_log_invalid");
+          }
+          await file.chmod(0o600);
+          await file.writeFile(`${validated.serialized}\n`, "utf8");
+          await file.sync();
+        } finally {
+          await file.close();
+        }
+      });
+    },
+    async read() {
+      await (managedAgentAppendQueues.get(logPath) ?? Promise.resolve());
+      return readManagedAgentLog(logPath);
+    },
+  };
+}
+
+async function ensureManagedAgentLogFile(path: string): Promise<void> {
+  const file = await open(
+    path,
+    constants.O_APPEND |
+      constants.O_CREAT |
+      constants.O_RDWR |
+      constants.O_NOFOLLOW |
+      constants.O_NONBLOCK,
+    0o600,
+  );
+  try {
+    const stats = await file.stat();
+    if (!stats.isFile()) {
+      throw new ManagedAgentStoreError("managed_agent_log_invalid");
+    }
+    await file.chmod(0o600);
+    await file.sync();
+  } finally {
+    await file.close();
+  }
+}
+
+async function readManagedAgentLog(path: string): Promise<readonly ManagedAgentRecord[]> {
+  const contents = await readFile(path, "utf8");
+  if (contents.length === 0) {
+    return [];
+  }
+  if (!contents.endsWith("\n")) {
+    throw new ManagedAgentStoreError("managed_agent_log_invalid");
+  }
+  const records: ManagedAgentRecord[] = [];
+  for (const line of contents.slice(0, -1).split("\n")) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line) as unknown;
+    } catch {
+      throw new ManagedAgentStoreError("managed_agent_log_invalid");
+    }
+    records.push(validateManagedAgentRecord(parsed, records).record);
+  }
+  return records;
+}
+
+function enqueueManagedAgentAppend(path: string, operation: () => Promise<void>): Promise<void> {
+  const previous = managedAgentAppendQueues.get(path) ?? Promise.resolve();
+  const queued = previous.then(operation, operation);
+  const settled = queued.then(
+    () => undefined,
+    () => undefined,
+  );
+  managedAgentAppendQueues.set(path, settled);
+  void settled.then(() => {
+    if (managedAgentAppendQueues.get(path) === settled) {
+      managedAgentAppendQueues.delete(path);
+    }
+  });
+  return queued;
+}
+
+function defaultManagedAgentStateRoot(): string {
+  const { XDG_STATE_HOME: xdgStateHome } = process.env;
+  return xdgStateHome === undefined || xdgStateHome.length === 0
+    ? join(homedir(), ".local", "state", "adam-agent")
+    : join(xdgStateHome, "adam-agent");
+}

--- a/packages/agent/src/managed-agent.ts
+++ b/packages/agent/src/managed-agent.ts
@@ -35,22 +35,22 @@ const managedAgentTaskSchema = z.strictObject({
     .refine((task) => Buffer.byteLength(task, "utf8") <= maximumManagedAgentTaskBytes),
 });
 const targetIdentitySchema = z.strictObject({
-  targetId: z.string(),
-  vendor: z.string(),
-  modelId: z.string(),
+  targetId: z.string().min(1).max(256),
+  vendor: z.string().min(1).max(128),
+  modelId: z.string().min(1).max(256),
   route: z.enum(["direct", "vercel-ai-gateway"]),
-  upstreamProviderId: z.string().optional(),
+  upstreamProviderId: z.string().min(1).max(128).optional(),
   profileVersion: z.number().int().positive(),
   certification: z.enum(["certified", "experimental"]),
 });
 const thinkingPolicySchema = z.strictObject({
   schemaVersion: z.literal(1),
-  requestedLevelId: z.string(),
-  effectiveLevelId: z.string(),
+  requestedLevelId: z.string().min(1).max(128),
+  effectiveLevelId: z.string().min(1).max(128),
   capability: z.strictObject({
-    id: z.string(),
+    id: z.string().min(1).max(256),
     version: z.literal(1),
-    digest: z.string().startsWith("sha256:"),
+    digest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
   }),
   mapping: z.discriminatedUnion("thinkingType", [
     z.strictObject({
@@ -74,7 +74,7 @@ const managedAgentTerminalOutputSchema = z.strictObject({
     z.strictObject({ text: z.string() }),
     z.strictObject({
       artifact: z.strictObject({
-        id: z.string().startsWith("sha256:"),
+        id: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
         mediaType: z.literal("text/plain; charset=utf-8"),
         byteCount: z.number().int().positive(),
       }),
@@ -90,7 +90,7 @@ const managedAgentTerminalOutputSchema = z.strictObject({
   cost: z.strictObject({ status: z.literal("unavailable") }),
   transcript: z.strictObject({
     sessionId: z.string().uuid(),
-    digest: z.string().startsWith("sha256:"),
+    digest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
     throughSequence: z.number().int().nonnegative(),
   }),
 });
@@ -238,7 +238,7 @@ const managedAgentRecordSchema = z.union([
       }),
       z.strictObject({
         artifact: z.strictObject({
-          id: z.string().startsWith("sha256:"),
+          id: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
           mediaType: z.literal("text/plain; charset=utf-8"),
           byteCount: z.number().int().positive(),
         }),

--- a/packages/agent/src/managed-agent.ts
+++ b/packages/agent/src/managed-agent.ts
@@ -115,7 +115,7 @@ export type ManagedAgentRecord =
         readonly maximumDeadlineMilliseconds: 600_000;
       };
       readonly taskDigest: `sha256:${string}`;
-      readonly task: string;
+      readonly childInputDigest: `sha256:${string}`;
       readonly targetIdentity: ModelTargetIdentity;
       readonly thinkingPolicy?: ThinkingPolicySnapshotV1;
       readonly repository?: {
@@ -257,10 +257,7 @@ const managedAgentRecordSchema = z.union([
       maximumDeadlineMilliseconds: z.literal(600_000),
     }),
     taskDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
-    task: z
-      .string()
-      .min(1)
-      .refine((task) => Buffer.byteLength(task, "utf8") <= maximumManagedAgentTaskBytes),
+    childInputDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
     targetIdentity: targetIdentitySchema,
     thinkingPolicy: thinkingPolicySchema.optional(),
     repository: z
@@ -391,7 +388,7 @@ export async function recoverInterruptedManagedAgents(
     const logicalRun = childRecords?.find(
       (record) => record.schemaVersion === 3 && record.record.type === "logical_run_started",
     );
-    const validIdentity =
+    const validGenesisIdentity =
       genesis?.schemaVersion === 3 &&
       genesis.record.type === "session_genesis" &&
       genesis.record.sessionId === admission.childSessionId &&
@@ -405,20 +402,11 @@ export async function recoverInterruptedManagedAgents(
         maximumDeadlineMilliseconds: scoutManagedAgentProfileV1.limits.maximumDeadlineMilliseconds,
       }) &&
       admission.parentRootId === `session:${admission.parentSessionId}` &&
-      logicalRun?.schemaVersion === 3 &&
-      logicalRun.record.type === "logical_run_started" &&
-      logicalRun.record.userMessage === childTaskMessage(admission.task) &&
-      digest(admission.task) === admission.taskDigest &&
-      isDeepStrictEqual(logicalRun.record.thinkingPolicy, admission.thinkingPolicy) &&
-      isDeepStrictEqual(logicalRun.record.limits, {
-        maxTurns: admission.limits.maximumTurns,
-        maxTokens: admission.limits.maximumTokens,
-      }) &&
       (admission.repository === undefined
         ? repository?.sources.length === 0
         : repository?.revision === admission.repository.revision &&
           repository.effectiveDigest === admission.repository.effectiveDigest);
-    if (childRecords !== undefined && !validIdentity) {
+    if (childRecords !== undefined && !validGenesisIdentity) {
       const terminal: ManagedAgentRecord = {
         schemaVersion: 1,
         type: "managed_agent_terminal",
@@ -461,6 +449,34 @@ export async function recoverInterruptedManagedAgents(
               transcriptDigest: digest(JSON.stringify(childRecords)),
               throughSequence: childRecords.at(-1)?.sequence ?? 0,
             }),
+      };
+      await store.append(terminal);
+      records = [...records, terminal];
+      terminalAttempts.add(admission.attemptId);
+      continue;
+    }
+    const validRunIdentity =
+      logicalRun?.schemaVersion === 3 &&
+      logicalRun.record.type === "logical_run_started" &&
+      digest(logicalRun.record.userMessage) === admission.childInputDigest &&
+      isDeepStrictEqual(logicalRun.record.thinkingPolicy, admission.thinkingPolicy) &&
+      isDeepStrictEqual(logicalRun.record.limits, {
+        maxTurns: admission.limits.maximumTurns,
+        maxTokens: admission.limits.maximumTokens,
+      });
+    if (childRecords !== undefined && !validRunIdentity) {
+      const terminal: ManagedAgentRecord = {
+        schemaVersion: 1,
+        type: "managed_agent_terminal",
+        sequence: records.length + 1,
+        agentId: admission.agentId,
+        attemptId: admission.attemptId,
+        childSessionId: admission.childSessionId,
+        status: "inspection_required",
+        error: {
+          code: "managed_agent_inspection_required",
+          message: "The durable child run does not match its Managed Agent admission.",
+        },
       };
       await store.append(terminal);
       records = [...records, terminal];
@@ -635,7 +651,6 @@ export function validateManagedAgentRecord(
   const candidate = parsed.data;
   if (candidate.type === "managed_agent_admitted") {
     if (
-      digest(candidate.task) !== candidate.taskDigest ||
       history.some(
         (record) =>
           record.agentId === candidate.agentId ||
@@ -824,7 +839,7 @@ export function createAgentManager(options: {
               scoutManagedAgentProfileV1.limits.maximumDeadlineMilliseconds,
           },
           taskDigest,
-          task: input.task,
+          childInputDigest: digest(childTaskMessage(input.task)),
           targetIdentity: options.targetIdentity,
           ...(options.thinkingPolicy === undefined
             ? {}

--- a/packages/agent/src/managed-agent.ts
+++ b/packages/agent/src/managed-agent.ts
@@ -1,0 +1,990 @@
+import { createHash, randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { chmod, mkdir, open, readFile, realpath } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { z } from "zod";
+import { AgentSession, sessionInitialThinkingPolicy } from "./agent-session.js";
+import type { ModelDriver, ModelMessage } from "./agent-session-contracts.js";
+import type { ArtifactReference, ArtifactStore } from "./artifact-store.js";
+import type { ContextProfile } from "./context-profile.js";
+import { scoutManagedAgentProfileV1 } from "./managed-agent-profiles.js";
+import type { ModelTargetIdentity } from "./model-targets.js";
+import type { ProjectExecutionRootClaim } from "./project-execution-domain.js";
+import { createPromptContextV1, type PromptContextRecord } from "./prompt-assembly.js";
+import { sessionDurableContext } from "./session-durable-context.js";
+import type { SessionRecord, SessionStore, SessionStoreDirectory } from "./session-store.js";
+import type { ThinkingPolicySnapshotV1 } from "./thinking-policy.js";
+import {
+  createInternalToolAdapter,
+  createInternalToolRegistry,
+  createReadToolRegistry,
+  type JsonValue,
+  type PermissionPolicy,
+  type ToolRegistry,
+  type ToolResult,
+} from "./tool-runtime.js";
+
+const maximumManagedAgentTaskBytes = 16 * 1024;
+const maximumManagedAgentResultBytes = 16 * 1024;
+const managedAgentTaskSchema = z.strictObject({
+  task: z
+    .string()
+    .min(1)
+    .refine((task) => Buffer.byteLength(task, "utf8") <= maximumManagedAgentTaskBytes),
+});
+const targetIdentitySchema = z.strictObject({
+  targetId: z.string(),
+  vendor: z.string(),
+  modelId: z.string(),
+  route: z.enum(["direct", "vercel-ai-gateway"]),
+  upstreamProviderId: z.string().optional(),
+  profileVersion: z.number().int().positive(),
+  certification: z.enum(["certified", "experimental"]),
+});
+const thinkingPolicySchema = z.strictObject({
+  schemaVersion: z.literal(1),
+  requestedLevelId: z.string(),
+  effectiveLevelId: z.string(),
+  capability: z.strictObject({
+    id: z.string(),
+    version: z.literal(1),
+    digest: z.string().startsWith("sha256:"),
+  }),
+  mapping: z.discriminatedUnion("thinkingType", [
+    z.strictObject({
+      requestPath: z.enum(["provider_options.deepseek", "reasoning.effort"]),
+      thinkingType: z.literal("disabled"),
+    }),
+    z.strictObject({
+      requestPath: z.enum(["provider_options.deepseek", "reasoning.effort"]),
+      thinkingType: z.literal("enabled"),
+      reasoningEffort: z.enum(["low", "high", "max"]),
+    }),
+  ]),
+  reasoningArtifact: z.literal("provider_reasoning"),
+});
+const managedAgentTerminalOutputSchema = z.strictObject({
+  agentId: z.string().uuid(),
+  attemptId: z.string().uuid(),
+  profile: z.literal("scout.v1"),
+  status: z.literal("completed"),
+  result: z.union([
+    z.strictObject({ text: z.string() }),
+    z.strictObject({
+      artifact: z.strictObject({
+        id: z.string().startsWith("sha256:"),
+        mediaType: z.literal("text/plain; charset=utf-8"),
+        byteCount: z.number().int().positive(),
+      }),
+    }),
+  ]),
+  targetIdentity: targetIdentitySchema,
+  thinkingPolicy: thinkingPolicySchema.optional(),
+  usage: z.strictObject({
+    inputTokens: z.number().int().nonnegative(),
+    outputTokens: z.number().int().nonnegative(),
+    reasoningTokens: z.number().int().nonnegative(),
+  }),
+  cost: z.strictObject({ status: z.literal("unavailable") }),
+  transcript: z.strictObject({
+    sessionId: z.string().uuid(),
+    digest: z.string().startsWith("sha256:"),
+    throughSequence: z.number().int().nonnegative(),
+  }),
+});
+
+export type ManagedAgentRecord =
+  | {
+      readonly schemaVersion: 1;
+      readonly type: "managed_agent_admitted";
+      readonly sequence: number;
+      readonly agentId: string;
+      readonly attemptId: string;
+      readonly childSessionId: string;
+      readonly parentSessionId: string;
+      readonly parentToolCallId: string;
+      readonly parentRootId: string;
+      readonly projectId: `sha256:${string}`;
+      readonly profile: "scout.v1";
+      readonly taskDigest: `sha256:${string}`;
+      readonly targetIdentity: ModelTargetIdentity;
+      readonly thinkingPolicy?: ThinkingPolicySnapshotV1;
+      readonly repository?: {
+        readonly revision: number;
+        readonly effectiveDigest: `sha256:${string}`;
+      };
+    }
+  | {
+      readonly schemaVersion: 1;
+      readonly type: "managed_agent_terminal";
+      readonly sequence: number;
+      readonly agentId: string;
+      readonly attemptId: string;
+      readonly childSessionId: string;
+      readonly status: "completed";
+      readonly result:
+        | { readonly text: string }
+        | {
+            readonly artifact: Pick<ArtifactReference, "id" | "mediaType" | "byteCount">;
+          };
+      readonly transcriptDigest: `sha256:${string}`;
+      readonly throughSequence: number;
+      readonly usage: {
+        readonly inputTokens: number;
+        readonly outputTokens: number;
+        readonly reasoningTokens: number;
+      };
+      readonly cost: { readonly status: "unavailable" };
+    }
+  | {
+      readonly schemaVersion: 1;
+      readonly type: "managed_agent_terminal";
+      readonly sequence: number;
+      readonly agentId: string;
+      readonly attemptId: string;
+      readonly childSessionId: string;
+      readonly status: "failed";
+      readonly error: { readonly code: string; readonly message: string };
+      readonly transcriptDigest: `sha256:${string}`;
+      readonly throughSequence: number;
+    }
+  | {
+      readonly schemaVersion: 1;
+      readonly type: "managed_agent_terminal";
+      readonly sequence: number;
+      readonly agentId: string;
+      readonly attemptId: string;
+      readonly childSessionId: string;
+      readonly status: "cancelled";
+      readonly reason: "caller";
+      readonly transcriptDigest: `sha256:${string}`;
+      readonly throughSequence: number;
+    }
+  | {
+      readonly schemaVersion: 1;
+      readonly type: "managed_agent_terminal";
+      readonly sequence: number;
+      readonly agentId: string;
+      readonly attemptId: string;
+      readonly childSessionId: string;
+      readonly status: "recovery_required";
+      readonly error: {
+        readonly code: "managed_agent_recovery_required";
+        readonly message: string;
+      };
+    };
+
+type ManagedAgentRecordInput = ManagedAgentRecord extends infer RecordType
+  ? RecordType extends ManagedAgentRecord
+    ? Omit<RecordType, "schemaVersion" | "sequence">
+    : never
+  : never;
+
+export type ManagedAgentStore = {
+  append(record: ManagedAgentRecord): Promise<void>;
+  read(): Promise<readonly ManagedAgentRecord[]>;
+};
+
+export class ManagedAgentStoreError extends Error {
+  readonly code: "managed_agent_log_invalid" | "managed_agent_log_too_large";
+
+  constructor(code: ManagedAgentStoreError["code"]) {
+    super(
+      code === "managed_agent_log_too_large"
+        ? "The Managed Agent lifecycle log exceeds its bound."
+        : "The Managed Agent lifecycle log is invalid.",
+    );
+    this.name = "ManagedAgentStoreError";
+    this.code = code;
+  }
+}
+
+const managedAgentRecordSchema = z.union([
+  z.strictObject({
+    schemaVersion: z.literal(1),
+    type: z.literal("managed_agent_admitted"),
+    sequence: z.number().int().positive(),
+    agentId: z.uuid(),
+    attemptId: z.uuid(),
+    childSessionId: z.uuid(),
+    parentSessionId: z.uuid(),
+    parentToolCallId: z.string().min(1).max(256),
+    parentRootId: z.string().min(1).max(256),
+    projectId: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+    profile: z.literal("scout.v1"),
+    taskDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+    targetIdentity: targetIdentitySchema,
+    thinkingPolicy: thinkingPolicySchema.optional(),
+    repository: z
+      .strictObject({
+        revision: z.number().int().positive(),
+        effectiveDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+      })
+      .optional(),
+  }),
+  z.strictObject({
+    schemaVersion: z.literal(1),
+    type: z.literal("managed_agent_terminal"),
+    sequence: z.number().int().positive(),
+    agentId: z.uuid(),
+    attemptId: z.uuid(),
+    childSessionId: z.uuid(),
+    status: z.literal("completed"),
+    result: z.union([
+      z.strictObject({
+        text: z.string().refine((text) => Buffer.byteLength(text, "utf8") <= 16 * 1024),
+      }),
+      z.strictObject({
+        artifact: z.strictObject({
+          id: z.string().startsWith("sha256:"),
+          mediaType: z.literal("text/plain; charset=utf-8"),
+          byteCount: z.number().int().positive(),
+        }),
+      }),
+    ]),
+    transcriptDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+    throughSequence: z.number().int().nonnegative(),
+    usage: z.strictObject({
+      inputTokens: z.number().int().nonnegative(),
+      outputTokens: z.number().int().nonnegative(),
+      reasoningTokens: z.number().int().nonnegative(),
+    }),
+    cost: z.strictObject({ status: z.literal("unavailable") }),
+  }),
+  z.strictObject({
+    schemaVersion: z.literal(1),
+    type: z.literal("managed_agent_terminal"),
+    sequence: z.number().int().positive(),
+    agentId: z.uuid(),
+    attemptId: z.uuid(),
+    childSessionId: z.uuid(),
+    status: z.literal("failed"),
+    error: z.strictObject({
+      code: z.string().min(1).max(128),
+      message: z.string().min(1).max(4_096),
+    }),
+    transcriptDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+    throughSequence: z.number().int().nonnegative(),
+  }),
+  z.strictObject({
+    schemaVersion: z.literal(1),
+    type: z.literal("managed_agent_terminal"),
+    sequence: z.number().int().positive(),
+    agentId: z.uuid(),
+    attemptId: z.uuid(),
+    childSessionId: z.uuid(),
+    status: z.literal("cancelled"),
+    reason: z.literal("caller"),
+    transcriptDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+    throughSequence: z.number().int().nonnegative(),
+  }),
+  z.strictObject({
+    schemaVersion: z.literal(1),
+    type: z.literal("managed_agent_terminal"),
+    sequence: z.number().int().positive(),
+    agentId: z.uuid(),
+    attemptId: z.uuid(),
+    childSessionId: z.uuid(),
+    status: z.literal("recovery_required"),
+    error: z.strictObject({
+      code: z.literal("managed_agent_recovery_required"),
+      message: z.string().min(1).max(4_096),
+    }),
+  }),
+]) as z.ZodType<ManagedAgentRecord>;
+
+const maximumManagedAgentRecordBytes = 1024 * 1024;
+const maximumManagedAgentLogBytes = 32 * 1024 * 1024;
+const managedAgentAppendQueues = new Map<string, Promise<void>>();
+
+export function createInMemoryManagedAgentStore(): ManagedAgentStore {
+  const records: ManagedAgentRecord[] = [];
+  return {
+    async append(record) {
+      const validated = validateManagedAgentRecord(record, records);
+      const storedBytes = records.reduce(
+        (total, entry) => total + Buffer.byteLength(JSON.stringify(entry), "utf8") + 1,
+        0,
+      );
+      if (storedBytes + validated.byteLength > maximumManagedAgentLogBytes) {
+        throw new ManagedAgentStoreError("managed_agent_log_too_large");
+      }
+      records.push(validated.record);
+    },
+    async read() {
+      return [...records];
+    },
+  };
+}
+
+export async function createJsonlManagedAgentStore(options: {
+  readonly workspaceRoot: string;
+  readonly stateRoot?: string;
+}): Promise<ManagedAgentStore> {
+  const canonicalWorkspaceRoot = await realpath(options.workspaceRoot);
+  const projectKey = createHash("sha256").update(canonicalWorkspaceRoot).digest("hex");
+  const stateRoot = options.stateRoot ?? defaultManagedAgentStateRoot();
+  const directories = [
+    join(stateRoot, "projects"),
+    join(stateRoot, "projects", projectKey),
+    join(stateRoot, "projects", projectKey, "managed-agents"),
+  ];
+  for (const directory of directories) {
+    await mkdir(directory, { recursive: true, mode: 0o700 });
+    await chmod(directory, 0o700);
+  }
+  const logPath = join(directories.at(-1) as string, "events-v1.jsonl");
+  await ensureManagedAgentLogFile(logPath);
+  await readManagedAgentLog(logPath);
+  return {
+    append(record) {
+      return enqueueManagedAgentAppend(logPath, async () => {
+        const records = await readManagedAgentLog(logPath);
+        const validated = validateManagedAgentRecord(record, records);
+        const storedBytes = records.reduce(
+          (total, entry) => total + Buffer.byteLength(JSON.stringify(entry), "utf8") + 1,
+          0,
+        );
+        if (storedBytes + validated.byteLength > maximumManagedAgentLogBytes) {
+          throw new ManagedAgentStoreError("managed_agent_log_too_large");
+        }
+        const file = await open(
+          logPath,
+          constants.O_APPEND | constants.O_RDWR | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+          0o600,
+        );
+        try {
+          const stats = await file.stat();
+          if (!stats.isFile()) {
+            throw new ManagedAgentStoreError("managed_agent_log_invalid");
+          }
+          await file.chmod(0o600);
+          await file.writeFile(`${validated.serialized}\n`, "utf8");
+          await file.sync();
+        } finally {
+          await file.close();
+        }
+      });
+    },
+    async read() {
+      await (managedAgentAppendQueues.get(logPath) ?? Promise.resolve());
+      return readManagedAgentLog(logPath);
+    },
+  };
+}
+
+export async function recoverInterruptedManagedAgents(
+  store: ManagedAgentStore,
+  childSessionStores?: SessionStoreDirectory<SessionRecord>,
+): Promise<void> {
+  let records = await store.read();
+  const terminalAttempts = new Set(
+    records.flatMap((record) =>
+      record.type === "managed_agent_terminal" ? [record.attemptId] : [],
+    ),
+  );
+  for (const admission of records) {
+    if (admission.type !== "managed_agent_admitted" || terminalAttempts.has(admission.attemptId)) {
+      continue;
+    }
+    const childStore = await childSessionStores?.open(admission.childSessionId);
+    const childRecords = await childStore?.read();
+    const childSettlement = childRecords
+      ?.flatMap((record) =>
+        record.schemaVersion === 1 || record.schemaVersion === 2
+          ? [record.event]
+          : record.record.type === "runtime_event"
+            ? [record.record.event]
+            : [],
+      )
+      .findLast((event) => event.type === "session_settled");
+    if (
+      childSettlement?.type === "session_settled" &&
+      childSettlement.result.status === "completed" &&
+      Buffer.byteLength(childSettlement.result.answer, "utf8") <= maximumManagedAgentResultBytes
+    ) {
+      const terminal: ManagedAgentRecord = {
+        schemaVersion: 1,
+        type: "managed_agent_terminal",
+        sequence: records.length + 1,
+        agentId: admission.agentId,
+        attemptId: admission.attemptId,
+        childSessionId: admission.childSessionId,
+        status: "completed",
+        result: { text: childSettlement.result.answer },
+        transcriptDigest: digest(JSON.stringify(childRecords)),
+        throughSequence: childRecords?.at(-1)?.sequence ?? 0,
+        usage: usageFromChildRecords(childRecords ?? []),
+        cost: { status: "unavailable" },
+      };
+      await store.append(terminal);
+      records = [...records, terminal];
+      terminalAttempts.add(admission.attemptId);
+      continue;
+    }
+    const terminal: ManagedAgentRecord = {
+      schemaVersion: 1,
+      type: "managed_agent_terminal",
+      sequence: records.length + 1,
+      agentId: admission.agentId,
+      attemptId: admission.attemptId,
+      childSessionId: admission.childSessionId,
+      status: "recovery_required",
+      error: {
+        code: "managed_agent_recovery_required",
+        message:
+          "The child process ended without a causally proven terminal result. Adam did not replay the interrupted model request.",
+      },
+    };
+    await store.append(terminal);
+    records = [...records, terminal];
+    terminalAttempts.add(admission.attemptId);
+  }
+}
+
+async function ensureManagedAgentLogFile(path: string): Promise<void> {
+  const file = await open(
+    path,
+    constants.O_APPEND |
+      constants.O_CREAT |
+      constants.O_RDWR |
+      constants.O_NOFOLLOW |
+      constants.O_NONBLOCK,
+    0o600,
+  );
+  try {
+    const stats = await file.stat();
+    if (!stats.isFile()) {
+      throw new ManagedAgentStoreError("managed_agent_log_invalid");
+    }
+    await file.chmod(0o600);
+    await file.sync();
+  } finally {
+    await file.close();
+  }
+}
+
+async function readManagedAgentLog(path: string): Promise<readonly ManagedAgentRecord[]> {
+  const contents = await readFile(path, "utf8");
+  if (contents.length === 0) {
+    return [];
+  }
+  if (!contents.endsWith("\n")) {
+    throw new ManagedAgentStoreError("managed_agent_log_invalid");
+  }
+  const records: ManagedAgentRecord[] = [];
+  for (const line of contents.slice(0, -1).split("\n")) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line) as unknown;
+    } catch {
+      throw new ManagedAgentStoreError("managed_agent_log_invalid");
+    }
+    records.push(validateManagedAgentRecord(parsed, records).record);
+  }
+  return records;
+}
+
+function validateManagedAgentRecord(
+  input: unknown,
+  history: readonly ManagedAgentRecord[],
+): {
+  readonly byteLength: number;
+  readonly record: ManagedAgentRecord;
+  readonly serialized: string;
+} {
+  const parsed = managedAgentRecordSchema.safeParse(input);
+  if (!parsed.success || parsed.data.sequence !== history.length + 1) {
+    throw new ManagedAgentStoreError("managed_agent_log_invalid");
+  }
+  const candidate = parsed.data;
+  if (candidate.type === "managed_agent_admitted") {
+    if (
+      history.some(
+        (record) =>
+          record.agentId === candidate.agentId ||
+          record.attemptId === candidate.attemptId ||
+          record.childSessionId === candidate.childSessionId,
+      )
+    ) {
+      throw new ManagedAgentStoreError("managed_agent_log_invalid");
+    }
+  } else {
+    const admission = history.find(
+      (record) =>
+        record.type === "managed_agent_admitted" && record.attemptId === candidate.attemptId,
+    );
+    if (
+      admission === undefined ||
+      admission.agentId !== candidate.agentId ||
+      admission.childSessionId !== candidate.childSessionId ||
+      history.some(
+        (record) =>
+          record.type === "managed_agent_terminal" && record.attemptId === candidate.attemptId,
+      )
+    ) {
+      throw new ManagedAgentStoreError("managed_agent_log_invalid");
+    }
+  }
+  const serialized = JSON.stringify(candidate);
+  const byteLength = Buffer.byteLength(serialized, "utf8") + 1;
+  if (byteLength > maximumManagedAgentRecordBytes) {
+    throw new ManagedAgentStoreError("managed_agent_log_too_large");
+  }
+  return { byteLength, record: candidate, serialized };
+}
+
+function enqueueManagedAgentAppend(path: string, operation: () => Promise<void>): Promise<void> {
+  const previous = managedAgentAppendQueues.get(path) ?? Promise.resolve();
+  const queued = previous.then(operation, operation);
+  const settled = queued.then(
+    () => undefined,
+    () => undefined,
+  );
+  managedAgentAppendQueues.set(path, settled);
+  void settled.then(() => {
+    if (managedAgentAppendQueues.get(path) === settled) {
+      managedAgentAppendQueues.delete(path);
+    }
+  });
+  return queued;
+}
+
+function defaultManagedAgentStateRoot(): string {
+  const { XDG_STATE_HOME: xdgStateHome } = process.env;
+  return xdgStateHome === undefined || xdgStateHome.length === 0
+    ? join(homedir(), ".local", "state", "adam-agent")
+    : join(xdgStateHome, "adam-agent");
+}
+
+export type AgentManager = {
+  readonly parentRootId: string;
+  readonly targetIdentity: ModelTargetIdentity;
+  readonly thinkingPolicy?: ThinkingPolicySnapshotV1;
+  spawnForeground(input: {
+    readonly callId: string;
+    readonly parentSessionId: string;
+    readonly signal: AbortSignal;
+    readonly task: string;
+  }): Promise<ToolResult>;
+};
+
+export type ManagedAgentDeadlineScheduler = {
+  schedule(delayMilliseconds: number, onDeadline: () => void): { cancel(): void };
+};
+
+const nodeManagedAgentDeadlineScheduler: ManagedAgentDeadlineScheduler = {
+  schedule(delayMilliseconds, onDeadline) {
+    const timer = setTimeout(onDeadline, delayMilliseconds);
+    timer.unref();
+    return { cancel: () => clearTimeout(timer) };
+  },
+};
+
+export function createAgentManager(options: {
+  readonly childContextProfile: ContextProfile;
+  readonly childModel: ModelDriver;
+  readonly artifactStore?: ArtifactStore;
+  readonly childSessionStores: SessionStoreDirectory<SessionRecord>;
+  readonly managedStore: ManagedAgentStore;
+  readonly parentPermissions: PermissionPolicy;
+  readonly deadlineScheduler?: ManagedAgentDeadlineScheduler;
+  readonly parentRoot: ProjectExecutionRootClaim;
+  readonly projectId: `sha256:${string}`;
+  readonly repository?: PromptContextRecord["repository"];
+  readonly targetIdentity: ModelTargetIdentity;
+  readonly thinkingPolicy?: ThinkingPolicySnapshotV1;
+  readonly workspaceRoot: string;
+}): AgentManager {
+  let appendQueue = Promise.resolve();
+  const appendManagedRecord = async (input: ManagedAgentRecordInput): Promise<void> => {
+    const operation = appendQueue.then(async () => {
+      const records = await options.managedStore.read();
+      await options.managedStore.append({
+        ...input,
+        schemaVersion: 1,
+        sequence: records.length + 1,
+      });
+    });
+    appendQueue = operation.catch(() => undefined);
+    await operation;
+  };
+  return {
+    parentRootId: options.parentRoot.rootId,
+    targetIdentity: options.targetIdentity,
+    ...(options.thinkingPolicy === undefined ? {} : { thinkingPolicy: options.thinkingPolicy }),
+    async spawnForeground(input) {
+      const existingAdmissions = (await options.managedStore.read()).filter(
+        (record) =>
+          record.type === "managed_agent_admitted" &&
+          record.parentSessionId === input.parentSessionId,
+      );
+      if (new Set(existingAdmissions.map((record) => record.agentId)).size >= 8) {
+        return toolFailure(
+          "managed_agent_capacity_exceeded",
+          "This parent session already owns the maximum eight managed child identities.",
+        );
+      }
+      const agentId = randomUUID();
+      const attemptId = randomUUID();
+      const childSessionId = randomUUID();
+      const taskDigest = digest(input.task);
+      const childClaim = await options.parentRoot.claimChild({ childId: agentId });
+      const childController = new AbortController();
+      let deadlineExpired = false;
+      const abortFromCaller = () => childController.abort(input.signal.reason);
+      if (input.signal.aborted) {
+        abortFromCaller();
+      } else {
+        input.signal.addEventListener("abort", abortFromCaller, { once: true });
+      }
+      const deadline = (options.deadlineScheduler ?? nodeManagedAgentDeadlineScheduler).schedule(
+        scoutManagedAgentProfileV1.limits.maximumDeadlineMilliseconds,
+        () => {
+          deadlineExpired = true;
+          childController.abort(new Error("Managed Agent deadline exceeded."));
+        },
+      );
+      try {
+        await appendManagedRecord({
+          type: "managed_agent_admitted",
+          agentId,
+          attemptId,
+          childSessionId,
+          parentSessionId: input.parentSessionId,
+          parentToolCallId: input.callId,
+          parentRootId: options.parentRoot.rootId,
+          projectId: options.projectId,
+          profile: "scout.v1",
+          taskDigest,
+          targetIdentity: options.targetIdentity,
+          ...(options.thinkingPolicy === undefined
+            ? {}
+            : { thinkingPolicy: options.thinkingPolicy }),
+          ...(options.repository === undefined
+            ? {}
+            : {
+                repository: {
+                  revision: options.repository.revision,
+                  effectiveDigest: options.repository.effectiveDigest,
+                },
+              }),
+        });
+        const childStore = await options.childSessionStores.create(childSessionId);
+        const childTools = createReadToolRegistry({ workspaceRoot: options.workspaceRoot });
+        const childPromptContext = createPromptContextV1(childTools, options.repository);
+        await childStore.append({
+          schemaVersion: 3,
+          sequence: 1,
+          record: {
+            type: "session_genesis",
+            recordVersion: 2,
+            sessionId: childSessionId,
+            projectId: options.projectId,
+            targetIdentity: options.targetIdentity,
+            contextProfile: options.childContextProfile,
+            promptContext: childPromptContext,
+          },
+        });
+        const initialMessages: ModelMessage[] = [
+          {
+            role: "developer",
+            content:
+              "Managed child profile scout.v1. Work only on the exact delegated task. Use repository reads only. Do not write, execute, use Web or MCP, select Skills, access extensions, spawn, coordinate with peers, or change model and permission authority.",
+          },
+        ];
+        const childPermissions: PermissionPolicy = {
+          decide(permission) {
+            if (permission.effect !== "read") {
+              return "deny";
+            }
+            return options.parentPermissions.decide(permission) === "allow" ? "allow" : "deny";
+          },
+        };
+        const childDependencies = {
+          contextProfile: options.childContextProfile,
+          model: options.childModel,
+          permissions: childPermissions,
+          store: childStore as SessionStore,
+          tools: childTools,
+          [sessionDurableContext]: {
+            initialMessages,
+            nextSequence: 2,
+            projectId: options.projectId,
+            promptContext: childPromptContext,
+            repositoryWorkspaceRoot: options.workspaceRoot,
+            authorizeProjectContextLoad: async () => true,
+            sessionId: childSessionId,
+            targetIdentity: options.targetIdentity,
+            ...(options.thinkingPolicy === undefined
+              ? {}
+              : { thinkingPolicy: options.thinkingPolicy }),
+          },
+          ...(options.thinkingPolicy === undefined
+            ? {}
+            : { [sessionInitialThinkingPolicy]: options.thinkingPolicy }),
+        };
+        const child = new AgentSession(childDependencies);
+        const result = await child.run(
+          {
+            text: `${input.task}\n\nThis child reads the live workspace. Parent changes may alter what it observes; isolated transcript does not mean repository snapshot or sandbox.`,
+          },
+          {
+            signal: childController.signal,
+            limits: {
+              maxTurns: scoutManagedAgentProfileV1.limits.maximumTurnsPerAttempt,
+              maxTokens: scoutManagedAgentProfileV1.limits.maximumCumulativeTokens,
+            },
+          },
+        );
+        const childRecords = await childStore.read();
+        const transcriptDigest = digest(JSON.stringify(childRecords));
+        const throughSequence = childRecords.at(-1)?.sequence ?? 0;
+        const usage = usageFromChildRecords(childRecords);
+        if (result.status === "cancelled") {
+          if (deadlineExpired) {
+            await appendManagedRecord({
+              type: "managed_agent_terminal",
+              agentId,
+              attemptId,
+              childSessionId,
+              status: "failed",
+              error: {
+                code: "managed_agent_deadline_exceeded",
+                message: "The foreground scout exceeded its aggregate deadline.",
+              },
+              transcriptDigest,
+              throughSequence,
+            });
+            return toolFailure(
+              "managed_agent_deadline_exceeded",
+              "The foreground scout deadline expired.",
+            );
+          }
+          await appendManagedRecord({
+            type: "managed_agent_terminal",
+            agentId,
+            attemptId,
+            childSessionId,
+            status: "cancelled",
+            reason: "caller",
+            transcriptDigest,
+            throughSequence,
+          });
+          return toolFailure("managed_agent_cancelled", "The foreground scout was cancelled.");
+        }
+        if (result.status !== "completed") {
+          const error =
+            result.status === "failed"
+              ? { code: result.error.code, message: result.error.message }
+              : {
+                  code: "model_output_truncated",
+                  message: "The foreground scout reached its output limit.",
+                };
+          await appendManagedRecord({
+            type: "managed_agent_terminal",
+            agentId,
+            attemptId,
+            childSessionId,
+            status: "failed",
+            error,
+            transcriptDigest,
+            throughSequence,
+          });
+          return toolFailure("managed_agent_failed", "The foreground scout did not complete.");
+        }
+        const resultBytes = Buffer.from(result.answer, "utf8");
+        const createTerminalOutput = (
+          terminalResult:
+            | { readonly text: string }
+            | {
+                readonly artifact: Pick<ArtifactReference, "id" | "mediaType" | "byteCount">;
+              },
+        ) => ({
+          agentId,
+          attemptId,
+          profile: "scout.v1" as const,
+          status: "completed" as const,
+          result: terminalResult,
+          targetIdentity: options.targetIdentity,
+          ...(options.thinkingPolicy === undefined
+            ? {}
+            : { thinkingPolicy: options.thinkingPolicy }),
+          transcript: {
+            sessionId: childSessionId,
+            digest: transcriptDigest,
+            throughSequence,
+          },
+          usage,
+          cost: { status: "unavailable" as const },
+        });
+        const inlineResult = { text: result.answer } as const;
+        const terminalResult =
+          Buffer.byteLength(JSON.stringify(createTerminalOutput(inlineResult)), "utf8") <=
+          maximumManagedAgentResultBytes
+            ? inlineResult
+            : options.artifactStore === undefined
+              ? undefined
+              : {
+                  artifact: await options.artifactStore
+                    .write({
+                      bytes: resultBytes,
+                      mediaType: "text/plain; charset=utf-8",
+                      source: {
+                        type: "managed_agent_result",
+                        schemaVersion: 1,
+                        agentId,
+                        attemptId,
+                        childSessionId,
+                        totalBytes: resultBytes.byteLength,
+                      },
+                    })
+                    .then(({ id, mediaType, byteCount }) => ({ id, mediaType, byteCount })),
+                };
+        if (terminalResult === undefined) {
+          await appendManagedRecord({
+            type: "managed_agent_terminal",
+            agentId,
+            attemptId,
+            childSessionId,
+            status: "failed",
+            error: {
+              code: "managed_agent_result_too_large",
+              message: "The foreground scout result exceeds its inline bound.",
+            },
+            transcriptDigest,
+            throughSequence,
+          });
+          return toolFailure(
+            "managed_agent_result_too_large",
+            "The foreground scout result exceeds its bound.",
+          );
+        }
+        await appendManagedRecord({
+          type: "managed_agent_terminal",
+          agentId,
+          attemptId,
+          childSessionId,
+          status: "completed",
+          result: terminalResult,
+          transcriptDigest,
+          throughSequence,
+          usage,
+          cost: { status: "unavailable" },
+        });
+        return {
+          status: "completed",
+          output: createTerminalOutput(terminalResult),
+        };
+      } catch {
+        return toolFailure(
+          "managed_agent_unavailable",
+          "The foreground scout could not be started safely.",
+        );
+      } finally {
+        deadline.cancel();
+        input.signal.removeEventListener("abort", abortFromCaller);
+        await childClaim.release();
+      }
+    },
+  };
+}
+
+export function createManagedAgentToolRegistry(options: {
+  readonly manager: AgentManager;
+}): ToolRegistry {
+  const adapter = createInternalToolAdapter(
+    {
+      definition: {
+        name: "spawn_agent",
+        description:
+          "Run one foreground read-only scout with fresh bounded context. It cannot run in background, select Skills, write, execute, spawn, inherit extensions, or change its model or permissions.",
+        inputSchema: z.toJSONSchema(managedAgentTaskSchema),
+      },
+      outputSchema: managedAgentTerminalOutputSchema as z.ZodType<JsonValue>,
+      effect: "delegate",
+      cancellation: "abort_signal",
+      maximumResult: { maximumBytes: maximumManagedAgentResultBytes },
+      prepare(argumentsJson) {
+        const parsed = managedAgentTaskSchema.safeParse(parseJson(argumentsJson));
+        if (!parsed.success) {
+          return toolFailure("invalid_tool_input", "Tool input is invalid.");
+        }
+        return {
+          status: "ready",
+          permissionSubject: {
+            type: "managed_agent_spawn",
+            parentRootId: options.manager.parentRootId,
+            profile: "scout.v1",
+            targetIdentity: options.manager.targetIdentity,
+            taskDigest: digest(parsed.data.task),
+            ...(options.manager.thinkingPolicy === undefined
+              ? {}
+              : { thinkingPolicy: options.manager.thinkingPolicy }),
+          },
+          execute(context) {
+            return options.manager.spawnForeground({
+              callId: context.callId,
+              parentSessionId: context.sessionId,
+              signal: context.signal,
+              task: parsed.data.task,
+            });
+          },
+        };
+      },
+    },
+    "never",
+  );
+  return createInternalToolRegistry([adapter]);
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function digest(value: string): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function usageFromChildRecords(records: readonly SessionRecord[]): {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly reasoningTokens: number;
+} {
+  return records.reduce(
+    (total, record) => {
+      const response =
+        record.schemaVersion === 3 && record.record.type === "model_response_completed"
+          ? record.record.response
+          : undefined;
+      return response?.usage === undefined
+        ? total
+        : {
+            inputTokens: total.inputTokens + response.usage.inputTokens,
+            outputTokens: total.outputTokens + response.usage.outputTokens,
+            reasoningTokens: total.reasoningTokens + (response.usage.reasoningTokens ?? 0),
+          };
+    },
+    { inputTokens: 0, outputTokens: 0, reasoningTokens: 0 },
+  );
+}
+
+function toolFailure(
+  code:
+    | "invalid_tool_input"
+    | "managed_agent_cancelled"
+    | "managed_agent_capacity_exceeded"
+    | "managed_agent_deadline_exceeded"
+    | "managed_agent_failed"
+    | "managed_agent_result_too_large"
+    | "managed_agent_unavailable",
+  message: string,
+): Extract<ToolResult, { readonly status: "failed" }> {
+  return { status: "failed", error: { code, message } };
+}

--- a/packages/agent/src/managed-agent.ts
+++ b/packages/agent/src/managed-agent.ts
@@ -1,8 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { constants } from "node:fs";
-import { chmod, mkdir, open, readFile, realpath } from "node:fs/promises";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { isDeepStrictEqual } from "node:util";
 
 import { z } from "zod";
 import { AgentSession, sessionInitialThinkingPolicy } from "./agent-session.js";
@@ -69,6 +66,7 @@ const managedAgentTerminalOutputSchema = z.strictObject({
   agentId: z.string().uuid(),
   attemptId: z.string().uuid(),
   profile: z.literal("scout.v1"),
+  profileDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
   status: z.literal("completed"),
   result: z.union([
     z.strictObject({ text: z.string() }),
@@ -108,6 +106,12 @@ export type ManagedAgentRecord =
       readonly parentRootId: string;
       readonly projectId: `sha256:${string}`;
       readonly profile: "scout.v1";
+      readonly profileDigest: `sha256:${string}`;
+      readonly limits: {
+        readonly maximumTurns: 8;
+        readonly maximumTokens: 128_000;
+        readonly maximumDeadlineMilliseconds: 600_000;
+      };
       readonly taskDigest: `sha256:${string}`;
       readonly targetIdentity: ModelTargetIdentity;
       readonly thinkingPolicy?: ThinkingPolicySnapshotV1;
@@ -174,6 +178,19 @@ export type ManagedAgentRecord =
         readonly code: "managed_agent_recovery_required";
         readonly message: string;
       };
+    }
+  | {
+      readonly schemaVersion: 1;
+      readonly type: "managed_agent_terminal";
+      readonly sequence: number;
+      readonly agentId: string;
+      readonly attemptId: string;
+      readonly childSessionId: string;
+      readonly status: "inspection_required";
+      readonly error: {
+        readonly code: "managed_agent_inspection_required";
+        readonly message: string;
+      };
     };
 
 type ManagedAgentRecordInput = ManagedAgentRecord extends infer RecordType
@@ -214,6 +231,12 @@ const managedAgentRecordSchema = z.union([
     parentRootId: z.string().min(1).max(256),
     projectId: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
     profile: z.literal("scout.v1"),
+    profileDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+    limits: z.strictObject({
+      maximumTurns: z.literal(8),
+      maximumTokens: z.literal(128_000),
+      maximumDeadlineMilliseconds: z.literal(600_000),
+    }),
     taskDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
     targetIdentity: targetIdentitySchema,
     thinkingPolicy: thinkingPolicySchema.optional(),
@@ -293,91 +316,27 @@ const managedAgentRecordSchema = z.union([
       message: z.string().min(1).max(4_096),
     }),
   }),
+  z.strictObject({
+    schemaVersion: z.literal(1),
+    type: z.literal("managed_agent_terminal"),
+    sequence: z.number().int().positive(),
+    agentId: z.uuid(),
+    attemptId: z.uuid(),
+    childSessionId: z.uuid(),
+    status: z.literal("inspection_required"),
+    error: z.strictObject({
+      code: z.literal("managed_agent_inspection_required"),
+      message: z.string().min(1).max(4_096),
+    }),
+  }),
 ]) as z.ZodType<ManagedAgentRecord>;
 
 const maximumManagedAgentRecordBytes = 1024 * 1024;
-const maximumManagedAgentLogBytes = 32 * 1024 * 1024;
-const managedAgentAppendQueues = new Map<string, Promise<void>>();
-
-export function createInMemoryManagedAgentStore(): ManagedAgentStore {
-  const records: ManagedAgentRecord[] = [];
-  return {
-    async append(record) {
-      const validated = validateManagedAgentRecord(record, records);
-      const storedBytes = records.reduce(
-        (total, entry) => total + Buffer.byteLength(JSON.stringify(entry), "utf8") + 1,
-        0,
-      );
-      if (storedBytes + validated.byteLength > maximumManagedAgentLogBytes) {
-        throw new ManagedAgentStoreError("managed_agent_log_too_large");
-      }
-      records.push(validated.record);
-    },
-    async read() {
-      return [...records];
-    },
-  };
-}
-
-export async function createJsonlManagedAgentStore(options: {
-  readonly workspaceRoot: string;
-  readonly stateRoot?: string;
-}): Promise<ManagedAgentStore> {
-  const canonicalWorkspaceRoot = await realpath(options.workspaceRoot);
-  const projectKey = createHash("sha256").update(canonicalWorkspaceRoot).digest("hex");
-  const stateRoot = options.stateRoot ?? defaultManagedAgentStateRoot();
-  const directories = [
-    join(stateRoot, "projects"),
-    join(stateRoot, "projects", projectKey),
-    join(stateRoot, "projects", projectKey, "managed-agents"),
-  ];
-  for (const directory of directories) {
-    await mkdir(directory, { recursive: true, mode: 0o700 });
-    await chmod(directory, 0o700);
-  }
-  const logPath = join(directories.at(-1) as string, "events-v1.jsonl");
-  await ensureManagedAgentLogFile(logPath);
-  await readManagedAgentLog(logPath);
-  return {
-    append(record) {
-      return enqueueManagedAgentAppend(logPath, async () => {
-        const records = await readManagedAgentLog(logPath);
-        const validated = validateManagedAgentRecord(record, records);
-        const storedBytes = records.reduce(
-          (total, entry) => total + Buffer.byteLength(JSON.stringify(entry), "utf8") + 1,
-          0,
-        );
-        if (storedBytes + validated.byteLength > maximumManagedAgentLogBytes) {
-          throw new ManagedAgentStoreError("managed_agent_log_too_large");
-        }
-        const file = await open(
-          logPath,
-          constants.O_APPEND | constants.O_RDWR | constants.O_NOFOLLOW | constants.O_NONBLOCK,
-          0o600,
-        );
-        try {
-          const stats = await file.stat();
-          if (!stats.isFile()) {
-            throw new ManagedAgentStoreError("managed_agent_log_invalid");
-          }
-          await file.chmod(0o600);
-          await file.writeFile(`${validated.serialized}\n`, "utf8");
-          await file.sync();
-        } finally {
-          await file.close();
-        }
-      });
-    },
-    async read() {
-      await (managedAgentAppendQueues.get(logPath) ?? Promise.resolve());
-      return readManagedAgentLog(logPath);
-    },
-  };
-}
 
 export async function recoverInterruptedManagedAgents(
   store: ManagedAgentStore,
   childSessionStores?: SessionStoreDirectory<SessionRecord>,
+  artifactStore?: ArtifactStore,
 ): Promise<void> {
   let records = await store.read();
   const terminalAttempts = new Set(
@@ -391,6 +350,75 @@ export async function recoverInterruptedManagedAgents(
     }
     const childStore = await childSessionStores?.open(admission.childSessionId);
     const childRecords = await childStore?.read();
+    const genesis = childRecords?.[0];
+    const repository =
+      genesis?.schemaVersion === 3 && genesis.record.type === "session_genesis"
+        ? genesis.record.promptContext?.repository
+        : undefined;
+    const expectedPromptContext =
+      repository === undefined
+        ? undefined
+        : createPromptContextV1(
+            createReadToolRegistry({ workspaceRoot: process.cwd() }),
+            repository,
+          );
+    const validIdentity =
+      genesis?.schemaVersion === 3 &&
+      genesis.record.type === "session_genesis" &&
+      genesis.record.sessionId === admission.childSessionId &&
+      genesis.record.projectId === admission.projectId &&
+      isDeepStrictEqual(genesis.record.targetIdentity, admission.targetIdentity) &&
+      isDeepStrictEqual(genesis.record.promptContext, expectedPromptContext) &&
+      admission.profileDigest === scoutManagedAgentProfileV1.digest &&
+      isDeepStrictEqual(admission.limits, {
+        maximumTurns: scoutManagedAgentProfileV1.limits.maximumTurnsPerAttempt,
+        maximumTokens: scoutManagedAgentProfileV1.limits.maximumCumulativeTokens,
+        maximumDeadlineMilliseconds: scoutManagedAgentProfileV1.limits.maximumDeadlineMilliseconds,
+      }) &&
+      admission.parentRootId === `session:${admission.parentSessionId}` &&
+      (admission.repository === undefined
+        ? repository?.sources.length === 0
+        : repository?.revision === admission.repository.revision &&
+          repository.effectiveDigest === admission.repository.effectiveDigest);
+    if (childRecords !== undefined && !validIdentity) {
+      const terminal: ManagedAgentRecord = {
+        schemaVersion: 1,
+        type: "managed_agent_terminal",
+        sequence: records.length + 1,
+        agentId: admission.agentId,
+        attemptId: admission.attemptId,
+        childSessionId: admission.childSessionId,
+        status: "inspection_required",
+        error: {
+          code: "managed_agent_inspection_required",
+          message: "The durable child identity does not match its Managed Agent admission.",
+        },
+      };
+      await store.append(terminal);
+      records = [...records, terminal];
+      terminalAttempts.add(admission.attemptId);
+      continue;
+    }
+    if (childRecords === undefined) {
+      const terminal: ManagedAgentRecord = {
+        schemaVersion: 1,
+        type: "managed_agent_terminal",
+        sequence: records.length + 1,
+        agentId: admission.agentId,
+        attemptId: admission.attemptId,
+        childSessionId: admission.childSessionId,
+        status: "recovery_required",
+        error: {
+          code: "managed_agent_recovery_required",
+          message:
+            "The child process ended without a causally proven terminal result. Adam did not replay the interrupted model request.",
+        },
+      };
+      await store.append(terminal);
+      records = [...records, terminal];
+      terminalAttempts.add(admission.attemptId);
+      continue;
+    }
     const childSettlement = childRecords
       ?.flatMap((record) =>
         record.schemaVersion === 1 || record.schemaVersion === 2
@@ -400,94 +428,131 @@ export async function recoverInterruptedManagedAgents(
             : [],
       )
       .findLast((event) => event.type === "session_settled");
-    if (
-      childSettlement?.type === "session_settled" &&
-      childSettlement.result.status === "completed" &&
-      Buffer.byteLength(childSettlement.result.answer, "utf8") <= maximumManagedAgentResultBytes
-    ) {
-      const terminal: ManagedAgentRecord = {
+    const transcriptDigest = digest(JSON.stringify(childRecords));
+    const throughSequence = childRecords?.at(-1)?.sequence ?? 0;
+    const usage = usageFromChildRecords(childRecords ?? []);
+    let terminal: ManagedAgentRecord | undefined;
+    if (childSettlement?.type === "session_settled") {
+      if (childSettlement.result.status === "completed") {
+        const answerBytes = Buffer.from(childSettlement.result.answer, "utf8");
+        const inlineResult = { text: childSettlement.result.answer } as const;
+        const inlineEnvelopeBytes = Buffer.byteLength(
+          JSON.stringify({
+            agentId: admission.agentId,
+            attemptId: admission.attemptId,
+            profile: "scout.v1",
+            profileDigest: admission.profileDigest,
+            status: "completed",
+            result: inlineResult,
+            targetIdentity: admission.targetIdentity,
+            ...(admission.thinkingPolicy === undefined
+              ? {}
+              : { thinkingPolicy: admission.thinkingPolicy }),
+            transcript: {
+              sessionId: admission.childSessionId,
+              digest: transcriptDigest,
+              throughSequence,
+            },
+            usage,
+            cost: { status: "unavailable" },
+          }),
+          "utf8",
+        );
+        const recoveredResult =
+          inlineEnvelopeBytes <= maximumManagedAgentResultBytes
+            ? inlineResult
+            : artifactStore === undefined
+              ? undefined
+              : {
+                  artifact: await artifactStore
+                    .write({
+                      bytes: answerBytes,
+                      mediaType: "text/plain; charset=utf-8",
+                      source: {
+                        type: "managed_agent_result",
+                        schemaVersion: 1,
+                        agentId: admission.agentId,
+                        attemptId: admission.attemptId,
+                        childSessionId: admission.childSessionId,
+                        totalBytes: answerBytes.byteLength,
+                      },
+                    })
+                    .then(({ id, mediaType, byteCount }) => ({ id, mediaType, byteCount })),
+                };
+        if (recoveredResult !== undefined) {
+          terminal = {
+            schemaVersion: 1,
+            type: "managed_agent_terminal",
+            sequence: records.length + 1,
+            agentId: admission.agentId,
+            attemptId: admission.attemptId,
+            childSessionId: admission.childSessionId,
+            status: "completed",
+            result: recoveredResult,
+            transcriptDigest,
+            throughSequence,
+            usage,
+            cost: { status: "unavailable" },
+          };
+        }
+      } else if (childSettlement.result.status === "cancelled") {
+        terminal = {
+          schemaVersion: 1,
+          type: "managed_agent_terminal",
+          sequence: records.length + 1,
+          agentId: admission.agentId,
+          attemptId: admission.attemptId,
+          childSessionId: admission.childSessionId,
+          status: "cancelled",
+          reason: "caller",
+          transcriptDigest,
+          throughSequence,
+        };
+      } else {
+        const error =
+          childSettlement.result.status === "failed"
+            ? childSettlement.result.error
+            : {
+                code: "model_output_truncated",
+                message: "The foreground scout reached its output limit.",
+              };
+        terminal = {
+          schemaVersion: 1,
+          type: "managed_agent_terminal",
+          sequence: records.length + 1,
+          agentId: admission.agentId,
+          attemptId: admission.attemptId,
+          childSessionId: admission.childSessionId,
+          status: "failed",
+          error: { code: error.code, message: error.message.slice(0, 4_096) },
+          transcriptDigest,
+          throughSequence,
+        };
+      }
+    }
+    if (terminal === undefined) {
+      terminal = {
         schemaVersion: 1,
         type: "managed_agent_terminal",
         sequence: records.length + 1,
         agentId: admission.agentId,
         attemptId: admission.attemptId,
         childSessionId: admission.childSessionId,
-        status: "completed",
-        result: { text: childSettlement.result.answer },
-        transcriptDigest: digest(JSON.stringify(childRecords)),
-        throughSequence: childRecords?.at(-1)?.sequence ?? 0,
-        usage: usageFromChildRecords(childRecords ?? []),
-        cost: { status: "unavailable" },
+        status: "recovery_required",
+        error: {
+          code: "managed_agent_recovery_required",
+          message:
+            "The child process ended without a causally proven terminal result. Adam did not replay the interrupted model request.",
+        },
       };
-      await store.append(terminal);
-      records = [...records, terminal];
-      terminalAttempts.add(admission.attemptId);
-      continue;
     }
-    const terminal: ManagedAgentRecord = {
-      schemaVersion: 1,
-      type: "managed_agent_terminal",
-      sequence: records.length + 1,
-      agentId: admission.agentId,
-      attemptId: admission.attemptId,
-      childSessionId: admission.childSessionId,
-      status: "recovery_required",
-      error: {
-        code: "managed_agent_recovery_required",
-        message:
-          "The child process ended without a causally proven terminal result. Adam did not replay the interrupted model request.",
-      },
-    };
     await store.append(terminal);
     records = [...records, terminal];
     terminalAttempts.add(admission.attemptId);
   }
 }
 
-async function ensureManagedAgentLogFile(path: string): Promise<void> {
-  const file = await open(
-    path,
-    constants.O_APPEND |
-      constants.O_CREAT |
-      constants.O_RDWR |
-      constants.O_NOFOLLOW |
-      constants.O_NONBLOCK,
-    0o600,
-  );
-  try {
-    const stats = await file.stat();
-    if (!stats.isFile()) {
-      throw new ManagedAgentStoreError("managed_agent_log_invalid");
-    }
-    await file.chmod(0o600);
-    await file.sync();
-  } finally {
-    await file.close();
-  }
-}
-
-async function readManagedAgentLog(path: string): Promise<readonly ManagedAgentRecord[]> {
-  const contents = await readFile(path, "utf8");
-  if (contents.length === 0) {
-    return [];
-  }
-  if (!contents.endsWith("\n")) {
-    throw new ManagedAgentStoreError("managed_agent_log_invalid");
-  }
-  const records: ManagedAgentRecord[] = [];
-  for (const line of contents.slice(0, -1).split("\n")) {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(line) as unknown;
-    } catch {
-      throw new ManagedAgentStoreError("managed_agent_log_invalid");
-    }
-    records.push(validateManagedAgentRecord(parsed, records).record);
-  }
-  return records;
-}
-
-function validateManagedAgentRecord(
+export function validateManagedAgentRecord(
   input: unknown,
   history: readonly ManagedAgentRecord[],
 ): {
@@ -536,31 +601,9 @@ function validateManagedAgentRecord(
   return { byteLength, record: candidate, serialized };
 }
 
-function enqueueManagedAgentAppend(path: string, operation: () => Promise<void>): Promise<void> {
-  const previous = managedAgentAppendQueues.get(path) ?? Promise.resolve();
-  const queued = previous.then(operation, operation);
-  const settled = queued.then(
-    () => undefined,
-    () => undefined,
-  );
-  managedAgentAppendQueues.set(path, settled);
-  void settled.then(() => {
-    if (managedAgentAppendQueues.get(path) === settled) {
-      managedAgentAppendQueues.delete(path);
-    }
-  });
-  return queued;
-}
-
-function defaultManagedAgentStateRoot(): string {
-  const { XDG_STATE_HOME: xdgStateHome } = process.env;
-  return xdgStateHome === undefined || xdgStateHome.length === 0
-    ? join(homedir(), ".local", "state", "adam-agent")
-    : join(xdgStateHome, "adam-agent");
-}
-
 export type AgentManager = {
   readonly parentRootId: string;
+  readonly parentSessionId: string;
   readonly targetIdentity: ModelTargetIdentity;
   readonly thinkingPolicy?: ThinkingPolicySnapshotV1;
   spawnForeground(input: {
@@ -592,6 +635,7 @@ export function createAgentManager(options: {
   readonly parentPermissions: PermissionPolicy;
   readonly deadlineScheduler?: ManagedAgentDeadlineScheduler;
   readonly parentRoot: ProjectExecutionRootClaim;
+  readonly parentSessionId?: string;
   readonly projectId: `sha256:${string}`;
   readonly repository?: PromptContextRecord["repository"];
   readonly targetIdentity: ModelTargetIdentity;
@@ -613,6 +657,7 @@ export function createAgentManager(options: {
   };
   return {
     parentRootId: options.parentRoot.rootId,
+    parentSessionId: options.parentSessionId ?? "00000000-0000-4000-8000-000000000001",
     targetIdentity: options.targetIdentity,
     ...(options.thinkingPolicy === undefined ? {} : { thinkingPolicy: options.thinkingPolicy }),
     async spawnForeground(input) {
@@ -647,6 +692,9 @@ export function createAgentManager(options: {
           childController.abort(new Error("Managed Agent deadline exceeded."));
         },
       );
+      let admissionCommitted = false;
+      let terminalCommitted = false;
+      let releaseChildClaim = true;
       try {
         await appendManagedRecord({
           type: "managed_agent_admitted",
@@ -658,6 +706,13 @@ export function createAgentManager(options: {
           parentRootId: options.parentRoot.rootId,
           projectId: options.projectId,
           profile: "scout.v1",
+          profileDigest: scoutManagedAgentProfileV1.digest,
+          limits: {
+            maximumTurns: scoutManagedAgentProfileV1.limits.maximumTurnsPerAttempt,
+            maximumTokens: scoutManagedAgentProfileV1.limits.maximumCumulativeTokens,
+            maximumDeadlineMilliseconds:
+              scoutManagedAgentProfileV1.limits.maximumDeadlineMilliseconds,
+          },
           taskDigest,
           targetIdentity: options.targetIdentity,
           ...(options.thinkingPolicy === undefined
@@ -672,6 +727,7 @@ export function createAgentManager(options: {
                 },
               }),
         });
+        admissionCommitted = true;
         const childStore = await options.childSessionStores.create(childSessionId);
         const childTools = createReadToolRegistry({ workspaceRoot: options.workspaceRoot });
         const childPromptContext = createPromptContextV1(childTools, options.repository);
@@ -758,6 +814,7 @@ export function createAgentManager(options: {
               transcriptDigest,
               throughSequence,
             });
+            terminalCommitted = true;
             return toolFailure(
               "managed_agent_deadline_exceeded",
               "The foreground scout deadline expired.",
@@ -773,6 +830,7 @@ export function createAgentManager(options: {
             transcriptDigest,
             throughSequence,
           });
+          terminalCommitted = true;
           return toolFailure("managed_agent_cancelled", "The foreground scout was cancelled.");
         }
         if (result.status !== "completed") {
@@ -793,6 +851,7 @@ export function createAgentManager(options: {
             transcriptDigest,
             throughSequence,
           });
+          terminalCommitted = true;
           return toolFailure("managed_agent_failed", "The foreground scout did not complete.");
         }
         const resultBytes = Buffer.from(result.answer, "utf8");
@@ -806,6 +865,7 @@ export function createAgentManager(options: {
           agentId,
           attemptId,
           profile: "scout.v1" as const,
+          profileDigest: scoutManagedAgentProfileV1.digest,
           status: "completed" as const,
           result: terminalResult,
           targetIdentity: options.targetIdentity,
@@ -857,6 +917,7 @@ export function createAgentManager(options: {
             transcriptDigest,
             throughSequence,
           });
+          terminalCommitted = true;
           return toolFailure(
             "managed_agent_result_too_large",
             "The foreground scout result exceeds its bound.",
@@ -874,11 +935,32 @@ export function createAgentManager(options: {
           usage,
           cost: { status: "unavailable" },
         });
+        terminalCommitted = true;
         return {
           status: "completed",
           output: createTerminalOutput(terminalResult),
         };
-      } catch {
+      } catch (error) {
+        if (admissionCommitted && !terminalCommitted) {
+          try {
+            await appendManagedRecord({
+              type: "managed_agent_terminal",
+              agentId,
+              attemptId,
+              childSessionId,
+              status: "recovery_required",
+              error: {
+                code: "managed_agent_recovery_required",
+                message:
+                  "The child process ended without a causally proven terminal result. Adam did not replay the interrupted model request.",
+              },
+            });
+            terminalCommitted = true;
+          } catch {
+            releaseChildClaim = false;
+            throw error;
+          }
+        }
         return toolFailure(
           "managed_agent_unavailable",
           "The foreground scout could not be started safely.",
@@ -886,7 +968,9 @@ export function createAgentManager(options: {
       } finally {
         deadline.cancel();
         input.signal.removeEventListener("abort", abortFromCaller);
-        await childClaim.release();
+        if (releaseChildClaim) {
+          await childClaim.release();
+        }
       }
     },
   };
@@ -917,9 +1001,17 @@ export function createManagedAgentToolRegistry(options: {
           permissionSubject: {
             type: "managed_agent_spawn",
             parentRootId: options.manager.parentRootId,
+            parentSessionId: options.manager.parentSessionId,
             profile: "scout.v1",
+            profileDigest: scoutManagedAgentProfileV1.digest,
             targetIdentity: options.manager.targetIdentity,
             taskDigest: digest(parsed.data.task),
+            limits: {
+              maximumTurns: scoutManagedAgentProfileV1.limits.maximumTurnsPerAttempt,
+              maximumTokens: scoutManagedAgentProfileV1.limits.maximumCumulativeTokens,
+              maximumDeadlineMilliseconds:
+                scoutManagedAgentProfileV1.limits.maximumDeadlineMilliseconds,
+            },
             ...(options.manager.thinkingPolicy === undefined
               ? {}
               : { thinkingPolicy: options.manager.thinkingPolicy }),
@@ -963,12 +1055,23 @@ function usageFromChildRecords(records: readonly SessionRecord[]): {
         record.schemaVersion === 3 && record.record.type === "model_response_completed"
           ? record.record.response
           : undefined;
-      return response?.usage === undefined
+      const compactionUsage =
+        record.schemaVersion === 3 &&
+        (record.record.type === "context_compaction_committed" ||
+          record.record.type === "context_compaction_failed")
+          ? record.record.usage
+          : record.schemaVersion === 3 &&
+              record.record.type === "context_compaction_interrupted" &&
+              !("status" in record.record.usage)
+            ? record.record.usage
+            : undefined;
+      const usage = response?.usage ?? compactionUsage;
+      return usage === undefined
         ? total
         : {
-            inputTokens: total.inputTokens + response.usage.inputTokens,
-            outputTokens: total.outputTokens + response.usage.outputTokens,
-            reasoningTokens: total.reasoningTokens + (response.usage.reasoningTokens ?? 0),
+            inputTokens: total.inputTokens + usage.inputTokens,
+            outputTokens: total.outputTokens + usage.outputTokens,
+            reasoningTokens: total.reasoningTokens + (usage.reasoningTokens ?? 0),
           };
     },
     { inputTokens: 0, outputTokens: 0, reasoningTokens: 0 },

--- a/packages/agent/src/managed-agent.ts
+++ b/packages/agent/src/managed-agent.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 
 import { z } from "zod";
-import { AgentSession, sessionInitialThinkingPolicy } from "./agent-session.js";
+import { AgentSession } from "./agent-session.js";
 import type { ModelDriver, ModelMessage } from "./agent-session-contracts.js";
 import type { ArtifactReference, ArtifactStore } from "./artifact-store.js";
 import type { ContextProfile } from "./context-profile.js";
@@ -25,6 +25,8 @@ import {
 
 const maximumManagedAgentTaskBytes = 16 * 1024;
 const maximumManagedAgentResultBytes = 16 * 1024;
+const childLiveWorkspaceNotice =
+  "This child reads the live workspace. Parent changes may alter what it observes; isolated transcript does not mean repository snapshot or sandbox.";
 const managedAgentTaskSchema = z.strictObject({
   task: z
     .string()
@@ -113,12 +115,21 @@ export type ManagedAgentRecord =
         readonly maximumDeadlineMilliseconds: 600_000;
       };
       readonly taskDigest: `sha256:${string}`;
+      readonly task: string;
       readonly targetIdentity: ModelTargetIdentity;
       readonly thinkingPolicy?: ThinkingPolicySnapshotV1;
       readonly repository?: {
         readonly revision: number;
         readonly effectiveDigest: `sha256:${string}`;
       };
+    }
+  | {
+      readonly schemaVersion: 1;
+      readonly type: "managed_agent_deadline_expired";
+      readonly sequence: number;
+      readonly agentId: string;
+      readonly attemptId: string;
+      readonly childSessionId: string;
     }
   | {
       readonly schemaVersion: 1;
@@ -151,8 +162,8 @@ export type ManagedAgentRecord =
       readonly childSessionId: string;
       readonly status: "failed";
       readonly error: { readonly code: string; readonly message: string };
-      readonly transcriptDigest: `sha256:${string}`;
-      readonly throughSequence: number;
+      readonly transcriptDigest?: `sha256:${string}`;
+      readonly throughSequence?: number;
     }
   | {
       readonly schemaVersion: 1;
@@ -221,6 +232,14 @@ export class ManagedAgentStoreError extends Error {
 const managedAgentRecordSchema = z.union([
   z.strictObject({
     schemaVersion: z.literal(1),
+    type: z.literal("managed_agent_deadline_expired"),
+    sequence: z.number().int().positive(),
+    agentId: z.uuid(),
+    attemptId: z.uuid(),
+    childSessionId: z.uuid(),
+  }),
+  z.strictObject({
+    schemaVersion: z.literal(1),
     type: z.literal("managed_agent_admitted"),
     sequence: z.number().int().positive(),
     agentId: z.uuid(),
@@ -238,6 +257,10 @@ const managedAgentRecordSchema = z.union([
       maximumDeadlineMilliseconds: z.literal(600_000),
     }),
     taskDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+    task: z
+      .string()
+      .min(1)
+      .refine((task) => Buffer.byteLength(task, "utf8") <= maximumManagedAgentTaskBytes),
     targetIdentity: targetIdentitySchema,
     thinkingPolicy: thinkingPolicySchema.optional(),
     repository: z
@@ -288,8 +311,11 @@ const managedAgentRecordSchema = z.union([
       code: z.string().min(1).max(128),
       message: z.string().min(1).max(4_096),
     }),
-    transcriptDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
-    throughSequence: z.number().int().nonnegative(),
+    transcriptDigest: z
+      .string()
+      .regex(/^sha256:[0-9a-f]{64}$/u)
+      .optional(),
+    throughSequence: z.number().int().nonnegative().optional(),
   }),
   z.strictObject({
     schemaVersion: z.literal(1),
@@ -362,6 +388,9 @@ export async function recoverInterruptedManagedAgents(
             createReadToolRegistry({ workspaceRoot: process.cwd() }),
             repository,
           );
+    const logicalRun = childRecords?.find(
+      (record) => record.schemaVersion === 3 && record.record.type === "logical_run_started",
+    );
     const validIdentity =
       genesis?.schemaVersion === 3 &&
       genesis.record.type === "session_genesis" &&
@@ -376,6 +405,15 @@ export async function recoverInterruptedManagedAgents(
         maximumDeadlineMilliseconds: scoutManagedAgentProfileV1.limits.maximumDeadlineMilliseconds,
       }) &&
       admission.parentRootId === `session:${admission.parentSessionId}` &&
+      logicalRun?.schemaVersion === 3 &&
+      logicalRun.record.type === "logical_run_started" &&
+      logicalRun.record.userMessage === childTaskMessage(admission.task) &&
+      digest(admission.task) === admission.taskDigest &&
+      isDeepStrictEqual(logicalRun.record.thinkingPolicy, admission.thinkingPolicy) &&
+      isDeepStrictEqual(logicalRun.record.limits, {
+        maxTurns: admission.limits.maximumTurns,
+        maxTokens: admission.limits.maximumTokens,
+      }) &&
       (admission.repository === undefined
         ? repository?.sources.length === 0
         : repository?.revision === admission.repository.revision &&
@@ -393,6 +431,36 @@ export async function recoverInterruptedManagedAgents(
           code: "managed_agent_inspection_required",
           message: "The durable child identity does not match its Managed Agent admission.",
         },
+      };
+      await store.append(terminal);
+      records = [...records, terminal];
+      terminalAttempts.add(admission.attemptId);
+      continue;
+    }
+    const deadlineRecord = records.find(
+      (record) =>
+        record.type === "managed_agent_deadline_expired" &&
+        record.attemptId === admission.attemptId,
+    );
+    if (deadlineRecord !== undefined) {
+      const terminal: ManagedAgentRecord = {
+        schemaVersion: 1,
+        type: "managed_agent_terminal",
+        sequence: records.length + 1,
+        agentId: admission.agentId,
+        attemptId: admission.attemptId,
+        childSessionId: admission.childSessionId,
+        status: "failed",
+        error: {
+          code: "managed_agent_deadline_exceeded",
+          message: "The foreground scout exceeded its aggregate deadline.",
+        },
+        ...(childRecords === undefined
+          ? {}
+          : {
+              transcriptDigest: digest(JSON.stringify(childRecords)),
+              throughSequence: childRecords.at(-1)?.sequence ?? 0,
+            }),
       };
       await store.append(terminal);
       records = [...records, terminal];
@@ -567,11 +635,30 @@ export function validateManagedAgentRecord(
   const candidate = parsed.data;
   if (candidate.type === "managed_agent_admitted") {
     if (
+      digest(candidate.task) !== candidate.taskDigest ||
       history.some(
         (record) =>
           record.agentId === candidate.agentId ||
           record.attemptId === candidate.attemptId ||
           record.childSessionId === candidate.childSessionId,
+      )
+    ) {
+      throw new ManagedAgentStoreError("managed_agent_log_invalid");
+    }
+  } else if (candidate.type === "managed_agent_deadline_expired") {
+    const admission = history.find(
+      (record) =>
+        record.type === "managed_agent_admitted" && record.attemptId === candidate.attemptId,
+    );
+    if (
+      admission === undefined ||
+      admission.agentId !== candidate.agentId ||
+      admission.childSessionId !== candidate.childSessionId ||
+      history.some(
+        (record) =>
+          (record.type === "managed_agent_deadline_expired" ||
+            record.type === "managed_agent_terminal") &&
+          record.attemptId === candidate.attemptId,
       )
     ) {
       throw new ManagedAgentStoreError("managed_agent_log_invalid");
@@ -679,6 +766,31 @@ export function createAgentManager(options: {
       const childClaim = await options.parentRoot.claimChild({ childId: agentId });
       const childController = new AbortController();
       let deadlineExpired = false;
+      let deadlineRequested = false;
+      let deadlineOperation: Promise<void> | undefined;
+      let admissionCommitted = false;
+      let terminalCommitStarted = false;
+      let terminalCommitted = false;
+      let releaseChildClaim = true;
+      const commitDeadlineExpiration = (): Promise<void> => {
+        if (terminalCommitStarted) {
+          return Promise.resolve();
+        }
+        if (!admissionCommitted) {
+          deadlineRequested = true;
+          return Promise.resolve();
+        }
+        deadlineOperation ??= appendManagedRecord({
+          type: "managed_agent_deadline_expired",
+          agentId,
+          attemptId,
+          childSessionId,
+        }).then(() => {
+          deadlineExpired = true;
+          childController.abort(new Error("Managed Agent deadline exceeded."));
+        });
+        return deadlineOperation;
+      };
       const abortFromCaller = () => childController.abort(input.signal.reason);
       if (input.signal.aborted) {
         abortFromCaller();
@@ -688,13 +800,11 @@ export function createAgentManager(options: {
       const deadline = (options.deadlineScheduler ?? nodeManagedAgentDeadlineScheduler).schedule(
         scoutManagedAgentProfileV1.limits.maximumDeadlineMilliseconds,
         () => {
-          deadlineExpired = true;
-          childController.abort(new Error("Managed Agent deadline exceeded."));
+          void commitDeadlineExpiration().catch(() => {
+            childController.abort(new Error("Managed Agent deadline persistence failed."));
+          });
         },
       );
-      let admissionCommitted = false;
-      let terminalCommitted = false;
-      let releaseChildClaim = true;
       try {
         await appendManagedRecord({
           type: "managed_agent_admitted",
@@ -714,6 +824,7 @@ export function createAgentManager(options: {
               scoutManagedAgentProfileV1.limits.maximumDeadlineMilliseconds,
           },
           taskDigest,
+          task: input.task,
           targetIdentity: options.targetIdentity,
           ...(options.thinkingPolicy === undefined
             ? {}
@@ -728,6 +839,9 @@ export function createAgentManager(options: {
               }),
         });
         admissionCommitted = true;
+        if (deadlineRequested) {
+          await commitDeadlineExpiration();
+        }
         const childStore = await options.childSessionStores.create(childSessionId);
         const childTools = createReadToolRegistry({ workspaceRoot: options.workspaceRoot });
         const childPromptContext = createPromptContextV1(childTools, options.repository);
@@ -778,14 +892,11 @@ export function createAgentManager(options: {
               ? {}
               : { thinkingPolicy: options.thinkingPolicy }),
           },
-          ...(options.thinkingPolicy === undefined
-            ? {}
-            : { [sessionInitialThinkingPolicy]: options.thinkingPolicy }),
         };
         const child = new AgentSession(childDependencies);
         const result = await child.run(
           {
-            text: `${input.task}\n\nThis child reads the live workspace. Parent changes may alter what it observes; isolated transcript does not mean repository snapshot or sandbox.`,
+            text: childTaskMessage(input.task),
           },
           {
             signal: childController.signal,
@@ -799,27 +910,36 @@ export function createAgentManager(options: {
         const transcriptDigest = digest(JSON.stringify(childRecords));
         const throughSequence = childRecords.at(-1)?.sequence ?? 0;
         const usage = usageFromChildRecords(childRecords);
-        if (result.status === "cancelled") {
-          if (deadlineExpired) {
-            await appendManagedRecord({
-              type: "managed_agent_terminal",
-              agentId,
-              attemptId,
-              childSessionId,
-              status: "failed",
-              error: {
-                code: "managed_agent_deadline_exceeded",
-                message: "The foreground scout exceeded its aggregate deadline.",
-              },
-              transcriptDigest,
-              throughSequence,
-            });
-            terminalCommitted = true;
-            return toolFailure(
-              "managed_agent_deadline_exceeded",
-              "The foreground scout deadline expired.",
-            );
+        const settleExpiredDeadline = async (): Promise<boolean> => {
+          await deadlineOperation;
+          if (!deadlineExpired) {
+            return false;
           }
+          terminalCommitStarted = true;
+          await appendManagedRecord({
+            type: "managed_agent_terminal",
+            agentId,
+            attemptId,
+            childSessionId,
+            status: "failed",
+            error: {
+              code: "managed_agent_deadline_exceeded",
+              message: "The foreground scout exceeded its aggregate deadline.",
+            },
+            transcriptDigest,
+            throughSequence,
+          });
+          terminalCommitted = true;
+          return true;
+        };
+        if (await settleExpiredDeadline()) {
+          return toolFailure(
+            "managed_agent_deadline_exceeded",
+            "The foreground scout deadline expired.",
+          );
+        }
+        if (result.status === "cancelled") {
+          terminalCommitStarted = true;
           await appendManagedRecord({
             type: "managed_agent_terminal",
             agentId,
@@ -841,6 +961,7 @@ export function createAgentManager(options: {
                   code: "model_output_truncated",
                   message: "The foreground scout reached its output limit.",
                 };
+          terminalCommitStarted = true;
           await appendManagedRecord({
             type: "managed_agent_terminal",
             agentId,
@@ -904,6 +1025,7 @@ export function createAgentManager(options: {
                     .then(({ id, mediaType, byteCount }) => ({ id, mediaType, byteCount })),
                 };
         if (terminalResult === undefined) {
+          terminalCommitStarted = true;
           await appendManagedRecord({
             type: "managed_agent_terminal",
             agentId,
@@ -923,6 +1045,13 @@ export function createAgentManager(options: {
             "The foreground scout result exceeds its bound.",
           );
         }
+        if (await settleExpiredDeadline()) {
+          return toolFailure(
+            "managed_agent_deadline_exceeded",
+            "The foreground scout deadline expired.",
+          );
+        }
+        terminalCommitStarted = true;
         await appendManagedRecord({
           type: "managed_agent_terminal",
           agentId,
@@ -943,18 +1072,34 @@ export function createAgentManager(options: {
       } catch (error) {
         if (admissionCommitted && !terminalCommitted) {
           try {
-            await appendManagedRecord({
-              type: "managed_agent_terminal",
-              agentId,
-              attemptId,
-              childSessionId,
-              status: "recovery_required",
-              error: {
-                code: "managed_agent_recovery_required",
-                message:
-                  "The child process ended without a causally proven terminal result. Adam did not replay the interrupted model request.",
-              },
-            });
+            await deadlineOperation;
+            terminalCommitStarted = true;
+            await appendManagedRecord(
+              deadlineExpired
+                ? {
+                    type: "managed_agent_terminal",
+                    agentId,
+                    attemptId,
+                    childSessionId,
+                    status: "failed",
+                    error: {
+                      code: "managed_agent_deadline_exceeded",
+                      message: "The foreground scout exceeded its aggregate deadline.",
+                    },
+                  }
+                : {
+                    type: "managed_agent_terminal",
+                    agentId,
+                    attemptId,
+                    childSessionId,
+                    status: "recovery_required",
+                    error: {
+                      code: "managed_agent_recovery_required",
+                      message:
+                        "The child process ended without a causally proven terminal result. Adam did not replay the interrupted model request.",
+                    },
+                  },
+            );
             terminalCommitted = true;
           } catch {
             releaseChildClaim = false;
@@ -1042,6 +1187,10 @@ function parseJson(value: string): unknown {
 
 function digest(value: string): `sha256:${string}` {
   return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function childTaskMessage(task: string): string {
+  return `${task}\n\n${childLiveWorkspaceNotice}`;
 }
 
 function usageFromChildRecords(records: readonly SessionRecord[]): {

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -972,7 +972,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       return base;
     }
     const managerRouter: AgentManager = {
-      parentRootId: projectRuntimeRootId,
+      parentRootId: `session:${sessionId}`,
       targetIdentity,
       ...(thinkingPolicy === undefined ? {} : { thinkingPolicy }),
       async spawnForeground(input) {
@@ -1099,20 +1099,19 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
   const executeWithOwner = async <T>(
     kind: "ordinary" | "title",
     operation: (rootClaim: ProjectExecutionRootClaim) => Promise<T>,
+    rootId = projectRuntimeRootId,
   ): Promise<T> => {
     const active = coordinatingOwnerOperation;
     if (active !== undefined && (kind === "title" || active.kind === "title")) {
       await active.settlement;
     }
-    const operationPromise = executionDomain
-      .claimRoot({ rootId: projectRuntimeRootId })
-      .then(async (rootClaim) => {
-        try {
-          return await operation(rootClaim);
-        } finally {
-          await rootClaim.release();
-        }
-      });
+    const operationPromise = executionDomain.claimRoot({ rootId }).then(async (rootClaim) => {
+      try {
+        return await operation(rootClaim);
+      } finally {
+        await rootClaim.release();
+      }
+    });
     const tracked = {
       kind,
       settlement: operationPromise.then(
@@ -1142,17 +1141,19 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
   };
   const runWithOwner = <T>(
     operation: (rootClaim: ProjectExecutionRootClaim) => Promise<T>,
-  ): Promise<T> => executeWithOwner("ordinary", operation);
+    rootId?: string,
+  ): Promise<T> => executeWithOwner("ordinary", operation, rootId);
   const runTitleWithOwner = <T>(
     operation: (rootClaim: ProjectExecutionRootClaim) => Promise<T>,
   ): Promise<T> => executeWithOwner("title", operation);
   const withOwner = async <T>(
     operation: (rootClaim: ProjectExecutionRootClaim) => Promise<T>,
+    rootId?: string,
   ): Promise<T> => {
     if (lifecycleClosing) {
       throw new SessionLifecycleError("session_invalid");
     }
-    return runWithOwner(operation);
+    return runWithOwner(operation, rootId);
   };
   const drainOwnerOperations = async (): Promise<void> => {
     while (trackedOwnerOperations.size > 0) {
@@ -3500,7 +3501,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             armMcpIdle(input.sessionId, live.activation.generationId);
           }
         }
-      });
+      }, `session:${input.sessionId}`);
       const titleSnapshot = await startAutomaticTitle(
         input.sessionId,
         continued.snapshot,

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -41,11 +41,11 @@ import {
 import {
   type AgentManager,
   createAgentManager,
-  createJsonlManagedAgentStore,
   createManagedAgentToolRegistry,
   type ManagedAgentStore,
   recoverInterruptedManagedAgents,
 } from "./managed-agent.js";
+import { createJsonlManagedAgentStore } from "./managed-agent-store.js";
 import {
   createMcpRuntimeHost,
   inspectMcpConfiguration,
@@ -973,6 +973,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     }
     const managerRouter: AgentManager = {
       parentRootId: `session:${sessionId}`,
+      parentSessionId: sessionId,
       targetIdentity,
       ...(thinkingPolicy === undefined ? {} : { thinkingPolicy }),
       async spawnForeground(input) {
@@ -2708,7 +2709,13 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       await waitForMcpIdleOperation(input.sessionId);
       const continued = await withOwner(async (parentRoot) => {
         if (options.managedAgentTools === "managed-agent-tools.a1.v1") {
-          await recoverInterruptedManagedAgents(managedAgentStore, managedChildSessionStores);
+          await recoverInterruptedManagedAgents(
+            managedAgentStore,
+            managedChildSessionStores,
+            createLazyArtifactStore(
+              join(effectiveSessionStateRoot(options.stateRoot), "artifacts"),
+            ),
+          );
         }
         const workspaceTrusted = (await inspectWorkspaceTrust()).status === "trusted";
         const artifactCache = createArtifactMaterializationCache();
@@ -3421,6 +3428,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           managedStore: managedAgentStore,
           parentPermissions: options.permissions ?? createPermissionPolicy({ allowedEffects: [] }),
           parentRoot,
+          parentSessionId: input.sessionId,
           projectId: resumed.snapshot.projectId as `sha256:${string}`,
           ...(activePromptContext === undefined
             ? {}

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -39,6 +39,14 @@ import {
   inputResourceLimitsV1,
 } from "./input-resources.js";
 import {
+  type AgentManager,
+  createAgentManager,
+  createJsonlManagedAgentStore,
+  createManagedAgentToolRegistry,
+  type ManagedAgentStore,
+  recoverInterruptedManagedAgents,
+} from "./managed-agent.js";
+import {
   createMcpRuntimeHost,
   inspectMcpConfiguration,
   type McpBeforeToolDispatchBarrier,
@@ -94,6 +102,7 @@ import {
 import {
   createProjectExecutionDomain,
   ProjectExecutionDomainError,
+  type ProjectExecutionRootClaim,
   projectRuntimeRootId,
 } from "./project-execution-domain.js";
 import {
@@ -218,6 +227,7 @@ import {
 import {
   bindInputResourceToolRegistry,
   createCodingToolRegistry,
+  createPermissionPolicy,
   type PermissionPolicy,
   type ToolEffect,
   type ToolRegistry,
@@ -353,6 +363,7 @@ export type WorkspaceMcpLeaseTransitionBarrier = {
 export type SessionLifecycleOptions = {
   readonly extensionHost?: ExtensionHost;
   readonly modelTargets?: ModelTargets;
+  readonly managedAgentTools?: "managed-agent-tools.a1.v1";
   readonly permissions?: PermissionPolicy;
   readonly preferences?: UserModelPolicyResolver;
   readonly workspaceRoot: string;
@@ -926,6 +937,59 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           lifecycleOwner:
             options[sessionProjectLifecycleOwner] ?? createProjectLifecycleOwner(options),
         });
+  let managedAgentStorePromise: Promise<ManagedAgentStore> | undefined;
+  const resolveManagedAgentStore = () => {
+    managedAgentStorePromise ??= createJsonlManagedAgentStore({
+      workspaceRoot: options.workspaceRoot,
+      ...(options.stateRoot === undefined ? {} : { stateRoot: options.stateRoot }),
+    });
+    return managedAgentStorePromise;
+  };
+  const managedAgentStore: ManagedAgentStore = {
+    async append(record) {
+      return (await resolveManagedAgentStore()).append(record);
+    },
+    async read() {
+      return (await resolveManagedAgentStore()).read();
+    },
+  };
+  const managedChildSessionStores = createJsonlSessionStoreDirectory<SessionRecord>({
+    workspaceRoot: options.workspaceRoot,
+    stateRoot: join(effectiveSessionStateRoot(options.stateRoot), "managed-child-sessions"),
+  });
+  const activeAgentManagers = new Map<string, AgentManager>();
+  const toolsForSession = (
+    sessionId: string,
+    targetIdentity: ModelTargetIdentity,
+    thinkingPolicy?: ThinkingPolicySnapshotV1,
+    managedAgentTools = options.managedAgentTools,
+  ): ToolRegistry => {
+    const base = options.tools;
+    if (options.modelTargets === undefined || managedAgentTools !== "managed-agent-tools.a1.v1") {
+      if (base === undefined) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      return base;
+    }
+    const managerRouter: AgentManager = {
+      parentRootId: projectRuntimeRootId,
+      targetIdentity,
+      ...(thinkingPolicy === undefined ? {} : { thinkingPolicy }),
+      async spawnForeground(input) {
+        const manager = activeAgentManagers.get(sessionId);
+        return manager === undefined
+          ? {
+              status: "failed",
+              error: {
+                code: "managed_agent_unavailable",
+                message: "The foreground scout host is unavailable.",
+              },
+            }
+          : manager.spawnForeground(input);
+      },
+    };
+    return combineToolRegistries(base, createManagedAgentToolRegistry({ manager: managerRouter }));
+  };
   const pendingMcpCatalogChanges = new Map<
     string,
     {
@@ -1034,13 +1098,21 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
   let coordinatingOwnerOperation: TrackedOwnerOperation | undefined;
   const executeWithOwner = async <T>(
     kind: "ordinary" | "title",
-    operation: () => Promise<T>,
+    operation: (rootClaim: ProjectExecutionRootClaim) => Promise<T>,
   ): Promise<T> => {
     const active = coordinatingOwnerOperation;
     if (active !== undefined && (kind === "title" || active.kind === "title")) {
       await active.settlement;
     }
-    const operationPromise = executionDomain.runRoot({ rootId: projectRuntimeRootId }, operation);
+    const operationPromise = executionDomain
+      .claimRoot({ rootId: projectRuntimeRootId })
+      .then(async (rootClaim) => {
+        try {
+          return await operation(rootClaim);
+        } finally {
+          await rootClaim.release();
+        }
+      });
     const tracked = {
       kind,
       settlement: operationPromise.then(
@@ -1068,11 +1140,15 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       }
     }
   };
-  const runWithOwner = <T>(operation: () => Promise<T>): Promise<T> =>
-    executeWithOwner("ordinary", operation);
-  const runTitleWithOwner = <T>(operation: () => Promise<T>): Promise<T> =>
-    executeWithOwner("title", operation);
-  const withOwner = async <T>(operation: () => Promise<T>): Promise<T> => {
+  const runWithOwner = <T>(
+    operation: (rootClaim: ProjectExecutionRootClaim) => Promise<T>,
+  ): Promise<T> => executeWithOwner("ordinary", operation);
+  const runTitleWithOwner = <T>(
+    operation: (rootClaim: ProjectExecutionRootClaim) => Promise<T>,
+  ): Promise<T> => executeWithOwner("title", operation);
+  const withOwner = async <T>(
+    operation: (rootClaim: ProjectExecutionRootClaim) => Promise<T>,
+  ): Promise<T> => {
     if (lifecycleClosing) {
       throw new SessionLifecycleError("session_invalid");
     }
@@ -1755,7 +1831,14 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         promptGenesis !== undefined && isGenesisRecord(promptGenesis)
           ? promptContextRecordFromRecords(promptGenesis, promptRecords)
           : undefined;
-      let compatibleTools = options.tools;
+      let compatibleTools = toolsForSession(
+        input.sessionId,
+        snapshot.targetIdentity,
+        undefined,
+        promptGenesis !== undefined && isGenesisRecord(promptGenesis)
+          ? promptGenesis.record.managedAgentTools
+          : undefined,
+      );
       if (activePromptContext?.recordVersion === 3 && activePromptContext.mcp !== undefined) {
         const profile =
           promptGenesis === undefined || !isGenesisRecord(promptGenesis)
@@ -1765,7 +1848,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           throw new SessionLifecycleError("session_invalid");
         }
         compatibleTools = combineToolRegistries(
-          options.tools,
+          compatibleTools,
           mcpProfileDefinitionRegistry(profile),
         );
       }
@@ -2006,7 +2089,14 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           sessionId,
           projectId,
           targetIdentity: input.targetIdentity,
-          promptContext: createPromptContextV3(options.tools, repository, skillContext),
+          ...(options.managedAgentTools === undefined
+            ? {}
+            : { managedAgentTools: options.managedAgentTools }),
+          promptContext: createPromptContextV3(
+            toolsForSession(sessionId, input.targetIdentity),
+            repository,
+            skillContext,
+          ),
           skillContext,
         },
       },
@@ -2345,6 +2435,9 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             sessionId,
             projectId: parent.projectId,
             targetIdentity,
+            ...(parentGenesis.record.managedAgentTools === undefined
+              ? {}
+              : { managedAgentTools: parentGenesis.record.managedAgentTools }),
             naming: { profileVersion: 1, fallbackTitle: branchFallback },
             ...(parentPromptContext === undefined ? {} : { promptContext: parentPromptContext }),
             ...(parentSkillContext === undefined ? {} : { skillContext: parentSkillContext }),
@@ -2612,7 +2705,10 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       let effectiveInput = input.input;
       disarmMcpIdle(input.sessionId);
       await waitForMcpIdleOperation(input.sessionId);
-      const continued = await withOwner(async () => {
+      const continued = await withOwner(async (parentRoot) => {
+        if (options.managedAgentTools === "managed-agent-tools.a1.v1") {
+          await recoverInterruptedManagedAgents(managedAgentStore, managedChildSessionStores);
+        }
         const workspaceTrusted = (await inspectWorkspaceTrust()).status === "trusted";
         const artifactCache = createArtifactMaterializationCache();
         const resumed = await resumeSession({ sessionId: input.sessionId }, artifactCache);
@@ -3187,6 +3283,13 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             "The selected input resources exceed the v1 session-lineage aggregate byte limit.",
           );
         }
+        const effectiveThinkingPolicy = recoveredThinkingPolicy ?? newRunThinkingPolicy;
+        const sessionTools = toolsForSession(
+          input.sessionId,
+          resumed.snapshot.targetIdentity,
+          effectiveThinkingPolicy,
+          first.record.managedAgentTools,
+        );
         const sessionDependencies = {
           artifactStore,
           model: resolved.driver,
@@ -3290,29 +3393,43 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           ...(durableOutputLimits === undefined
             ? {}
             : { [sessionDurableOutputLimits]: durableOutputLimits }),
-          ...(options.tools === undefined
-            ? {}
-            : {
-                tools: bindInputResourceToolRegistry(
-                  activePromptContext?.recordVersion === 3 && activePromptContext.mcp !== undefined
-                    ? combineToolRegistries(
-                        options.tools,
-                        workspaceTrusted
-                          ? mcpHost.toolRegistry(
-                              input.sessionId,
-                              requireMcpCommittedProfile(committedMcpProfile, activePromptContext),
-                              artifactStore,
-                            )
-                          : mcpProfileDefinitionRegistry(
-                              requireMcpCommittedProfile(committedMcpProfile, activePromptContext),
-                            ),
+          tools: bindInputResourceToolRegistry(
+            activePromptContext?.recordVersion === 3 && activePromptContext.mcp !== undefined
+              ? combineToolRegistries(
+                  sessionTools,
+                  workspaceTrusted
+                    ? mcpHost.toolRegistry(
+                        input.sessionId,
+                        requireMcpCommittedProfile(committedMcpProfile, activePromptContext),
+                        artifactStore,
                       )
-                    : options.tools,
-                  { artifactStore, occurrences: runtimeInputResources },
-                ),
-              }),
+                    : mcpProfileDefinitionRegistry(
+                        requireMcpCommittedProfile(committedMcpProfile, activePromptContext),
+                      ),
+                )
+              : sessionTools,
+            { artifactStore, occurrences: runtimeInputResources },
+          ),
           ...(options.permissions === undefined ? {} : { permissions: options.permissions }),
         };
+        const agentManager = createAgentManager({
+          artifactStore,
+          childContextProfile: resolved.contextProfile,
+          childModel: resolved.driver,
+          childSessionStores: managedChildSessionStores,
+          managedStore: managedAgentStore,
+          parentPermissions: options.permissions ?? createPermissionPolicy({ allowedEffects: [] }),
+          parentRoot,
+          projectId: resumed.snapshot.projectId as `sha256:${string}`,
+          ...(activePromptContext === undefined
+            ? {}
+            : { repository: activePromptContext.repository }),
+          targetIdentity: resumed.snapshot.targetIdentity,
+          ...(effectiveThinkingPolicy === undefined
+            ? {}
+            : { thinkingPolicy: effectiveThinkingPolicy }),
+          workspaceRoot: options.workspaceRoot,
+        });
         const session = new AgentSession(sessionDependencies);
         let resolveSessionSettlement = () => {};
         const sessionSettlement = new Promise<void>((resolve) => {
@@ -3343,6 +3460,9 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         });
         activeSession = session;
         activeSessionSettlement = sessionSettlement;
+        if (first.record.managedAgentTools === "managed-agent-tools.a1.v1") {
+          activeAgentManagers.set(input.sessionId, agentManager);
+        }
         try {
           const runLimits = resumeState?.limits ?? input.limits;
           const result = await session.run(runInput ?? { text: resumeState?.userMessage ?? "" }, {
@@ -3356,6 +3476,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           }
           return { result, snapshot };
         } finally {
+          activeAgentManagers.delete(input.sessionId);
           resolveSessionSettlement();
           if (activeSession === session) {
             activeSession = undefined;

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -1401,7 +1401,9 @@ const skillPermissionSubjectSchema = z.strictObject({
 const managedAgentSpawnPermissionSubjectSchema = z.strictObject({
   type: z.literal("managed_agent_spawn"),
   parentRootId: z.string().min(1).max(256),
+  parentSessionId: z.uuid(),
   profile: z.literal("scout.v1"),
+  profileDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
   targetIdentity: z.strictObject({
     targetId: z.string().min(1).max(256),
     vendor: z.string().min(1).max(128),
@@ -1412,6 +1414,11 @@ const managedAgentSpawnPermissionSubjectSchema = z.strictObject({
     certification: z.enum(["certified", "experimental"]),
   }),
   taskDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+  limits: z.strictObject({
+    maximumTurns: z.literal(8),
+    maximumTokens: z.literal(128_000),
+    maximumDeadlineMilliseconds: z.literal(600_000),
+  }),
   thinkingPolicy: z
     .strictObject({
       schemaVersion: z.literal(1),

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -63,7 +63,15 @@ export type CanonicalRuntimeEvent = Exclude<
 
 type V1PermissionSubject = Exclude<
   PermissionSubject,
-  { readonly type: "extension_capability" | "mcp_tool" | "patch" | "plan_command" | "skill" }
+  {
+    readonly type:
+      | "extension_capability"
+      | "managed_agent_spawn"
+      | "mcp_tool"
+      | "patch"
+      | "plan_command"
+      | "skill";
+  }
 >;
 type V1ToolError = {
   readonly code:
@@ -125,6 +133,7 @@ export type SessionGenesisRecord = {
     readonly sessionId: string;
     readonly projectId: string;
     readonly targetIdentity: ModelTargetIdentity;
+    readonly managedAgentTools?: "managed-agent-tools.a1.v1";
     readonly naming?: {
       readonly profileVersion: 1;
       readonly fallbackTitle: string;
@@ -1282,6 +1291,12 @@ const currentToolErrorSchema = z.union([
       "todo_dependency_incomplete",
       "todo_entity_limit_exceeded",
       "todo_revision_stale",
+      "managed_agent_cancelled",
+      "managed_agent_capacity_exceeded",
+      "managed_agent_deadline_exceeded",
+      "managed_agent_failed",
+      "managed_agent_result_too_large",
+      "managed_agent_unavailable",
     ]),
     message: z.string(),
   }),
@@ -1383,12 +1398,52 @@ const skillPermissionSubjectSchema = z.strictObject({
     .refine((value) => /^[\x20-\x7e]+$/u.test(value)),
   path: z.string().min(1).max(4_096).optional(),
 });
+const managedAgentSpawnPermissionSubjectSchema = z.strictObject({
+  type: z.literal("managed_agent_spawn"),
+  parentRootId: z.string().min(1).max(256),
+  profile: z.literal("scout.v1"),
+  targetIdentity: z.strictObject({
+    targetId: z.string().min(1).max(256),
+    vendor: z.string().min(1).max(128),
+    modelId: z.string().min(1).max(256),
+    route: z.enum(["direct", "vercel-ai-gateway"]),
+    upstreamProviderId: z.string().min(1).max(128).optional(),
+    profileVersion: z.number().int().positive(),
+    certification: z.enum(["certified", "experimental"]),
+  }),
+  taskDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+  thinkingPolicy: z
+    .strictObject({
+      schemaVersion: z.literal(1),
+      requestedLevelId: z.string().min(1).max(128),
+      effectiveLevelId: z.string().min(1).max(128),
+      capability: z.strictObject({
+        id: z.string().min(1).max(256),
+        version: z.literal(1),
+        digest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+      }),
+      mapping: z.discriminatedUnion("thinkingType", [
+        z.strictObject({
+          requestPath: z.enum(["provider_options.deepseek", "reasoning.effort"]),
+          thinkingType: z.literal("disabled"),
+        }),
+        z.strictObject({
+          requestPath: z.enum(["provider_options.deepseek", "reasoning.effort"]),
+          thinkingType: z.literal("enabled"),
+          reasoningEffort: z.enum(["low", "high", "max"]),
+        }),
+      ]),
+      reasoningArtifact: z.literal("provider_reasoning"),
+    })
+    .optional(),
+});
 const v2PermissionSubjectSchema = z.discriminatedUnion("type", [
   z.strictObject({ type: z.literal("file"), path: z.string() }),
   z.strictObject({ type: z.literal("workspace_path"), path: z.string() }),
   extensionCapabilityPermissionSubjectSchema,
   patchPermissionSubjectSchema,
   skillPermissionSubjectSchema,
+  managedAgentSpawnPermissionSubjectSchema,
   z.strictObject({
     type: z.literal("command"),
     command: z.string(),
@@ -1466,6 +1521,7 @@ const currentPermissionSubjectSchema = z.discriminatedUnion("type", [
   skillPermissionSubjectSchema,
   mcpPermissionSubjectSchema,
   inputResourcePermissionSubjectSchema,
+  managedAgentSpawnPermissionSubjectSchema,
   planCommandPermissionSubjectSchema,
   z.strictObject({
     type: z.literal("command"),
@@ -1848,6 +1904,7 @@ const sessionGenesisV1RecordSchema = z.strictObject({
   sessionId: z.uuid(),
   projectId: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
   targetIdentity: modelTargetIdentitySchema,
+  managedAgentTools: z.literal("managed-agent-tools.a1.v1").optional(),
   naming: z
     .strictObject({
       profileVersion: z.literal(1),

--- a/packages/agent/src/tool-runtime.ts
+++ b/packages/agent/src/tool-runtime.ts
@@ -127,6 +127,12 @@ export type ToolResult =
               | "mcp_output_invalid"
               | "mcp_output_unsupported"
               | "mcp_result_too_large"
+              | "managed_agent_cancelled"
+              | "managed_agent_capacity_exceeded"
+              | "managed_agent_deadline_exceeded"
+              | "managed_agent_failed"
+              | "managed_agent_result_too_large"
+              | "managed_agent_unavailable"
               | "shell_start_failed"
               | "tool_io_failed";
             readonly message: string;
@@ -190,6 +196,24 @@ function identifyToolAdapter(
         }),
       )
       .digest("hex")}`,
+  };
+}
+
+export function createInternalToolAdapter(
+  adapter: Omit<ToolAdapter, "definitionDigest" | "replay">,
+  replay: ToolReplayClass,
+): ToolAdapter {
+  return identifyToolAdapter(adapter, replay);
+}
+
+export function createInternalToolRegistry(adapters: readonly ToolAdapter[]): ToolRegistry {
+  const byName = new Map(adapters.map((adapter) => [adapter.definition.name, adapter]));
+  if (byName.size !== adapters.length) {
+    throw new TypeError("Tool adapter names must be unique.");
+  }
+  return {
+    definitions: () => [...byName.values()].map((adapter) => adapter.definition),
+    resolve: (name) => byName.get(name),
   };
 }
 
@@ -320,6 +344,42 @@ export type PermissionSubject =
       readonly serverDefinitionDigest: `sha256:${string}`;
       readonly definitionDigest: `sha256:${string}`;
       readonly argumentsDigest: `sha256:${string}`;
+    }
+  | {
+      readonly type: "managed_agent_spawn";
+      readonly parentRootId: string;
+      readonly profile: "scout.v1";
+      readonly targetIdentity: {
+        readonly targetId: string;
+        readonly vendor: string;
+        readonly modelId: string;
+        readonly route: "direct" | "vercel-ai-gateway";
+        readonly upstreamProviderId?: string;
+        readonly profileVersion: number;
+        readonly certification: "certified" | "experimental";
+      };
+      readonly taskDigest: `sha256:${string}`;
+      readonly thinkingPolicy?: {
+        readonly schemaVersion: 1;
+        readonly requestedLevelId: string;
+        readonly effectiveLevelId: string;
+        readonly capability: {
+          readonly id: string;
+          readonly version: 1;
+          readonly digest: `sha256:${string}`;
+        };
+        readonly mapping:
+          | {
+              readonly requestPath: "provider_options.deepseek" | "reasoning.effort";
+              readonly thinkingType: "disabled";
+            }
+          | {
+              readonly requestPath: "provider_options.deepseek" | "reasoning.effort";
+              readonly thinkingType: "enabled";
+              readonly reasoningEffort: "low" | "high" | "max";
+            };
+        readonly reasoningArtifact: "provider_reasoning";
+      };
     };
 
 export type PermissionPolicyInput = {

--- a/packages/agent/src/tool-runtime.ts
+++ b/packages/agent/src/tool-runtime.ts
@@ -348,7 +348,9 @@ export type PermissionSubject =
   | {
       readonly type: "managed_agent_spawn";
       readonly parentRootId: string;
+      readonly parentSessionId: string;
       readonly profile: "scout.v1";
+      readonly profileDigest: `sha256:${string}`;
       readonly targetIdentity: {
         readonly targetId: string;
         readonly vendor: string;
@@ -359,6 +361,11 @@ export type PermissionSubject =
         readonly certification: "certified" | "experimental";
       };
       readonly taskDigest: `sha256:${string}`;
+      readonly limits: {
+        readonly maximumTurns: 8;
+        readonly maximumTokens: 128000;
+        readonly maximumDeadlineMilliseconds: 600000;
+      };
       readonly thinkingPolicy?: {
         readonly schemaVersion: 1;
         readonly requestedLevelId: string;

--- a/packages/testkit/src/managed-agent.os.test.ts
+++ b/packages/testkit/src/managed-agent.os.test.ts
@@ -7,6 +7,7 @@ import {
   createInMemoryManagedAgentStore,
   createJsonlManagedAgentStore,
   ManagedAgentStoreError,
+  scoutManagedAgentProfileV1,
 } from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
 
@@ -37,6 +38,11 @@ const thinkingPolicy = {
 } as const;
 
 const projectId = `sha256:${"d".repeat(64)}` as const;
+const managedLimits = {
+  maximumTurns: 8,
+  maximumTokens: 128_000,
+  maximumDeadlineMilliseconds: 600_000,
+} as const;
 
 test("ManagedAgentStore preserves one admitted and terminal identity across JSONL reopen", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-store-jsonl-"));
@@ -70,9 +76,7 @@ test("ManagedAgentStore rejects a torn JSONL tail without truncation or replay",
   try {
     const store = await createJsonlManagedAgentStore({ stateRoot, workspaceRoot });
     await store.append(managedStoreRecords()[0] as ReturnType<typeof managedStoreRecords>[number]);
-    const canonicalRoot = await realpath(workspaceRoot);
-    const projectKey = createHash("sha256").update(canonicalRoot).digest("hex");
-    const logPath = join(stateRoot, "projects", projectKey, "managed-agents", "events-v1.jsonl");
+    const logPath = await managedAgentLogPath(stateRoot, workspaceRoot);
     const before = `${JSON.stringify(managedStoreRecords()[0])}\n`;
     await writeFile(logPath, `${before}{"torn":true}`, "utf8");
 
@@ -83,6 +87,41 @@ test("ManagedAgentStore rejects a torn JSONL tail without truncation or replay",
     await rm(testRoot, { recursive: true, force: true });
   }
 });
+
+test.each([
+  {
+    caseName: "empty target identity",
+    mutation: { targetIdentity: { ...targetIdentity, targetId: "" } },
+  },
+  { caseName: "malformed digest", mutation: { taskDigest: "sha256:not-a-digest" } },
+])("ManagedAgentStore rejects restored authority with $caseName", async ({ mutation }) => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-store-authority-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    await createJsonlManagedAgentStore({ stateRoot, workspaceRoot });
+    const malformed = { ...managedStoreRecords()[0], ...mutation };
+    await writeFile(
+      await managedAgentLogPath(stateRoot, workspaceRoot),
+      `${JSON.stringify(malformed)}\n`,
+      "utf8",
+    );
+
+    await expect(createJsonlManagedAgentStore({ stateRoot, workspaceRoot })).rejects.toEqual(
+      new ManagedAgentStoreError("managed_agent_log_invalid"),
+    );
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+async function managedAgentLogPath(stateRoot: string, workspaceRoot: string): Promise<string> {
+  const canonicalRoot = await realpath(workspaceRoot);
+  const projectKey = createHash("sha256").update(canonicalRoot).digest("hex");
+  return join(stateRoot, "projects", projectKey, "managed-agents", "events-v1.jsonl");
+}
 
 function managedStoreRecords() {
   return [
@@ -98,6 +137,8 @@ function managedStoreRecords() {
       parentRootId: "parent-session",
       projectId,
       profile: "scout.v1" as const,
+      profileDigest: scoutManagedAgentProfileV1.digest,
+      limits: managedLimits,
       taskDigest: `sha256:${"b".repeat(64)}` as const,
       targetIdentity,
       thinkingPolicy,

--- a/packages/testkit/src/managed-agent.os.test.ts
+++ b/packages/testkit/src/managed-agent.os.test.ts
@@ -44,6 +44,8 @@ const managedLimits = {
   maximumDeadlineMilliseconds: 600_000,
 } as const;
 const durableTask = "Persist one durable scout result.";
+const childLiveWorkspaceNotice =
+  "This child reads the live workspace. Parent changes may alter what it observes; isolated transcript does not mean repository snapshot or sandbox.";
 
 test("ManagedAgentStore preserves one admitted and terminal identity across JSONL reopen", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-store-jsonl-"));
@@ -140,8 +142,10 @@ function managedStoreRecords() {
       profile: "scout.v1" as const,
       profileDigest: scoutManagedAgentProfileV1.digest,
       limits: managedLimits,
-      task: durableTask,
       taskDigest: `sha256:${createHash("sha256").update(durableTask).digest("hex")}` as const,
+      childInputDigest: `sha256:${createHash("sha256")
+        .update(`${durableTask}\n\n${childLiveWorkspaceNotice}`)
+        .digest("hex")}` as const,
       targetIdentity,
       thinkingPolicy,
     },

--- a/packages/testkit/src/managed-agent.os.test.ts
+++ b/packages/testkit/src/managed-agent.os.test.ts
@@ -43,6 +43,7 @@ const managedLimits = {
   maximumTokens: 128_000,
   maximumDeadlineMilliseconds: 600_000,
 } as const;
+const durableTask = "Persist one durable scout result.";
 
 test("ManagedAgentStore preserves one admitted and terminal identity across JSONL reopen", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-store-jsonl-"));
@@ -139,7 +140,8 @@ function managedStoreRecords() {
       profile: "scout.v1" as const,
       profileDigest: scoutManagedAgentProfileV1.digest,
       limits: managedLimits,
-      taskDigest: `sha256:${"b".repeat(64)}` as const,
+      task: durableTask,
+      taskDigest: `sha256:${createHash("sha256").update(durableTask).digest("hex")}` as const,
       targetIdentity,
       thinkingPolicy,
     },

--- a/packages/testkit/src/managed-agent.os.test.ts
+++ b/packages/testkit/src/managed-agent.os.test.ts
@@ -1,0 +1,120 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createInMemoryManagedAgentStore,
+  createJsonlManagedAgentStore,
+  ManagedAgentStoreError,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+
+const targetIdentity = {
+  targetId: "deepseek-v4-flash.direct",
+  vendor: "deepseek",
+  modelId: "deepseek-v4-flash",
+  route: "direct",
+  profileVersion: 1,
+  certification: "certified",
+} as const;
+
+const thinkingPolicy = {
+  schemaVersion: 1,
+  requestedLevelId: "high",
+  effectiveLevelId: "high",
+  capability: {
+    id: "deepseek-thinking.v1",
+    version: 1,
+    digest: `sha256:${"a".repeat(64)}` as const,
+  },
+  mapping: {
+    requestPath: "reasoning.effort",
+    thinkingType: "enabled",
+    reasoningEffort: "high",
+  },
+  reasoningArtifact: "provider_reasoning",
+} as const;
+
+const projectId = `sha256:${"d".repeat(64)}` as const;
+
+test("ManagedAgentStore preserves one admitted and terminal identity across JSONL reopen", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-store-jsonl-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+  const records = managedStoreRecords();
+
+  try {
+    const memory = createInMemoryManagedAgentStore();
+    const warm = await createJsonlManagedAgentStore({ stateRoot, workspaceRoot });
+    for (const record of records) {
+      await memory.append(record);
+      await warm.append(record);
+    }
+    const cold = await createJsonlManagedAgentStore({ stateRoot, workspaceRoot });
+
+    await expect(memory.read()).resolves.toEqual(records);
+    await expect(cold.read()).resolves.toEqual(records);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("ManagedAgentStore rejects a torn JSONL tail without truncation or replay", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-store-torn-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const store = await createJsonlManagedAgentStore({ stateRoot, workspaceRoot });
+    await store.append(managedStoreRecords()[0] as ReturnType<typeof managedStoreRecords>[number]);
+    const canonicalRoot = await realpath(workspaceRoot);
+    const projectKey = createHash("sha256").update(canonicalRoot).digest("hex");
+    const logPath = join(stateRoot, "projects", projectKey, "managed-agents", "events-v1.jsonl");
+    const before = `${JSON.stringify(managedStoreRecords()[0])}\n`;
+    await writeFile(logPath, `${before}{"torn":true}`, "utf8");
+
+    await expect(createJsonlManagedAgentStore({ stateRoot, workspaceRoot })).rejects.toEqual(
+      new ManagedAgentStoreError("managed_agent_log_invalid"),
+    );
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+function managedStoreRecords() {
+  return [
+    {
+      schemaVersion: 1 as const,
+      type: "managed_agent_admitted" as const,
+      sequence: 1,
+      agentId: "123e4567-e89b-42d3-a456-426614174101",
+      attemptId: "123e4567-e89b-42d3-a456-426614174102",
+      childSessionId: "123e4567-e89b-42d3-a456-426614174103",
+      parentSessionId: "123e4567-e89b-42d3-a456-426614174104",
+      parentToolCallId: "spawn-store-contract",
+      parentRootId: "parent-session",
+      projectId,
+      profile: "scout.v1" as const,
+      taskDigest: `sha256:${"b".repeat(64)}` as const,
+      targetIdentity,
+      thinkingPolicy,
+    },
+    {
+      schemaVersion: 1 as const,
+      type: "managed_agent_terminal" as const,
+      sequence: 2,
+      agentId: "123e4567-e89b-42d3-a456-426614174101",
+      attemptId: "123e4567-e89b-42d3-a456-426614174102",
+      childSessionId: "123e4567-e89b-42d3-a456-426614174103",
+      status: "completed" as const,
+      result: { text: "Durable scout result." },
+      transcriptDigest: `sha256:${"c".repeat(64)}` as const,
+      throughSequence: 9,
+      usage: { inputTokens: 100, outputTokens: 20, reasoningTokens: 5 },
+      cost: { status: "unavailable" as const },
+    },
+  ] as const;
+}

--- a/packages/testkit/src/managed-agent.test.ts
+++ b/packages/testkit/src/managed-agent.test.ts
@@ -1,0 +1,1096 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  AgentSession,
+  type AgentSessionDependencies,
+  createFileArtifactStore,
+  createPermissionPolicy,
+  createSessionLifecycle,
+  type ModelDriver,
+  type ModelRequest,
+  type ModelTargets,
+} from "@adam-agent/agent";
+import {
+  createAgentManager,
+  createInMemoryManagedAgentStore,
+  createInMemorySessionStore,
+  createInMemorySessionStoreDirectory,
+  createManagedAgentToolRegistry,
+  createProjectExecutionDomain,
+  createTrustedWorkspaceTrustForTesting,
+  type ManagedAgentDeadlineScheduler,
+  ManagedAgentStoreError,
+  type ProjectLifecycleOwner,
+  recoverInterruptedManagedAgents,
+  type SessionRecord,
+  type SessionStore,
+  sessionToolProfileNames,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+
+const targetIdentity = {
+  targetId: "deepseek-v4-flash.direct",
+  vendor: "deepseek",
+  modelId: "deepseek-v4-flash",
+  route: "direct",
+  profileVersion: 1,
+  certification: "certified",
+} as const;
+
+const contextProfile = {
+  version: 1,
+  contextWindowTokens: 128_000,
+  maximumOutputTokens: 4_096,
+  compactAtTokens: 96_000,
+  postCompactTargetTokens: 32_000,
+  retainedTargetTokens: 8_000,
+  estimatorVersion: 1,
+} as const;
+
+const thinkingPolicy = {
+  schemaVersion: 1,
+  requestedLevelId: "high",
+  effectiveLevelId: "high",
+  capability: {
+    id: "deepseek-thinking.v1",
+    version: 1,
+    digest: `sha256:${"a".repeat(64)}` as const,
+  },
+  mapping: {
+    requestPath: "reasoning.effort",
+    thinkingType: "enabled",
+    reasoningEffort: "high",
+  },
+  reasoningArtifact: "provider_reasoning",
+} as const;
+
+const projectId = `sha256:${"d".repeat(64)}` as const;
+
+test("AgentSession spawns one permitted foreground scout and receives its durable result", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-scout-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "evidence.txt"), "foreground scout evidence\n", "utf8");
+  const childRequests: ModelRequest[] = [];
+  let childCall = 0;
+  const childModel: ModelDriver = {
+    async *stream(request) {
+      childRequests.push(request);
+      childCall += 1;
+      if (childCall === 1) {
+        yield { type: "tool_call_start", id: "child-read", name: "read_file" };
+        yield {
+          type: "tool_call_delta",
+          id: "child-read",
+          json: '{"path":"evidence.txt"}',
+        };
+        yield { type: "tool_call_end", id: "child-read" };
+        yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+        yield { type: "finish", reason: "tool_calls" };
+        return;
+      }
+      yield { type: "text_delta", text: "Scout found foreground scout evidence." };
+      yield { type: "usage", inputTokens: 120, outputTokens: 12 };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  let parentCall = 0;
+  let parentToolResult: unknown;
+  const parentRequests: ModelRequest[] = [];
+  const parentModel: ModelDriver = {
+    async *stream(request) {
+      parentRequests.push(request);
+      parentCall += 1;
+      if (parentCall === 1) {
+        yield { type: "tool_call_start", id: "spawn-scout", name: "spawn_agent" };
+        yield {
+          type: "tool_call_delta",
+          id: "spawn-scout",
+          json: '{"task":"Read evidence.txt and report its exact evidence."}',
+        };
+        yield { type: "tool_call_end", id: "spawn-scout" };
+        yield { type: "finish", reason: "tool_calls" };
+        return;
+      }
+      parentToolResult = request.messages.findLast((message) => message.role === "tool");
+      yield { type: "text_delta", text: "The foreground scout completed." };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return { async release() {} };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const parentRoot = await domain.claimRoot({ rootId: "parent-session" });
+  const managedStore = createInMemoryManagedAgentStore();
+  const childSessionStores = createInMemorySessionStoreDirectory<SessionRecord>();
+  const manager = createAgentManager({
+    childContextProfile: contextProfile,
+    childModel,
+    childSessionStores,
+    managedStore,
+    parentPermissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    parentRoot,
+    projectId,
+    targetIdentity,
+    thinkingPolicy,
+    workspaceRoot,
+  });
+  const parentStore = createInMemorySessionStore();
+  const parentDependencies: AgentSessionDependencies & {
+    readonly [sessionToolProfileNames]: readonly string[];
+  } = {
+    contextProfile,
+    model: parentModel,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"], askedEffects: ["delegate"] }),
+    store: parentStore,
+    tools: createManagedAgentToolRegistry({ manager }),
+    [sessionToolProfileNames]: ["spawn_agent"],
+  };
+  const parent = new AgentSession(parentDependencies);
+  const permissionSubjects: unknown[] = [];
+  parent.subscribe((event) => {
+    if (event.type === "tool_permission_requested") {
+      permissionSubjects.push(event.subject);
+      parent.decidePermission({ requestId: event.requestId, decision: "allow" });
+    }
+  });
+
+  try {
+    const result = await parent.run({ text: "Ask one foreground scout for evidence." });
+    const managedRecords = await managedStore.read();
+    const terminal = managedRecords.find((record) => record.type === "managed_agent_terminal");
+    const childSessionId = terminal?.childSessionId;
+    const childStore =
+      childSessionId === undefined ? undefined : await childSessionStores.open(childSessionId);
+    const childRecords = await childStore?.read();
+
+    expect(result).toEqual({ status: "completed", answer: "The foreground scout completed." });
+    expect(parentToolResult).toMatchObject({ role: "tool", result: { status: "completed" } });
+    expect(permissionSubjects).toEqual([
+      expect.objectContaining({
+        type: "managed_agent_spawn",
+        profile: "scout.v1",
+        targetIdentity,
+        thinkingPolicy,
+      }),
+    ]);
+    expect(parentToolResult).toMatchObject({
+      role: "tool",
+      result: {
+        status: "completed",
+        output: {
+          profile: "scout.v1",
+          status: "completed",
+          result: { text: "Scout found foreground scout evidence." },
+          targetIdentity,
+          thinkingPolicy,
+          usage: { inputTokens: 220, outputTokens: 32, reasoningTokens: 0 },
+          cost: { status: "unavailable" },
+          transcript: {
+            sessionId: expect.any(String),
+            digest: expect.stringMatching(/^sha256:/u),
+            throughSequence: expect.any(Number),
+          },
+        },
+      },
+    });
+    expect(managedRecords.map((record) => record.type)).toEqual([
+      "managed_agent_admitted",
+      "managed_agent_terminal",
+    ]);
+    expect(
+      childRecords?.findLast(
+        (record) =>
+          record.schemaVersion === 3 &&
+          record.record.type === "runtime_event" &&
+          record.record.event.type === "session_settled",
+      ),
+    ).toMatchObject({
+      record: {
+        event: {
+          type: "session_settled",
+          result: {
+            status: "completed",
+            answer: "Scout found foreground scout evidence.",
+          },
+        },
+      },
+    });
+    expect(childRequests[1]?.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "tool",
+          callId: "child-read",
+          name: "read_file",
+          result: {
+            status: "completed",
+            output: {
+              path: "evidence.txt",
+              content: "foreground scout evidence\n",
+              truncated: false,
+            },
+          },
+        }),
+      ]),
+    );
+    expect(childRequests.every((request) => request.thinkingPolicy === thinkingPolicy)).toBe(true);
+    expect(parentRequests[0]?.tools).toEqual([
+      expect.objectContaining({
+        name: "spawn_agent",
+        inputSchema: expect.objectContaining({
+          additionalProperties: false,
+          required: ["task"],
+          properties: { task: expect.any(Object) },
+        }),
+      }),
+    ]);
+    expect(childRequests[0]?.tools.map((tool) => tool.name)).toEqual([
+      "read_file",
+      "search_repository",
+    ]);
+    expect(await readFile(join(workspaceRoot, "evidence.txt"), "utf8")).toBe(
+      "foreground scout evidence\n",
+    );
+  } finally {
+    await parentRoot.release();
+    await domain.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("AgentSession rejects managed profile selection before permission or child provider work", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-profile-reject-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  let childProviderCalls = 0;
+  const childModel: ModelDriver = {
+    async *stream() {
+      childProviderCalls += 1;
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  let parentCall = 0;
+  let toolResult: unknown;
+  const parentModel: ModelDriver = {
+    async *stream(request) {
+      parentCall += 1;
+      if (parentCall === 1) {
+        yield { type: "tool_call_start", id: "invalid-spawn", name: "spawn_agent" };
+        yield {
+          type: "tool_call_delta",
+          id: "invalid-spawn",
+          json: '{"task":"Inspect the repository","profile":"research.v1"}',
+        };
+        yield { type: "tool_call_end", id: "invalid-spawn" };
+        yield { type: "finish", reason: "tool_calls" };
+        return;
+      }
+      toolResult = request.messages.findLast(
+        (message) => message.role === "tool" && message.name === "spawn_agent",
+      );
+      yield { type: "text_delta", text: "The invalid spawn was rejected." };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return { async release() {} };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const parentRoot = await domain.claimRoot({ rootId: "parent-session" });
+  const managedStore = createInMemoryManagedAgentStore();
+  const manager = createAgentManager({
+    childContextProfile: contextProfile,
+    childModel,
+    childSessionStores: createInMemorySessionStoreDirectory<SessionRecord>(),
+    managedStore,
+    parentPermissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    parentRoot,
+    projectId,
+    targetIdentity,
+    workspaceRoot,
+  });
+  const parentDependencies: AgentSessionDependencies & {
+    readonly [sessionToolProfileNames]: readonly string[];
+  } = {
+    contextProfile,
+    model: parentModel,
+    permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["delegate"] }),
+    store: createInMemorySessionStore(),
+    tools: createManagedAgentToolRegistry({ manager }),
+    [sessionToolProfileNames]: ["spawn_agent"],
+  };
+  const parent = new AgentSession(parentDependencies);
+  let permissionRequests = 0;
+  parent.subscribe((event) => {
+    if (event.type === "tool_permission_requested") {
+      permissionRequests += 1;
+    }
+  });
+
+  try {
+    await expect(parent.run({ text: "Try an invalid managed profile." })).resolves.toEqual({
+      status: "completed",
+      answer: "The invalid spawn was rejected.",
+    });
+    expect(toolResult).toMatchObject({
+      result: { status: "failed", error: { code: "invalid_tool_input" } },
+    });
+    expect({
+      childProviderCalls,
+      permissionRequests,
+      managedRecords: await managedStore.read(),
+    }).toEqual({ childProviderCalls: 0, permissionRequests: 0, managedRecords: [] });
+  } finally {
+    await parentRoot.release();
+    await domain.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("AgentManager records missing child token usage as durable terminal failure", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-usage-failure-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const childModel: ModelDriver = {
+    async *stream() {
+      yield { type: "text_delta", text: "Unaccounted child answer." };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return { async release() {} };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const parentRoot = await domain.claimRoot({ rootId: "parent-session" });
+  const managedStore = createInMemoryManagedAgentStore();
+  const manager = createAgentManager({
+    childContextProfile: contextProfile,
+    childModel,
+    childSessionStores: createInMemorySessionStoreDirectory<SessionRecord>(),
+    managedStore,
+    parentPermissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    parentRoot,
+    projectId,
+    targetIdentity,
+    workspaceRoot,
+  });
+
+  try {
+    await expect(
+      manager.spawnForeground({
+        callId: "missing-usage-spawn",
+        parentSessionId: "123e4567-e89b-42d3-a456-426614174105",
+        signal: new AbortController().signal,
+        task: "Return an answer without usage.",
+      }),
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "managed_agent_failed" },
+    });
+    expect(await managedStore.read()).toMatchObject([
+      { type: "managed_agent_admitted" },
+      {
+        type: "managed_agent_terminal",
+        status: "failed",
+        error: { code: "token_usage_missing" },
+      },
+    ]);
+  } finally {
+    await parentRoot.release();
+    await domain.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle exposes foreground scout through the exact new-session Tool Profile", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-lifecycle-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "evidence.txt"), "lifecycle scout evidence\n", "utf8");
+  await writeFile(
+    join(workspaceRoot, "AGENTS.md"),
+    "# Scout repository instruction\n\nReport exact file evidence.\n",
+    "utf8",
+  );
+  const requestCounts = new Map<"child" | "parent", number>();
+  let parentToolResult: unknown;
+  let parentFirstTools: ModelRequest["tools"] | undefined;
+  let childFirstMessages: ModelRequest["messages"] | undefined;
+  const driver: ModelDriver = {
+    async *stream(request) {
+      if (request.purpose === "title") {
+        yield { type: "text_delta", text: "Managed scout session" };
+        yield { type: "finish", reason: "stop" };
+        return;
+      }
+      const child = request.messages.some(
+        (message) =>
+          message.role === "user" &&
+          typeof message.content === "string" &&
+          message.content.includes("Read lifecycle evidence"),
+      );
+      const kind = child ? "child" : "parent";
+      const count = (requestCounts.get(kind) ?? 0) + 1;
+      requestCounts.set(kind, count);
+      if (kind === "parent" && count === 1) {
+        parentFirstTools = request.tools;
+        yield { type: "tool_call_start", id: "lifecycle-spawn", name: "spawn_agent" };
+        yield {
+          type: "tool_call_delta",
+          id: "lifecycle-spawn",
+          json: '{"task":"Read lifecycle evidence from evidence.txt."}',
+        };
+        yield { type: "tool_call_end", id: "lifecycle-spawn" };
+        yield { type: "finish", reason: "tool_calls" };
+        return;
+      }
+      if (kind === "child" && count === 1) {
+        childFirstMessages = request.messages;
+        yield { type: "tool_call_start", id: "lifecycle-child-read", name: "read_file" };
+        yield {
+          type: "tool_call_delta",
+          id: "lifecycle-child-read",
+          json: '{"path":"evidence.txt"}',
+        };
+        yield { type: "tool_call_end", id: "lifecycle-child-read" };
+        yield { type: "usage", inputTokens: 80, outputTokens: 15 };
+        yield { type: "finish", reason: "tool_calls" };
+        return;
+      }
+      if (kind === "child") {
+        yield { type: "text_delta", text: "Scout found lifecycle scout evidence." };
+        yield { type: "usage", inputTokens: 100, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+        return;
+      }
+      parentToolResult = request.messages.findLast((message) => message.role === "tool");
+      yield { type: "text_delta", text: "Lifecycle foreground scout completed." };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = createSessionLifecycle({
+    managedAgentTools: "managed-agent-tools.a1.v1",
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"], askedEffects: ["delegate"] }),
+    stateRoot,
+    workspaceRoot,
+    workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
+  });
+  lifecycle.subscribe((event) => {
+    if (event.type === "tool_permission_requested") {
+      lifecycle.decidePermission({ requestId: event.requestId, decision: "allow" });
+    }
+  });
+  let cold: ReturnType<typeof createSessionLifecycle> | undefined;
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    expect(created.promptContext?.toolProfile.definitions).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "spawn_agent" })]),
+    );
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: "Use the foreground scout." },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "Lifecycle foreground scout completed." },
+    });
+    expect(parentToolResult).toMatchObject({
+      result: {
+        status: "completed",
+        output: {
+          profile: "scout.v1",
+          result: { text: "Scout found lifecycle scout evidence." },
+          targetIdentity,
+        },
+      },
+    });
+    expect(parentFirstTools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "spawn_agent",
+          description:
+            "Run one foreground read-only scout with fresh bounded context. It cannot run in background, select Skills, write, execute, spawn, inherit extensions, or change its model or permissions.",
+        }),
+      ]),
+    );
+    expect(childFirstMessages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "developer",
+          content: expect.stringContaining("Managed child profile scout.v1"),
+        }),
+        expect.objectContaining({
+          role: "user",
+          content: expect.stringContaining("Report exact file evidence."),
+        }),
+      ]),
+    );
+    expect(childFirstMessages).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ role: "user", content: "Use the foreground scout." }),
+      ]),
+    );
+    expect(requestCounts).toEqual(
+      new Map<"child" | "parent", number>([
+        ["parent", 2],
+        ["child", 2],
+      ]),
+    );
+    await expect(lifecycle.listProjectSessions()).resolves.toMatchObject({
+      items: [{ sessionId: created.sessionId }],
+    });
+    await lifecycle.close();
+    const requestCountsBeforeResume = new Map(requestCounts);
+    cold = createSessionLifecycle({
+      managedAgentTools: "managed-agent-tools.a1.v1",
+      modelTargets,
+      permissions: createPermissionPolicy({
+        allowedEffects: ["read"],
+        askedEffects: ["delegate"],
+      }),
+      stateRoot,
+      workspaceRoot,
+      workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
+    });
+    await expect(cold.resume({ sessionId: created.sessionId })).resolves.toMatchObject({
+      status: "ready",
+      snapshot: {
+        promptContext: {
+          toolProfile: {
+            definitions: expect.arrayContaining([expect.objectContaining({ name: "spawn_agent" })]),
+          },
+        },
+      },
+    });
+    expect(requestCounts).toEqual(requestCountsBeforeResume);
+  } finally {
+    await cold?.close();
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("AgentManager cancels a foreground child through its exact caller signal before terminal link", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-cancel-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const childStarted = Promise.withResolvers<void>();
+  const childModel: ModelDriver = {
+    async *stream(request) {
+      childStarted.resolve();
+      if (!request.signal.aborted) {
+        await new Promise<void>((resolve) =>
+          request.signal.addEventListener("abort", () => resolve(), { once: true }),
+        );
+      }
+    },
+  };
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return { async release() {} };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const parentRoot = await domain.claimRoot({ rootId: "parent-session" });
+  const managedStore = createInMemoryManagedAgentStore();
+  const manager = createAgentManager({
+    childContextProfile: contextProfile,
+    childModel,
+    childSessionStores: createInMemorySessionStoreDirectory<SessionRecord>(),
+    managedStore,
+    parentPermissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    parentRoot,
+    projectId,
+    targetIdentity,
+    workspaceRoot,
+  });
+  const controller = new AbortController();
+
+  try {
+    const spawning = manager.spawnForeground({
+      callId: "cancel-spawn",
+      parentSessionId: "123e4567-e89b-42d3-a456-426614174106",
+      signal: controller.signal,
+      task: "Wait until cancelled.",
+    });
+    await childStarted.promise;
+    controller.abort(new Error("caller cancelled foreground scout"));
+
+    await expect(spawning).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "managed_agent_cancelled" },
+    });
+    expect(await managedStore.read()).toMatchObject([
+      { type: "managed_agent_admitted" },
+      { type: "managed_agent_terminal", status: "cancelled", reason: "caller" },
+    ]);
+  } finally {
+    controller.abort();
+    await parentRoot.release();
+    await domain.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("AgentManager settles its injected aggregate deadline as durable terminal failure", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-deadline-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const childStarted = Promise.withResolvers<void>();
+  const childModel: ModelDriver = {
+    async *stream(request) {
+      childStarted.resolve();
+      if (!request.signal.aborted) {
+        await new Promise<void>((resolve) =>
+          request.signal.addEventListener("abort", () => resolve(), { once: true }),
+        );
+      }
+    },
+  };
+  let scheduledDelay: number | undefined;
+  let expire = () => {};
+  const deadlineScheduler: ManagedAgentDeadlineScheduler = {
+    schedule(delayMilliseconds, onDeadline) {
+      scheduledDelay = delayMilliseconds;
+      expire = onDeadline;
+      return { cancel() {} };
+    },
+  };
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return { async release() {} };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const parentRoot = await domain.claimRoot({ rootId: "parent-session" });
+  const managedStore = createInMemoryManagedAgentStore();
+  const manager = createAgentManager({
+    childContextProfile: contextProfile,
+    childModel,
+    childSessionStores: createInMemorySessionStoreDirectory<SessionRecord>(),
+    deadlineScheduler,
+    managedStore,
+    parentPermissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    parentRoot,
+    projectId,
+    targetIdentity,
+    workspaceRoot,
+  });
+
+  try {
+    const spawning = manager.spawnForeground({
+      callId: "deadline-spawn",
+      parentSessionId: "123e4567-e89b-42d3-a456-426614174107",
+      signal: new AbortController().signal,
+      task: "Wait for the aggregate deadline.",
+    });
+    await childStarted.promise;
+    expect(scheduledDelay).toBe(10 * 60 * 1_000);
+    expire();
+
+    await expect(spawning).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "managed_agent_deadline_exceeded" },
+    });
+    expect(await managedStore.read()).toMatchObject([
+      { type: "managed_agent_admitted" },
+      {
+        type: "managed_agent_terminal",
+        status: "failed",
+        error: { code: "managed_agent_deadline_exceeded" },
+      },
+    ]);
+  } finally {
+    await parentRoot.release();
+    await domain.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("AgentManager publishes an oversized completed result through one immutable artifact", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-result-artifact-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const artifactRoot = join(testRoot, "artifacts");
+  await mkdir(workspaceRoot);
+  const largeAnswer = `Managed result\n${"x".repeat(70 * 1024)}`;
+  const childModel: ModelDriver = {
+    async *stream() {
+      yield { type: "text_delta", text: largeAnswer };
+      yield { type: "usage", inputTokens: 100, outputTokens: 20_000 };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return { async release() {} };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const parentRoot = await domain.claimRoot({ rootId: "parent-session" });
+  const managedStore = createInMemoryManagedAgentStore();
+  const artifactStore = await createFileArtifactStore({ root: artifactRoot });
+  const manager = createAgentManager({
+    artifactStore,
+    childContextProfile: contextProfile,
+    childModel,
+    childSessionStores: createInMemorySessionStoreDirectory<SessionRecord>(),
+    managedStore,
+    parentPermissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    parentRoot,
+    projectId,
+    targetIdentity,
+    workspaceRoot,
+  });
+
+  try {
+    const result = await manager.spawnForeground({
+      callId: "overflow-spawn",
+      parentSessionId: "123e4567-e89b-42d3-a456-426614174108",
+      signal: new AbortController().signal,
+      task: "Return one large result.",
+    });
+    expect(result).toMatchObject({
+      status: "completed",
+      output: {
+        status: "completed",
+        result: {
+          artifact: {
+            id: expect.stringMatching(/^sha256:/u),
+            mediaType: "text/plain; charset=utf-8",
+            byteCount: Buffer.byteLength(largeAnswer, "utf8"),
+          },
+        },
+      },
+    });
+    const output =
+      result.status === "completed"
+        ? (result.output as { readonly result: { readonly artifact: { readonly id: string } } })
+        : undefined;
+    if (output === undefined) {
+      throw new Error("Expected one Managed Agent result artifact.");
+    }
+    const bytes = await artifactStore.read(output.result.artifact.id);
+    expect(new TextDecoder().decode(bytes)).toBe(largeAnswer);
+    expect(await managedStore.read()).toMatchObject([
+      { type: "managed_agent_admitted" },
+      {
+        type: "managed_agent_terminal",
+        status: "completed",
+        result: { artifact: { id: output.result.artifact.id } },
+      },
+    ]);
+  } finally {
+    await parentRoot.release();
+    await domain.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("ManagedAgentStore folds an admitted restart window without child provider replay", async () => {
+  const managedStore = createInMemoryManagedAgentStore();
+  await managedStore.append({
+    schemaVersion: 1,
+    type: "managed_agent_admitted",
+    sequence: 1,
+    agentId: "123e4567-e89b-42d3-a456-426614174111",
+    attemptId: "123e4567-e89b-42d3-a456-426614174112",
+    childSessionId: "123e4567-e89b-42d3-a456-426614174113",
+    parentSessionId: "123e4567-e89b-42d3-a456-426614174114",
+    parentToolCallId: "restart-window-spawn",
+    parentRootId: "parent-session",
+    projectId,
+    profile: "scout.v1",
+    taskDigest: `sha256:${"e".repeat(64)}`,
+    targetIdentity,
+  });
+  await recoverInterruptedManagedAgents(managedStore);
+
+  expect(await managedStore.read()).toMatchObject([
+    { type: "managed_agent_admitted" },
+    {
+      type: "managed_agent_terminal",
+      status: "recovery_required",
+      error: { code: "managed_agent_recovery_required" },
+    },
+  ]);
+});
+
+test("ManagedAgentStore rejects a terminal link with a different child identity", async () => {
+  const managedStore = createInMemoryManagedAgentStore();
+  const admission = {
+    schemaVersion: 1 as const,
+    type: "managed_agent_admitted" as const,
+    sequence: 1,
+    agentId: "123e4567-e89b-42d3-a456-426614174151",
+    attemptId: "123e4567-e89b-42d3-a456-426614174152",
+    childSessionId: "123e4567-e89b-42d3-a456-426614174153",
+    parentSessionId: "123e4567-e89b-42d3-a456-426614174154",
+    parentToolCallId: "mismatched-terminal-spawn",
+    parentRootId: "parent-session",
+    projectId,
+    profile: "scout.v1" as const,
+    taskDigest: `sha256:${"1".repeat(64)}` as const,
+    targetIdentity,
+  };
+  await managedStore.append(admission);
+
+  await expect(
+    managedStore.append({
+      schemaVersion: 1,
+      type: "managed_agent_terminal",
+      sequence: 2,
+      agentId: admission.agentId,
+      attemptId: admission.attemptId,
+      childSessionId: "123e4567-e89b-42d3-a456-426614174155",
+      status: "completed",
+      result: { text: "Forged terminal." },
+      transcriptDigest: `sha256:${"2".repeat(64)}`,
+      throughSequence: 4,
+      usage: { inputTokens: 10, outputTokens: 2, reasoningTokens: 0 },
+      cost: { status: "unavailable" },
+    }),
+  ).rejects.toEqual(new ManagedAgentStoreError("managed_agent_log_invalid"));
+  await expect(managedStore.read()).resolves.toEqual([admission]);
+});
+
+test("ManagedAgentStore links a complete child transcript after a terminal-link crash", async () => {
+  const managedStore = createInMemoryManagedAgentStore();
+  const childSessionStores = createInMemorySessionStoreDirectory<SessionRecord>();
+  const childSessionId = "123e4567-e89b-42d3-a456-426614174123";
+  const childStore = await childSessionStores.create(childSessionId);
+  let providerCalls = 0;
+  const child = new AgentSession({
+    contextProfile,
+    model: {
+      async *stream() {
+        providerCalls += 1;
+        yield { type: "text_delta", text: "Recovered completed scout result." };
+        yield { type: "usage", inputTokens: 30, outputTokens: 8 };
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    store: childStore as SessionStore,
+  });
+  await child.run(
+    { text: "Complete before the manager link." },
+    { limits: { maxTurns: 8, maxTokens: 128_000 } },
+  );
+  await managedStore.append({
+    schemaVersion: 1,
+    type: "managed_agent_admitted",
+    sequence: 1,
+    agentId: "123e4567-e89b-42d3-a456-426614174121",
+    attemptId: "123e4567-e89b-42d3-a456-426614174122",
+    childSessionId,
+    parentSessionId: "123e4567-e89b-42d3-a456-426614174124",
+    parentToolCallId: "terminal-link-window-spawn",
+    parentRootId: "parent-session",
+    projectId,
+    profile: "scout.v1",
+    taskDigest: `sha256:${"f".repeat(64)}`,
+    targetIdentity,
+  });
+
+  await recoverInterruptedManagedAgents(managedStore, childSessionStores);
+
+  expect(providerCalls).toBe(1);
+  expect(await managedStore.read()).toMatchObject([
+    { type: "managed_agent_admitted" },
+    {
+      type: "managed_agent_terminal",
+      status: "completed",
+      result: { text: "Recovered completed scout result." },
+      transcriptDigest: expect.stringMatching(/^sha256:/u),
+      throughSequence: expect.any(Number),
+    },
+  ]);
+});
+
+test("AgentManager rejects a ninth foreground identity before child provider work", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-identity-cap-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  let providerCalls = 0;
+  const childModel: ModelDriver = {
+    async *stream() {
+      providerCalls += 1;
+      yield { type: "text_delta", text: "Bounded scout result." };
+      yield { type: "usage", inputTokens: 20, outputTokens: 5 };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return { async release() {} };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const parentRoot = await domain.claimRoot({ rootId: "parent-session" });
+  const managedStore = createInMemoryManagedAgentStore();
+  const manager = createAgentManager({
+    childContextProfile: contextProfile,
+    childModel,
+    childSessionStores: createInMemorySessionStoreDirectory<SessionRecord>(),
+    managedStore,
+    parentPermissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    parentRoot,
+    projectId,
+    targetIdentity,
+    workspaceRoot,
+  });
+  const parentSessionId = "123e4567-e89b-42d3-a456-426614174131";
+
+  try {
+    for (let index = 0; index < 8; index += 1) {
+      await expect(
+        manager.spawnForeground({
+          callId: `bounded-spawn-${index + 1}`,
+          parentSessionId,
+          signal: new AbortController().signal,
+          task: `Run bounded scout ${index + 1}.`,
+        }),
+      ).resolves.toMatchObject({ status: "completed" });
+    }
+    await expect(
+      manager.spawnForeground({
+        callId: "bounded-spawn-9",
+        parentSessionId,
+        signal: new AbortController().signal,
+        task: "Run forbidden ninth scout.",
+      }),
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "managed_agent_capacity_exceeded" },
+    });
+    expect(providerCalls).toBe(8);
+    expect(
+      (await managedStore.read()).filter((record) => record.type === "managed_agent_admitted"),
+    ).toHaveLength(8);
+  } finally {
+    await parentRoot.release();
+    await domain.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("AgentManager hard-denies child read when the current parent ceiling does not allow it", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-parent-ceiling-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "secret.txt"), "must not be returned\n", "utf8");
+  let childCall = 0;
+  let childToolResult: unknown;
+  const childModel: ModelDriver = {
+    async *stream(request) {
+      childCall += 1;
+      if (childCall === 1) {
+        yield { type: "tool_call_start", id: "denied-child-read", name: "read_file" };
+        yield {
+          type: "tool_call_delta",
+          id: "denied-child-read",
+          json: '{"path":"secret.txt"}',
+        };
+        yield { type: "tool_call_end", id: "denied-child-read" };
+        yield { type: "usage", inputTokens: 40, outputTokens: 10 };
+        yield { type: "finish", reason: "tool_calls" };
+        return;
+      }
+      childToolResult = request.messages.findLast((message) => message.role === "tool");
+      yield { type: "text_delta", text: "The parent ceiling denied the read." };
+      yield { type: "usage", inputTokens: 50, outputTokens: 8 };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return { async release() {} };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const parentRoot = await domain.claimRoot({ rootId: "parent-session" });
+  const manager = createAgentManager({
+    childContextProfile: contextProfile,
+    childModel,
+    childSessionStores: createInMemorySessionStoreDirectory<SessionRecord>(),
+    managedStore: createInMemoryManagedAgentStore(),
+    parentPermissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["read"] }),
+    parentRoot,
+    projectId,
+    targetIdentity,
+    workspaceRoot,
+  });
+
+  try {
+    await expect(
+      manager.spawnForeground({
+        callId: "parent-ceiling-spawn",
+        parentSessionId: "123e4567-e89b-42d3-a456-426614174141",
+        signal: new AbortController().signal,
+        task: "Attempt the parent-denied read.",
+      }),
+    ).resolves.toMatchObject({
+      status: "completed",
+      output: { result: { text: "The parent ceiling denied the read." } },
+    });
+    expect(childToolResult).toMatchObject({
+      result: { status: "failed", error: { code: "permission_denied" } },
+    });
+    expect(JSON.stringify(childToolResult)).not.toContain("must not be returned");
+  } finally {
+    await parentRoot.release();
+    await domain.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/testkit/src/managed-agent.test.ts
+++ b/packages/testkit/src/managed-agent.test.ts
@@ -7,6 +7,7 @@ import {
   type AgentSessionDependencies,
   createFileArtifactStore,
   createPermissionPolicy,
+  createReadToolRegistry,
   createSessionLifecycle,
   type ModelDriver,
   type ModelRequest,
@@ -19,6 +20,7 @@ import {
   createInMemorySessionStoreDirectory,
   createManagedAgentToolRegistry,
   createProjectExecutionDomain,
+  createPromptContextV1,
   createTrustedWorkspaceTrustForTesting,
   type ManagedAgentDeadlineScheduler,
   ManagedAgentStoreError,
@@ -26,6 +28,9 @@ import {
   recoverInterruptedManagedAgents,
   type SessionRecord,
   type SessionStore,
+  type SessionStoreDirectory,
+  scoutManagedAgentProfileV1,
+  sessionDurableContext,
   sessionToolProfileNames,
 } from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
@@ -67,6 +72,11 @@ const thinkingPolicy = {
 } as const;
 
 const projectId = `sha256:${"d".repeat(64)}` as const;
+const managedLimits = {
+  maximumTurns: 8,
+  maximumTokens: 128_000,
+  maximumDeadlineMilliseconds: 600_000,
+} as const;
 
 test("AgentSession spawns one permitted foreground scout and receives its durable result", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-scout-"));
@@ -177,7 +187,11 @@ test("AgentSession spawns one permitted foreground scout and receives its durabl
     expect(permissionSubjects).toEqual([
       expect.objectContaining({
         type: "managed_agent_spawn",
+        parentRootId: "parent-session",
+        parentSessionId: "00000000-0000-4000-8000-000000000001",
         profile: "scout.v1",
+        profileDigest: scoutManagedAgentProfileV1.digest,
+        limits: managedLimits,
         targetIdentity,
         thinkingPolicy,
       }),
@@ -420,6 +434,78 @@ test("AgentManager records missing child token usage as durable terminal failure
   }
 });
 
+test("AgentManager records recovery-required before releasing a post-admission failure", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-post-admission-failure-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  let ownerReleases = 0;
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return {
+        async release() {
+          ownerReleases += 1;
+        },
+      };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const unavailableChildStores: SessionStoreDirectory<SessionRecord> = {
+    async create() {
+      throw new Error("injected child genesis failure");
+    },
+    async listSessionEntries() {
+      return [];
+    },
+    async listSessionIds() {
+      return [];
+    },
+    async open() {
+      return undefined;
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const parentRoot = await domain.claimRoot({ rootId: "parent-session" });
+  const managedStore = createInMemoryManagedAgentStore();
+  const manager = createAgentManager({
+    childContextProfile: contextProfile,
+    childModel: { async *stream() {} },
+    childSessionStores: unavailableChildStores,
+    managedStore,
+    parentPermissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    parentRoot,
+    projectId,
+    targetIdentity,
+    workspaceRoot,
+  });
+
+  try {
+    await expect(
+      manager.spawnForeground({
+        callId: "post-admission-failure-spawn",
+        parentSessionId: "123e4567-e89b-42d3-a456-426614174161",
+        signal: new AbortController().signal,
+        task: "Fail after durable admission.",
+      }),
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "managed_agent_unavailable" },
+    });
+    expect(await managedStore.read()).toMatchObject([
+      { type: "managed_agent_admitted" },
+      { type: "managed_agent_terminal", status: "recovery_required" },
+    ]);
+    expect(ownerReleases).toBe(0);
+    await parentRoot.release();
+    expect(ownerReleases).toBe(1);
+  } finally {
+    await parentRoot.release();
+    await domain.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("SessionLifecycle exposes foreground scout through the exact new-session Tool Profile", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-lifecycle-"));
   const stateRoot = join(testRoot, "state");
@@ -511,8 +597,10 @@ test("SessionLifecycle exposes foreground scout through the exact new-session To
     workspaceRoot,
     workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
   });
+  const lifecyclePermissionSubjects: unknown[] = [];
   lifecycle.subscribe((event) => {
     if (event.type === "tool_permission_requested") {
+      lifecyclePermissionSubjects.push(event.subject);
       lifecycle.decidePermission({ requestId: event.requestId, decision: "allow" });
     }
   });
@@ -541,6 +629,15 @@ test("SessionLifecycle exposes foreground scout through the exact new-session To
         },
       },
     });
+    expect(lifecyclePermissionSubjects).toEqual([
+      expect.objectContaining({
+        type: "managed_agent_spawn",
+        parentRootId: `session:${created.sessionId}`,
+        parentSessionId: created.sessionId,
+        profileDigest: scoutManagedAgentProfileV1.digest,
+        limits: managedLimits,
+      }),
+    ]);
     expect(parentFirstTools).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -843,9 +940,11 @@ test("ManagedAgentStore folds an admitted restart window without child provider 
     childSessionId: "123e4567-e89b-42d3-a456-426614174113",
     parentSessionId: "123e4567-e89b-42d3-a456-426614174114",
     parentToolCallId: "restart-window-spawn",
-    parentRootId: "parent-session",
+    parentRootId: "session:123e4567-e89b-42d3-a456-426614174114",
     projectId,
     profile: "scout.v1",
+    profileDigest: scoutManagedAgentProfileV1.digest,
+    limits: managedLimits,
     taskDigest: `sha256:${"e".repeat(64)}`,
     targetIdentity,
   });
@@ -872,9 +971,11 @@ test("ManagedAgentStore rejects a terminal link with a different child identity"
     childSessionId: "123e4567-e89b-42d3-a456-426614174153",
     parentSessionId: "123e4567-e89b-42d3-a456-426614174154",
     parentToolCallId: "mismatched-terminal-spawn",
-    parentRootId: "parent-session",
+    parentRootId: "session:123e4567-e89b-42d3-a456-426614174124",
     projectId,
     profile: "scout.v1" as const,
+    profileDigest: scoutManagedAgentProfileV1.digest,
+    limits: managedLimits,
     taskDigest: `sha256:${"1".repeat(64)}` as const,
     targetIdentity,
   };
@@ -904,8 +1005,31 @@ test("ManagedAgentStore links a complete child transcript after a terminal-link 
   const childSessionStores = createInMemorySessionStoreDirectory<SessionRecord>();
   const childSessionId = "123e4567-e89b-42d3-a456-426614174123";
   const childStore = await childSessionStores.create(childSessionId);
+  const childTools = createReadToolRegistry({ workspaceRoot: process.cwd() });
+  const childPromptContext = createPromptContextV1(childTools);
+  await childStore.append({
+    schemaVersion: 3,
+    sequence: 1,
+    record: {
+      type: "session_genesis",
+      recordVersion: 2,
+      sessionId: childSessionId,
+      projectId,
+      targetIdentity,
+      contextProfile,
+      promptContext: childPromptContext,
+    },
+  });
   let providerCalls = 0;
-  const child = new AgentSession({
+  const childDependencies: AgentSessionDependencies & {
+    readonly [sessionDurableContext]: {
+      readonly nextSequence: number;
+      readonly projectId: string;
+      readonly promptContext: typeof childPromptContext;
+      readonly sessionId: string;
+      readonly targetIdentity: typeof targetIdentity;
+    };
+  } = {
     contextProfile,
     model: {
       async *stream() {
@@ -916,11 +1040,37 @@ test("ManagedAgentStore links a complete child transcript after a terminal-link 
       },
     },
     store: childStore as SessionStore,
-  });
+    tools: childTools,
+    [sessionDurableContext]: {
+      nextSequence: 2,
+      projectId,
+      promptContext: childPromptContext,
+      sessionId: childSessionId,
+      targetIdentity,
+    },
+  };
+  const child = new AgentSession(childDependencies);
   await child.run(
     { text: "Complete before the manager link." },
     { limits: { maxTurns: 8, maxTokens: 128_000 } },
   );
+  const childRecordsBeforeCompaction = await childStore.read();
+  await childStore.append({
+    schemaVersion: 3,
+    sequence: childRecordsBeforeCompaction.length + 1,
+    record: {
+      type: "context_compaction_interrupted",
+      recordVersion: 1,
+      runId: "123e4567-e89b-42d3-a456-426614174125",
+      attemptId: "123e4567-e89b-42d3-a456-426614174126",
+      attemptNumber: 1,
+      windowNumber: 1,
+      trigger: "automatic_threshold",
+      sourceThrough: 1,
+      reason: "caller_cancelled",
+      usage: { inputTokens: 11, outputTokens: 3, reasoningTokens: 2 },
+    },
+  });
   await managedStore.append({
     schemaVersion: 1,
     type: "managed_agent_admitted",
@@ -930,9 +1080,11 @@ test("ManagedAgentStore links a complete child transcript after a terminal-link 
     childSessionId,
     parentSessionId: "123e4567-e89b-42d3-a456-426614174124",
     parentToolCallId: "terminal-link-window-spawn",
-    parentRootId: "parent-session",
+    parentRootId: "session:123e4567-e89b-42d3-a456-426614174124",
     projectId,
     profile: "scout.v1",
+    profileDigest: scoutManagedAgentProfileV1.digest,
+    limits: managedLimits,
     taskDigest: `sha256:${"f".repeat(64)}`,
     targetIdentity,
   });
@@ -948,6 +1100,58 @@ test("ManagedAgentStore links a complete child transcript after a terminal-link 
       result: { text: "Recovered completed scout result." },
       transcriptDigest: expect.stringMatching(/^sha256:/u),
       throughSequence: expect.any(Number),
+      usage: { inputTokens: 41, outputTokens: 11, reasoningTokens: 2 },
+      cost: { status: "unavailable" },
+    },
+  ]);
+});
+
+test("ManagedAgentStore requires inspection for a child genesis with a different project identity", async () => {
+  const managedStore = createInMemoryManagedAgentStore();
+  const childSessionStores = createInMemorySessionStoreDirectory<SessionRecord>();
+  const childSessionId = "123e4567-e89b-42d3-a456-426614174173";
+  const childStore = await childSessionStores.create(childSessionId);
+  const childTools = createReadToolRegistry({ workspaceRoot: process.cwd() });
+  await childStore.append({
+    schemaVersion: 3,
+    sequence: 1,
+    record: {
+      type: "session_genesis",
+      recordVersion: 2,
+      sessionId: childSessionId,
+      projectId,
+      targetIdentity,
+      contextProfile,
+      promptContext: createPromptContextV1(childTools),
+    },
+  });
+  const parentSessionId = "123e4567-e89b-42d3-a456-426614174174";
+  await managedStore.append({
+    schemaVersion: 1,
+    type: "managed_agent_admitted",
+    sequence: 1,
+    agentId: "123e4567-e89b-42d3-a456-426614174171",
+    attemptId: "123e4567-e89b-42d3-a456-426614174172",
+    childSessionId,
+    parentSessionId,
+    parentToolCallId: "identity-mismatch-spawn",
+    parentRootId: `session:${parentSessionId}`,
+    projectId: `sha256:${"9".repeat(64)}`,
+    profile: "scout.v1",
+    profileDigest: scoutManagedAgentProfileV1.digest,
+    limits: managedLimits,
+    taskDigest: `sha256:${"8".repeat(64)}`,
+    targetIdentity,
+  });
+
+  await recoverInterruptedManagedAgents(managedStore, childSessionStores);
+
+  expect(await managedStore.read()).toMatchObject([
+    { type: "managed_agent_admitted" },
+    {
+      type: "managed_agent_terminal",
+      status: "inspection_required",
+      error: { code: "managed_agent_inspection_required" },
     },
   ]);
 });

--- a/packages/testkit/src/managed-agent.test.ts
+++ b/packages/testkit/src/managed-agent.test.ts
@@ -1050,8 +1050,8 @@ test("ManagedAgentStore folds an admitted restart window without child provider 
     profile: "scout.v1",
     profileDigest: scoutManagedAgentProfileV1.digest,
     limits: managedLimits,
-    task: "Interrupted admitted task.",
     taskDigest: testTaskDigest("Interrupted admitted task."),
+    childInputDigest: testTaskDigest(`Interrupted admitted task.\n\n${childLiveWorkspaceNotice}`),
     targetIdentity,
   });
   await recoverInterruptedManagedAgents(managedStore);
@@ -1082,8 +1082,10 @@ test("ManagedAgentStore rejects a terminal link with a different child identity"
     profile: "scout.v1" as const,
     profileDigest: scoutManagedAgentProfileV1.digest,
     limits: managedLimits,
-    task: "Reject a mismatched terminal.",
     taskDigest: testTaskDigest("Reject a mismatched terminal."),
+    childInputDigest: testTaskDigest(
+      `Reject a mismatched terminal.\n\n${childLiveWorkspaceNotice}`,
+    ),
     targetIdentity,
   };
   await managedStore.append(admission);
@@ -1193,8 +1195,8 @@ test("ManagedAgentStore links a complete child transcript after a terminal-link 
     profile: "scout.v1",
     profileDigest: scoutManagedAgentProfileV1.digest,
     limits: managedLimits,
-    task: recoveredTask,
     taskDigest: testTaskDigest(recoveredTask),
+    childInputDigest: testTaskDigest(`${recoveredTask}\n\n${childLiveWorkspaceNotice}`),
     targetIdentity,
   });
 
@@ -1249,8 +1251,10 @@ test("ManagedAgentStore requires inspection for a child genesis with a different
     profile: "scout.v1",
     profileDigest: scoutManagedAgentProfileV1.digest,
     limits: managedLimits,
-    task: "Inspect a mismatched child identity.",
     taskDigest: testTaskDigest("Inspect a mismatched child identity."),
+    childInputDigest: testTaskDigest(
+      `Inspect a mismatched child identity.\n\n${childLiveWorkspaceNotice}`,
+    ),
     targetIdentity,
   });
 
@@ -1262,6 +1266,69 @@ test("ManagedAgentStore requires inspection for a child genesis with a different
       type: "managed_agent_terminal",
       status: "inspection_required",
       error: { code: "managed_agent_inspection_required" },
+    },
+  ]);
+});
+
+test("ManagedAgentStore preserves a durable deadline between child genesis and logical run", async () => {
+  const managedStore = createInMemoryManagedAgentStore();
+  const childSessionStores = createInMemorySessionStoreDirectory<SessionRecord>();
+  const childSessionId = "123e4567-e89b-42d3-a456-426614174193";
+  const childStore = await childSessionStores.create(childSessionId);
+  const childTools = createReadToolRegistry({ workspaceRoot: process.cwd() });
+  await childStore.append({
+    schemaVersion: 3,
+    sequence: 1,
+    record: {
+      type: "session_genesis",
+      recordVersion: 2,
+      sessionId: childSessionId,
+      projectId,
+      targetIdentity,
+      contextProfile,
+      promptContext: createPromptContextV1(childTools),
+    },
+  });
+  const parentSessionId = "123e4567-e89b-42d3-a456-426614174194";
+  const agentId = "123e4567-e89b-42d3-a456-426614174191";
+  const attemptId = "123e4567-e89b-42d3-a456-426614174192";
+  const task = "Expire before the child logical run.";
+  await managedStore.append({
+    schemaVersion: 1,
+    type: "managed_agent_admitted",
+    sequence: 1,
+    agentId,
+    attemptId,
+    childSessionId,
+    parentSessionId,
+    parentToolCallId: "pre-run-deadline-spawn",
+    parentRootId: `session:${parentSessionId}`,
+    projectId,
+    profile: "scout.v1",
+    profileDigest: scoutManagedAgentProfileV1.digest,
+    limits: managedLimits,
+    taskDigest: testTaskDigest(task),
+    childInputDigest: testTaskDigest(`${task}\n\n${childLiveWorkspaceNotice}`),
+    targetIdentity,
+  });
+  await managedStore.append({
+    schemaVersion: 1,
+    type: "managed_agent_deadline_expired",
+    sequence: 2,
+    agentId,
+    attemptId,
+    childSessionId,
+  });
+
+  await recoverInterruptedManagedAgents(managedStore, childSessionStores);
+
+  expect(await managedStore.read()).toMatchObject([
+    { type: "managed_agent_admitted" },
+    { type: "managed_agent_deadline_expired" },
+    {
+      type: "managed_agent_terminal",
+      status: "failed",
+      error: { code: "managed_agent_deadline_exceeded" },
     },
   ]);
 });

--- a/packages/testkit/src/managed-agent.test.ts
+++ b/packages/testkit/src/managed-agent.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -5,7 +6,7 @@ import { join } from "node:path";
 import {
   AgentSession,
   type AgentSessionDependencies,
-  createFileArtifactStore,
+  type ArtifactStore,
   createPermissionPolicy,
   createReadToolRegistry,
   createSessionLifecycle,
@@ -77,6 +78,10 @@ const managedLimits = {
   maximumTokens: 128_000,
   maximumDeadlineMilliseconds: 600_000,
 } as const;
+const childLiveWorkspaceNotice =
+  "This child reads the live workspace. Parent changes may alter what it observes; isolated transcript does not mean repository snapshot or sandbox.";
+const testTaskDigest = (task: string) =>
+  `sha256:${createHash("sha256").update(task).digest("hex")}` as const;
 
 test("AgentSession spawns one permitted foreground scout and receives its durable result", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-scout-"));
@@ -834,6 +839,7 @@ test("AgentManager settles its injected aggregate deadline as durable terminal f
     });
     expect(await managedStore.read()).toMatchObject([
       { type: "managed_agent_admitted" },
+      { type: "managed_agent_deadline_expired" },
       {
         type: "managed_agent_terminal",
         status: "failed",
@@ -847,10 +853,98 @@ test("AgentManager settles its injected aggregate deadline as durable terminal f
   }
 });
 
+test("AgentManager cannot publish completion when deadline expires during artifact durability", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-deadline-artifact-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const largeAnswer = `Deadline artifact\n${"z".repeat(20 * 1024)}`;
+  const childModel: ModelDriver = {
+    async *stream() {
+      yield { type: "text_delta", text: largeAnswer };
+      yield { type: "usage", inputTokens: 50, outputTokens: 6_000 };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const artifactWriteStarted = Promise.withResolvers<void>();
+  const allowArtifactWrite = Promise.withResolvers<void>();
+  const artifactStore: ArtifactStore = {
+    async write({ bytes, mediaType, source }) {
+      artifactWriteStarted.resolve();
+      await allowArtifactWrite.promise;
+      const id = `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+      return { id, mediaType, byteCount: bytes.byteLength, source };
+    },
+    async read() {
+      return undefined;
+    },
+  };
+  let expire = () => {};
+  const deadlineScheduler: ManagedAgentDeadlineScheduler = {
+    schedule(_delayMilliseconds, onDeadline) {
+      expire = onDeadline;
+      return { cancel() {} };
+    },
+  };
+  const owner: ProjectLifecycleOwner = {
+    async acquire() {
+      return { async release() {} };
+    },
+    async run(operation) {
+      return operation();
+    },
+  };
+  const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
+  const parentRoot = await domain.claimRoot({ rootId: "parent-session" });
+  const managedStore = createInMemoryManagedAgentStore();
+  const manager = createAgentManager({
+    artifactStore,
+    childContextProfile: contextProfile,
+    childModel,
+    childSessionStores: createInMemorySessionStoreDirectory<SessionRecord>(),
+    deadlineScheduler,
+    managedStore,
+    parentPermissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    parentRoot,
+    projectId,
+    targetIdentity,
+    workspaceRoot,
+  });
+
+  try {
+    const spawning = manager.spawnForeground({
+      callId: "deadline-artifact-spawn",
+      parentSessionId: "123e4567-e89b-42d3-a456-426614174181",
+      signal: new AbortController().signal,
+      task: "Return a large result before the deadline.",
+    });
+    await artifactWriteStarted.promise;
+    expire();
+    allowArtifactWrite.resolve();
+
+    await expect(spawning).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "managed_agent_deadline_exceeded" },
+    });
+    expect(await managedStore.read()).toMatchObject([
+      { type: "managed_agent_admitted" },
+      { type: "managed_agent_deadline_expired" },
+      {
+        type: "managed_agent_terminal",
+        status: "failed",
+        error: { code: "managed_agent_deadline_exceeded" },
+      },
+    ]);
+  } finally {
+    allowArtifactWrite.resolve();
+    await parentRoot.release();
+    await domain.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("AgentManager publishes an oversized completed result through one immutable artifact", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-result-artifact-"));
   const workspaceRoot = join(testRoot, "workspace");
-  const artifactRoot = join(testRoot, "artifacts");
   await mkdir(workspaceRoot);
   const largeAnswer = `Managed result\n${"x".repeat(70 * 1024)}`;
   const childModel: ModelDriver = {
@@ -871,7 +965,18 @@ test("AgentManager publishes an oversized completed result through one immutable
   const domain = createProjectExecutionDomain({ lifecycleOwner: owner });
   const parentRoot = await domain.claimRoot({ rootId: "parent-session" });
   const managedStore = createInMemoryManagedAgentStore();
-  const artifactStore = await createFileArtifactStore({ root: artifactRoot });
+  const storedArtifacts = new Map<string, Uint8Array>();
+  const artifactStore: ArtifactStore = {
+    async write({ bytes, mediaType, source }) {
+      const stored = Uint8Array.from(bytes);
+      const id = `sha256:${createHash("sha256").update(stored).digest("hex")}`;
+      storedArtifacts.set(id, stored);
+      return { id, mediaType, byteCount: stored.byteLength, source };
+    },
+    async read(id) {
+      return storedArtifacts.get(id);
+    },
+  };
   const manager = createAgentManager({
     artifactStore,
     childContextProfile: contextProfile,
@@ -945,7 +1050,8 @@ test("ManagedAgentStore folds an admitted restart window without child provider 
     profile: "scout.v1",
     profileDigest: scoutManagedAgentProfileV1.digest,
     limits: managedLimits,
-    taskDigest: `sha256:${"e".repeat(64)}`,
+    task: "Interrupted admitted task.",
+    taskDigest: testTaskDigest("Interrupted admitted task."),
     targetIdentity,
   });
   await recoverInterruptedManagedAgents(managedStore);
@@ -976,7 +1082,8 @@ test("ManagedAgentStore rejects a terminal link with a different child identity"
     profile: "scout.v1" as const,
     profileDigest: scoutManagedAgentProfileV1.digest,
     limits: managedLimits,
-    taskDigest: `sha256:${"1".repeat(64)}` as const,
+    task: "Reject a mismatched terminal.",
+    taskDigest: testTaskDigest("Reject a mismatched terminal."),
     targetIdentity,
   };
   await managedStore.append(admission);
@@ -1004,6 +1111,7 @@ test("ManagedAgentStore links a complete child transcript after a terminal-link 
   const managedStore = createInMemoryManagedAgentStore();
   const childSessionStores = createInMemorySessionStoreDirectory<SessionRecord>();
   const childSessionId = "123e4567-e89b-42d3-a456-426614174123";
+  const recoveredTask = "Complete before the manager link.";
   const childStore = await childSessionStores.create(childSessionId);
   const childTools = createReadToolRegistry({ workspaceRoot: process.cwd() });
   const childPromptContext = createPromptContextV1(childTools);
@@ -1051,7 +1159,7 @@ test("ManagedAgentStore links a complete child transcript after a terminal-link 
   };
   const child = new AgentSession(childDependencies);
   await child.run(
-    { text: "Complete before the manager link." },
+    { text: `${recoveredTask}\n\n${childLiveWorkspaceNotice}` },
     { limits: { maxTurns: 8, maxTokens: 128_000 } },
   );
   const childRecordsBeforeCompaction = await childStore.read();
@@ -1085,7 +1193,8 @@ test("ManagedAgentStore links a complete child transcript after a terminal-link 
     profile: "scout.v1",
     profileDigest: scoutManagedAgentProfileV1.digest,
     limits: managedLimits,
-    taskDigest: `sha256:${"f".repeat(64)}`,
+    task: recoveredTask,
+    taskDigest: testTaskDigest(recoveredTask),
     targetIdentity,
   });
 
@@ -1140,7 +1249,8 @@ test("ManagedAgentStore requires inspection for a child genesis with a different
     profile: "scout.v1",
     profileDigest: scoutManagedAgentProfileV1.digest,
     limits: managedLimits,
-    taskDigest: `sha256:${"8".repeat(64)}`,
+    task: "Inspect a mismatched child identity.",
+    taskDigest: testTaskDigest("Inspect a mismatched child identity."),
     targetIdentity,
   });
 

--- a/packages/testkit/src/project-execution-domain-topology.test.ts
+++ b/packages/testkit/src/project-execution-domain-topology.test.ts
@@ -15,6 +15,7 @@ test("ProjectExecutionDomain is the sole production caller of ProjectLifecycleOw
   );
 
   expect(ownerMethodCalls).toEqual([
+    { call: "child.run", path: "managed-agent.ts" },
     { call: "options.lifecycleOwner.acquire", path: "project-execution-domain.ts" },
     { call: "session.run", path: "session-lifecycle.ts" },
     { call: "coordinator.run", path: "tool-runtime.ts" },


### PR DESCRIPTION
## Summary
- add exact historical `managed-agent-tools.a1.v1` with one foreground `scout.v1` spawn tool
- run a fresh bounded real child AgentSession with read-only parent-intersected authority, isolated durable transcript, and versioned ManagedAgentStore
- preserve target/thinking/repository/root/profile/limits, typed cancellation/deadline/usage/capacity truth, artifact overflow, and crash recovery without replay

## Evidence
- `pnpm quality:check` (84 files passed, 2 opt-in skipped; 1736 tests passed, 18 opt-in skipped)
- focused managed-agent semantic/OS, lifecycle semantic/OS, CLI/TUI composition, and structural scans
- independent GPT-5.6 Sol High Standards and Spec final re-reviews: clean

Scope is strictly S4-A1 foreground `scout.v1`. No background, dedicated TUI/Presentation state, Web, Skills, mailbox, peers, nesting, write, execute, or later Slice 4 capability.