### PR TITLE
fix(todo): preserve dependency reopen invariant

### DIFF
--- a/packages/agent/src/todo.test.ts
+++ b/packages/agent/src/todo.test.ts
@@ -4,6 +4,7 @@ import type { SessionRecord } from "./session-store.js";
 
 import {
   createTodoMutationV1,
+  isTodoStoreSnapshotV1Valid,
   listTodosV1,
   type TodoStoreSnapshotV1,
   todoLimitsV1,
@@ -191,6 +192,71 @@ describe("Todo v1", () => {
     });
     expect(snapshot).toEqual({ ...snapshot, storeRevision: 7, items: [item] });
   });
+
+  test.each([
+    ["in_progress", "pending"],
+    ["completed", "in_progress"],
+  ] as const)(
+    "update rejects reopening across transitive dependent status %s without a cascade",
+    (transitiveStatus, reopenedStatus) => {
+      const snapshot: TodoStoreSnapshotV1 = {
+        policyVersion: todoPolicyVersionV1,
+        storeRevision: 6,
+        items: [
+          {
+            id: todoId(0),
+            createdOrdinal: 1,
+            itemRevision: 2,
+            status: "completed",
+            title: "Root prerequisite",
+            dependencyIds: [],
+          },
+          {
+            id: todoId(1),
+            createdOrdinal: 2,
+            itemRevision: 2,
+            status: "completed",
+            title: "Completed middle dependent",
+            dependencyIds: [todoId(0)],
+          },
+          {
+            id: todoId(2),
+            createdOrdinal: 3,
+            itemRevision: 2,
+            status: transitiveStatus,
+            title: "Transitive dependent",
+            dependencyIds: [todoId(1)],
+          },
+        ],
+      };
+      expect(isTodoStoreSnapshotV1Valid(snapshot)).toBe(true);
+
+      expect(
+        updateTodoMutationV1(snapshot, {
+          id: todoId(0),
+          expectedItemRevision: 2,
+          expectedStoreRevision: 6,
+          status: reopenedStatus,
+        }),
+      ).toEqual({
+        status: "failed",
+        error: {
+          code: "todo_completed_dependent",
+          message:
+            "In-progress or completed dependent Todos must return to pending before this prerequisite can be reopened.",
+        },
+      });
+      expect(snapshot).toEqual({
+        policyVersion: todoPolicyVersionV1,
+        storeRevision: 6,
+        items: [
+          expect.objectContaining({ id: todoId(0), itemRevision: 2, status: "completed" }),
+          expect.objectContaining({ id: todoId(1), itemRevision: 2, status: "completed" }),
+          expect.objectContaining({ id: todoId(2), itemRevision: 2, status: transitiveStatus }),
+        ],
+      });
+    },
+  );
 
   test("list enforces the 16 KiB page bound and resumes from a stateless cursor", () => {
     const items = Array.from({ length: 50 }, (_, index) => ({

--- a/packages/agent/src/todo.ts
+++ b/packages/agent/src/todo.ts
@@ -388,13 +388,14 @@ export function updateTodoMutationV1(
   if (
     current.status === "completed" &&
     status !== "completed" &&
-    hasCompletedTodoDependentV1(snapshot, current.id)
+    hasNonPendingTodoDependentV1(snapshot, current.id)
   ) {
     return {
       status: "failed",
       error: {
         code: "todo_completed_dependent",
-        message: "Completed dependent Todos must be reopened before this prerequisite.",
+        message:
+          "In-progress or completed dependent Todos must return to pending before this prerequisite can be reopened.",
       },
     };
   }
@@ -721,13 +722,13 @@ export function wouldCreateTodoDependencyCycleV1(
   return false;
 }
 
-export function hasCompletedTodoDependentV1(
+function hasNonPendingTodoDependentV1(
   snapshot: TodoStoreSnapshotV1,
   dependencyId: string,
 ): boolean {
   const dependenciesById = new Map(snapshot.items.map((item) => [item.id, item.dependencyIds]));
   return snapshot.items.some((item) => {
-    if (item.status !== "completed" || item.id === dependencyId) {
+    if (item.status === "pending" || item.id === dependencyId) {
       return false;
     }
     const visited = new Set<string>();

--- a/packages/testkit/src/session-lifecycle-test-topology.test.ts
+++ b/packages/testkit/src/session-lifecycle-test-topology.test.ts
@@ -202,13 +202,14 @@ test("SessionLifecycle behavior and OS contracts keep separate environment owner
 
   const behaviorNames = declaredTestNames(behaviorSource);
   const operatingSystemNames = declaredTestNames(operatingSystemSource);
-  expect.soft(behaviorNames).toHaveLength(120);
+  expect.soft(behaviorNames).toHaveLength(121);
   expect.soft(operatingSystemNames).toEqual([...operatingSystemTestNames].sort());
   expect.soft(operatingSystemNames).toHaveLength(29);
   expect
     .soft(behaviorNames.filter((name) => name.includes("Todo")))
     .toEqual([
       "SessionLifecycle Plan may read Todo but cannot mutate or materialize it",
+      "SessionLifecycle Todo rejects reopening a prerequisite while its direct dependent is in progress",
       "SessionLifecycle binds Todo reads to the exact folded store revision",
       "SessionLifecycle branches a Todo store larger than one record through bounded inheritance chunks",
       "SessionLifecycle folds Todo state across a deterministic restart",

--- a/packages/testkit/src/session-lifecycle.test.ts
+++ b/packages/testkit/src/session-lifecycle.test.ts
@@ -25,6 +25,7 @@ import {
   type LocalInputResourceSelectionV1,
   type ModelDriver,
   type ModelMessage,
+  type ModelRequest,
   type ModelTargetIdentity,
   type ModelTargets,
   type ModelToolDefinition,
@@ -232,6 +233,199 @@ test("SessionLifecycle folds Todo state across a deterministic restart", async (
     await resumedLifecycle.close();
   } finally {
     await firstLifecycle.close();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle Todo rejects reopening a prerequisite while its direct dependent is in progress", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-session-todo-active-reopen-"));
+  const stateRoot = join(testRoot, "state");
+  const workspaceRoot = join(testRoot, "workspace");
+  await mkdir(workspaceRoot);
+  const requests: ModelRequest[] = [];
+  let prerequisiteId: string | undefined;
+  let dependentId: string | undefined;
+  let call = 0;
+  const driver = new FakeModelDriver((request) => {
+    requests.push(request);
+    call += 1;
+    if (call === 1) {
+      return [
+        { type: "tool_call_start", id: "create-active-prerequisite", name: "create_todo" },
+        {
+          type: "tool_call_delta",
+          id: "create-active-prerequisite",
+          json: '{"title":"Active prerequisite"}',
+        },
+        { type: "tool_call_end", id: "create-active-prerequisite" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    if (call === 2) {
+      prerequisiteId = completedTodoItemId(request.messages, "create_todo");
+      if (prerequisiteId === undefined) {
+        throw new Error("Expected the prerequisite Todo identity.");
+      }
+      return [
+        { type: "tool_call_start", id: "create-active-dependent", name: "create_todo" },
+        {
+          type: "tool_call_delta",
+          id: "create-active-dependent",
+          json: JSON.stringify({ title: "Active dependent", dependencyIds: [prerequisiteId] }),
+        },
+        { type: "tool_call_end", id: "create-active-dependent" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    if (call === 3) {
+      dependentId = completedTodoItemId(request.messages, "create_todo");
+      if (dependentId === undefined) {
+        throw new Error("Expected the dependent Todo identity.");
+      }
+      return [
+        { type: "tool_call_start", id: "complete-active-prerequisite", name: "update_todo" },
+        {
+          type: "tool_call_delta",
+          id: "complete-active-prerequisite",
+          json: JSON.stringify({
+            id: prerequisiteId,
+            expectedItemRevision: 1,
+            expectedStoreRevision: 2,
+            status: "completed",
+          }),
+        },
+        { type: "tool_call_end", id: "complete-active-prerequisite" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    if (call === 4) {
+      return [
+        { type: "tool_call_start", id: "start-active-dependent", name: "update_todo" },
+        {
+          type: "tool_call_delta",
+          id: "start-active-dependent",
+          json: JSON.stringify({
+            id: dependentId,
+            expectedItemRevision: 1,
+            expectedStoreRevision: 3,
+            status: "in_progress",
+          }),
+        },
+        { type: "tool_call_end", id: "start-active-dependent" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    if (call === 5) {
+      return [
+        {
+          type: "tool_call_start",
+          id: "reject-active-prerequisite-reopen",
+          name: "update_todo",
+        },
+        {
+          type: "tool_call_delta",
+          id: "reject-active-prerequisite-reopen",
+          json: JSON.stringify({
+            id: prerequisiteId,
+            expectedItemRevision: 2,
+            expectedStoreRevision: 4,
+            status: "pending",
+          }),
+        },
+        { type: "tool_call_end", id: "reject-active-prerequisite-reopen" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    if (call === 6) {
+      return [
+        { type: "tool_call_start", id: "read-unchanged-prerequisite", name: "get_todo" },
+        {
+          type: "tool_call_delta",
+          id: "read-unchanged-prerequisite",
+          json: JSON.stringify({ id: prerequisiteId }),
+        },
+        { type: "tool_call_end", id: "read-unchanged-prerequisite" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    }
+    return [
+      { type: "text_delta", text: "The active dependent kept its prerequisite closed." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({
+    modelTargets: modelTargetsWithDriver(driver),
+    permissions: createPermissionPolicy({ allowedEffects: ["read", "write"] }),
+    stateRoot,
+    tools: createCodingToolRegistry({ workspaceRoot }),
+    workspaceRoot,
+  });
+
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    const continued = await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Reject reopening a prerequisite needed by active work." },
+    });
+
+    expect(continued).toMatchObject({
+      result: {
+        status: "completed",
+        answer: "The active dependent kept its prerequisite closed.",
+      },
+      snapshot: {
+        todo: {
+          storeRevision: 4,
+          counts: { pending: 0, inProgress: 1, completed: 1 },
+          blockedCount: 0,
+        },
+      },
+    });
+    expect(
+      requests[5]?.messages.findLast(
+        (message) => message.role === "tool" && message.name === "update_todo",
+      ),
+    ).toMatchObject({
+      result: {
+        status: "failed",
+        error: {
+          code: "todo_completed_dependent",
+          message:
+            "In-progress or completed dependent Todos must return to pending before this prerequisite can be reopened.",
+        },
+      },
+    });
+    expect(
+      requests[5]?.messages.find(
+        (message) =>
+          message.role === "assistant" &&
+          message.content.startsWith("Adam runtime Todo summary v1"),
+      )?.content,
+    ).toContain(
+      '"storeRevision":4,"counts":{"pending":0,"inProgress":1,"completed":1},"blockedCount":0',
+    );
+    expect(
+      requests[6]?.messages.findLast(
+        (message) => message.role === "tool" && message.name === "get_todo",
+      ),
+    ).toMatchObject({
+      result: {
+        status: "completed",
+        output: {
+          storeRevision: 4,
+          item: { id: prerequisiteId, itemRevision: 2, status: "completed" },
+        },
+      },
+    });
+    expect(prerequisiteId).toMatch(/^[0-9a-f-]{36}$/u);
+    expect(dependentId).toMatch(/^[0-9a-f-]{36}$/u);
+    const records = await (await harness.sessions.open(created.sessionId))?.read();
+    expect(
+      records?.filter((entry) => entry.schemaVersion === 3 && entry.record.type === "todo_updated"),
+    ).toHaveLength(2);
+  } finally {
+    await lifecycle.close();
     await rm(testRoot, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
S34-T0 rejects reopening a completed prerequisite while any direct or transitive dependent remains in progress or completed. The existing typed error family is retained, failed mutation leaves item/store revisions and summary unchanged, and no cascade is introduced. Lifecycle caller coverage, deep graph cases, legal transitions, topology guards, and a read-only historical-state audit passed. Local Quality passed 82 files with 1774 tests and 18 opt-in skips. Independent Standards and Spec reviews reported zero findings.