### PR TITLE
docs: streamline engineering guidance and test workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
 
 Build a lightweight, inspectable local coding agent. Make the core coding path reliable and pleasant before expanding automation, orchestration, or presentation features.
 
+The runtime, mechanism, security, and session rules below govern the Adam product being developed. The development agent uses its host's tools and permissions to carry out the user's authorized task.
+
 ## Engineering rules
 
 - Deliver working end-to-end slices and keep the CLI runnable after every merged slice.
@@ -15,7 +17,7 @@ Build a lightweight, inspectable local coding agent. Make the core coding path r
 - Fail closed on authorization and unknown effect classes. Keep model approval, user confirmation, permission policy, and OS sandbox enforcement as separate controls.
 - Do not claim production readiness, sandbox strength, or model improvement from deterministic fixtures or synthetic evaluation data.
 - Keep source provenance and third-party license notices at file or module level for reused or adapted code.
-- Every behavior change and bug fix must include proportionate tests at a pre-agreed caller-visible seam.
+- Verify behavior changes and bug fixes through observable interfaces using the [testing guide](docs/testing.md). Choose the test scope and development cadence to fit the risk; follow any task-specific acceptance contract without reconfirming settled decisions.
 - Linux is the only required platform until the first portfolio release is complete.
 
 ## Runtime ownership
@@ -65,20 +67,19 @@ Build a lightweight, inspectable local coding agent. Make the core coding path r
 
 ## Testing and toolchain
 
-- Before writing a behavior test, name the public interface and observable result under test. Work one failing behavior test and the minimum implementation to pass it at a time.
-- Do not pre-write a horizontal test suite, test private internals, or mock Adam-owned modules. Fake external providers, clocks, processes, filesystems, MCP servers, and Web sources only at their real seams.
-- Test through module interfaces and observable runtime events rather than private implementation state.
-- Synchronize concurrent and process tests on causal observables such as events, IPC, filesystem notifications, stream output, or child closure. Never use polling intervals, arbitrary sleeps, elapsed-time assertions, or wait-then-assert-absence as success criteria; timeouts are failure and cleanup guards only.
-- Test deadline and backoff policy with a fake clock. Use real time only when timer or OS-process integration is itself under test and no causal fake-clock seam exists; block fixtures on events or open streams instead of finite sleeps.
-- Keep semantic behavior suites below expensive OS adapters whenever the behavior does not require the adapter itself. Real JSONL/fsync, child-process, MCP stdio, and PTY tests must each prove a unique external contract; do not make them the default fixture for catalog projection, lifecycle policy, Presentation projection, or renderer state.
-- Require every test to pass independently under focused name selection. Correctness must not depend on suite order, a shared live `beforeAll` fixture, state leaked by another test, or batching several behavior cases behind one external process.
-- Treat test duration and aggregate runtime only as diagnostic telemetry. A duration threshold, timeout increase, worker-count cap, or changed-path CI skip cannot establish correctness or repay architectural test debt.
-- Use deterministic provider streams for tool ordering, rejection, cancellation, malformed output, compaction, and retry tests.
-- Add real-process tests for shell cancellation, MCP lifecycle, path confinement, and signal handling when the corresponding adapters exist.
-- Add PTY or real-terminal coverage for resize, bracketed paste, wide-character input, permission prompts, interrupt, and cleanup when the interactive terminal exists.
-- Keep live-provider, live-Web, and external MCP tests opt-in; ordinary CI must not require credentials or network access.
-- Run focused tests while iterating and the complete Linux check once before merge.
 - Use Node.js 24 LTS, ESM, strict TypeScript, and the exact pnpm 11 release declared by `packageManager`. Commit `pnpm-lock.yaml`; do not use npm, Yarn, or Bun lockfiles.
 - Use Biome for TypeScript and JavaScript formatting and linting, and markdownlint-cli2 for Markdown. Keep hooks check-only; use explicit `*:fix` commands for intentional rewrites. Treat `useLiteralKeys` as a required check: prefer dot access after narrowing known fields, but retain `noPropertyAccessFromIndexSignature` and use a narrowly explained suppression when an intentionally dynamic key cannot be typed safely.
-- Run `pnpm quality:check` before merge. Keep one Linux quality workflow until product behavior creates a demonstrated need for another job.
+- Keep Markdown paragraphs and individual list items on one physical source line; separate paragraphs with blank lines. `MD013` is disabled.
+- Run focused checks during iteration and `pnpm quality:check` on the final candidate before a product PR. Require the single Linux hosted `quality` job before merge. Repeat or broaden checks only for subsequent changes, failures, unresolved concerns, or an explicit acceptance gate.
 - Do not introduce Nx, Turborepo, or another task orchestrator while pnpm workspaces and TypeScript project references are sufficient.
