### PR TITLE
S4-C0: compose public Eve managed reviews

### DIFF
--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -756,11 +756,11 @@ test("the production TUI reviews real Git changes through the exact public Eve a
   const corePackage = JSON.parse(await readFile(join(coreRoot, "package.json"), "utf8"));
   expect(adapterPackage).toMatchObject({
     name: "@eve-reviewer/adam-extension",
-    version: "0.3.0",
-    dependencies: { "@eve-reviewer/core": "0.2.0" },
-    peerDependencies: { "@adam-agent/extension-api": "0.3.0" },
+    version: "0.4.0",
+    dependencies: { "@eve-reviewer/core": "0.3.0" },
+    peerDependencies: { "@adam-agent/extension-api": "0.4.0" },
   });
-  expect(corePackage).toMatchObject({ name: "@eve-reviewer/core", version: "0.2.0" });
+  expect(corePackage).toMatchObject({ name: "@eve-reviewer/core", version: "0.3.0" });
   await mkdir(configDirectory, { recursive: true, mode: 0o700 });
   await chmod(configDirectory, 0o700);
   await writeFile(
@@ -776,10 +776,11 @@ test("the production TUI reviews real Git changes through the exact public Eve a
             { id: "adam.analyzer-execution.biome@1", version: "1.0.0" },
             { id: "adam.artifact.publish@1", version: "1.0.0" },
             { id: "adam.storage.records@1", version: "1.0.0" },
+            { id: "adam.managed-session@1", version: "1.0.0" },
           ],
           packageName: "@eve-reviewer/adam-extension",
           packageRoot: adapterRoot,
-          packageVersion: "0.3.0",
+          packageVersion: "0.4.0",
         },
       ],
     }),
@@ -788,6 +789,8 @@ test("the production TUI reviews real Git changes through the exact public Eve a
 
   const environment = {
     ADAM_TEST_TERMINAL_PROCESS_MARKER: terminalProcessMarker,
+    ADAM_TEST_MODEL_RESPONSE:
+      '{"kind":"eve-reviewer.model-review-candidates","schemaVersion":1,"payload":{"candidates":[]}}',
     DEEPSEEK_API_KEY: "deterministic-non-network-fixture",
     XDG_CONFIG_HOME: configRoot,
   } as const;
@@ -819,7 +822,7 @@ test("the production TUI reviews real Git changes through the exact public Eve a
     await fixture.waitFor("Adam · New session");
     await fixture.resize(120, 40);
     fixture.write("/review\r");
-    await fixture.waitFor("eve-reviewer@0.3.0");
+    await fixture.waitFor("eve-reviewer@0.4.0");
     await fixture.waitFor("Completed");
     await fixture.waitFor("Report · eve-reviewer.review-result@1 · application/json");
 

--- a/apps/tui/src/production-main.fixture.ts
+++ b/apps/tui/src/production-main.fixture.ts
@@ -5,4 +5,22 @@ if (marker === undefined) {
   throw new TypeError("The production TUI fixture requires its process marker.");
 }
 await writeFile(marker, `${process.pid}\n`, "utf8");
+// biome-ignore lint/complexity/useLiteralKeys: ProcessEnv requires indexed access under strict TypeScript.
+const modelResponse = process.env["ADAM_TEST_MODEL_RESPONSE"];
+if (modelResponse !== undefined) {
+  globalThis.fetch = async () =>
+    new Response(
+      [
+        `data: ${JSON.stringify({ id: "fixture", choices: [{ index: 0, delta: { role: "assistant", content: modelResponse }, finish_reason: null }], created: 1, model: "fixture", object: "chat.completion.chunk", usage: null })}`,
+        "",
+        'data: {"id":"fixture","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"created":1,"model":"fixture","object":"chat.completion.chunk","usage":null}',
+        "",
+        'data: {"id":"fixture","choices":[],"created":1,"model":"fixture","object":"chat.completion.chunk","usage":{"prompt_tokens":100,"completion_tokens":20,"total_tokens":120}}',
+        "",
+        "data: [DONE]",
+        "",
+      ].join("\n"),
+      { headers: { "content-type": "text/event-stream" }, status: 200 },
+    );
+}
 await import("./main.js");

--- a/apps/tui/src/project-runtime.test.ts
+++ b/apps/tui/src/project-runtime.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -53,6 +53,76 @@ test("the project runtime owns only one Presentation across a concurrent close",
       "The production project runtime is closing or closed.",
     );
   } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the production runtime activates the exact public Eve managed-review contribution", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-project-runtime-eve-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const configRoot = join(testRoot, "config");
+  const configDirectory = join(configRoot, "adam-agent");
+  await mkdir(workspaceRoot);
+  await mkdir(configDirectory, { recursive: true, mode: 0o700 });
+  const evePackageRoot = await realpath(
+    join(process.cwd(), "node_modules", "@eve-reviewer", "adam-extension"),
+  );
+  await writeFile(
+    join(configDirectory, "extensions.json"),
+    JSON.stringify({
+      schemaVersion: 1,
+      extensions: [
+        {
+          enabled: true,
+          extensionId: "eve-reviewer",
+          grants: [
+            { id: "adam.analyzer-execution.biome@1", version: "1.0.0" },
+            { id: "adam.artifact.publish@1", version: "1.0.0" },
+            { id: "adam.storage.records@1", version: "1.0.0" },
+            { id: "adam.managed-session@1", version: "1.0.0" },
+          ],
+          packageName: "@eve-reviewer/adam-extension",
+          packageRoot: evePackageRoot,
+          packageVersion: "0.4.0",
+        },
+      ],
+    }),
+    { encoding: "utf8", mode: 0o600 },
+  );
+  const environment = {
+    DEEPSEEK_API_KEY: "deterministic-non-network-fixture",
+    XDG_CONFIG_HOME: configRoot,
+  };
+  const runtime = await createProductionProjectRuntime({
+    environment,
+    extensionPermissions: createPermissionPolicy({ allowedEffects: ["execute"] }),
+    modelTargets: createModelTargets({ environment }),
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    preferences: createPresentationPreferences({ environment }),
+    projectLabel: "eve-runtime-fixture",
+    reservedCommandNames: [],
+    stateRoot,
+    workspaceRoot,
+    workspaceTrust: createWorkspaceTrust({ environment, workspaceRoot }),
+  });
+
+  try {
+    expect(runtime.extensionAvailability).toEqual({
+      configurationUnavailable: false,
+      rejectedCount: 0,
+    });
+    expect(runtime.contributions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          extensionId: "eve-reviewer",
+          id: "eve-reviewer.local-worktree-review@1",
+          managedOutput: { id: "eve-reviewer.model-review-candidates", version: 1 },
+        }),
+      ]),
+    );
+  } finally {
+    await runtime.close();
     await rm(testRoot, { recursive: true, force: true });
   }
 });

