### PR TITLE
fix(tui): retain fuzzy path mention matches

### DIFF
--- a/apps/tui/src/command-autocomplete.test.ts
+++ b/apps/tui/src/command-autocomplete.test.ts
@@ -107,3 +107,38 @@ test("path mention rows separate file names from parent paths without changing i
     prefix: "@",
   });
 });
+
+test("path mentions recall root and nested files with the same matching name", async () => {
+  const provider = new AdamAutocompleteProvider({
+    getProjectPaths: () => [
+      "AGENTS.md",
+      "examples/portfolio-walkthrough/AGENTS.md",
+      "src/alpha.ts",
+    ],
+    getRunActive: () => false,
+    getSkills: () => [],
+  });
+  const input = "Use @agents";
+
+  await expect(
+    provider.getSuggestions([input], 0, input.length, {
+      signal: new AbortController().signal,
+    }),
+  ).resolves.toEqual({
+    items: [
+      {
+        adamPath: { path: "AGENTS.md" },
+        value: "@AGENTS.md",
+        label: "@AGENTS.md",
+        description: "./",
+      },
+      {
+        adamPath: { path: "examples/portfolio-walkthrough/AGENTS.md" },
+        value: "@examples/portfolio-walkthrough/AGENTS.md",
+        label: "@AGENTS.md",
+        description: "examples/portfolio-walkthrough/",
+      },
+    ],
+    prefix: "@agents",
+  });
+});

--- a/apps/tui/src/command-autocomplete.ts
+++ b/apps/tui/src/command-autocomplete.ts
@@ -199,14 +199,14 @@ export class AdamAutocompleteProvider implements AutocompleteProvider {
     const pathValuePrefix = pathMention?.[2];
     if (pathPrefix !== undefined && pathValuePrefix !== undefined) {
       const normalizedPrefix = pathValuePrefix.toLocaleLowerCase();
-      const paths = this.#getProjectPaths();
-      const prefixMatches = paths.filter((path) =>
-        path.toLocaleLowerCase().startsWith(normalizedPrefix),
-      );
-      const candidates =
-        prefixMatches.length > 0
-          ? prefixMatches
-          : paths.filter((path) => fuzzyMatch(path, normalizedPrefix));
+      const candidates = this.#getProjectPaths()
+        .map((path, index) => {
+          const rank = projectPathMatchRank(path, normalizedPrefix);
+          return rank === null ? null : { index, path, rank };
+        })
+        .filter((candidate) => candidate !== null)
+        .sort((left, right) => left.rank - right.rank || left.index - right.index)
+        .map((candidate) => candidate.path);
       const pathItems = candidates.map<PathAutocompleteItem>((path) => {
         const safePath = safeTerminalText(path);
         const columns = projectPathColumns(safePath);
@@ -260,6 +260,14 @@ function projectPathColumns(path: string): {
     fileName: withoutTrailingSlash.slice(separator + 1),
     parentPath: separator < 0 ? "./" : withoutTrailingSlash.slice(0, separator + 1),
   };
+}
+
+function projectPathMatchRank(path: string, query: string): number | null {
+  const normalizedPath = path.toLocaleLowerCase();
+  const fileName = projectPathColumns(normalizedPath).fileName;
+  if (fileName.startsWith(query)) return 0;
+  if (normalizedPath.startsWith(query)) return 1;
+  return fuzzyMatch(normalizedPath, query) ? 2 : null;
 }
 
 function fuzzyMatch(candidate: string, query: string): boolean {


### PR DESCRIPTION
Summary:
- recall root and nested same-name files for @ filename queries
- rank basename prefixes before relative-path prefixes and existing fuzzy matches
- preserve current catalog, row projection, full path identity, and path atoms

Verification:
- focused RED then GREEN for @agents recall
- command autocomplete 4/4
- production TUI path completion tracer 1/1
- full pnpm quality:check: 82 files passed, 2 skipped; 1747 tests passed, 18 skipped