### PR TITLE
fix: preserve managed origin policy and usage

### DIFF
--- a/apps/tui/src/project-runtime.ts
+++ b/apps/tui/src/project-runtime.ts
@@ -106,19 +106,7 @@ export async function createProductionProjectRuntime(
       parentPermissions: options.permissions,
       async resolveOrigin({ origin, signal }) {
         if (lifecycle === undefined) throw new Error("The session lifecycle is unavailable.");
-        const snapshot = await lifecycle.inspect({ sessionId: origin.sessionId });
-        if (snapshot.schemaVersion !== 3) throw new Error("The origin session is unavailable.");
-        const resolved = await options.modelTargets.resolve({
-          allowExperimental: true,
-          signal,
-          targetId: snapshot.targetIdentity.targetId,
-          targetIdentity: snapshot.targetIdentity,
-        });
-        return {
-          childContextProfile: resolved.contextProfile,
-          childModel: resolved.driver,
-          targetIdentity: resolved.identity,
-        };
+        return lifecycle.resolveManagedSessionOrigin({ origin, signal });
       },
       workspaceRoot: options.workspaceRoot,
     },

--- a/packages/agent/src/managed-agent.ts
+++ b/packages/agent/src/managed-agent.ts
@@ -214,6 +214,7 @@ export type ManagedAgentRecord =
       readonly profile: "reviewer.v1" | "scout.v1" | "research.v1";
       readonly mode?: "foreground" | "background";
       readonly profileDigest: `sha256:${string}`;