--- a/apps/tui/src/project-runtime.ts
+++ b/apps/tui/src/project-runtime.ts
@@ -4,16 +4,20 @@ import {
   createBiomeExecutionAdapter,
   createExtensionHost,
   createFileArtifactStore,
+  createJsonlManagedAgentStore,
   createJsonlOperationStore,
+  createJsonlSessionStoreDirectory,
   createPresentationSession,
   createSessionLifecycle,
   createWebSearchConfiguration,
   ExtensionConfigurationError,
   type ExtensionContributionSummary,
   loadExtensionConfiguration,
+  type ManagedAgentStore,
   type ModelTargets,
   type PermissionPolicy,
   type PresentationPreferences,
+  type SessionRecord,
   type SessionSnapshot,
   type WorkspaceTrustController,
 } from "@adam-agent/agent";
@@ -69,6 +73,22 @@ export async function createProductionProjectRuntime(
     stateRoot: options.stateRoot,
     workspaceRoot: options.workspaceRoot,
   });
+  const managedStorePromise = createJsonlManagedAgentStore({
+    stateRoot: options.stateRoot,
+    workspaceRoot: options.workspaceRoot,
+  });
+  const managedStore: ManagedAgentStore = {
+    async append(record) {
+      return (await managedStorePromise).append(record);
+    },
+    async read() {
+      return (await managedStorePromise).read();
+    },
+  };
+  const managedChildSessionStores = createJsonlSessionStoreDirectory<SessionRecord>({
+    workspaceRoot: options.workspaceRoot,
+    stateRoot: join(options.stateRoot, "managed-review-sessions"),
+  });
   let lifecycle: ReturnType<typeof createSessionLifecycle> | undefined;
   const host = createExtensionHost({
     artifactStore,
@@ -77,8 +97,31 @@ export async function createProductionProjectRuntime(
       { id: "adam.analyzer-execution.biome@1", version: "1.0.0" },
       { id: "adam.artifact.publish@1", version: "1.0.0" },
       { id: "adam.storage.records@1", version: "1.0.0" },
+      { id: "adam.managed-session@1", version: "1.0.0" },
     ],
     extensions,
+    managedSession: {
+      childSessionStores: managedChildSessionStores,
+      managedStore,
+      parentPermissions: options.permissions,
+      async resolveOrigin({ origin, signal }) {
+        if (lifecycle === undefined) throw new Error("The session lifecycle is unavailable.");
+        const snapshot = await lifecycle.inspect({ sessionId: origin.sessionId });
+        if (snapshot.schemaVersion !== 3) throw new Error("The origin session is unavailable.");
+        const resolved = await options.modelTargets.resolve({
+          allowExperimental: true,
+          signal,
+          targetId: snapshot.targetIdentity.targetId,
+          targetIdentity: snapshot.targetIdentity,
+        });
+        return {
+          childContextProfile: resolved.contextProfile,
+          childModel: resolved.driver,
+          targetIdentity: resolved.identity,
+        };
+      },
+      workspaceRoot: options.workspaceRoot,
+    },
     operationOriginAuthority: {
       async validateBoundary({ origin, projectId }) {
         if (lifecycle === undefined) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.8",
-    "@eve-reviewer/adam-extension": "0.3.0",
+    "@eve-reviewer/adam-extension": "0.4.0",
+    "@eve-reviewer/core": "0.3.0",
     "@types/node": "24.13.3",
     "@types/semver": "7.8.0",
     "markdownlint-cli2": "0.23.2",

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -60,6 +60,8 @@ export {
   type LocalInputResourceSelectionV1,
   type StagedInputResourceSelectionV1,
 } from "./input-resources.js";
+export type { ManagedAgentStore } from "./managed-agent.js";
+export { createJsonlManagedAgentStore } from "./managed-agent-store.js";
 export {
   type ModelDriverDiagnosticCode,
   ModelDriverError,
@@ -164,7 +166,9 @@ export {
   type CanonicalRuntimeEvent,
   createInMemorySessionStore,
   createJsonlSessionStore,
+  createJsonlSessionStoreDirectory,
   type SessionEventRecord,
+  type SessionRecord,
   type SessionStore,
   SessionStoreError,
 } from "./session-store.js";

--- a/packages/agent/src/operation-host.ts
+++ b/packages/agent/src/operation-host.ts
@@ -88,6 +88,25 @@ export type RegisteredOperation = {
   readonly registration: ExtensionOperationRegistration;
 };
 
+export type ManagedSessionRuntime = {
+  readonly childContextProfile?: ContextProfile;
+  readonly childModel?: ModelDriver;
+  readonly childSessionStores: SessionStoreDirectory<SessionRecord>;
+  readonly managedStore: ManagedAgentStore;
+  readonly parentPermissions: PermissionPolicy;
+  resolveOrigin(input: {
+    readonly origin: OperationOrigin;
+    readonly projectId: `sha256:${string}`;
+    readonly signal: AbortSignal;
+  }): Promise<{
+    readonly targetIdentity: ModelTargetIdentity;
+    readonly thinkingPolicy?: ThinkingPolicySnapshotV1;
+    readonly childContextProfile?: ContextProfile;
+    readonly childModel?: ModelDriver;
+  }>;
+  readonly workspaceRoot: string;
+};
+
 export type OperationStartOptions = {
   readonly contributionId: string;
   readonly deadlineMs?: number;
@@ -284,21 +303,7 @@ export function createOperationHost(options: {
   readonly originAuthority?: OperationOriginAuthority;
   readonly projectRoot: string;
   readonly permissions?: PermissionPolicy;
-  readonly managedSession?: {
-    readonly childContextProfile: ContextProfile;
-    readonly childModel: ModelDriver;
-    readonly childSessionStores: SessionStoreDirectory<SessionRecord>;
-    readonly managedStore: ManagedAgentStore;
-    readonly parentPermissions: PermissionPolicy;
-    resolveOrigin(input: {
-      readonly origin: OperationOrigin;
-      readonly projectId: `sha256:${string}`;
-    }): Promise<{
-      readonly targetIdentity: ModelTargetIdentity;
-      readonly thinkingPolicy?: ThinkingPolicySnapshotV1;
-    }>;
-    readonly workspaceRoot: string;
-  };
+  readonly managedSession?: ManagedSessionRuntime;
   readonly recordStore?: ExtensionRecordStore;
   readonly resolveOperation: (contributionId: string) => RegisteredOperation | undefined;
   readonly store?: OperationStore;
@@ -951,10 +956,16 @@ function createManagedSessionCapability(
         const resolved = await runtime.resolveOrigin({
           origin,
           projectId: active.projectId as `sha256:${string}`,
+          signal: active.abortController.signal,
         });
+        const childModel = resolved.childModel ?? runtime.childModel;
+        const childContextProfile = resolved.childContextProfile ?? runtime.childContextProfile;
+        if (childModel === undefined || childContextProfile === undefined) {
+          throw new TypeError("The managed session target is unavailable.");
+        }
         const manager = createAgentManager({
-          childContextProfile: runtime.childContextProfile,
-          childModel: runtime.childModel,
+          childContextProfile,
+          childModel,
           childSessionStores: runtime.childSessionStores,
           managedStore: runtime.managedStore,
           parentPermissions: runtime.parentPermissions,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,11 @@ importers:
         specifier: 2.5.8
         version: 2.5.8
       '@eve-reviewer/adam-extension':
+        specifier: 0.4.0
+        version: 0.4.0(@adam-agent/extension-api@0.4.0)
+      '@eve-reviewer/core':
         specifier: 0.3.0
-        version: 0.3.0(@adam-agent/extension-api@0.3.0)
+        version: 0.3.0
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
@@ -140,8 +143,8 @@ importers:
 
 packages:
 
-  '@adam-agent/extension-api@0.3.0':
-    resolution: {integrity: sha512-ijWL5/NhP0Gvd0fNJGkfzNoL6MSKmdo48RcQRnTN2GqhcJnnOaFqCBr3iywxekbstPe7wxx5bs59aCI2ETdxWA==}
+  '@adam-agent/extension-api@0.4.0':
+    resolution: {integrity: sha512-Z/BJekz1aA1skHaVaL0+3kEx8D8UMwuQAdOAWTcDezy0ef0CojkFNdGEDln6bLmGHpVumg1enKSbx+sAVVaMtw==}
     engines: {node: '>=24.0.0 <25'}
 
   '@ai-sdk/deepseek@3.0.30':
@@ -233,14 +236,14 @@ packages:
     resolution: {integrity: sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg==}
     engines: {node: '>=22.19.0'}
 
-  '@eve-reviewer/adam-extension@0.3.0':
-    resolution: {integrity: sha512-VtOEsY5CMxmdj2Klkvo53dQiaWIsLnKsrgd16RQ9NNnwqqCPL+3YaeCP+s9eWzsVn5i/7tWkviK1ZQNVAf1m0g==}
+  '@eve-reviewer/adam-extension@0.4.0':
+    resolution: {integrity: sha512-BHqb2hQ8z46Wu5p3m99xz8D3yimHJdM3A7bnyOA3bHwM1jwfnesGa4QcJtvzdTitsSfOvtFoTCSwNUTwFvLggw==}
     engines: {node: '>=24.0.0 <25'}
     peerDependencies:
-      '@adam-agent/extension-api': 0.3.0
+      '@adam-agent/extension-api': 0.4.0
 
-  '@eve-reviewer/core@0.2.0':
-    resolution: {integrity: sha512-IYlTrWlno+z9GTK5dSOMfeWdEbwspfuKkHr5o/k31sCh8vw8S1Ii8ZSR7xx0+RKM3w0B/Kr3UgK1j2EibUAGqA==}
+  '@eve-reviewer/core@0.3.0':
+    resolution: {integrity: sha512-JsnwrNLPNAuoQERwj0AKrZMBBe8MN2MbtCBgIIJOkgDiRzOj9R6JN/cAGynFESIv7Ve3CvzC2dX9+foohReRSQ==}
     engines: {node: '>=24.0.0 <25'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
@@ -1360,7 +1363,7 @@ packages:
 
 snapshots:
 
-  '@adam-agent/extension-api@0.3.0':
+  '@adam-agent/extension-api@0.4.0':
     dependencies:
       semver: 7.8.5
       zod: 4.4.3
@@ -1440,12 +1443,12 @@ snapshots:
       get-east-asian-width: 1.6.0
       marked: 18.0.5
 
-  '@eve-reviewer/adam-extension@0.3.0(@adam-agent/extension-api@0.3.0)':
+  '@eve-reviewer/adam-extension@0.4.0(@adam-agent/extension-api@0.4.0)':
     dependencies:
-      '@adam-agent/extension-api': 0.3.0
-      '@eve-reviewer/core': 0.2.0
+      '@adam-agent/extension-api': 0.4.0
+      '@eve-reviewer/core': 0.3.0
 
-  '@eve-reviewer/core@0.2.0':
+  '@eve-reviewer/core@0.3.0':
     dependencies:
       diff: 9.0.0
       typebox: 1.3.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,8 +2,8 @@ packages:
   - "apps/*"
   - "packages/*"
 minimumReleaseAgeExclude:
-  - '@adam-agent/extension-api@0.3.0'
-  - '@eve-reviewer/adam-extension@0.3.0'
-  - '@eve-reviewer/core@0.2.0'
+  - '@adam-agent/extension-api@0.3.0 || 0.4.0'
+  - '@eve-reviewer/adam-extension@0.3.0 || 0.4.0'
+  - '@eve-reviewer/core@0.2.0 || 0.3.0'
 patchedDependencies:
   '@earendil-works/pi-tui@0.84.2': patches/@earendil-works__pi-tui@0.84.2.patch


### PR DESCRIPTION
Closes the frozen Slice 4 C0 checkpoint. Pins exact public Eve core 0.3.0 and Adapter 0.4.0, advertises the existing managed-session capability in production, resolves the managed reviewer from the origin session target through existing ModelTargets, and reuses JSONL managed stores plus ProjectExecutionDomain. Real production TUI /review, generic report opening, restart, absence safety, package scans and full local Quality pass: 82 files, 1,754 tests, 18 opt-in skips.