### PR TITLE
Fix Plan settlement validation and TUI cleanup

### DIFF
--- a/apps/tui/src/fixture-scenario.ts
+++ b/apps/tui/src/fixture-scenario.ts
@@ -20,6 +20,7 @@ export const fixtureScenarios = [
   "mutation-delayed-preview",
   "plan-review",
   "plan-review-recovery",
+  "plan-settlement-read-failure",
   "provider-no-usage",
   "provider-usage",
   "read",

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -39,6 +39,20 @@ afterEach(async () => {
   await cleanupActiveTuiFixtures();
 });
 
+function expectEveryTerminalInputModeRestored(result: { readonly stdout: string }): void {
+  expect(result.stdout).toContain("\u001b[?2004h");
+  expect(result.stdout).toContain("\u001b[?2004l");
+  expect(result.stdout).toContain("\u001b[?2026l");
+  expect(result.stdout).toContain("\u001b[?25h");
+  for (const mode of ["1000", "1002", "1003", "1004", "1006"]) {
+    expect(result.stdout).toContain(`\u001b[?${mode}h`);
+    expect(result.stdout).toContain(`\u001b[?${mode}l`);
+    expect(result.stdout.indexOf(`\u001b[?${mode}h`)).toBeLessThan(
+      result.stdout.lastIndexOf(`\u001b[?${mode}l`),
+    );
+  }
+}
+
 test("the real TUI process restores the terminal after staging one input resource", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-resource-process-"));
   const workspaceRoot = join(testRoot, "workspace");
@@ -349,6 +363,74 @@ test("real PTY streams Ctrl+T reasoning and restores application mouse modes on 
     expect(result.stdout).toContain("\u001b[?1006h");
     expect(result.stdout).toContain("\u001b[?1000l");
     expect(result.stdout).toContain("\u001b[?1006l");
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("real PTY submits a Plan with assistant preamble and restores every terminal input mode", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-plan-preamble-pty-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      external: true,
+      scenario: "plan-review",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    const beforePlan = fixture.output().length;
+    fixture.write("/plan\r");
+    await fixture.waitForCompleteFrameAfter("Plan exploring · read-only", beforePlan);
+    const beforeSubmission = fixture.output().length;
+    fixture.write("Create the exact PTY Plan\r");
+    await fixture.waitForCompleteFrameAfter("Review exact submitted plan", beforeSubmission);
+    expect(fixture.output().slice(beforeSubmission)).toContain(
+      "Fixture Plan 1 is ready for external review.",
+    );
+
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).not.toContain("session_invalid");
+    expectEveryTerminalInputModeRestored(result);
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("real PTY restores every terminal input mode after Plan settlement and refresh both fail", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-plan-settlement-failure-pty-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+
+  try {
+    const fixture = startFixture({
+      controlRoot,
+      external: true,
+      scenario: "plan-settlement-read-failure",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Adam · New session");
+    const beforePlan = fixture.output().length;
+    fixture.write("/plan\r");
+    await fixture.waitForCompleteFrameAfter("Plan exploring · read-only", beforePlan);
+    fixture.write("Create the failing-refresh PTY Plan\r");
+    await waitForFileContents(join(controlRoot, "plan-settlement-read-failed"), "failed\n");
+
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expect(result.stdout).not.toContain("SessionLifecycleError");
+    expect(result.stdout).not.toContain("UnhandledPromiseRejection");
+    expectEveryTerminalInputModeRestored(result);
   } finally {
     await rm(testRoot, { recursive: true, force: true });
   }

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -22,6 +22,7 @@ import {
   type WorkspaceTrustController,
 } from "@adam-agent/agent";
 import {
+  createInMemorySessionStoreDirectory,
   createTrustedWorkspaceTrustForTesting,
   mcpCloseConfirmation,
   type PresentationArtifactReadBarrier,
@@ -29,6 +30,10 @@ import {
   preparedDirectDeepSeekV2ContextProfile,
   presentationArtifactReadBarrier,
   presentationHistoryPageSize,
+  type SessionRecord,
+  type SessionStore,
+  type SessionStoreDirectory,
+  sessionStoreDirectory,
   turnComposerStageBarrier,
 } from "@adam-agent/agent/internal-testing";
 import type { PresentationSession } from "@adam-agent/presentation";
@@ -173,6 +178,57 @@ export type TuiFixtureOptions = {
   readonly workspaceRoot: string;
 };
 
+function createPostSettlementReadFailureDirectory(
+  failureMarker?: string,
+): SessionStoreDirectory<SessionRecord> {
+  const backing = createInMemorySessionStoreDirectory<SessionRecord>();
+  const wrappedStores = new Map<string, SessionStore<SessionRecord>>();
+  return {
+    async create(sessionId) {
+      const store = await backing.create(sessionId);
+      let rejectReads = false;
+      const wrapped: SessionStore<SessionRecord> = {
+        async append(record) {
+          await store.append(record);
+          rejectReads ||=
+            record.schemaVersion === 3 &&
+            (record.record.type === "run_settled" ||
+              (record.record.type === "runtime_event" &&
+                record.record.event.type === "session_settled"));
+        },
+        async appendBatch(records) {
+          await store.appendBatch(records);
+          rejectReads ||= records.some(
+            (record) =>
+              record.schemaVersion === 3 &&
+              (record.record.type === "run_settled" ||
+                (record.record.type === "runtime_event" &&
+                  record.record.event.type === "session_settled")),
+          );
+        },
+        async read() {
+          if (rejectReads) {
+            if (failureMarker !== undefined) {
+              writeFileSync(failureMarker, "failed\n", "utf8");
+            }
+            throw new Error("Injected post-admission session read failure.");
+          }
+          return store.read();
+        },
+      };
+      wrappedStores.set(sessionId, wrapped);
+      return wrapped;
+    },
+    listSessionEntries: () => backing.listSessionEntries(),
+    listSessionIds: () => backing.listSessionIds(),
+    async open(sessionId) {
+      return (await backing.open(sessionId)) === undefined
+        ? undefined
+        : wrappedStores.get(sessionId);
+    },
+  };
+}
+
 class TerminalRestorationFailure extends ProcessTerminal {
   readonly #failureMarker: string | undefined;
 
@@ -277,6 +333,15 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
               throw new Error("Injected stop after durable Plan approval intent.");
             },
           },
+        }
+      : {}),
+    ...(options.scenario === "plan-settlement-read-failure"
+      ? {
+          [sessionStoreDirectory]: createPostSettlementReadFailureDirectory(
+            options.controlRoot === undefined
+              ? undefined
+              : join(options.controlRoot, "plan-settlement-read-failed"),
+          ),
         }
       : {}),
     ...(options.scenario === "mcp-close-unconfirmed"
@@ -1299,7 +1364,11 @@ function createFixtureModelTargets(options: {
         yield { type: "finish", reason: "stop" };
         return;
       }
-      if (options.scenario === "plan-review" || options.scenario === "plan-review-recovery") {
+      if (
+        options.scenario === "plan-review" ||
+        options.scenario === "plan-review-recovery" ||
+        options.scenario === "plan-settlement-read-failure"
+      ) {
         if (request.approvedPlan !== undefined) {
           yield { type: "text_delta", text: "Approved Plan implementation complete." };
         } else {
@@ -1312,6 +1381,10 @@ function createFixtureModelTargets(options: {
           }
           planSubmissionOrdinal += 1;
           const callId = `submit-plan-review-${planSubmissionOrdinal}`;
+          yield {
+            type: "text_delta",
+            text: `Fixture Plan ${planSubmissionOrdinal} is ready for external review.`,
+          };
           yield { type: "tool_call_start", id: callId, name: "submit_plan" };
           yield {
             type: "tool_call_delta",

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -1349,6 +1349,39 @@ export async function createPresentationSession(
       );
       return activation;
     };
+    const recoverAdmittedRunSnapshot = async (sessionId: string): Promise<void> => {
+      if (closed) {
+        return;
+      }
+      try {
+        const inspected = await options.lifecycle.inspect({ sessionId });
+        if (inspected.schemaVersion === 3) {
+          await activateSnapshot(inspected);
+        }
+      } catch {
+        const activeSessionId = state.authoritative.active?.session.id;
+        if (closed || (activeSessionId !== undefined && activeSessionId !== sessionId)) {
+          return;
+        }
+        state = {
+          revision: state.revision + 1,
+          authoritative: {
+            ...state.authoritative,
+            continuity: {
+              status: "degraded",
+              fault: {
+                code: "authoritative_state_unavailable",
+                message: "The durable session view is temporarily unavailable.",
+              },
+            },
+          },
+          draft: state.draft,
+          composer: state.composer,
+          transient: null,
+        };
+        publishStateChange();
+      }
+    };
     const refreshActiveNaming = async (
       sessionId: string,
       throughSequence: number,
@@ -2932,6 +2965,13 @@ export async function createPresentationSession(
             message: "The prompt does not target the active session or is blank.",
           };
         }
+        if (state.authoritative.continuity.status !== "current") {
+          return {
+            status: "rejected",
+            code: "stale_interaction",
+            message: "The active session boundary is no longer available for this command.",
+          };
+        }
         if (activeRun !== undefined) {
           return {
             status: "rejected",
@@ -3084,15 +3124,7 @@ export async function createPresentationSession(
               await activateSnapshot(continued.snapshot);
             }
           })
-          .catch(async () => {
-            if (closed) {
-              return;
-            }
-            const inspected = await options.lifecycle.inspect({ sessionId: command.sessionId });
-            if (inspected.schemaVersion === 3) {
-              await activateSnapshot(inspected);
-            }
-          })
+          .catch(() => recoverAdmittedRunSnapshot(command.sessionId))
           .finally(() => {
             if (activeRun === runState) {
               activeRun = undefined;
@@ -3148,6 +3180,13 @@ export async function createPresentationSession(
             status: "rejected",
             code: "invalid_command",
             message: "A non-empty prompt and exact draft target are required.",
+          };
+        }
+        if (state.authoritative.continuity.status !== "current") {
+          return {
+            status: "rejected",
+            code: "stale_interaction",
+            message: "The active session boundary is no longer available for this command.",
           };
         }
         if (activeRun !== undefined) {
@@ -3268,15 +3307,12 @@ export async function createPresentationSession(
               await activateSnapshot(continued.snapshot);
             }
           })
-          .catch(async () => {
+          .catch(() => {
             const sessionId = admittedSessionId;
             if (closed || sessionId === null) {
               return;
             }
-            const inspected = await options.lifecycle.inspect({ sessionId });
-            if (inspected.schemaVersion === 3) {
-              await activateSnapshot(inspected);
-            }
+            return recoverAdmittedRunSnapshot(sessionId);
           })
           .finally(() => {
             if (activeRun === runState) {
@@ -3311,7 +3347,18 @@ export async function createPresentationSession(
         if (activeRun === runState) {
           runState.sessionId = admitted.sessionId;
         }
-        const admittedSnapshot = await options.lifecycle.inspect({ sessionId: admitted.sessionId });
+        let admittedSnapshot: Awaited<ReturnType<SessionLifecycle["inspect"]>>;
+        try {
+          admittedSnapshot = await options.lifecycle.inspect({ sessionId: admitted.sessionId });
+        } catch {
+          await settlement;
+          turnComposer.unseal();
+          return {
+            status: "rejected",
+            code: "persistence_failed",
+            message: "The admitted draft session could not be read from durable history.",
+          };
+        }
         if (admittedSnapshot.schemaVersion !== 3) {
           await settlement;
           turnComposer.unseal();

--- a/packages/agent/src/session-history-validation.ts
+++ b/packages/agent/src/session-history-validation.ts
@@ -187,6 +187,8 @@ export function validateCurrentSessionHistory(
   let activePlanApprovalCommandId: string | undefined;
   let activePlanKickoffRunId: string | undefined;
   let planSubmissionTerminal = false;
+  const isCompletedRunFinishReason = (finishReason: unknown): boolean =>
+    finishReason === "stop" || (planSubmissionTerminal && finishReason === "tool_calls");
   let activePlanPolicyVersion: "plan-policy.read-v1" | "plan-policy.hybrid-v1" | undefined;
   let activePlanShellPolicyVersion: "plan-shell-policy.v1" | undefined;
   let activePlanShellEnvironmentDigest: string | undefined;
@@ -1593,7 +1595,7 @@ export function validateCurrentSessionHistory(
     if (record.type === "run_settled") {
       const finishReason = attemptState?.response?.response.finishReason;
       const settlementMatchesResponse =
-        (record.status === "completed" && finishReason === "stop") ||
+        (record.status === "completed" && isCompletedRunFinishReason(finishReason)) ||
         (record.status === "incomplete" &&
           record.reason === "output_limit" &&
           finishReason === "length");
@@ -1795,12 +1797,12 @@ export function validateCurrentSessionHistory(
           JSON.stringify(terminalIntent) !== JSON.stringify(event.result)) ||
         (event.result.status === "completed" &&
           (attemptState?.status !== "completed" ||
-            (attemptState.response?.response.finishReason !== "stop" &&
-              !(
-                planSubmissionTerminal &&
-                attemptState.response?.response.finishReason === "tool_calls"
-              )) ||
-            inlineModelResponseField(attemptState.response.response.text) !== event.result.answer ||
+            attemptState.response === undefined ||
+            !isCompletedRunFinishReason(attemptState.response.response.finishReason) ||
+            (planSubmissionTerminal
+              ? event.result.answer !== ""
+              : inlineModelResponseField(attemptState.response.response.text) !==
+                event.result.answer) ||
             !sawModelCompletion)) ||
         (event.result.status === "incomplete" &&
           (attemptState?.status !== "completed" ||

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -739,6 +739,63 @@ function readInMemoryPresentationRecords(directory: SessionStoreDirectory<Sessio
   return async (sessionId: string): Promise<readonly SessionRecord[]> =>
     (await directory.open(sessionId))?.read() ?? [];
 }
+
+function createSessionReadFailureDirectory(trigger: "logical_run_started" | "run_settlement"): {
+  readonly directory: SessionStoreDirectory<SessionRecord>;
+  readonly readRejected: Promise<void>;
+} {
+  const backing = createInMemorySessionStoreDirectory<SessionRecord>();
+  const wrappedStores = new Map<string, SessionStore<SessionRecord>>();
+  const readRejected = Promise.withResolvers<void>();
+  const wrap = (store: SessionStore<SessionRecord>): SessionStore<SessionRecord> => {
+    let rejectReads = false;
+    const isFailureTrigger = (record: SessionRecord): boolean => {
+      if (record.schemaVersion !== 3) {
+        return false;
+      }
+      if (trigger === "logical_run_started") {
+        return record.record.type === "logical_run_started";
+      }
+      return (
+        record.record.type === "run_settled" ||
+        (record.record.type === "runtime_event" && record.record.event.type === "session_settled")
+      );
+    };
+    return {
+      async append(record) {
+        await store.append(record);
+        rejectReads ||= isFailureTrigger(record);
+      },
+      async appendBatch(records) {
+        await store.appendBatch(records);
+        rejectReads ||= records.some(isFailureTrigger);
+      },
+      async read() {
+        if (rejectReads) {
+          readRejected.resolve();
+          throw new Error("Injected durable session read failure after run settlement.");
+        }
+        return store.read();
+      },
+    };
+  };
+  const directory: SessionStoreDirectory<SessionRecord> = {
+    async create(sessionId) {
+      const wrapped = wrap(await backing.create(sessionId));
+      wrappedStores.set(sessionId, wrapped);
+      return wrapped;
+    },
+    listSessionEntries: () => backing.listSessionEntries(),
+    listSessionIds: () => backing.listSessionIds(),
+    async open(sessionId) {
+      return (await backing.open(sessionId)) === undefined
+        ? undefined
+        : wrappedStores.get(sessionId);
+    },
+  };
+  return { directory, readRejected: readRejected.promise };
+}
+
 const testEnvironment = process.env as NodeJS.ProcessEnv & { HOME?: string };
 async function writeScriptedMcpConfiguration(
   testRoot: string,
@@ -13103,6 +13160,218 @@ test("PresentationSession recovers after one authoritative runtime refresh failu
     } finally {
       unsubscribe();
       await expect(presentation.close()).resolves.toBeUndefined();
+    }
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession degrades an admitted session when settlement and fallback inspection fail", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-presentation-settlement-failure-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  let modelCalls = 0;
+  const driver = new FakeModelDriver(() => {
+    modelCalls += 1;
+    return [
+      { type: "text_delta", text: "The durable run completed before refresh failed." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const readFailure = createSessionReadFailureDirectory("run_settlement");
+  const lifecycle = createSessionLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+    [sessionAutomaticTitlesEnabled]: false,
+    [sessionStoreDirectory]: readFailure.directory,
+  });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      projectLabel: "workspace",
+      targetIdentity,
+      stateRoot,
+      workspaceRoot,
+    });
+    const degraded = Promise.withResolvers<void>();
+    const unsubscribe = presentation.subscribe(() => {
+      if (presentation.getState().authoritative.continuity.status === "degraded") {
+        degraded.resolve();
+      }
+    });
+    try {
+      const sessionId = presentation.getState().authoritative.active?.session.id;
+      if (sessionId === undefined) {
+        throw new Error("Expected an active session.");
+      }
+      await expect(
+        presentation.dispatch({
+          type: "submit_prompt",
+          sessionId,
+          text: "Complete one durable run before refresh fails.",
+          skills: [],
+          thinkingSelection: null,
+        }),
+      ).resolves.toMatchObject({ status: "admitted", resource: null });
+      await readFailure.readRejected;
+      await degraded.promise;
+      expect(presentation.getState().authoritative.continuity).toEqual({
+        status: "degraded",
+        fault: {
+          code: "authoritative_state_unavailable",
+          message: "The durable session view is temporarily unavailable.",
+        },
+      });
+      await expect(
+        presentation.dispatch({
+          type: "submit_prompt",
+          sessionId,
+          text: "This command must remain blocked while continuity is degraded.",
+          skills: [],
+          thinkingSelection: null,
+        }),
+      ).resolves.toEqual({
+        status: "rejected",
+        code: "stale_interaction",
+        message: "The active session boundary is no longer available for this command.",
+      });
+      expect(modelCalls).toBe(1);
+      await expect(presentation.close()).resolves.toBeUndefined();
+    } finally {
+      unsubscribe();
+    }
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("PresentationSession degrades an admitted draft Plan when settlement and fallback inspection fail", async () => {
+  const testRoot = await mkdtemp(
+    join(tmpdir(), "adam-agent-presentation-draft-settlement-failure-"),
+  );
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const markdown = "# Draft Plan\n\n1. Admit the draft.\n2. Preserve terminal ownership.\n";
+  let modelCalls = 0;
+  const driver = new FakeModelDriver(() => {
+    modelCalls += 1;
+    return [
+      { type: "text_delta", text: "The draft Plan is ready for review." },
+      { type: "tool_call_start", id: "submit-draft-plan", name: "submit_plan" },
+      {
+        type: "tool_call_delta",
+        id: "submit-draft-plan",
+        json: JSON.stringify({ title: "Draft Plan", markdown }),
+      },
+      { type: "tool_call_end", id: "submit-draft-plan" },
+      { type: "finish", reason: "tool_calls" },
+    ];
+  });
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: { status: "available", credentialSource: "deterministic test adapter" },
+            contextProfile,
+          },
+        ],
+      };
+    },
+  };
+  const readFailure = createSessionReadFailureDirectory("logical_run_started");
+  const lifecycle = createSessionLifecycle({
+    modelTargets,
+    stateRoot,
+    workspaceRoot,
+    [sessionAutomaticTitlesEnabled]: false,
+    [sessionStoreDirectory]: readFailure.directory,
+  });
+
+  try {
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      openProject: true,
+      projectLabel: "workspace",
+      stateRoot,
+      workspaceRoot,
+    });
+    const degraded = Promise.withResolvers<void>();
+    const unsubscribe = presentation.subscribe(() => {
+      if (presentation.getState().authoritative.continuity.status === "degraded") {
+        degraded.resolve();
+      }
+    });
+    try {
+      await expect(
+        presentation.dispatch({ type: "create_session", targetId: targetIdentity.targetId }),
+      ).resolves.toMatchObject({ status: "admitted", resource: null });
+      await expect(
+        presentation.dispatch({ type: "set_draft_mode", mode: "plan" }),
+      ).resolves.toMatchObject({ status: "admitted", resource: null });
+      const submission = presentation.dispatch({
+        type: "submit_draft_prompt",
+        text: "Publish the first durable Plan.",
+        skills: [],
+        thinkingSelection: null,
+      });
+      await readFailure.readRejected;
+      await expect(submission).resolves.toEqual({
+        status: "rejected",
+        code: "persistence_failed",
+        message: "The admitted draft session could not be read from durable history.",
+      });
+      await degraded.promise;
+      expect(presentation.getState().authoritative.continuity).toEqual({
+        status: "degraded",
+        fault: {
+          code: "authoritative_state_unavailable",
+          message: "The durable session view is temporarily unavailable.",
+        },
+      });
+      await expect(
+        presentation.dispatch({
+          type: "submit_draft_prompt",
+          text: "This draft command must remain blocked while continuity is degraded.",
+          skills: [],
+          thinkingSelection: null,
+        }),
+      ).resolves.toEqual({
+        status: "rejected",
+        code: "stale_interaction",
+        message: "The active session boundary is no longer available for this command.",
+      });
+      expect(modelCalls).toBe(1);
+      await expect(presentation.close()).resolves.toBeUndefined();
+    } finally {
+      unsubscribe();
     }
   } finally {
     await lifecycle.close();

--- a/packages/testkit/src/session-lifecycle-test-topology.test.ts
+++ b/packages/testkit/src/session-lifecycle-test-topology.test.ts
@@ -202,7 +202,7 @@ test("SessionLifecycle behavior and OS contracts keep separate environment owner
 
   const behaviorNames = declaredTestNames(behaviorSource);
   const operatingSystemNames = declaredTestNames(operatingSystemSource);
-  expect.soft(behaviorNames).toHaveLength(117);
+  expect.soft(behaviorNames).toHaveLength(120);
   expect.soft(operatingSystemNames).toEqual([...operatingSystemTestNames].sort());
   expect.soft(operatingSystemNames).toHaveLength(29);
   expect

--- a/packages/testkit/src/session-lifecycle.test.ts
+++ b/packages/testkit/src/session-lifecycle.test.ts
@@ -47,6 +47,7 @@ import {
   type SessionStoreDirectory,
   sessionAutomaticTitlesEnabled,
   sessionCloseDrainBarrier,
+  sessionDurableOutputLimits,
   sessionLogicalRunStartedBarrier,
   sessionProjectLifecycleOwner,
   sessionStoreDirectory,
@@ -584,6 +585,220 @@ test("SessionLifecycle exposes submit_plan only while exploring and makes it ter
   }
 });
 
+test("SessionLifecycle preserves a non-empty submit_plan preamble across current and cold inspection", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-submit-preamble-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const markdown = "# Reviewed plan\n\n1. Preserve the preamble.\n2. Submit the artifact.\n";
+  const title = "Reviewed plan";
+  const driver = new FakeModelDriver([
+    { type: "text_delta", text: "The exact Plan is ready for external review." },
+    { type: "tool_call_start", id: "submit-plan-with-preamble", name: "submit_plan" },
+    {
+      type: "tool_call_delta",
+      id: "submit-plan-with-preamble",
+      json: JSON.stringify({ title, markdown }),
+    },
+    { type: "tool_call_end", id: "submit-plan-with-preamble" },
+    { type: "finish", reason: "tool_calls" },
+  ]);
+  const modelTargets = modelTargetsWithDriver(driver);
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycleOptions = {
+    modelTargets,
+    stateRoot,
+    tools: createCodingToolRegistry({ workspaceRoot }),
+    workspaceRoot,
+  };
+  let lifecycle = harness.createLifecycle(lifecycleOptions);
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.enterPlan({ sessionId: created.sessionId });
+
+    const continued = await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Publish the exact implementation plan." },
+    });
+
+    expect(continued).toMatchObject({
+      result: { status: "completed", answer: "" },
+      snapshot: {
+        plan: {
+          state: "ready",
+          revision: 2,
+          submission: {
+            title,
+            contentDigest: `sha256:${createHash("sha256").update(markdown).digest("hex")}`,
+          },
+        },
+      },
+    });
+    await expect(lifecycle.inspect({ sessionId: created.sessionId })).resolves.toMatchObject({
+      plan: { state: "ready", revision: 2, submission: { title } },
+    });
+
+    await lifecycle.close();
+    lifecycle = harness.createLifecycle(lifecycleOptions);
+    await expect(lifecycle.inspect({ sessionId: created.sessionId })).resolves.toMatchObject({
+      plan: { state: "ready", revision: 2, submission: { title } },
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle preserves an artifact-backed submit_plan preamble across current and cold inspection", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-submit-artifact-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const markdown =
+    "# Artifact-backed plan\n\n1. Retain the assistant preamble.\n2. Review the Plan.\n";
+  const title = "Artifact-backed plan";
+  const driver = new FakeModelDriver([
+    { type: "text_delta", text: "This preamble must be stored outside the inline response field." },
+    { type: "tool_call_start", id: "submit-artifact-plan", name: "submit_plan" },
+    {
+      type: "tool_call_delta",
+      id: "submit-artifact-plan",
+      json: JSON.stringify({ title, markdown }),
+    },
+    { type: "tool_call_end", id: "submit-artifact-plan" },
+    { type: "finish", reason: "tool_calls" },
+  ]);
+  const modelTargets = modelTargetsWithDriver(driver);
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycleOptions = {
+    modelTargets,
+    stateRoot,
+    tools: createCodingToolRegistry({ workspaceRoot }),
+    workspaceRoot,
+    [sessionDurableOutputLimits]: {
+      maximumInlineFieldBytes: 4,
+      maximumReferencedArtifactBytes: 1_024,
+      maximumResponseContentBytes: 2_048,
+    },
+  };
+  let lifecycle = harness.createLifecycle(lifecycleOptions);
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.enterPlan({ sessionId: created.sessionId });
+
+    const continued = await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Publish an artifact-backed Plan response." },
+    });
+
+    expect(continued).toMatchObject({
+      result: { status: "completed", answer: "" },
+      snapshot: { plan: { state: "ready", revision: 2, submission: { title } } },
+    });
+    const store = await harness.sessions.open(created.sessionId);
+    const durableTypes =
+      (await store?.read())?.flatMap((record) =>
+        record.schemaVersion === 3 ? [record.record.type] : [],
+      ) ?? [];
+    expect(durableTypes).toContain("model_response_published");
+    expect(durableTypes).toContain("run_settled");
+    expect(durableTypes).not.toContain("session_settled");
+    await expect(lifecycle.inspect({ sessionId: created.sessionId })).resolves.toMatchObject({
+      plan: { state: "ready", revision: 2, submission: { title } },
+    });
+
+    await lifecycle.close();
+    lifecycle = harness.createLifecycle(lifecycleOptions);
+    await expect(lifecycle.inspect({ sessionId: created.sessionId })).resolves.toMatchObject({
+      plan: { state: "ready", revision: 2, submission: { title } },
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle rejects a terminal submit_plan history whose Plan record is missing", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-submit-missing-record-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const driver = new FakeModelDriver([
+    { type: "text_delta", text: "The Plan record must remain authoritative." },
+    { type: "tool_call_start", id: "submit-plan-without-record", name: "submit_plan" },
+    {
+      type: "tool_call_delta",
+      id: "submit-plan-without-record",
+      json: '{"markdown":"# Missing durable Plan record\\n"}',
+    },
+    { type: "tool_call_end", id: "submit-plan-without-record" },
+    { type: "finish", reason: "tool_calls" },
+  ]);
+  const backing = createInMemorySessionStoreDirectory<SessionRecord>();
+  const wrapStore = (
+    store: Awaited<ReturnType<SessionStoreDirectory<SessionRecord>["create"]>>,
+  ) => {
+    let droppedSequence: number | undefined;
+    return {
+      async append(record: SessionRecord) {
+        await store.append(
+          droppedSequence === undefined || record.sequence < droppedSequence
+            ? record
+            : { ...record, sequence: record.sequence - 1 },
+        );
+      },
+      async appendBatch(records: readonly SessionRecord[]) {
+        const filtered = records.flatMap((record) => {
+          if (record.schemaVersion === 3 && record.record.type === "plan_submitted") {
+            droppedSequence = record.sequence;
+            return [];
+          }
+          return [record];
+        });
+        await store.appendBatch(filtered);
+      },
+      read: () => store.read(),
+    };
+  };
+  const directory: SessionStoreDirectory<SessionRecord> = {
+    async create(sessionId) {
+      return wrapStore(await backing.create(sessionId));
+    },
+    listSessionEntries: () => backing.listSessionEntries(),
+    listSessionIds: () => backing.listSessionIds(),
+    async open(sessionId) {
+      const store = await backing.open(sessionId);
+      return store === undefined ? undefined : wrapStore(store);
+    },
+  };
+  const lifecycle = createSessionLifecycle({
+    modelTargets: modelTargetsWithDriver(driver),
+    stateRoot,
+    workspaceRoot,
+    [sessionAutomaticTitlesEnabled]: false,
+    [sessionStoreDirectory]: directory,
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.enterPlan({ sessionId: created.sessionId });
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: "Publish a Plan whose canonical record is dropped." },
+      }),
+    ).rejects.toMatchObject({ code: "session_invalid" });
+    await expect(lifecycle.inspect({ sessionId: created.sessionId })).rejects.toMatchObject({
+      code: "session_invalid",
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("SessionLifecycle accepts submit_plan at the exact UTF-8 title and Markdown byte boundaries", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-submit-boundary-"));
   const stateRoot = join(testRoot, "state");
@@ -779,7 +994,13 @@ test.each(["first", "last"] as const)(
   },
 );
 
-test.each(["failed terminal", "mismatched completed output", "mismatched artifact byte count"])(
+test.each([
+  "failed terminal",
+  "mismatched completed output",
+  "mismatched artifact byte count",
+  "mismatched content digest",
+  "non-empty session settlement",
+])(
   "SessionLifecycle rejects a forged plan_submitted record after a $caseName",
   async (caseName) => {
     const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-plan-submit-forged-"));
@@ -822,14 +1043,23 @@ test.each(["failed terminal", "mismatched completed output", "mismatched artifac
       const submitted = records?.find(
         (entry) => entry.schemaVersion === 3 && entry.record.type === "plan_submitted",
       );
+      const settlement = records?.find(
+        (entry) =>
+          entry.schemaVersion === 3 &&
+          entry.record.type === "runtime_event" &&
+          entry.record.event.type === "session_settled",
+      );
       if (
         terminal?.schemaVersion !== 3 ||
         terminal.record.type !== "runtime_event" ||
         terminal.record.event.type !== "tool_completed" ||
         submitted?.schemaVersion !== 3 ||
-        submitted.record.type !== "plan_submitted"
+        submitted.record.type !== "plan_submitted" ||
+        settlement?.schemaVersion !== 3 ||
+        settlement.record.type !== "runtime_event" ||
+        settlement.record.event.type !== "session_settled"
       ) {
-        throw new Error("Expected the exact submit terminal and Plan record.");
+        throw new Error("Expected the exact submit terminal, Plan record, and settlement.");
       }
       if (caseName === "failed terminal") {
         Object.assign(terminal.record, {
@@ -849,9 +1079,15 @@ test.each(["failed terminal", "mismatched completed output", "mismatched artifac
             contentDigest: submitted.record.contentDigest,
           },
         });
-      } else {
+      } else if (caseName === "mismatched artifact byte count") {
         Object.assign(submitted.record.artifact, {
           byteCount: submitted.record.artifact.byteCount + 1,
+        });
+      } else if (caseName === "mismatched content digest") {
+        Object.assign(submitted.record, { contentDigest: `sha256:${"0".repeat(64)}` });
+      } else {
+        Object.assign(settlement.record.event, {
+          result: { status: "completed", answer: "forged Plan answer" },
         });
       }
 


### PR DESCRIPTION
## Summary

- accept terminal `submit_plan` responses that include assistant preamble text in both inline and artifact-backed durable histories while keeping Plan settlement answers empty
- consume failed post-admission Presentation refreshes into existing degraded continuity, block later submissions, and preserve the authoritative TUI cleanup path
- cover successful and double-failure Plan flows through real PTY terminal-mode restoration plus strict negative history cases

## Verification

- `pnpm quality:check`
- 82 test files passed, 2 opt-in files skipped
- 1,767 tests passed, 18 opt-in tests skipped
- independent Standards review: 0 findings
- independent Spec review: 0 findings