+      readonly usageAccountingVersion?: 2;
       readonly effectiveToolProfileDigest?: `sha256:${string}`;
       readonly skillActivationDigest?: `sha256:${string}`;
       readonly selectedSkills?: readonly {
@@ -598,6 +599,7 @@ const managedAgentRecordSchema = z.union([
     profile: z.enum(["reviewer.v1", "scout.v1", "research.v1"]),
     mode: z.enum(["foreground", "background"]).optional(),
     profileDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+    usageAccountingVersion: z.literal(2).optional(),
     effectiveToolProfileDigest: z
       .string()
       .regex(/^sha256:[0-9a-f]{64}$/u)
@@ -1064,13 +1066,9 @@ export async function recoverInterruptedManagedAgents(
           managedAttemptHistory(source, records, childSessionStores),
         ),
       );
-      const cumulativeTokens = sourceHistories.reduce(
-        (total, history) =>
-          total +
-          history.usage.inputTokens +
-          history.usage.outputTokens +
-          history.usage.reasoningTokens,
-        0,
+      const cumulativeTokens = managedCumulativeTokens(
+        sourceHistories,
+        admission.usageAccountingVersion ?? 1,
       );
       const sourceTranscriptDigest = digest(JSON.stringify(sourceRecords ?? []));
       const sourceThroughSequence = sourceRecords?.at(-1)?.sequence ?? 0;
@@ -1524,6 +1522,7 @@ export function validateManagedAgentRecord(
           previous.projectId !== candidate.projectId ||
           previous.profile !== candidate.profile ||
           previous.profileDigest !== candidate.profileDigest ||
+          (previous.usageAccountingVersion === 2 && candidate.usageAccountingVersion !== 2) ||
           previous.effectiveToolProfileDigest !== candidate.effectiveToolProfileDigest ||
           previous.skillActivationDigest !== candidate.skillActivationDigest ||
           !isDeepStrictEqual(previous.selectedSkills, candidate.selectedSkills) ||
@@ -3090,6 +3089,7 @@ export function createAgentManager(options: {
         profile,
         mode: input.mode,
         profileDigest: managedProfile.digest,
+        usageAccountingVersion: 2,
         ...(input.preserveLegacyProfile === true
           ? {}
           : { effectiveToolProfileDigest: childPromptContext.toolProfile.digest }),
@@ -3918,14 +3918,7 @@ export function createAgentManager(options: {
           managedAttemptHistory(admission, records, options.childSessionStores),
         ),
       );
-      const cumulativeTokens = attemptHistories.reduce(
-        (total, history) =>
-          total +
-          history.usage.inputTokens +
-          history.usage.outputTokens +
-          history.usage.reasoningTokens,
-        0,
-      );
+      const cumulativeTokens = managedCumulativeTokens(attemptHistories, 2);
       const deadlineAtUnixMilliseconds = admissions[0]?.deadlineAtUnixMilliseconds;
       const followUpNow = (options.now ?? Date.now)();
       const followUpProfile =
@@ -4889,6 +4882,26 @@ function usageFromChildRecords(records: readonly SessionRecord[]): {
           };
     },
     { inputTokens: 0, outputTokens: 0, reasoningTokens: 0 },
+  );
+}
+
+function managedCumulativeTokens(
+  histories: readonly {
+    readonly usage: {
+      readonly inputTokens: number;
+      readonly outputTokens: number;
+      readonly reasoningTokens: number;
+    };
+  }[],
+  usageAccountingVersion: 1 | 2,
+): number {
+  return histories.reduce(
+    (total, history) =>
+      total +
+      history.usage.inputTokens +
+      history.usage.outputTokens +
+      (usageAccountingVersion === 1 ? history.usage.reasoningTokens : 0),
+    0,
   );
 }
 

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -5,6 +5,7 @@ import { isDeepStrictEqual } from "node:util";
 import { z } from "zod";
 import { AgentSession, managedAgentPromptSummary } from "./agent-session.js";
 import type {
+  ModelDriver,
   ModelMessage,
   PermissionDecisionCommand,
   PermissionDecisionCommandResult,
@@ -717,6 +718,18 @@ export interface SessionLifecycle {
   }): Promise<RepositoryInstructionsReloadResult>;
   reloadSkills(input: { readonly sessionId: string }): Promise<SkillsReloadResult>;
   regenerateSessionTitle(input: { readonly sessionId: string }): Promise<SessionNamingResult>;
+  resolveManagedSessionOrigin(input: {
+    readonly origin: {
+      readonly sessionId: string;
+      readonly sourceSequence: number;
+    };
+    readonly signal: AbortSignal;
+  }): Promise<{
+    readonly targetIdentity: ModelTargetIdentity;
+    readonly childContextProfile: ContextProfile;
+    readonly childModel: ModelDriver;
+    readonly thinkingPolicy?: ThinkingPolicySnapshotV1;
+  }>;
   resume(input: { readonly sessionId: string }): Promise<SessionResumeResult>;
   clearSessionManualName(input: { readonly sessionId: string }): Promise<SessionNamingResult>;
   setSessionManualName(input: {
@@ -5280,6 +5293,62 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         admission.resolve();
         titleAdmissionOperations.delete(admission.promise);
       }
+    },
+    async resolveManagedSessionOrigin(input) {
+      await prepareSessionInspection(input.origin.sessionId);
+      if (
+        !Number.isSafeInteger(input.origin.sourceSequence) ||
+        input.origin.sourceSequence <= 0 ||
+        options.modelTargets === undefined
+      ) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      const snapshot = await inspectSession({ sessionId: input.origin.sessionId });
+      if (snapshot.schemaVersion !== 3 || input.origin.sourceSequence > snapshot.lastSequence) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      const records = await readSessionRecords(options, input.origin.sessionId);
+      const prefix = records.filter((record) => record.sequence <= input.origin.sourceSequence);
+      if (prefix.at(-1)?.sequence !== input.origin.sourceSequence) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      const genesis = prefix[0];
+      if (genesis === undefined || !isGenesisRecord(genesis)) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      const resolved = await options.modelTargets.resolve({
+        targetId: snapshot.targetIdentity.targetId,
+        targetIdentity: snapshot.targetIdentity,
+        allowExperimental: snapshot.targetIdentity.certification === "experimental",
+        signal: input.signal,
+      });
+      const childContextProfile = historicalContextProfile(
+        genesis,
+        contextSnapshotFromRecords(prefix)?.profile,
+        resolved.contextProfile,
+      );
+      if (
+        !sameModelTargetIdentity(resolved.identity, snapshot.targetIdentity) ||
+        !modelTargetUsesContextProfile(snapshot.targetIdentity, childContextProfile) ||
+        !isHistoricalContextProfileSupported(resolved.contextProfile, childContextProfile)
+      ) {
+        throw new SessionLifecycleError("session_model_target_incompatible");
+      }
+      const sourceRun = prefix.findLast(
+        (record) => record.schemaVersion === 3 && record.record.type === "logical_run_started",
+      );
+      const thinkingPolicy =
+        sourceRun?.schemaVersion === 3 && sourceRun.record.type === "logical_run_started"
+          ? sourceRun.record.thinkingPolicy
+          : undefined;
+      return {
+        targetIdentity: resolved.identity,
+        childContextProfile,
+        childModel: resolved.driver,
+        ...(thinkingPolicy === undefined
+          ? {}
+          : { thinkingPolicy: requireRecoveredThinkingPolicy(resolved, thinkingPolicy) }),
+      };
     },
     async resume(input) {
       if (activeTitleSessions.has(input.sessionId)) {

--- a/packages/testkit/src/extension-capabilities.test.ts
+++ b/packages/testkit/src/extension-capabilities.test.ts
@@ -4,19 +4,31 @@ import { join } from "node:path";
 
 import {
   type ArtifactStore,
+  type ContextProfile,
   createBiomeExecutionAdapter,
   createExtensionHost,
   createFileArtifactStore,
   createInMemoryOperationStore,
+  createModelTargets,
   createPermissionPolicy,
+  createReadToolRegistry,
+  createSessionLifecycle,
   type ModelDriver,
+  type ModelRequest,
+  type ModelTargetIdentity,
+  type ModelTargets,
+  type SessionLifecycle,
 } from "@adam-agent/agent";
 import {
   createInMemoryManagedAgentStore,
   createInMemorySessionStoreDirectory,
   createObservedBiomeExecutionAdapter,
+  createTrustedWorkspaceTrustForTesting,
   type ObservedBiomeProcess,
+  preparedDirectDeepSeekV2ContextProfile,
   type SessionRecord,
+  sessionAutomaticTitlesEnabled,
+  sessionStoreDirectory,
 } from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
 
@@ -314,6 +326,244 @@ test("ExtensionHost forces typed failure when a caught managed output codec reje
       },
     });
   } finally {
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("ExtensionHost preserves the exact historical origin policy for one managed reviewer", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-managed-review-origin-policy-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const packageRoot = join(testRoot, "extension");
+  const stateRoot = join(testRoot, "state");
+  const artifactStore = await createFileArtifactStore({ root: join(testRoot, "artifacts") });
+  const managedStore = createInMemoryManagedAgentStore();
+  const originSessionStores = createInMemorySessionStoreDirectory<SessionRecord>();
+  const childSessionStores = createInMemorySessionStoreDirectory<SessionRecord>();
+  const targetIdentity: ModelTargetIdentity = {
+    targetId: "deepseek-v4-flash.direct",
+    vendor: "deepseek",
+    modelId: "deepseek-v4-flash",
+    route: "direct",
+    profileVersion: 3,
+    certification: "certified",
+  };
+  const productionTargets = createModelTargets({
+    environment: { DEEPSEEK_API_KEY: "deterministic-non-network-fixture" },
+  });
+  const productionSnapshot = await productionTargets.snapshot({
+    signal: new AbortController().signal,
+  });
+  const thinkingCapability = productionSnapshot.targets.find(
+    (target) =>
+      target.identity.targetId === targetIdentity.targetId &&
+      target.identity.profileVersion === targetIdentity.profileVersion,
+  )?.thinkingCapability;
+  if (thinkingCapability === undefined) {
+    throw new Error("Expected the exact Direct DeepSeek thinking capability.");
+  }
+  const tightenedContextProfile: ContextProfile = {
+    ...preparedDirectDeepSeekV2ContextProfile,
+    contextWindowTokens: 500_000,
+    maximumOutputTokens: 64_000,
+    compactAtTokens: 400_000,
+  };
+  const requests: ModelRequest[] = [];
+  let currentSupportIncludesOriginPolicy = true;
+  const childModel: ModelDriver = {
+    async *stream(request) {
+      requests.push(request);
+      yield {
+        type: "text_delta",
+        text: requests.length === 1 ? "Origin settled." : '{"verdict":"verified"}',
+      };
+      yield { type: "usage", inputTokens: 10, outputTokens: 3, reasoningTokens: 2 };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return {
+        identity: targetIdentity,
+        driver: childModel,
+        contextProfile: preparedDirectDeepSeekV2ContextProfile,
+        ...(currentSupportIncludesOriginPolicy ? { thinkingCapability } : {}),
+      };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            readiness: {
+              status: "available",
+              credentialSource: "deterministic test adapter",
+            },
+            contextProfile: preparedDirectDeepSeekV2ContextProfile,
+            thinkingCapability,
+          },
+        ],
+      };
+    },
+  };
+  let useTightenedPreferences = true;
+  let lifecycle: SessionLifecycle | undefined;
+
+  try {
+    await mkdir(workspaceRoot);
+    await writeManagedSessionRunExtension(packageRoot);
+    const host = createExtensionHost({
+      artifactStore,
+      capabilities: [
+        { id: "adam.artifact.publish@1", version: "1.0.0" },
+        { id: "adam.managed-session@1", version: "1.0.0" },
+      ],
+      extensions: [
+        {
+          enabled: true,
+          extensionId: "fixture.managed-review",
+          grants: [
+            { id: "adam.artifact.publish@1", version: "^1.0.0" },
+            { id: "adam.managed-session@1", version: "^1.0.0" },
+          ],
+          packageName: "@fixture/managed-review-extension",
+          packageRoot,
+          packageVersion: "1.0.0",
+        },
+      ],
+      managedSession: {
+        childSessionStores,
+        managedStore,
+        parentPermissions: createPermissionPolicy({ allowedEffects: [] }),
+        async resolveOrigin(input) {
+          if (lifecycle === undefined) {
+            throw new Error("The session lifecycle is unavailable.");
+          }
+          const resolver = Reflect.get(lifecycle, "resolveManagedSessionOrigin");
+          if (typeof resolver === "function") {
+            return (await Reflect.apply(resolver, lifecycle, [input])) as {
+              readonly targetIdentity: ModelTargetIdentity;
+              readonly childContextProfile?: ContextProfile;
+              readonly childModel?: ModelDriver;
+              readonly thinkingPolicy?: NonNullable<ModelRequest["thinkingPolicy"]>;
+            };
+          }
+          const snapshot = await lifecycle.inspect({ sessionId: input.origin.sessionId });
+          if (snapshot.schemaVersion !== 3) {
+            throw new Error("The origin session is unavailable.");
+          }
+          const resolved = await modelTargets.resolve({
+            allowExperimental: true,
+            signal: input.signal,
+            targetId: snapshot.targetIdentity.targetId,
+            targetIdentity: snapshot.targetIdentity,
+          });
+          return {
+            childContextProfile: resolved.contextProfile,
+            childModel: resolved.driver,
+            targetIdentity: resolved.identity,
+          };
+        },
+        workspaceRoot,
+      },
+      operationOriginAuthority: {
+        async validateBoundary({ origin, projectId }) {
+          if (lifecycle === undefined) return false;
+          const snapshot = await lifecycle.inspect({ sessionId: origin.sessionId });
+          return (
+            snapshot.schemaVersion === 3 &&
+            snapshot.projectId === projectId &&
+            origin.sourceSequence <= snapshot.lastSequence
+          );
+        },
+      },
+      operationStore: createInMemoryOperationStore(),
+      projectRoot: workspaceRoot,
+      stateRoot,
+    });
+    await host.loadConfiguredExtensions();
+    lifecycle = createSessionLifecycle({
+      extensionHost: host,
+      modelTargets,
+      preferences: {
+        async resolveContextProfile(profile) {
+          return useTightenedPreferences ? tightenedContextProfile : profile;
+        },
+      },
+      stateRoot,
+      tools: createReadToolRegistry({ workspaceRoot }),
+      workspaceRoot,
+      workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
+      [sessionAutomaticTitlesEnabled]: false,
+      [sessionStoreDirectory]: originSessionStores,
+    });
+    const origin = await lifecycle.admit({
+      targetIdentity,
+      input: { text: "Create the immutable review origin." },
+      thinkingSelection: {
+        requestedLevelId: "max",
+        capability: {
+          id: thinkingCapability.capabilityId,
+          version: thinkingCapability.capabilityVersion,
+          digest: thinkingCapability.capabilityDigest,
+        },
+      },
+    });
+    useTightenedPreferences = false;
+
+    const started = await host.operations.startLinked({
+      contributionId: "fixture.managed-review",
+      idempotencyKey: "managed-review-origin-policy-1",
+      input: { revision: "abc123" },
+      origin: {
+        invocation: { id: "review", kind: "presentation_command", version: 1 },
+        sessionId: origin.snapshot.sessionId,
+        sourceSequence: origin.snapshot.lastSequence,
+      },
+    });
+    const events = await collectOperationEvents(host, started.operationId);
+    expect(events.at(-1)).toMatchObject({ event: { type: "operation_completed" } });
+    expect(requests).toHaveLength(2);
+    expect(requests[1]).toMatchObject({
+      maximumOutputTokens: tightenedContextProfile.maximumOutputTokens,
+      thinkingPolicy: requests[0]?.thinkingPolicy,
+    });
+    const admission = (await managedStore.read()).find(
+      (record) => record.type === "managed_agent_admitted",
+    );
+    expect(admission).toMatchObject({ thinkingPolicy: requests[0]?.thinkingPolicy });
+    if (admission?.type !== "managed_agent_admitted") {
+      throw new Error("Expected the managed reviewer admission.");
+    }
+    const childStore = await childSessionStores.open(admission.childSessionId);
+    const childGenesis = (await childStore?.read())?.[0];
+    expect(childGenesis).toMatchObject({
+      record: {
+        type: "session_genesis",
+        contextProfile: tightenedContextProfile,
+      },
+    });
+
+    currentSupportIncludesOriginPolicy = false;
+    const unsupported = await host.operations.startLinked({
+      contributionId: "fixture.managed-review",
+      idempotencyKey: "managed-review-origin-policy-unsupported-1",
+      input: { revision: "unsupported" },
+      origin: {
+        invocation: { id: "review", kind: "presentation_command", version: 1 },
+        sessionId: origin.snapshot.sessionId,
+        sourceSequence: origin.snapshot.lastSequence,
+      },
+    });
+    const unsupportedEvents = await collectOperationEvents(host, unsupported.operationId);
+    expect(unsupportedEvents.at(-1)).toMatchObject({
+      event: {
+        error: { code: "operation_capability_execution_failed" },
+        type: "operation_failed",
+      },
+    });
+    expect(requests).toHaveLength(2);
+  } finally {
+    await lifecycle?.close();
     await rm(testRoot, { recursive: true, force: true });
   }
 });

