### PR TITLE
fix(tui): make Plan copy policy-aware

### DIFF
--- a/apps/tui/src/command-registry.test.ts
+++ b/apps/tui/src/command-registry.test.ts
@@ -4,6 +4,16 @@ import {
   createAdamCommandRegistryFromContributions,
 } from "./command-registry.js";
 
+test("Plan Registry copy stays policy-neutral", () => {
+  const parsed = adamCommandRegistry.parse("/plan");
+  expect(parsed).toMatchObject({
+    kind: "known",
+    command: {
+      summary: "Enter or exit the authoritative Plan cycle.",
+    },
+  });
+});
+
 test("the TUI Registry hides attachment actions for a historical text-only session", () => {
   const attachmentCommands = adamCommandRegistry
     .entries()

--- a/apps/tui/src/command-registry.ts
+++ b/apps/tui/src/command-registry.ts
@@ -360,7 +360,7 @@ const builtInCommands: readonly AdamCommandDefinition[] = [
     availability: "idle",
     id: "plan",
     name: "plan",
-    summary: "Enter or exit the authoritative read-only Plan cycle.",
+    summary: "Enter or exit the authoritative Plan cycle.",
     usage: "/plan",
   },
   {

--- a/apps/tui/src/fixture-scenario.ts
+++ b/apps/tui/src/fixture-scenario.ts
@@ -19,6 +19,7 @@ export const fixtureScenarios = [
   "mutation-after-release-with-continuation-barrier",
   "mutation-delayed-preview",
   "plan-review",
+  "plan-read-v1",
   "plan-review-recovery",
   "plan-settlement-read-failure",
   "provider-no-usage",

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -384,7 +384,7 @@ test("real PTY submits a Plan with assistant preamble and restores every termina
     await fixture.waitFor("Adam · New session");
     const beforePlan = fixture.output().length;
     fixture.write("/plan\r");
-    await fixture.waitForCompleteFrameAfter("Plan exploring · read-only", beforePlan);
+    await fixture.waitForCompleteFrameAfter("Plan exploring", beforePlan);
     const beforeSubmission = fixture.output().length;
     fixture.write("Create the exact PTY Plan\r");
     await fixture.waitForCompleteFrameAfter("Review exact submitted plan", beforeSubmission);
@@ -421,7 +421,7 @@ test("real PTY restores every terminal input mode after Plan settlement and refr
     await fixture.waitFor("Adam · New session");
     const beforePlan = fixture.output().length;
     fixture.write("/plan\r");
-    await fixture.waitForCompleteFrameAfter("Plan exploring · read-only", beforePlan);
+    await fixture.waitForCompleteFrameAfter("Plan exploring", beforePlan);
     fixture.write("Create the failing-refresh PTY Plan\r");
     await waitForFileContents(join(controlRoot, "plan-settlement-read-failed"), "failed\n");
 

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -4133,7 +4133,157 @@ test("the idle footer exposes Registry-driven interaction hints", async () => {
   }
 });
 
-test("a new-session draft toggles read-only Plan without creating durable identity", async () => {
+test("current hybrid Plan copy is policy-aware in notices and footer", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-plan-hybrid-copy-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      launch: {},
+      scenario: "skill-selection",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Admit the current hybrid Plan session\r");
+    await fixture.waitFor("Skill selection complete.");
+    const afterAnswer = fixture.output().lastIndexOf("Skill selection complete.");
+    await fixture.waitForCompleteFrameAfter(" · idle", afterAnswer);
+    const beforePlan = fixture.output().length;
+    fixture.write("/plan\r");
+    await fixture.waitForCompleteFrameAfter("Plan exploring", beforePlan);
+    const output = fixture.output().slice(beforePlan);
+    const frame = fixture.screen()?.join("\n") ?? "";
+
+    expect(output).toContain("Entered Plan.");
+    expect(frame).toContain("Plan exploring");
+    expect(frame).toContain(
+      "plan-policy.hybrid-v1 · inspect auto · ambiguous exec asks · mutation denies",
+    );
+    expect(`${output}\n${frame}`).not.toContain("read-only Plan");
+    expect(frame).not.toContain("Plan exploring · read-only");
+
+    for (const [columns, rows, policyCopy] of [
+      [120, 40, ["plan-policy.hybrid-v1 · inspect auto · ambiguous exec asks · mutation denies"]],
+      [80, 24, ["plan-policy.hybrid-v1 · inspect auto · ambiguous exec asks · mutation denies"]],
+      [40, 12, ["inspect:auto · ambig:ask ·", "mutate:deny"]],
+    ] as const) {
+      await fixture.resize(columns, rows);
+      const resizedFrame = fixture.screen() ?? [];
+      for (const expected of policyCopy) {
+        expect(resizedFrame.join("\n")).toContain(expected);
+      }
+      expect(resizedFrame.join("\n")).not.toContain("read-only");
+      expect(resizedFrame.every((line) => visibleWidth(line) <= columns)).toBe(true);
+    }
+
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("production Help renders policy-neutral Plan Registry copy", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-plan-help-copy-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ stateRoot, workspaceRoot });
+    await fixture.waitFor("Adam · New session");
+    await fixture.resize(120, 40);
+    const beforeHelp = fixture.output().length;
+    fixture.write("/help commands\r");
+    await fixture.waitForCompleteFrameAfter("Command Reference", beforeHelp);
+    const frame = fixture.screen()?.join("\n") ?? "";
+    expect(frame).toContain("/plan · idle only · Enter or exit the authoritative Plan cycle.");
+    expect(frame).not.toContain("read-only Plan");
+
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("NO_COLOR preserves current hybrid Plan policy copy without claiming read-only", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-plan-hybrid-no-color-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({
+      launch: {},
+      noColor: true,
+      scenario: "skill-selection",
+      stateRoot,
+      workspaceRoot,
+    });
+    await fixture.waitFor("Select an exact model target");
+    fixture.write("\r");
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Admit the colorless hybrid Plan session\r");
+    await fixture.waitFor("Skill selection complete.");
+    const afterAnswer = fixture.output().lastIndexOf("Skill selection complete.");
+    await fixture.waitForCompleteFrameAfter(" · idle", afterAnswer);
+    const beforePlan = fixture.output().length;
+    fixture.write("/plan\r");
+    await fixture.waitForCompleteFrameAfter(
+      "plan-policy.hybrid-v1 · inspect auto · ambiguous exec asks · mutation denies",
+      beforePlan,
+    );
+    const frame = fixture.screen()?.join("\n") ?? "";
+
+    expect(frame).toContain("Entered Plan.");
+    expect(frame).not.toContain("read-only");
+    expect(frame).not.toContain("\u001b[38;2;");
+    expect(frame).not.toContain("\u001b[48;2;");
+
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("historical read-v1 Plan keeps exact read-only footer wording", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-plan-read-v1-copy-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  await mkdir(workspaceRoot);
+
+  try {
+    const fixture = startFixture({ scenario: "plan-read-v1", stateRoot, workspaceRoot });
+    await fixture.waitForCompleteFrameAfter("plan-policy.read-v1 · read-only", 0);
+    let frame = fixture.screen() ?? [];
+    expect(frame.join("\n")).toContain("Plan exploring");
+    expect(frame.join("\n")).not.toContain("hybrid-v1");
+
+    await fixture.resize(40, 12);
+    frame = fixture.screen() ?? [];
+    expect(frame.join("\n")).toContain("plan read-only");
+    expect(frame.every((line) => visibleWidth(line) <= 40)).toBe(true);
+
+    const beforeExit = fixture.output().length;
+    fixture.write("/plan\r");
+    await fixture.waitForCompleteFrameAfter("Exited Plan.", beforeExit);
+    expect(fixture.screen()?.join("\n") ?? "").not.toContain("plan read-only");
+
+    fixture.write("\u0011");
+    await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
+  } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a new-session draft toggles policy-aware Plan without creating durable identity", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-plan-status-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
@@ -4151,9 +4301,11 @@ test("a new-session draft toggles read-only Plan without creating durable identi
 
     const beforeEntry = fixture.output().length;
     fixture.write("/plan\r");
-    await fixture.waitForCompleteFrameAfter("Plan exploring · read-only", beforeEntry);
+    await fixture.waitForCompleteFrameAfter("Plan exploring", beforeEntry);
     let frame = latestSynchronizedFrame(fixture.output()).join("\n");
-    expect(frame).toContain("Plan exploring · read-only");
+    expect(frame).toContain("Plan exploring");
+    expect(frame).not.toContain("read-only");
+    expect(frame).not.toContain("plan-policy.");
     expect(await readFilesRecursively(stateRoot)).not.toContain('"type":"session_genesis"');
 
     const beforeTargetSwitch = fixture.output().length;
@@ -4166,17 +4318,15 @@ test("a new-session draft toggles read-only Plan without creating durable identi
       beforeTargetSelection,
     );
     const beforeSwitchedTargetClose = fixture.output().length;
-    await fixture.waitForCompleteFrameAfter(
-      "Plan exploring · read-only",
-      beforeSwitchedTargetClose,
-    );
-    expect(fixture.screen()?.join("\n") ?? "").toContain("Plan exploring · read-only");
+    await fixture.waitForCompleteFrameAfter("Plan exploring", beforeSwitchedTargetClose);
+    expect(fixture.screen()?.join("\n") ?? "").not.toContain("read-only");
+    expect(fixture.screen()?.join("\n") ?? "").not.toContain("plan-policy.");
 
     const beforeExit = fixture.output().length;
     fixture.write("/plan\r");
-    await fixture.waitForAfter("Exited read-only Plan.", beforeExit);
+    await fixture.waitForAfter("Exited Plan.", beforeExit);
     frame = latestSynchronizedFrame(fixture.output().slice(beforeExit)).join("\n");
-    expect(frame).not.toContain("Plan exploring · read-only");
+    expect(frame).not.toContain("Plan exploring");
 
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
@@ -4185,7 +4335,7 @@ test("a new-session draft toggles read-only Plan without creating durable identi
   }
 });
 
-test("a prompt-admitted production session enters read-only Plan after its first turn", async () => {
+test("a prompt-admitted production session enters policy-aware Plan after its first turn", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-tui-plan-after-admission-"));
   const workspaceRoot = join(testRoot, "workspace");
   const stateRoot = join(testRoot, "state");
@@ -4213,9 +4363,13 @@ test("a prompt-admitted production session enters read-only Plan after its first
 
     const beforePlan = fixture.output().length;
     fixture.write("/plan\r");
-    await fixture.waitForCompleteFrameAfter("Plan exploring · read-only", beforePlan);
+    await fixture.waitForCompleteFrameAfter(
+      "plan-policy.hybrid-v1 · inspect auto · ambiguous exec asks · mutation denies",
+      beforePlan,
+    );
     const frame = latestSynchronizedFrame(fixture.output().slice(beforePlan)).join("\n");
-    expect(frame).toContain("Plan exploring · read-only");
+    expect(frame).toContain("Plan exploring");
+    expect(frame).not.toContain("read-only");
     expect(frame).not.toContain("Plan could not be entered from the current session state.");
 
     fixture.write("\u0011");
@@ -4242,7 +4396,7 @@ test("the production TUI reviews, revises, and implements the exact ready Plan",
     await fixture.resize(120, 40);
     const beforeEntry = fixture.output().length;
     fixture.write("/plan\r");
-    await fixture.waitForCompleteFrameAfter("Plan exploring · read-only", beforeEntry);
+    await fixture.waitForCompleteFrameAfter("Plan exploring", beforeEntry);
 
     const beforeInitialSubmission = fixture.output().length;
     fixture.write("Create the exact implementation plan\r");
@@ -4319,7 +4473,7 @@ test("the production TUI keeps the exact composer draft while a ready Plan revie
     await fixture.resize(120, 40);
     const beforeEntry = fixture.output().length;
     fixture.write("/plan\r");
-    await fixture.waitForCompleteFrameAfter("Plan exploring · read-only", beforeEntry);
+    await fixture.waitForCompleteFrameAfter("Plan exploring", beforeEntry);
     const beforePlan = fixture.output().length;
     fixture.write("Create a plan whose ready state must remain exact\r");
     await fixture.waitForCompleteFrameAfter("Review exact submitted plan", beforePlan);
@@ -4361,7 +4515,7 @@ test("the production TUI cancels a ready Plan only after concise confirmation", 
     await fixture.resize(120, 40);
     const beforeEntry = fixture.output().length;
     fixture.write("/plan\r");
-    await fixture.waitForCompleteFrameAfter("Plan exploring · read-only", beforeEntry);
+    await fixture.waitForCompleteFrameAfter("Plan exploring", beforeEntry);
     const beforePlan = fixture.output().length;
     fixture.write("Create a plan that will be cancelled exactly\r");
     await fixture.waitForCompleteFrameAfter("Review exact submitted plan", beforePlan);
@@ -4424,7 +4578,7 @@ test("the production TUI explicitly continues a recovered unstarted Plan approva
     await fixture.resize(120, 40);
     const beforeEntry = fixture.output().length;
     fixture.write("/plan\r");
-    await fixture.waitForCompleteFrameAfter("Plan exploring · read-only", beforeEntry);
+    await fixture.waitForCompleteFrameAfter("Plan exploring", beforeEntry);
     const beforePlan = fixture.output().length;
     fixture.write("Create a plan whose durable approval must be recovered\r");
     await fixture.waitForCompleteFrameAfter("Review exact submitted plan", beforePlan);

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   type ContextProfile,
+  createCodingToolRegistry,
   createExtensionHost,
   createFileArtifactStore,
   createInMemoryOperationStore,
@@ -23,6 +24,7 @@ import {
 } from "@adam-agent/agent";
 import {
   createInMemorySessionStoreDirectory,
+  createPlanToolProfileV1,
   createTrustedWorkspaceTrustForTesting,
   mcpCloseConfirmation,
   type PresentationArtifactReadBarrier,
@@ -324,6 +326,14 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
             };
           },
         };
+  const historicalPlanRegistry =
+    options.scenario === "plan-read-v1"
+      ? createCodingToolRegistry({ workspaceRoot: options.workspaceRoot })
+      : undefined;
+  const historicalPlanStores =
+    options.scenario === "plan-read-v1"
+      ? createInMemorySessionStoreDirectory<SessionRecord>()
+      : undefined;
   const lifecycle = createSessionLifecycle({
     ...(options.scenario === "managed-attention"
       ? { managedAgentTools: "managed-agent-tools.a3-long-lived.v1" as const }
@@ -357,6 +367,10 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
       : {}),
     ...(modelTargets === undefined ? {} : { modelTargets }),
     ...(preferences === undefined ? {} : { preferences }),
+    ...(historicalPlanStores === undefined
+      ? {}
+      : { [sessionStoreDirectory]: historicalPlanStores }),
+    ...(historicalPlanRegistry === undefined ? {} : { tools: historicalPlanRegistry }),
     permissions: createPermissionPolicy({
       allowedEffects:
         options.scenario === "managed-attention"
@@ -466,6 +480,7 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
       options.scenario === "history" ||
       options.scenario === "artifact-history" ||
       options.scenario === "copy-older-assistant" ||
+      options.scenario === "plan-read-v1" ||
       options.scenario === "reasoning-multiple" ||
       options.scenario === "reasoning-large-multiple" ||
       options.scenario === "reasoning-artifact-session-race" ||
@@ -474,7 +489,44 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
       options.scenario === "tool-multiple" ||
       options.scenario === "unsafe-history"
         ? await lifecycle.create({ targetIdentity }).then(async (created) => {
-            if (options.scenario === "history") {
+            if (options.scenario === "plan-read-v1") {
+              const source = created.promptContext?.toolProfile;
+              if (source === undefined || historicalPlanRegistry === undefined) {
+                throw new Error("Expected historical Plan source authority.");
+              }
+              const eligibleToolProfile = createPlanToolProfileV1({
+                source: { version: source.version, digest: source.digest },
+                definitions: source.definitions.flatMap((definition) => {
+                  const adapter = historicalPlanRegistry.resolve(definition.name);
+                  return adapter?.effect === "read"
+                    ? [
+                        {
+                          name: definition.name,
+                          definitionDigest: adapter.definitionDigest as `sha256:${string}`,
+                          effect: adapter.effect,
+                          source: "builtin" as const,
+                        },
+                      ]
+                    : [];
+                }),
+              });
+              const store = await historicalPlanStores?.open(created.sessionId);
+              if (store === undefined) {
+                throw new Error("Expected the historical Plan session store.");
+              }
+              await store.append({
+                schemaVersion: 3,
+                sequence: created.lastSequence + 1,
+                record: {
+                  type: "plan_cycle_entered",
+                  recordVersion: 1,
+                  cycleId: "123e4567-e89b-42d3-a456-426614176100",
+                  revision: 1,
+                  policyVersion: "plan-policy.read-v1",
+                  eligibleToolProfile,
+                },
+              });
+            } else if (options.scenario === "history") {
               for (let index = 1; index <= 3; index += 1) {
                 await lifecycle.continue({
                   sessionId: created.sessionId,

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -2125,7 +2125,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         selectedSkills.size === 0
           ? ""
           : ` · ${selectedSkills.size} Skill${selectedSkills.size === 1 ? "" : "s"} selected`;
-      const planSummary = draft.mode === "plan" ? " · Plan exploring · read-only" : "";
+      const planSummary = draft.mode === "plan" ? " · Plan exploring" : "";
       footer.setText({
         wide: theme.muted(
           `${safeTerminalText(state.authoritative.project.label)} · New session draft${planSummary} · idle\n${safeTerminalText(draft.targetId)} · ${target?.certification ?? "Experimental"}${upstreamSummary}${connectionSummary}${thinkingSummary}${selectedSkillSummary} · /help · Tab complete`,
@@ -2169,7 +2169,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         active.plan === undefined
           ? ""
           : active.plan.state === "exploring"
-            ? " · Plan exploring · read-only"
+            ? " · Plan exploring"
             : active.plan.state === "ready"
               ? ` · Plan ready r${active.plan.revision} · review required`
               : " · Plan approved · not started";
@@ -2181,7 +2181,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         active.plan === undefined
           ? ""
           : active.plan.state === "exploring"
-            ? " · plan read-only"
+            ? " · plan"
             : active.plan.state === "ready"
               ? " · plan ready"
               : " · plan pending";
@@ -2196,15 +2196,23 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           : ` · Agents ${managedAgents.active} active/${managedAgents.completed} completed`;
       const compactAgentSummary =
         managedAgents.active === 0 ? "" : ` · agents ${managedAgents.active}`;
+      const planPolicySummary =
+        active.plan?.state === "exploring"
+          ? planPolicyFooterSummary(active.plan.policyVersion, "standard")
+          : null;
+      const compactPlanPolicySummary =
+        active.plan?.state === "exploring"
+          ? planPolicyFooterSummary(active.plan.policyVersion, "compact")
+          : null;
       footer.setText({
         wide: theme.muted(
-          `${safeTerminalText(state.authoritative.project.label)} · ${footerContextText(active)}${planSummary} · ${runStatus}${todoSummary}${agentSummary}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}${upstreamSummary}${connectionSummary}${thinkingSummary}${selectedSkillSummary}${olderHistorySummary} · ${commandRegistry.footerHint()}`,
+          `${safeTerminalText(state.authoritative.project.label)} · ${footerContextText(active)}${planSummary} · ${runStatus}${todoSummary}${agentSummary}\n${planPolicySummary === null ? "" : `${planPolicySummary}\n`}${safeTerminalText(active.session.targetId)} · ${targetCertification}${upstreamSummary}${connectionSummary}${thinkingSummary}${selectedSkillSummary}${olderHistorySummary} · ${commandRegistry.footerHint()}`,
         ),
         standard: theme.muted(
-          `${safeTerminalText(state.authoritative.project.label)} · ${footerContextText(active)}${planSummary} · ${runStatus}${todoSummary}${agentSummary}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}${upstreamSummary}${connectionSummary}${thinkingSummary}${selectedSkillSummary}${olderHistorySummary} · /help · Tab complete`,
+          `${safeTerminalText(state.authoritative.project.label)} · ${footerContextText(active)}${planSummary} · ${runStatus}${todoSummary}${agentSummary}\n${planPolicySummary === null ? "" : `${planPolicySummary}\n`}${safeTerminalText(active.session.targetId)} · ${targetCertification}${upstreamSummary}${connectionSummary}${thinkingSummary}${selectedSkillSummary}${olderHistorySummary} · /help · Tab complete`,
         ),
         narrow: theme.muted(
-          `${runStatus}${compactPlanSummary} · ${footerContextCompactText(active)}${compactTodoSummary}${compactAgentSummary}\n${safeTerminalText(active.session.targetId)} · ${targetCertification}${upstreamSummary}\n/help · Tab complete`,
+          `${runStatus}${compactPlanSummary} · ${footerContextCompactText(active)}${compactTodoSummary}${compactAgentSummary}\n${compactPlanPolicySummary === null ? "" : `${compactPlanPolicySummary}\n`}${safeTerminalText(active.session.targetId)} · ${targetCertification}${upstreamSummary}\n/help · Tab complete`,
         ),
       });
     }
@@ -3811,7 +3819,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         editor.setText("");
         const planActionId = showNotice(
           "progress",
-          entering ? "Entering read-only Plan…" : "Exiting read-only Plan…",
+          entering ? "Entering Plan…" : "Exiting Plan…",
           "until_replaced",
         );
         void options.presentation
@@ -3821,7 +3829,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
               settleNotice(
                 planActionId,
                 "success",
-                entering ? "Entered read-only Plan." : "Exited read-only Plan.",
+                entering ? "Entered Plan." : "Exited Plan.",
                 "until_next_action",
               );
             } else {
@@ -4076,7 +4084,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       const entering = plan === undefined;
       const planActionId = showNotice(
         "progress",
-        entering ? "Entering read-only Plan…" : "Exiting read-only Plan…",
+        entering ? "Entering Plan…" : "Exiting Plan…",
         "until_replaced",
         active.session.id,
       );
@@ -4097,7 +4105,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
             settleNotice(
               planActionId,
               "success",
-              entering ? "Entered read-only Plan." : "Exited read-only Plan.",
+              entering ? "Entered Plan." : "Exited Plan.",
               "until_next_action",
               active.session.id,
             );
@@ -4109,9 +4117,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           settleNotice(
             planActionId,
             "error",
-            entering
-              ? "Read-only Plan could not be entered."
-              : "Read-only Plan could not be exited.",
+            entering ? "Plan could not be entered." : "Plan could not be exited.",
             "until_edit",
             active.session.id,
           );
@@ -5885,6 +5891,18 @@ async function readCompleteArtifact(
     throw new TypeError("The complete artifact is unavailable for copy.");
   }
   return receipt.resource.text;
+}
+
+function planPolicyFooterSummary(
+  policyVersion: NonNullable<ActiveSessionDisplay["plan"]>["policyVersion"],
+  density: "compact" | "standard",
+): string {
+  if (policyVersion === "plan-policy.read-v1") {
+    return density === "compact" ? "plan read-only" : "plan-policy.read-v1 · read-only";
+  }
+  return density === "compact"
+    ? "inspect:auto · ambig:ask · mutate:deny"
+    : "plan-policy.hybrid-v1 · inspect auto · ambiguous exec asks · mutation denies";
 }
 
 function footerContextText(active: ActiveSessionDisplay): string {

--- a/packages/testkit/src/session-lifecycle.test.ts
+++ b/packages/testkit/src/session-lifecycle.test.ts
@@ -4858,7 +4858,8 @@ test("SessionLifecycle enforces the exact eight MiB materialized-output budget p
       };
     },
   };
-  const lifecycle = createSessionLifecycle({ modelTargets, stateRoot, workspaceRoot });
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({ modelTargets, stateRoot, workspaceRoot });
 
   try {
     const created = await lifecycle.create({ targetIdentity });
@@ -4892,11 +4893,10 @@ test("SessionLifecycle enforces the exact eight MiB materialized-output budget p
     ).resolves.toMatchObject({
       result: { status: "completed", answer: "The lineage quota rejected another page." },
     });
-    const store = await openJsonlSessionStore({
-      stateRoot,
-      workspaceRoot,
-      sessionId: created.sessionId,
-    });
+    const store = await harness.sessions.open(created.sessionId);
+    if (store === undefined) {
+      throw new Error("Expected the materialized-output lineage store.");
+    }
     const records = await store.read();
     expect(
       records.filter(


### PR DESCRIPTION
S34-P0 removes blanket read-only wording from current hybrid Plan Registry, Help, notices, and footer copy. Active footer facts derive only from authoritative policyVersion: hybrid shows inspection auto-allow, ambiguous execute asks, and mutation denial; historical read-v1 keeps exact read-only wording. Draft Plan copy stays policy-neutral until admission. Focused 120/80/40, NO_COLOR, historical, Help, review, settlement, and real-PTY evidence passed. No Runtime, Plan policy, permission, persistence, shell, dependency, or public API changed. Local Quality passed 82 files with 1779 tests and 18 opt-in skips; independent Standards and Spec reviews reported zero findings.