+
+Run commands from the product root:
+
+| Purpose | Command |
+| --- | --- |
+| Install pinned dependencies | `pnpm install --frozen-lockfile` |
+| Launch TUI / CLI help | `pnpm tui` / `pnpm --silent adam --help` (see [setup and target selection](README.md)) |
+| Refresh generated package output | `pnpm build` |
+| Focused behavior tests | After building, `pnpm exec vitest run <test-file> -t '<test name>'` |
+| Markdown / code checks | `pnpm markdown:check` / `pnpm code:check` |
+| Complete Linux gate | `pnpm quality:check` |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,37 @@
+# Testing Guide
+
+This is the shared test contract for Adam contributors. Use it with the [engineering instructions](../AGENTS.md) and the active task's acceptance requirements.
+
+## Choose evidence that fits the change
+
+- Identify the observable behavior and the module interface, command, snapshot, event, or process result that proves it. Reuse the narrowest existing interface that exposes the result; routine test selection within accepted scope does not need separate approval.
+- Reproduce a defect before repairing it and retain meaningful regression evidence. For a behavior change, add or update tests where existing coverage does not establish the requested result. Choose an incremental implementation cadence appropriate to the risk; a task that explicitly requires test-first or ordered RED/GREEN retains that requirement.
+- Documentation, formatting, wiring with no observable behavior, mechanical refactors, and purely visual changes need proportionate checks rather than an artificial failing test. Use existing behavior checks for refactors and inspect the rendered result when appearance changes.
+- Expected values must come from independent worked literals, hand-authored fixtures, or an accepted external contract. Do not test private state, internal call order, or production helpers against their own output, and do not mock Adam-owned modules. Fake external providers, clocks, processes, filesystems, MCP transports, and Web sources only at their actual adapter interfaces.
+- Keep fixtures limited to the active behavior. Avoid speculative future-case suites and adapters; each retained test must detect a meaningful failure independently under focused name selection, without suite-order dependence, shared live `beforeAll` state, or several semantic cases batched behind one external process.
+
+## Deterministic behavior and external contracts
+
+Keep semantic tests below expensive OS adapters. Use deep in-process owners and deterministic adapters for lifecycle policy, catalog projection, Presentation snapshots, renderer state, and provider ordering, rejection, cancellation, malformed output, compaction, and retry behavior.
+
+Real JSONL/fsync, crash, path confinement, child-process, shell cancellation/signals, MCP stdio, PTY, and terminal-restoration tests must prove a unique external contract. Keep their ownership in explicit `.os.test.ts` suites; use a virtual terminal for ordinary rendering behavior and real PTY/terminal coverage where resize, bracketed paste, wide-character input, permission prompts, interrupt, or cleanup depends on the terminal adapter itself. Live provider, Web, and external MCP checks remain opt-in; ordinary CI requires no credentials or external network.
+
+When moving an existing test to a cheaper seam, preserve its name, input, observable outcome, and failure classification. Run old and new cases to establish equivalence before removing the redundant external fixture. Preserve the approximately 46.875 MiB encoded-record regression when changing large-output fixture construction; its opt-in command is `pnpm test:large-output`.
+
+Maintain structural guards against forbidden direct process ownership, suite-local timing policy, Adam-module mocks, duplicate exact test names, changed-path Quality skips, and extra optional Quality jobs. A passing duration threshold, larger timeout, worker cap, reduced coverage, or weaker assertion cannot repay test-architecture debt.
+
+## Causal synchronization and resource ownership
+
+- Synchronize on complete frames or stream output, exact runtime events, IPC, durable reads, effects, or child closure. Polling intervals, arbitrary sleeps, elapsed-time assertions, and wait-then-assert-absence are not success criteria. Timeouts are centralized, bounded failure/cleanup guards that report the missing causal state.
+- Test deadline and backoff policy with a fake clock. Use real time only for an explicit timer or OS adapter contract without a causal fake-clock seam; block fixtures on events or open streams instead of finite sleeps.
+- Treat inherited process environment as adapter input. A harness owns and restores capability variables such as `NO_COLOR` and `TERM` for its full lifetime; check both relevant inherited states when local and hosted environments may differ.
+- Only child `close` proves external-process reclamation. An `error` event reports failure without releasing ownership. Failure guards reject the caller directly; cleanup is bounded and single-flight through TERM then KILL; consume every background cleanup rejection and retain active tracking until close.
+- Filesystem notifications are wake-ups, not durable truth. Install the watcher before triggering the producer, reread the exact target after directory events even when filenames are absent or coalesced, and settle only from the expected durable contents or explicit producer failure.
+
+## Checks and failure diagnosis
+
+Refresh relevant TypeScript project references or package builds before focused cross-package tests consume generated output. Evidence against stale `dist` is invalid; rebuild and rerun the affected checks. Iterate with focused tests, then check the complete owning package or external-contract suite when the change warrants it.
+
+Review the final diff against the requested behavior and engineering rules. Run the complete Linux `pnpm quality:check` before a product PR and require hosted `quality` before merge. A later product change requires a fresh full candidate check; otherwise, repeat only when a failure, unresolved concern, or explicit task gate justifies it. Do not use full Quality as the inner development loop.
+
+For a hosted timeout or unexplained failure, inspect the failing test and resource owner before calling it flaky. Use independent exact-name runs and the owning test file; add a concurrent reproduction and historical CI comparison when contention or environment differences are plausible. Rerun an unchanged head only when the evidence supports that diagnosis. Repeated or caller-visible failures require causal repair, not timeout, worker, assertion, or coverage changes.


### PR DESCRIPTION
AGENTS.md required a fixed test-first cadence and pre-agreed test interfaces for every behavior change. This update lets contributors choose proportionate verification within accepted scope, while preserving explicit task acceptance requirements and the complete Linux Quality gate.

Move detailed testing rules into `docs/testing.md`, retain causal synchronization and deterministic/OS contract separation, clarify that runtime restrictions describe the Adam product, and add the existing setup and verification commands. Runtime ownership, security, persistence, and UI contracts are unchanged.

Validation: complete local `pnpm quality:check` passed: 86 test files and 1,841 tests passed; 2 opt-in files and 18 tests skipped. Markdown, local-link, and diff checks passed.