--- a/packages/testkit/src/extension-capabilities.test.ts
+++ b/packages/testkit/src/extension-capabilities.test.ts
@@ -438,30 +438,7 @@ test("ExtensionHost preserves the exact historical origin policy for one managed
           if (lifecycle === undefined) {
             throw new Error("The session lifecycle is unavailable.");
           }
-          const resolver = Reflect.get(lifecycle, "resolveManagedSessionOrigin");
-          if (typeof resolver === "function") {
-            return (await Reflect.apply(resolver, lifecycle, [input])) as {
-              readonly targetIdentity: ModelTargetIdentity;
-              readonly childContextProfile?: ContextProfile;
-              readonly childModel?: ModelDriver;
-              readonly thinkingPolicy?: NonNullable<ModelRequest["thinkingPolicy"]>;
-            };
-          }
-          const snapshot = await lifecycle.inspect({ sessionId: input.origin.sessionId });
-          if (snapshot.schemaVersion !== 3) {
-            throw new Error("The origin session is unavailable.");
-          }
-          const resolved = await modelTargets.resolve({
-            allowExperimental: true,
-            signal: input.signal,
-            targetId: snapshot.targetIdentity.targetId,
-            targetIdentity: snapshot.targetIdentity,
-          });
-          return {
-            childContextProfile: resolved.contextProfile,
-            childModel: resolved.driver,
-            targetIdentity: resolved.identity,
-          };
+          return lifecycle.resolveManagedSessionOrigin(input);
         },
         workspaceRoot,
       },

--- a/packages/testkit/src/managed-agent.test.ts
+++ b/packages/testkit/src/managed-agent.test.ts
@@ -4482,7 +4482,7 @@ test("AgentManager starts one explicit follow-up attempt on the same terminal ch
         await releaseFollowUp.promise;
       }
       yield { type: "text_delta", text: `${task} complete` };
-      yield { type: "usage", inputTokens: 10, outputTokens: 3 };
+      yield { type: "usage", inputTokens: 10, outputTokens: 3, reasoningTokens: 2 };
       yield { type: "finish", reason: "stop" };
     },
   };
@@ -4559,6 +4559,7 @@ test("AgentManager starts one explicit follow-up attempt on the same terminal ch
     expect(admissions.map((record) => record.agentId)).toEqual([agentId, agentId]);
     expect(new Set(admissions.map((record) => record.attemptId))).toHaveLength(2);
     expect(admissions[1]).toMatchObject({
+      usageAccountingVersion: 2,
       limits: { maximumTokens: 127_987 },
       deadlineAtUnixMilliseconds: admissions[0]?.deadlineAtUnixMilliseconds,
       resume: {


### PR DESCRIPTION
## Summary
- resolve managed-review target, driver, historical context profile, and source-bound thinking through Session Lifecycle
- record current managed usage accounting explicitly and count provider total as input plus output while preserving legacy recovery validation
- cover exact historical-policy inheritance, unsupported-policy pre-provider failure, corrected follow-up budget, JSONL/recovery, and production runtime composition

## Evidence
- focused owning matrix: 4 files, 84 tests passed
- full Linux quality: 82 files passed, 2 opt-in skipped; 1,780 tests passed, 18 opt-in skipped
- independent GPT-5.6 Sol xhigh Standards review: zero findings after repair
- independent GPT-5.6 Sol xhigh Spec review: zero findings
- frozen Slice 4 and S34-M0 scans passed