### PR TITLE
Add managed turn control and settlement recovery

### DIFF
--- a/packages/agent/src/agent-session.ts
+++ b/packages/agent/src/agent-session.ts
@@ -118,6 +118,7 @@ import {
   isSessionRecordWithinSizeLimit,
   type SessionModelResponse,
   type SessionModelResponseField,
+  type SessionPartialOutputV1,
   type SessionRecord,
   type SessionStore,
   type SessionToolIntent,
@@ -182,8 +183,12 @@ type AgentSessionBaseDependencies = {
 export const sessionToolProfileNames = Symbol("adam-agent.session-tool-profile-names");
 export const managedAgentPromptSummary = Symbol("adam-agent.managed-agent-prompt-summary");
 export const managedAgentRequestBoundary = Symbol("adam-agent.managed-agent-request-boundary");
+export const managedAgentPartialOutput = Symbol("adam-agent.managed-agent-partial-output");
+/** Internal crash conformance barrier, after the canonical append has succeeded. */
+export const sessionRecordCommittedBarrier = Symbol("adam-agent.session-record-committed-barrier");
 
 export type ManagedAgentRequestBoundary = () => Promise<{
+  readonly atomicReceipt?: true;
   readonly messages: readonly { readonly id: `sha256:${string}`; readonly text: string }[];
   readonly deliveries: readonly {
     readonly id: `sha256:${string}`;
@@ -221,6 +226,9 @@ export class AgentSession {
   readonly #permissions: PermissionPolicy | undefined;
   readonly #managedAgentPromptSummary: (() => string) | undefined;
   readonly #managedAgentRequestBoundary: ManagedAgentRequestBoundary | undefined;
+  readonly #recordCommittedBarrier: ((record: SessionRecord) => Promise<void>) | undefined;
+  readonly #retainManagedPartialOutput: boolean;
+  #managedPartialOutput: SessionPartialOutputV1 | undefined;
   #lastManagedAgentPromptSummary: string | undefined;
   #promptContext: PromptContextRecord | undefined;
   #skillContext: SkillContextRecordV1 | undefined;
@@ -355,6 +363,15 @@ export class AgentSession {
         readonly [managedAgentRequestBoundary]?: ManagedAgentRequestBoundary;
       }
     )[managedAgentRequestBoundary];
+    this.#retainManagedPartialOutput =
+      (dependencies as AgentSessionDependencies & { readonly [managedAgentPartialOutput]?: true })[
+        managedAgentPartialOutput
+      ] === true;
+    this.#recordCommittedBarrier = (
+      dependencies as AgentSessionDependencies & {
+        readonly [sessionRecordCommittedBarrier]?: (record: SessionRecord) => Promise<void>;
+      }
+    )[sessionRecordCommittedBarrier];
     this.#promptContext =
       this.#durableContext === undefined
         ? createPromptContextV1(this.#tools)
@@ -763,9 +780,11 @@ export class AgentSession {
       }
       skipProactiveCompaction = false;
       const managedDelivery = await this.#managedAgentRequestBoundary?.();
+      this.#managedPartialOutput = undefined;
       for (const message of managedDelivery?.messages ?? []) {
         const text = `Parent message (${message.id}): ${message.text}`;
-        await this.#emit({ type: "user_message", text });
+        if (managedDelivery?.atomicReceipt !== true)
+          await this.#emit({ type: "user_message", text });
         messages.push({ role: "user", content: text });
       }
       if ((managedDelivery?.deliveries.length ?? 0) > 0) {
@@ -817,9 +836,24 @@ export class AgentSession {
         const targetIdentity = this.#durableContext.targetIdentity;
         const approvedPlan = this.#durableContext.approvedPlan;
         const appendAttempt = async () => {
-          await this.#appendRecord({
+          const deliveryRecords: SessionRecord[] =
+            managedDelivery?.atomicReceipt !== true
+              ? []
+              : managedDelivery.messages.map((message, index) => ({
+                  schemaVersion: 3,
+                  sequence: this.#nextSequence + index,
+                  record: {
+                    type: "runtime_event",
+                    runId: this.#activeRunId as string,
+                    event: {
+                      type: "user_message",
+                      text: `Parent message (${message.id}): ${message.text}`,
+                    },
+                  },
+                }));
+          const providerRecord: SessionRecord = {
             schemaVersion: 3,
-            sequence: this.#nextSequence,
+            sequence: this.#nextSequence + deliveryRecords.length,
             record: {
               type: "provider_attempt_started",
               runId: this.#activeRunId as string,
@@ -828,7 +862,21 @@ export class AgentSession {
               targetIdentity,
               ...(managedDelivery === undefined || managedDelivery.deliveries.length === 0
                 ? {}
-                : { managedAgentDeliveries: managedDelivery.deliveries }),
+                : managedDelivery.atomicReceipt !== true
+                  ? { managedAgentDeliveries: managedDelivery.deliveries }
+                  : {
+                      managedAgentDeliveryVersion: 3 as const,
+                      managedAgentDeliveries: managedDelivery.deliveries.map((delivery, index) => {
+                        const message = managedDelivery.messages[index];
+                        if (message?.id !== delivery.id)
+                          throw new Error("Managed delivery identity mismatch.");
+                        return {
+                          ...delivery,
+                          messageDigest:
+                            `sha256:${createHash("sha256").update(`Parent message (${message.id}): ${message.text}`, "utf8").digest("hex")}` as const,
+                        };
+                      }),
+                    }),
               ...(projectedContent === undefined ? {} : { projectedContent }),
               ...(this.#promptContext === undefined
                 ? {}
@@ -849,7 +897,14 @@ export class AgentSession {
                     },
                   }),
             },
-          });
+          };
+          if (deliveryRecords.length === 0) await this.#appendRecord(providerRecord);
+          else {
+            await this.#appendRecordsAtomically([...deliveryRecords, providerRecord]);
+            for (const record of deliveryRecords)
+              if (record.schemaVersion === 3 && record.record.type === "runtime_event")
+                this.#publish(record.record.event);
+          }
           this.#activeProviderAttempt = {
             runId: this.#activeRunId as string,
             turn: modelTurns,
@@ -1119,6 +1174,17 @@ export class AgentSession {
         streamError = error;
       }
       const answer = answerChunks.join("");
+      if (this.#retainManagedPartialOutput && answer.length > 0) {
+        const bytes = Buffer.from(answer, "utf8");
+        let end = Math.min(bytes.length, 16 * 1024);
+        while (end > 0 && end < bytes.length && ((bytes[end] ?? 0) & 0xc0) === 0x80) end -= 1;
+        this.#managedPartialOutput = {
+          version: 1,
+          text: bytes.subarray(0, end).toString("utf8"),
+          byteCount: bytes.length,
+          truncated: end < bytes.length,
+        };
+      }
       const reasoning = reasoningChunks.join("");
 
       if (finishReason !== undefined && activeReasoningModelId !== undefined) {
@@ -3872,6 +3938,9 @@ export class AgentSession {
         attempt: attempt.attempt,
         reason: "run_terminal",
         result,
+        ...(this.#managedPartialOutput === undefined
+          ? {}
+          : { partialOutput: this.#managedPartialOutput }),
       },
     });
     this.#activeProviderAttempt = undefined;
@@ -4084,6 +4153,7 @@ export class AgentSession {
       throw new SessionPersistenceError();
     }
     this.#nextSequence += 1;
+    await this.#recordCommittedBarrier?.(record);
   }
 
   async #appendRecordsAtomically(records: readonly SessionRecord[]): Promise<void> {
@@ -4093,6 +4163,7 @@ export class AgentSession {
       throw new SessionPersistenceError();
     }
     this.#nextSequence += records.length;
+    for (const record of records) await this.#recordCommittedBarrier?.(record);
   }
 
   async #persistDurableModelResponse(input: {

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -1,6 +1,10 @@
 /** Tests only. This internal fault-injection surface has no compatibility promise. */
-
-export { managedAgentPromptSummary, sessionToolProfileNames } from "./agent-session.js";
+export {
+  managedAgentPromptSummary,
+  managedAgentRequestBoundary,
+  sessionRecordCommittedBarrier,
+  sessionToolProfileNames,
+} from "./agent-session.js";
 export { AiSdkModelDriver as AiSdkModelDriverForTesting } from "./ai-sdk-model-driver.js";
 export {
   createObservedBiomeExecutionAdapter,
@@ -21,13 +25,21 @@ export {
   recoverInterruptedManagedAgents,
 } from "./managed-agent.js";
 export {
+  createManagedAgentControl,
+  managedAgentRecordBarrier,
+  managedAgentSettlementBarrier,
+  managedControlMainRequestBoundary,
+} from "./managed-agent-control.js";
+export {
   researchManagedAgentProfileV1,
   researchManagedAgentProfileV2,
   scoutManagedAgentProfileV1,
   scoutManagedAgentProfileV2,
 } from "./managed-agent-profiles.js";
 export {
+  createInMemoryManagedAgentControlStore,
   createInMemoryManagedAgentStore,
+  createJsonlManagedAgentControlStore,
   createJsonlManagedAgentStore,
 } from "./managed-agent-store.js";
 export type {
@@ -139,6 +151,7 @@ export {
   sessionCloseDrainBarrier,
   sessionLogicalRunStartedBarrier,
   sessionManagedAgentInactivityScheduler,
+  sessionManagedControl,
   sessionProjectLifecycleOwner,
   sessionRuntimeNotificationTransform,
   sessionStoreDirectory,

--- a/packages/agent/src/managed-agent-control.ts
+++ b/packages/agent/src/managed-agent-control.ts
@@ -1,0 +1,1018 @@
+import type { ManagedControlCommand, ManagedControlReceipt } from "@adam-agent/presentation";
+
+export type { ManagedControlCommand, ManagedControlReceipt } from "@adam-agent/presentation";
+
+import { createHash, randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
+import { z } from "zod";
+
+import {
+  AgentSession,
+  type ManagedAgentRequestBoundary,
+  managedAgentPartialOutput,
+  managedAgentRequestBoundary,
+  sessionRecordCommittedBarrier,
+} from "./agent-session.js";
+import type { ModelDriver } from "./agent-session-contracts.js";
+import type { ContextProfile } from "./context-profile.js";
+import {
+  type ManagedAgentInactivityScheduler,
+  ManagedAgentStoreError,
+  nodeManagedAgentDeadlineScheduler,
+} from "./managed-agent.js";
+import {
+  foldManagedControl,
+  type ManagedControlEvent,
+  type ManagedControlIdentity,
+  type ManagedControlRecord,
+  type ManagedControlStore,
+  type ManagedWorkspaceSnapshot,
+  managedControlDigest,
+  managedControlLink,
+  managedTranscriptLink,
+} from "./managed-agent-folds.js";
+import {
+  inspectManagedChildReceipt,
+  managedChildTerminalResult,
+  managedOutcomeFromChild,
+  prepareManagedChildResume,
+  validateManagedParentHistory,
+} from "./managed-agent-recovery.js";
+import type { ModelTargetIdentity } from "./model-targets.js";
+import {
+  type ProjectExecutionDomain,
+  ProjectExecutionDomainError,
+} from "./project-execution-domain.js";
+import { createPromptContextV1 } from "./prompt-assembly.js";
+import { sessionDurableContext } from "./session-durable-context.js";
+import { modelMessagesFromCompleteRecords } from "./session-history-replay.js";
+import {
+  cancelManagedChildSessionRecords,
+  settleManagedChildTerminalIntent,
+} from "./session-lifecycle.js";
+import { SessionLifecycleError } from "./session-lifecycle-error.js";
+import type { SessionRecord, SessionStore, SessionStoreDirectory } from "./session-store.js";
+import { SessionStoreError } from "./session-store.js";
+import { createReadToolRegistry, type PermissionPolicy } from "./tool-runtime.js";
+
+/** Internal fault barrier for crash/settlement conformance; never selected by product configuration. */
+export const managedAgentSettlementBarrier = Symbol("managed-agent-settlement-barrier");
+export const managedAgentRecordBarrier = Symbol("managed-agent-record-barrier");
+
+export type ManagedWorkspaceFrame = {
+  readonly type: "snapshot" | "change" | "reset";
+  readonly snapshot: ManagedWorkspaceSnapshot;
+};
+
+export type ManagedAgentControl = {
+  inspect(input: { readonly parentSessionId: string }): Promise<ManagedWorkspaceSnapshot>;
+  observe(input: {
+    readonly parentSessionId: string;
+    readonly signal: AbortSignal;
+  }): AsyncIterable<ManagedWorkspaceFrame>;
+  dispatch(command: ManagedControlCommand): Promise<ManagedControlReceipt>;
+};
+
+const taskSchema = z
+  .string()
+  .refine((text) => text.trim().length > 0 && Buffer.byteLength(text, "utf8") <= 16 * 1024);
+const commandSchema = z.discriminatedUnion("type", [
+  z.strictObject({ type: z.literal("prepare_main_delivery"), parentSessionId: z.uuid() }),
+  z.strictObject({
+    type: z.literal("acknowledge_main_delivery"),
+    parentSessionId: z.uuid(),
+    deliveries: z
+      .array(
+        z.strictObject({
+          id: z.string().regex(/^sha256:[a-f0-9]{64}$/u),
+          digest: z.string().regex(/^sha256:[a-f0-9]{64}$/u),
+        }),
+      )
+      .max(32),
+  }),
+  z.strictObject({
+    type: z.literal("cancel_turn"),
+    parentSessionId: z.uuid(),
+    threadId: z.uuid(),
+    expectedTurnId: z.uuid(),
+  }),
+  z.strictObject({
+    type: z.literal("start_thread"),
+    parentSessionId: z.uuid(),
+    role: z.literal("builtin:explore"),
+    task: taskSchema,
+    description: z
+      .string()
+      .min(1)
+      .refine((text) => Buffer.byteLength(text, "utf8") <= 256 && !/\p{Cc}/u.test(text)),
+  }),
+  z.strictObject({
+    type: z.literal("next_turn"),
+    parentSessionId: z.uuid(),
+    threadId: z.uuid(),
+    expectedTurnId: z.uuid(),
+    task: taskSchema,
+  }),
+  z.strictObject({
+    type: z.literal("recover_turn"),
+    parentSessionId: z.uuid(),
+    threadId: z.uuid(),
+    expectedTurnId: z.uuid(),
+  }),
+  z.strictObject({ type: z.literal("close"), parentSessionId: z.uuid() }),
+]);
+
+export function createManagedAgentControl(options: {
+  readonly parentSessionId: string;
+  readonly projectId: `sha256:${string}`;
+  readonly workspaceRoot: string;
+  readonly targetIdentity: ModelTargetIdentity;
+  readonly contextProfile: ContextProfile;
+  readonly model: ModelDriver;
+  readonly permissions: PermissionPolicy;
+  readonly executionDomain: ProjectExecutionDomain;
+  readonly store: ManagedControlStore;
+  readonly childSessionStores: SessionStoreDirectory<SessionRecord>;
+  readonly parentSessionStore?: SessionStore<SessionRecord>;
+  readonly inactivityScheduler?: ManagedAgentInactivityScheduler;
+  readonly cleanupScheduler?: ManagedAgentInactivityScheduler;
+  readonly now?: () => number;
+  readonly [managedAgentSettlementBarrier]?: () => Promise<void>;
+  readonly [managedAgentRecordBarrier]?: (record: ManagedControlRecord) => Promise<void>;
+  readonly [sessionRecordCommittedBarrier]?: (record: SessionRecord) => Promise<void>;
+}): ManagedAgentControl {
+  const controlStore = options.store.forParent(options.parentSessionId);
+  let serial = Promise.resolve();
+  let closing = false;
+  const inFlight = new Set<Promise<void>>();
+  const failedAttempts = new Set<string>();
+  const active = new Map<
+    string,
+    {
+      readonly attemptId: string;
+      readonly controller: AbortController;
+      readonly completion: Promise<void>;
+    }
+  >();
+  const subscribers = new Set<(frame: ManagedWorkspaceFrame) => void>();
+  const serialized = <T>(operation: () => Promise<T>): Promise<T> => {
+    const next = serial.then(operation);
+    serial = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    return next;
+  };
+  const project = async (
+    records: readonly ManagedControlRecord[],
+    parentSessionId: string,
+    admittingTurnId?: string,
+  ): Promise<ManagedWorkspaceSnapshot> => {
+    const snapshot = foldManagedControl(records, parentSessionId);
+    const threads = await Promise.all(
+      snapshot.threads.map((thread) => {
+        const live =
+          active.get(thread.threadId)?.attemptId === thread.turn.attemptId ||
+          admittingTurnId === thread.turn.turnId;
+        const interrupted =
+          !live && thread.turn.phase !== "idle" && thread.turn.outcome === undefined;
+        return inspectManagedChildReceipt(
+          {
+            ...thread,
+            residency: live ? "live" : "unloaded",
+            turn: {
+              ...thread.turn,
+              recovery: !live && thread.turn.phase !== "idle" ? "required" : thread.turn.recovery,
+              ...(interrupted
+                ? {
+                    phase: "waiting" as const,
+                    waitReason: "suspended" as const,
+                    lastOutcome: "interrupted" as const,
+                    label: "Suspended · Resume or cancel",
+                  }
+                : {}),
+              ...(!live && thread.turn.watchdog?.state === "running"
+                ? { watchdog: { ...thread.turn.watchdog, state: "stopped" as const } }
+                : {}),
+            },
+          },
+          options.childSessionStores,
+        );
+      }),
+    );
+    return { ...snapshot, threads };
+  };
+  const append = async (identity: ManagedControlIdentity, event: ManagedControlEvent) => {
+    const record = await controlStore.appendNext({ ...identity, schemaVersion: 3, event });
+    await options[managedAgentRecordBarrier]?.(record);
+    const snapshot = await project(
+      await controlStore.read(),
+      options.parentSessionId,
+      event.type === "admitted" ? record.turnId : undefined,
+    );
+    for (const subscriber of subscribers) subscriber({ type: "change", snapshot });
+    return record;
+  };
+  const run = async (
+    identity: ManagedControlIdentity,
+    task: string,
+    previousSessionId?: string,
+    preparedStore?: SessionStore<SessionRecord>,
+    resume?: ReturnType<typeof prepareManagedChildResume>,
+  ) => {
+    const controller = new AbortController();
+    const completion = (async () => {
+      const claim = await options.executionDomain.claimScope({
+        kind: "child_attempt",
+        sessionId: identity.parentSessionId,
+        threadId: identity.threadId,
+        identity: identity.attemptId,
+      });
+      let cleanupDone = false;
+      let cleanupExpired = false;
+      let cleanupTimer: { cancel(): void } | undefined;
+      try {
+        const tools = createReadToolRegistry({ workspaceRoot: options.workspaceRoot });
+        const promptContext = createPromptContextV1(tools);
+        const store =
+          preparedStore ?? (await options.childSessionStores.create(identity.childSessionId));
+        if (preparedStore === undefined)
+          await store.append({
+            schemaVersion: 3,
+            sequence: 1,
+            record: {
+              type: "session_genesis",
+              recordVersion: 2,
+              sessionId: identity.childSessionId,
+              projectId: options.projectId,
+              targetIdentity: options.targetIdentity,
+              contextProfile: options.contextProfile,
+              promptContext,
+            },
+          });
+        if (preparedStore === undefined && options[sessionRecordCommittedBarrier] !== undefined) {
+          const genesis = (await store.read())[0];
+          if (genesis !== undefined) await options[sessionRecordCommittedBarrier]?.(genesis);
+        }
+        const previous =
+          previousSessionId === undefined
+            ? undefined
+            : await options.childSessionStores.open(previousSessionId);
+        let generation = 0;
+        let executing = false;
+        let timer: { cancel(): void } | undefined;
+        const resetInactivity = () => {
+          if (!executing) return;
+          timer?.cancel();
+          const scheduledGeneration = ++generation;
+          timer = (options.inactivityScheduler ?? nodeManagedAgentDeadlineScheduler).schedule(
+            300_000,
+            () => {
+              void serialized(async () => {
+                if (
+                  !executing ||
+                  generation !== scheduledGeneration ||
+                  active.get(identity.threadId)?.attemptId !== identity.attemptId
+                )
+                  return;
+                await append(identity, { type: "stalled", deadlineId: identity.attemptId });
+                executing = false;
+                controller.abort();
+              }).catch(() => controller.abort());
+            },
+          );
+        };
+        const dependencies = {
+          [managedAgentPartialOutput]: true as const,
+          ...(options[sessionRecordCommittedBarrier] === undefined
+            ? {}
+            : { [sessionRecordCommittedBarrier]: options[sessionRecordCommittedBarrier] }),
+          model: options.model,
+          contextProfile: options.contextProfile,
+          tools,
+          permissions: {
+            decide: (input: Parameters<PermissionPolicy["decide"]>[0]) =>
+              input.effect === "read" && options.permissions.decide(input) === "allow"
+                ? ("allow" as const)
+                : ("deny" as const),
+          },
+          store: store as SessionStore,
+          [managedAgentRequestBoundary]: async () => ({
+            messages: [],
+            deliveries: [],
+            acknowledge: async () => {
+              await serialized(async () => {
+                await append(identity, {
+                  type: "execution_progress",
+                  deadlineId: identity.attemptId,
+                  atUnixMilliseconds: (options.now ?? Date.now)(),
+                  transcript: managedTranscriptLink(await store.read()),
+                });
+                executing = true;
+                resetInactivity();
+              });
+            },
+          }),
+          [sessionDurableContext]: {
+            nextSequence: preparedStore === undefined ? 2 : (await preparedStore.read()).length + 1,
+            ...(resume === undefined ? {} : { resume: resume.agentState }),
+            sessionId: identity.childSessionId,
+            projectId: options.projectId,
+            targetIdentity: options.targetIdentity,
+            promptContext,
+            repositoryWorkspaceRoot: options.workspaceRoot,
+            initialMessages: [
+              {
+                role: "developer" as const,
+                content:
+                  "Explore the exact delegated task using local repository reads only. Do not write, execute, access Web, MCP or extensions, spawn children, or change authority. The workspace is live, not a filesystem snapshot.",
+              },
+              ...(previous === undefined
+                ? []
+                : modelMessagesFromCompleteRecords(await previous.read())),
+            ],
+          },
+        };
+        const child = new AgentSession(dependencies);
+        let lastAssistantDelta: string | undefined;
+        const lastReasoning = new Map<string, string>();
+        const unsubscribe = child.subscribe((event) => {
+          if (
+            event.type === "model_message_delta" &&
+            event.text.length > 0 &&
+            event.text !== lastAssistantDelta
+          ) {
+            lastAssistantDelta = event.text;
+            resetInactivity();
+          }
+          if (
+            event.type === "model_reasoning_updated" &&
+            event.text.length > 0 &&
+            event.text !== lastReasoning.get(event.id)
+          ) {
+            lastReasoning.set(event.id, event.text);
+            resetInactivity();
+          }
+          if (
+            event.type === "tool_completed" ||
+            event.type === "tool_failed" ||
+            event.type === "context_compaction_committed" ||
+            event.type === "context_compaction_failed" ||
+            event.type === "model_reasoning_started" ||
+            event.type === "model_reasoning_settled"
+          )
+            resetInactivity();
+        });
+        await serialized(async () => {
+          const records = await controlStore.read();
+          if (
+            !records.some(
+              (record) => record.turnId === identity.turnId && record.event.type === "started",
+            )
+          )
+            await append(identity, { type: "started" });
+        });
+        const result = await child
+          .run(
+            { text: resume?.userMessage ?? task },
+            {
+              signal: controller.signal,
+              limits: { maxTokens: options.contextProfile.contextWindowTokens },
+            },
+          )
+          .finally(() => {
+            unsubscribe();
+            executing = false;
+            generation += 1;
+            timer?.cancel();
+          });
+        const records = await store.read();
+        const outcome = await serialized(async () =>
+          append(
+            identity,
+            managedOutcomeFromChild(
+              result,
+              records,
+              (await controlStore.read()).filter((record) => record.turnId === identity.turnId),
+            ),
+          ),
+        );
+        cleanupTimer = (options.cleanupScheduler ?? nodeManagedAgentDeadlineScheduler).schedule(
+          10_000,
+          () => {
+            void serialized(async () => {
+              if (cleanupDone || cleanupExpired) return;
+              await append(identity, {
+                type: "cleanup_expired",
+                deadlineId: identity.attemptId,
+                maximumMilliseconds: 10_000,
+              });
+              cleanupExpired = true;
+            }).catch(() => {
+              failedAttempts.add(identity.attemptId);
+              closing = true;
+            });
+          },
+        );
+        await options[managedAgentSettlementBarrier]?.();
+        const settlementClaim = await options.executionDomain.claimScope({
+          kind: "control",
+          sessionId: identity.parentSessionId,
+          identity: `settlement:${identity.attemptId}`,
+        });
+        try {
+          await claim.release();
+          cleanupDone = true;
+          cleanupTimer.cancel();
+          if (active.get(identity.threadId)?.attemptId === identity.attemptId)
+            active.delete(identity.threadId);
+          await serialized(async () => {
+            const settled = await append(identity, {
+              type: "settled",
+              outcome: managedControlLink(outcome),
+            });
+            await append(identity, { type: "completion", settled: managedControlLink(settled) });
+          });
+        } finally {
+          await settlementClaim.release();
+        }
+      } finally {
+        cleanupTimer?.cancel();
+        await claim.release();
+      }
+    })();
+    active.set(identity.threadId, { attemptId: identity.attemptId, controller, completion });
+    inFlight.add(completion);
+    void completion.then(
+      () => inFlight.delete(completion),
+      () => {
+        inFlight.delete(completion);
+        failedAttempts.add(identity.attemptId);
+        if (active.get(identity.threadId)?.attemptId === identity.attemptId)
+          active.delete(identity.threadId);
+        closing = true;
+        for (const attempt of active.values()) attempt.controller.abort();
+        void control.inspect({ parentSessionId: options.parentSessionId }).then(
+          (snapshot) => {
+            for (const subscriber of subscribers) subscriber({ type: "reset", snapshot });
+          },
+          () => {
+            const snapshot: ManagedWorkspaceSnapshot = {
+              parentSessionId: options.parentSessionId,
+              revision: 0,
+              status: "runtime_unavailable",
+              diagnostic: "Managed runtime is unavailable. Inspect durable state.",
+              threads: [],
+              completions: [],
+            };
+            for (const subscriber of subscribers) subscriber({ type: "reset", snapshot });
+          },
+        );
+      },
+    );
+  };
+  const rejected = (
+    code: Extract<ManagedControlReceipt, { status: "rejected" }>["code"],
+    message: string,
+  ): ManagedControlReceipt => ({ status: "rejected", code, message });
+  const control: ManagedAgentControl = {
+    async inspect({ parentSessionId }) {
+      if (parentSessionId !== options.parentSessionId)
+        throw new TypeError("This control belongs to another parent Session.");
+      await serial;
+      try {
+        return await project(await controlStore.read(), parentSessionId);
+      } catch (error) {
+        if (!(error instanceof ManagedAgentStoreError)) throw error;
+        return {
+          parentSessionId,
+          status: "recovery_required",
+          diagnostic: "Managed history is unavailable. Inspect durable state.",
+          revision: 0,
+          threads: [],
+          completions: [],
+        };
+      }
+    },
+    async *observe({ parentSessionId, signal }) {
+      if (parentSessionId !== options.parentSessionId)
+        throw new TypeError("This control belongs to another parent Session.");
+      const pending: ManagedWorkspaceFrame[] = [];
+      let wake = Promise.withResolvers<void>();
+      const subscriber = (frame: ManagedWorkspaceFrame) => {
+        pending.push(frame);
+        wake.resolve();
+      };
+      const abort = () => wake.resolve();
+      subscribers.add(subscriber);
+      signal.addEventListener("abort", abort, { once: true });
+      try {
+        const snapshot = await control.inspect({ parentSessionId });
+        let revision = snapshot.revision;
+        yield { type: "snapshot", snapshot };
+        while (!signal.aborted) {
+          const frame = pending.shift();
+          if (frame === undefined) {
+            await wake.promise;
+            wake = Promise.withResolvers<void>();
+            continue;
+          }
+          if (frame.type !== "reset" && frame.snapshot.revision <= revision) continue;
+          yield {
+            ...frame,
+            type:
+              frame.type === "reset" || frame.snapshot.revision !== revision + 1
+                ? "reset"
+                : "change",
+          };
+          revision = frame.snapshot.revision;
+        }
+      } finally {
+        subscribers.delete(subscriber);
+        signal.removeEventListener("abort", abort);
+      }
+    },
+    async dispatch(command) {
+      if (!commandSchema.safeParse(command).success)
+        return rejected(
+          "action_unavailable",
+          "Historical agent controls are read-only. Start a new current Session to delegate work.",
+        );
+      if (command.parentSessionId !== options.parentSessionId)
+        return rejected("action_unavailable", "This control belongs to another parent Session.");
+      if (command.type === "cancel_turn") {
+        try {
+          const cancellation = await serialized(async () => {
+            const claim = await options.executionDomain.claimScope({
+              kind: "control",
+              sessionId: options.parentSessionId,
+              identity: randomUUID(),
+            });
+            try {
+              await controlStore.preflight();
+              const records = await controlStore.read();
+              const admission = records.findLast(
+                (record) =>
+                  record.threadId === command.threadId && record.event.type === "admitted",
+              );
+              if (
+                admission === undefined ||
+                admission.parentSessionId !== options.parentSessionId ||
+                admission.turnId !== command.expectedTurnId
+              )
+                return rejected(
+                  "stale_revision",
+                  "The selected turn changed. Inspect the current thread.",
+                );
+              const turn = records.filter((record) => record.turnId === admission.turnId);
+              const previousOutcome = turn.find((record) => record.event.type === "outcome");
+              if (previousOutcome !== undefined)
+                return rejected(
+                  "action_unavailable",
+                  "The selected turn already has an outcome. Inspect or recover settlement.",
+                );
+              if (!turn.some((record) => record.event.type === "cancel_requested"))
+                await append(admission, { type: "cancel_requested" });
+              const live = active.get(command.threadId);
+              if (live !== undefined) {
+                live.controller.abort();
+                return { completion: live.completion, turnId: admission.turnId };
+              }
+              const unstartedStore = await options.childSessionStores.open(
+                admission.childSessionId,
+              );
+              const childRecords =
+                unstartedStore === undefined &&
+                !turn.some((record) => record.event.type === "started")
+                  ? []
+                  : await cancelManagedChildSessionRecords({
+                      workspaceRoot: options.workspaceRoot,
+                      sessionId: admission.childSessionId,
+                      childSessionStores: options.childSessionStores,
+                    });
+              const outcome = await append(
+                admission,
+                managedOutcomeFromChild(
+                  {
+                    status: "cancelled",
+                    error: { code: "session_cancelled", message: "The session was cancelled." },
+                  },
+                  childRecords,
+                  turn,
+                ),
+              );
+              const settled = await append(admission, {
+                type: "settled",
+                outcome: managedControlLink(outcome),
+              });
+              await append(admission, { type: "completion", settled: managedControlLink(settled) });
+              return { status: "cancelled" as const, turnId: admission.turnId };
+            } finally {
+              await claim.release();
+            }
+          });
+          if ("completion" in cancellation) {
+            await cancellation.completion;
+            const outcome = (await controlStore.read()).find(
+              (record) => record.turnId === cancellation.turnId && record.event.type === "outcome",
+            );
+            return outcome?.event.type === "outcome" && outcome.event.status === "cancelled"
+              ? { status: "cancelled", turnId: cancellation.turnId }
+              : { status: "recovered" };
+          }
+          return cancellation;
+        } catch (error) {
+          if (error instanceof ProjectExecutionDomainError)
+            return rejected("authority_busy", error.message);
+          return rejected(
+            "recovery_required",
+            "The interrupted turn could not be durably cancelled. Inspect durable state.",
+          );
+        }
+      }
+      if (command.type === "close") {
+        closing = true;
+        const drain = (async () => {
+          await serial;
+          for (const attempt of active.values()) attempt.controller.abort();
+          const results = await Promise.allSettled([...inFlight]);
+          await serial;
+          return (
+            results.every((result) => result.status === "fulfilled") && failedAttempts.size === 0
+          );
+        })();
+        const expired = Promise.withResolvers<false>();
+        const timer = (options.cleanupScheduler ?? nodeManagedAgentDeadlineScheduler).schedule(
+          10_000,
+          () => expired.resolve(false),
+        );
+        try {
+          return (await Promise.race([drain, expired.promise]))
+            ? { status: "closed" }
+            : rejected(
+                "recovery_required",
+                "Managed cleanup is incomplete. Inspect durable state.",
+              );
+        } finally {
+          timer.cancel();
+        }
+      }
+      return serialized(async () => {
+        if (closing) return rejected("runtime_unavailable", "Managed control is closed.");
+        const claim = await options.executionDomain.claimScope({
+          kind: "control",
+          sessionId: options.parentSessionId,
+          identity: randomUUID(),
+        });
+        try {
+          await controlStore.preflight();
+          if (
+            command.type === "prepare_main_delivery" ||
+            command.type === "acknowledge_main_delivery"
+          ) {
+            if (options.parentSessionStore === undefined)
+              return rejected(
+                "action_unavailable",
+                "The canonical Main receipt owner is unavailable.",
+              );
+            const records = await controlStore.read();
+            const snapshot = foldManagedControl(records, options.parentSessionId);
+            const parentRecords = await options.parentSessionStore.read();
+            validateManagedParentHistory(
+              parentRecords,
+              options.parentSessionId,
+              options.projectId,
+              options.workspaceRoot,
+            );
+            if (
+              parentRecords.some(
+                (record) =>
+                  record.schemaVersion === 3 &&
+                  record.record.type === "provider_attempt_started" &&
+                  record.record.managedAgentDeliveryVersion === 3 &&
+                  record.record.managedAgentDeliveries?.some((delivery) =>
+                    snapshot.completions.some(
+                      (completion) =>
+                        completion.id === delivery.id &&
+                        (completion.receipt.digest !== delivery.digest ||
+                          managedControlMessageDigest(completion) !== delivery.messageDigest),
+                    ),
+                  ),
+              )
+            )
+              return rejected(
+                "recovery_required",
+                "The Main receipt does not match its exact completion content.",
+              );
+            const receipts = snapshot.completions.map((completion) => ({
+              completion,
+              parent: parentRecords.find(
+                (record) =>
+                  record.schemaVersion === 3 &&
+                  record.record.type === "provider_attempt_started" &&
+                  record.record.managedAgentDeliveryVersion === 3 &&
+                  record.record.managedAgentDeliveries?.some(
+                    (delivery) =>
+                      delivery.id === completion.id &&
+                      delivery.digest === completion.receipt.digest &&
+                      delivery.messageDigest === managedControlMessageDigest(completion),
+                  ),
+              ),
+            }));
+            if (
+              command.type === "acknowledge_main_delivery" &&
+              command.deliveries.some(
+                (delivery) =>
+                  !receipts.some(
+                    ({ completion, parent }) =>
+                      completion.id === delivery.id &&
+                      completion.receipt.digest === delivery.digest &&
+                      parent !== undefined,
+                  ),
+              )
+            )
+              return rejected(
+                "recovery_required",
+                "The exact Main request receipt is not durable.",
+              );
+            for (const { completion, parent } of receipts) {
+              if (parent === undefined || completion.consumption === "consumed") continue;
+              const record = records.find(
+                (entry) => entry.sequence === completion.receipt.sequence,
+              );
+              if (record === undefined)
+                return rejected("recovery_required", "The completion receipt is unavailable.");
+              await append(record, {
+                type: "consumed",
+                completion: completion.receipt,
+                parentReceipt: { sequence: parent.sequence, digest: managedControlDigest(parent) },
+              });
+            }
+            if (command.type === "acknowledge_main_delivery")
+              return { status: "acknowledged" as const };
+            const pending = receipts
+              .filter(
+                ({ completion, parent }) =>
+                  completion.consumption === "pending" && parent === undefined,
+              )
+              .slice(0, 32);
+            return {
+              status: "delivery" as const,
+              messages: pending.map(({ completion }) => ({
+                id: completion.id,
+                text: `Managed agent ${completion.threadId}, turn ${completion.turnId}: ${completion.outcome.status}\n${completion.outcome.summary}`,
+              })),
+              deliveries: pending.map(({ completion }) => ({
+                id: completion.id,
+                digest: completion.receipt.digest,
+              })),
+            };
+          }
+          if (command.type === "recover_turn") {
+            const records = await controlStore.read();
+            const admission = records.findLast(
+              (record) => record.threadId === command.threadId && record.event.type === "admitted",
+            );
+            if (
+              admission === undefined ||
+              admission.parentSessionId !== options.parentSessionId ||
+              admission.turnId !== command.expectedTurnId
+            )
+              return rejected(
+                "stale_revision",
+                "The selected turn changed. Inspect the current thread.",
+              );
+            if (active.has(command.threadId))
+              return rejected("authority_busy", "The selected turn has not settled.");
+            const turnRecords = records.filter((record) => record.turnId === admission.turnId);
+            let outcome = turnRecords.find((record) => record.event.type === "outcome");
+            const childStore = await options.childSessionStores.open(admission.childSessionId);
+            let childRecords = await childStore?.read();
+            const childGenesis = childRecords?.[0];
+            if (
+              outcome === undefined &&
+              childRecords !== undefined &&
+              childGenesis?.schemaVersion === 3 &&
+              childGenesis.record.type === "session_genesis" &&
+              childGenesis.record.sessionId === admission.childSessionId &&
+              childGenesis.record.projectId === options.projectId &&
+              isDeepStrictEqual(childGenesis.record.targetIdentity, options.targetIdentity)
+            ) {
+              if (
+                childRecords.some(
+                  (record) =>
+                    record.schemaVersion === 3 &&
+                    record.record.type === "provider_attempt_interrupted" &&
+                    record.record.reason === "run_terminal",
+                )
+              )
+                childRecords = await settleManagedChildTerminalIntent({
+                  workspaceRoot: options.workspaceRoot,
+                  sessionId: admission.childSessionId,
+                  childSessionStores: options.childSessionStores,
+                });
+              const result = managedChildTerminalResult(childRecords, options.workspaceRoot);
+              if (result !== undefined)
+                outcome = await append(
+                  admission,
+                  managedOutcomeFromChild(result, childRecords, turnRecords),
+                );
+            }
+            if (outcome?.event.type !== "outcome") {
+              const genesis = childRecords?.[0];
+              if (
+                admission.event.type === "admitted" &&
+                childStore !== undefined &&
+                childRecords !== undefined &&
+                genesis?.schemaVersion === 3 &&
+                genesis.record.type === "session_genesis" &&
+                genesis.record.sessionId === admission.childSessionId &&
+                genesis.record.projectId === options.projectId &&
+                isDeepStrictEqual(genesis.record.targetIdentity, options.targetIdentity) &&
+                isDeepStrictEqual(genesis.record.contextProfile, options.contextProfile) &&
+                isDeepStrictEqual(
+                  genesis.record.promptContext,
+                  createPromptContextV1(
+                    createReadToolRegistry({ workspaceRoot: options.workspaceRoot }),
+                  ),
+                ) &&
+                !turnRecords.some(
+                  (record) =>
+                    record.event.type === "cancel_requested" || record.event.type === "stalled",
+                )
+              ) {
+                const identity: ManagedControlIdentity = {
+                  parentSessionId: admission.parentSessionId,
+                  threadId: admission.threadId,
+                  turnId: admission.turnId,
+                  attemptId: admission.attemptId,
+                  childSessionId: admission.childSessionId,
+                };
+                const resume =
+                  childRecords.length === 1
+                    ? undefined
+                    : prepareManagedChildResume(
+                        childRecords,
+                        createReadToolRegistry({ workspaceRoot: options.workspaceRoot }),
+                        options.workspaceRoot,
+                      );
+                if (childRecords.length > 1 && resume === undefined)
+                  return rejected(
+                    "recovery_required",
+                    "This interrupted effect cannot be replayed safely.",
+                  );
+                await run(identity, admission.event.task, undefined, childStore, resume);
+                return { status: "accepted" as const, ...identity };
+              }
+              return rejected(
+                "recovery_required",
+                "This interrupted effect cannot be replayed safely.",
+              );
+            }
+            const provenRecords =
+              childRecords ??
+              (outcome.event.status === "cancelled" &&
+              outcome.event.transcript.sequence === 0 &&
+              !turnRecords.some((record) => record.event.type === "started")
+                ? []
+                : undefined);
+            if (
+              provenRecords === undefined ||
+              managedTranscriptLink(provenRecords).digest !== outcome.event.transcript.digest ||
+              (provenRecords.at(-1)?.sequence ?? 0) !== outcome.event.transcript.sequence
+            )
+              return rejected(
+                "recovery_required",
+                "The child transcript does not match its outcome receipt.",
+              );
+            const settled =
+              turnRecords.find((record) => record.event.type === "settled") ??
+              (await append(admission, { type: "settled", outcome: managedControlLink(outcome) }));
+            if (!turnRecords.some((record) => record.event.type === "completion"))
+              await append(admission, { type: "completion", settled: managedControlLink(settled) });
+            return { status: "recovered" as const };
+          }
+          const snapshot = foldManagedControl(await controlStore.read(), options.parentSessionId);
+          const previous =
+            command.type === "next_turn"
+              ? snapshot.threads.find((thread) => thread.threadId === command.threadId)
+              : undefined;
+          if (command.type === "next_turn") {
+            if (previous === undefined || previous.turn.turnId !== command.expectedTurnId)
+              return rejected(
+                "stale_revision",
+                "The selected turn changed. Inspect the current thread.",
+              );
+            if (previous.turn.phase !== "idle")
+              return rejected("authority_busy", "The selected turn has not settled.");
+            const previousStore = await options.childSessionStores.open(
+              previous.turn.childSessionId,
+            );
+            const previousRecords = await previousStore?.read();
+            const genesis = previousRecords?.[0];
+            if (
+              genesis?.schemaVersion !== 3 ||
+              genesis.record.type !== "session_genesis" ||
+              genesis.record.sessionId !== previous.turn.childSessionId ||
+              genesis.record.projectId !== options.projectId ||
+              previous.turn.outcome?.transcript.digest !==
+                managedTranscriptLink(previousRecords ?? []).digest
+            )
+              return rejected(
+                "recovery_required",
+                "The child transcript does not match its outcome receipt.",
+              );
+            if (
+              !isDeepStrictEqual(genesis.record.targetIdentity, options.targetIdentity) ||
+              !isDeepStrictEqual(genesis.record.contextProfile, options.contextProfile)
+            )
+              return rejected(
+                "action_unavailable",
+                "The thread's frozen target and context are unavailable.",
+              );
+          }
+          const identity: ManagedControlIdentity = {
+            parentSessionId: options.parentSessionId,
+            threadId: previous?.threadId ?? randomUUID(),
+            turnId: randomUUID(),
+            attemptId: randomUUID(),
+            childSessionId: randomUUID(),
+          };
+          await append(identity, {
+            type: "admitted",
+            role: previous?.role ?? "builtin:explore",
+            description:
+              previous?.description ?? (command.type === "start_thread" ? command.description : ""),
+            task: command.task,
+          });
+          await run(identity, command.task, previous?.turn.childSessionId);
+          return { status: "accepted" as const, ...identity };
+        } finally {
+          await claim.release();
+        }
+      }).catch((error: unknown) => {
+        if (error instanceof ProjectExecutionDomainError)
+          return rejected(
+            error.code === "root_conflict" || error.code === "project_in_use"
+              ? "authority_busy"
+              : "runtime_unavailable",
+            error.message,
+          );
+        if (
+          error instanceof ManagedAgentStoreError ||
+          error instanceof SessionStoreError ||
+          error instanceof SessionLifecycleError
+        )
+          return rejected(
+            "recovery_required",
+            "Managed history is unavailable. Inspect durable state.",
+          );
+        return rejected(
+          "persistence_failed",
+          "Managed control could not durably accept the request.",
+        );
+      });
+    },
+  };
+  return control;
+}
+
+function managedControlMessageDigest(
+  completion: ManagedWorkspaceSnapshot["completions"][number],
+): `sha256:${string}` {
+  const text = `Parent message (${completion.id}): Managed agent ${completion.threadId}, turn ${completion.turnId}: ${completion.outcome.status}\n${completion.outcome.summary}`;
+  return `sha256:${createHash("sha256").update(text, "utf8").digest("hex")}`;
+}
+
+/** AgentSession writes the canonical Main receipt before Control may acknowledge consumption. */
+export function managedControlMainRequestBoundary(
+  control: ManagedAgentControl,
+  parentSessionId: string,
+): ManagedAgentRequestBoundary {
+  return async () => {
+    const receipt = await control.dispatch({ type: "prepare_main_delivery", parentSessionId });
+    if (
+      receipt.status === "rejected" &&
+      receipt.code === "recovery_required" &&
+      (await control.inspect({ parentSessionId })).status === "recovery_required"
+    )
+      return { atomicReceipt: true, messages: [], deliveries: [], async acknowledge() {} };
+    if (receipt.status !== "delivery")
+      throw new Error("Managed completion delivery is unavailable.");
+    return {
+      atomicReceipt: true,
+      messages: receipt.messages,
+      deliveries: receipt.deliveries,
+      async acknowledge() {
+        if (receipt.deliveries.length === 0) return;
+        const acknowledged = await control.dispatch({
+          type: "acknowledge_main_delivery",
+          parentSessionId,
+          deliveries: receipt.deliveries,
+        });
+        if (acknowledged.status !== "acknowledged")
+          throw new Error("Managed completion acknowledgement is unavailable.");
+      },
+    };
+  };
+}

--- a/packages/agent/src/managed-agent-folds.ts
+++ b/packages/agent/src/managed-agent-folds.ts
@@ -1,0 +1,393 @@
+import type {
+  ManagedControlIdentity,
+  ManagedControlLink,
+  ManagedControlOutcome,
+  ManagedControlThread,
+  ManagedWorkspaceSnapshot,
+} from "@adam-agent/presentation";
+
+export type {
+  ManagedControlIdentity,
+  ManagedControlLink,
+  ManagedControlThread,
+  ManagedWorkspaceSnapshot,
+} from "@adam-agent/presentation";
+
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import { type ManagedAgentRecord, ManagedAgentStoreError } from "./managed-agent.js";
+import type { SessionRecord } from "./session-store.js";
+
+export type ManagedControlEvent =
+  | {
+      readonly type: "admitted";
+      readonly role: "builtin:explore";
+      readonly description: string;
+      readonly task: string;
+    }
+  | { readonly type: "started" }
+  | { readonly type: "cancel_requested" }
+  | {
+      readonly type: "execution_progress";
+      readonly deadlineId: string;
+      readonly atUnixMilliseconds: number;
+      readonly transcript: ManagedControlLink;
+    }
+  | { readonly type: "stalled"; readonly deadlineId: string }
+  | {
+      readonly type: "cleanup_expired";
+      readonly deadlineId: string;
+      readonly maximumMilliseconds: 10_000;
+    }
+  | {
+      readonly type: "consumed";
+      readonly completion: ManagedControlLink;
+      readonly parentReceipt: ManagedControlLink;
+    }
+  | ManagedControlOutcome
+  | { readonly type: "settled"; readonly outcome: ManagedControlLink }
+  | { readonly type: "completion"; readonly settled: ManagedControlLink };
+
+export type ManagedControlRecord = ManagedControlIdentity & {
+  readonly schemaVersion: 3;
+  readonly sequence: number;
+  readonly event: ManagedControlEvent;
+};
+
+export type ManagedControlStore = {
+  forParent(parentSessionId: string): ManagedControlStore;
+  preflight(): Promise<void>;
+  readLegacy(): Promise<readonly ManagedAgentRecord[]>;
+  read(): Promise<readonly ManagedControlRecord[]>;
+  append(record: ManagedControlRecord): Promise<void>;
+  appendNext(record: Omit<ManagedControlRecord, "sequence">): Promise<ManagedControlRecord>;
+};
+
+const linkSchema = z.strictObject({
+  sequence: z.number().int().nonnegative(),
+  digest: z.string().regex(/^sha256:[a-f0-9]{64}$/u),
+});
+const boundedText = (maximum: number) =>
+  z.string().refine((value) => Buffer.byteLength(value, "utf8") <= maximum);
+const eventSchema = z.discriminatedUnion("type", [
+  z.strictObject({
+    type: z.literal("admitted"),
+    role: z.literal("builtin:explore"),
+    description: boundedText(256).refine((value) => value.length > 0 && !/\p{Cc}/u.test(value)),
+    task: boundedText(16 * 1024).refine((value) => value.trim().length > 0),
+  }),
+  z.strictObject({ type: z.literal("started") }),
+  z.strictObject({ type: z.literal("cancel_requested") }),
+  z.strictObject({
+    type: z.literal("execution_progress"),
+    deadlineId: z.uuid(),
+    atUnixMilliseconds: z.number().int().nonnegative(),
+    transcript: linkSchema,
+  }),
+  z.strictObject({ type: z.literal("stalled"), deadlineId: z.uuid() }),
+  z.strictObject({
+    type: z.literal("cleanup_expired"),
+    deadlineId: z.uuid(),
+    maximumMilliseconds: z.literal(10_000),
+  }),
+  z.strictObject({
+    type: z.literal("consumed"),
+    completion: linkSchema,
+    parentReceipt: linkSchema,
+  }),
+  z.strictObject({
+    type: z.literal("outcome"),
+    usage: z.strictObject({
+      inputTokens: z.number().int().nonnegative(),
+      outputTokens: z.number().int().nonnegative(),
+      reasoningTokens: z.number().int().nonnegative(),
+      providerCalls: z.number().int().nonnegative(),
+      unknownCalls: z.number().int().nonnegative(),
+    }),
+    status: z.enum(["completed", "failed", "cancelled", "interrupted"]),
+    summary: boundedText(16 * 1024),
+    transcript: linkSchema,
+    error: z.strictObject({ code: boundedText(128), message: boundedText(1024) }).optional(),
+  }),
+  z.strictObject({ type: z.literal("settled"), outcome: linkSchema }),
+  z.strictObject({ type: z.literal("completion"), settled: linkSchema }),
+]);
+const recordSchema = z.strictObject({
+  schemaVersion: z.literal(3),
+  sequence: z.number().int().positive(),
+  parentSessionId: z.uuid(),
+  threadId: z.uuid(),
+  turnId: z.uuid(),
+  attemptId: z.uuid(),
+  childSessionId: z.uuid(),
+  event: eventSchema,
+});
+
+export function validateManagedControlRecord(
+  value: unknown,
+  previous: readonly ManagedControlRecord[],
+): ManagedControlRecord {
+  const parsed = recordSchema.safeParse(value);
+  const invalid = (): never => {
+    throw new ManagedAgentStoreError("managed_agent_log_invalid");
+  };
+  if (!parsed.success) return invalid();
+  const record = structuredClone(value) as ManagedControlRecord;
+  if (record.sequence !== previous.length + 1) return invalid();
+  const threadRecords = previous.filter((entry) => entry.threadId === record.threadId);
+  if (threadRecords.some((entry) => entry.parentSessionId !== record.parentSessionId))
+    return invalid();
+  const turnRecords = previous.filter((entry) => entry.turnId === record.turnId);
+  if (record.event.type === "admitted") {
+    if (
+      turnRecords.length > 0 ||
+      previous.some(
+        (entry) =>
+          entry.attemptId === record.attemptId || entry.childSessionId === record.childSessionId,
+      )
+    )
+      return invalid();
+    const last = threadRecords.at(-1);
+    if (last !== undefined && last.event.type !== "completion" && last.event.type !== "consumed")
+      return invalid();
+    const first = threadRecords[0];
+    if (
+      first?.event.type === "admitted" &&
+      (first.event.role !== record.event.role ||
+        first.event.description !== record.event.description)
+    )
+      return invalid();
+  } else {
+    const admission = turnRecords[0];
+    if (
+      admission?.event.type !== "admitted" ||
+      admission.threadId !== record.threadId ||
+      admission.parentSessionId !== record.parentSessionId ||
+      admission.attemptId !== record.attemptId ||
+      admission.childSessionId !== record.childSessionId
+    )
+      return invalid();
+    if (
+      record.event.type !== "execution_progress" &&
+      turnRecords.some((entry) => entry.event.type === record.event.type)
+    )
+      return invalid();
+    const last = turnRecords.at(-1);
+    const event = record.event;
+    if (
+      event.type === "cleanup_expired" &&
+      (last?.event.type !== "outcome" || event.deadlineId !== record.attemptId)
+    )
+      return invalid();
+    if (
+      event.type === "consumed" &&
+      (last?.event.type !== "completion" ||
+        event.completion.sequence !== last.sequence ||
+        event.completion.digest !== managedControlDigest(last))
+    )
+      return invalid();
+    if (
+      event.type === "started" &&
+      last?.event.type !== "admitted" &&
+      last?.event.type !== "cancel_requested"
+    )
+      return invalid();
+    const executing =
+      last?.event.type === "started" ||
+      last?.event.type === "execution_progress" ||
+      last?.event.type === "stalled";
+    if (
+      (event.type === "execution_progress" || event.type === "stalled") &&
+      (!executing || event.deadlineId !== record.attemptId)
+    )
+      return invalid();
+    if (event.type === "cancel_requested" && !executing && last?.event.type !== "admitted")
+      return invalid();
+    if (event.type === "outcome" && !executing && last?.event.type !== "cancel_requested")
+      return invalid();
+    if (event.type === "settled" || event.type === "completion") {
+      const targetType = event.type === "settled" ? "outcome" : "settled";
+      const link = event.type === "settled" ? event.outcome : event.settled;
+      const target =
+        event.type === "settled" && last?.event.type === "cleanup_expired"
+          ? turnRecords.find((entry) => entry.event.type === "outcome")
+          : last;
+      if (
+        target?.event.type !== targetType ||
+        link.sequence !== target.sequence ||
+        link.digest !== managedControlDigest(target)
+      )
+        return invalid();
+    }
+  }
+  return record;
+}
+
+export function managedControlDigest(value: unknown): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;
+}
+
+export function managedControlLink(record: ManagedControlRecord): ManagedControlLink {
+  return { sequence: record.sequence, digest: managedControlDigest(record) };
+}
+
+export function managedTranscriptLink(records: readonly SessionRecord[]): ManagedControlLink {
+  return { sequence: records.at(-1)?.sequence ?? 0, digest: managedControlDigest(records) };
+}
+
+export function managedCompletionId(identity: ManagedControlIdentity): `sha256:${string}` {
+  return managedControlDigest([identity.parentSessionId, identity.threadId, identity.turnId]);
+}
+
+export function foldManagedControl(
+  records: readonly ManagedControlRecord[],
+  parentSessionId: string,
+): ManagedWorkspaceSnapshot {
+  const threads = new Map<string, ManagedControlThread>();
+  for (const record of records) {
+    if (record.parentSessionId !== parentSessionId) continue;
+    const event = record.event;
+    if (event.type === "consumed") continue;
+    if (event.type === "admitted") {
+      const existing = threads.get(record.threadId);
+      threads.set(record.threadId, {
+        parentSessionId,
+        lifecycle: "open",
+        displayName: "Explore",
+        handle: existing?.handle ?? `@explore-${threads.size + 1}`,
+        residency: "live",
+        threadId: record.threadId,
+        role: event.role,
+        description: event.description,
+        turn: {
+          turnId: record.turnId,
+          attemptId: record.attemptId,
+          childSessionId: record.childSessionId,
+          phase: "starting",
+          label: "Starting",
+          recovery: "none",
+          health: "healthy",
+          waitReason: "none",
+          ownerPhase: "waiting",
+          lastOutcome: "none",
+        },
+      });
+      continue;
+    }
+    const thread = threads.get(record.threadId);
+    if (thread === undefined || thread.turn.turnId !== record.turnId)
+      throw new Error("Invalid managed control history.");
+    if (event.type === "completion" || event.type === "cancel_requested") continue;
+    if (event.type === "execution_progress") {
+      threads.set(record.threadId, {
+        ...thread,
+        turn: {
+          ...thread.turn,
+          phase: "executing",
+          label: "Running",
+          watchdog: {
+            deadlineId: event.deadlineId,
+            maximumInactivityMilliseconds: 300_000,
+            lastProgressAtUnixMilliseconds: event.atUnixMilliseconds,
+            transcript: event.transcript,
+            state: "running",
+          },
+        },
+      });
+      continue;
+    }
+    if (event.type === "stalled") {
+      threads.set(record.threadId, {
+        ...thread,
+        turn: {
+          ...thread.turn,
+          health: "stalled",
+          ...(thread.turn.watchdog === undefined
+            ? {}
+            : { watchdog: { ...thread.turn.watchdog, state: "stalled" } }),
+        },
+      });
+      continue;
+    }
+    if (event.type === "cleanup_expired") {
+      threads.set(record.threadId, {
+        ...thread,
+        turn: {
+          ...thread.turn,
+          recovery: "required",
+          diagnostic: "Cleanup has not settled. Inspect durable state.",
+        },
+      });
+      continue;
+    }
+    const previousTurn = { ...thread.turn };
+    if (event.type === "settled") {
+      delete previousTurn.diagnostic;
+      previousTurn.recovery = "none";
+    }
+    const phase =
+      event.type === "started" ? "executing" : event.type === "outcome" ? "settling" : "idle";
+    threads.set(record.threadId, {
+      ...thread,
+      residency: phase === "idle" ? "unloaded" : "live",
+      turn: {
+        ...previousTurn,
+        phase,
+        ownerPhase:
+          phase === "settling" ? "releasing" : phase === "executing" ? "claimed" : "released",
+        lastOutcome: event.type === "outcome" ? event.status : thread.turn.lastOutcome,
+        label:
+          phase === "settling"
+            ? "Settling"
+            : phase === "executing"
+              ? "Running"
+              : thread.turn.outcome?.status === "cancelled"
+                ? "Cancelled"
+                : thread.turn.outcome?.status === "failed"
+                  ? "Failed"
+                  : thread.turn.outcome?.status === "interrupted"
+                    ? "Interrupted"
+                    : "Completed",
+        ...(event.type === "outcome" ? { outcome: event } : {}),
+        ...(event.type === "outcome" && thread.turn.watchdog !== undefined
+          ? {
+              watchdog: {
+                ...thread.turn.watchdog,
+                state:
+                  thread.turn.health === "stalled" ? ("stalled" as const) : ("stopped" as const),
+              },
+            }
+          : {}),
+      },
+    });
+  }
+  return {
+    completions: records.flatMap((record) => {
+      if (record.parentSessionId !== parentSessionId || record.event.type !== "completion")
+        return [];
+      const outcome = records.find(
+        (entry) => entry.turnId === record.turnId && entry.event.type === "outcome",
+      );
+      if (outcome?.event.type !== "outcome")
+        throw new ManagedAgentStoreError("managed_agent_log_invalid");
+      return [
+        {
+          id: managedCompletionId(record),
+          threadId: record.threadId,
+          turnId: record.turnId,
+          receipt: managedControlLink(record),
+          outcome: outcome.event,
+          consumption: records.some(
+            (entry) => entry.turnId === record.turnId && entry.event.type === "consumed",
+          )
+            ? ("consumed" as const)
+            : ("pending" as const),
+        },
+      ];
+    }),
+    status: "ready",
+    parentSessionId,
+    revision: records.at(-1)?.sequence ?? 0,
+    threads: [...threads.values()],
+  };
+}

--- a/packages/agent/src/managed-agent-recovery.ts
+++ b/packages/agent/src/managed-agent-recovery.ts
@@ -1,0 +1,182 @@
+import type { ManagedControlOutcome, ManagedControlThread } from "@adam-agent/presentation";
+import type { RunResult } from "./agent-session-contracts.js";
+import { type ManagedControlRecord, managedTranscriptLink } from "./managed-agent-folds.js";
+import {
+  contextUsageSnapshotFromRecords,
+  isGenesisRecord,
+  snapshotFromRecords,
+} from "./session-history-folds.js";
+import { validateCurrentSessionHistory } from "./session-history-validation.js";
+import { createAgentResumeState } from "./session-lifecycle.js";
+import {
+  type SessionRecord,
+  type SessionStoreDirectory,
+  SessionStoreError,
+} from "./session-store.js";
+import type { ToolRegistry } from "./tool-runtime.js";
+
+/** Cross-store verification belongs to Control; child transcript bytes remain SessionStore-owned. */
+export async function inspectManagedChildReceipt(
+  thread: ManagedControlThread,
+  stores: SessionStoreDirectory<SessionRecord>,
+): Promise<ManagedControlThread> {
+  const outcome = thread.turn.outcome;
+  const receipt = outcome?.transcript ?? thread.turn.watchdog?.transcript;
+  if (receipt === undefined) return thread;
+  try {
+    const records = await (await stores.open(thread.turn.childSessionId))?.read();
+    if (
+      records === undefined &&
+      outcome?.status === "cancelled" &&
+      outcome.transcript.sequence === 0 &&
+      outcome.transcript.digest === managedTranscriptLink([]).digest
+    )
+      return thread;
+    const genesis = records?.[0];
+    if (
+      records === undefined ||
+      genesis?.schemaVersion !== 3 ||
+      genesis.record.type !== "session_genesis" ||
+      genesis.record.sessionId !== thread.turn.childSessionId ||
+      managedTranscriptLink(records.filter((record) => record.sequence <= receipt.sequence))
+        .digest !== receipt.digest ||
+      (outcome !== undefined && (records.at(-1)?.sequence ?? 0) !== receipt.sequence)
+    )
+      throw new SessionStoreError();
+    return thread;
+  } catch (error) {
+    if (!(error instanceof SessionStoreError)) throw error;
+    return {
+      ...thread,
+      turn: {
+        ...thread.turn,
+        recovery: "required",
+        diagnostic: "Child history is unavailable. Inspect durable state.",
+      },
+    };
+  }
+}
+
+export function prepareManagedChildResume(
+  records: readonly SessionRecord[],
+  tools: ToolRegistry,
+  workspaceRoot: string,
+): ReturnType<typeof createAgentResumeState> | undefined {
+  const genesis = records[0];
+  if (genesis === undefined || !isGenesisRecord(genesis)) return undefined;
+  validateCurrentSessionHistory(genesis, records, workspaceRoot);
+  const snapshot = snapshotFromRecords(genesis, records);
+  // An acknowledged provider request is never resent, even when no response bytes were observed.
+  if (
+    (snapshot.run?.lastAttempt !== undefined && snapshot.run.lastAttempt.status !== "completed") ||
+    snapshot.run?.result !== undefined
+  )
+    return undefined;
+  return createAgentResumeState(records, tools, snapshot);
+}
+
+export function managedChildTerminalResult(
+  records: readonly SessionRecord[],
+  workspaceRoot: string,
+): RunResult | undefined {
+  const genesis = records[0];
+  if (genesis === undefined || !isGenesisRecord(genesis)) return undefined;
+  validateCurrentSessionHistory(genesis, records, workspaceRoot);
+  return snapshotFromRecords(genesis, records).run?.result;
+}
+
+export function validateManagedParentHistory(
+  records: readonly SessionRecord[],
+  parentSessionId: string,
+  projectId: string,
+  workspaceRoot: string,
+): void {
+  const genesis = records[0];
+  if (
+    genesis === undefined ||
+    !isGenesisRecord(genesis) ||
+    genesis.record.sessionId !== parentSessionId ||
+    genesis.record.projectId !== projectId
+  )
+    throw new SessionStoreError();
+  validateCurrentSessionHistory(genesis, records, workspaceRoot);
+}
+
+/** One outcome projection serves live settlement and cold terminal materialization. */
+export function managedOutcomeFromChild(
+  result: RunResult,
+  records: readonly SessionRecord[],
+  turnRecords: readonly ManagedControlRecord[],
+): ManagedControlOutcome {
+  const stalled = turnRecords.some((record) => record.event.type === "stalled");
+  const provider = records.findLast(
+    (record) => record.schemaVersion === 3 && record.record.type === "provider_attempt_started",
+  );
+  const partial = records.findLast(
+    (record) =>
+      record.sequence > (provider?.sequence ?? 0) &&
+      record.schemaVersion === 3 &&
+      ((record.record.type === "provider_attempt_interrupted" &&
+        record.record.reason === "run_terminal" &&
+        record.record.partialOutput !== undefined) ||
+        (record.record.type === "runtime_event" &&
+          record.record.event.type === "model_message_completed")),
+  );
+  const partialText =
+    partial?.schemaVersion !== 3
+      ? ""
+      : partial.record.type === "provider_attempt_interrupted" &&
+          partial.record.reason === "run_terminal"
+        ? (partial.record.partialOutput?.text ?? "")
+        : partial.record.type === "runtime_event" &&
+            partial.record.event.type === "model_message_completed"
+          ? partial.record.event.text
+          : "";
+  const bytes = Buffer.from(result.status === "completed" ? result.answer : partialText, "utf8");
+  let end = Math.min(bytes.length, 16 * 1024);
+  while (end > 0 && end < bytes.length && ((bytes[end] ?? 0) & 0xc0) === 0x80) end -= 1;
+  const usage = contextUsageSnapshotFromRecords(records);
+  const ordinary = usage?.ordinaryUsage;
+  const compaction = usage?.compactionUsage;
+  return {
+    type: "outcome",
+    status: stalled
+      ? "failed"
+      : result.status === "completed"
+        ? "completed"
+        : result.status === "cancelled"
+          ? "cancelled"
+          : "failed",
+    summary: bytes.subarray(0, end).toString("utf8"),
+    transcript: managedTranscriptLink(records),
+    usage: {
+      inputTokens: (ordinary?.inputTokens ?? 0) + (compaction?.inputTokens ?? 0),
+      outputTokens: (ordinary?.outputTokens ?? 0) + (compaction?.outputTokens ?? 0),
+      reasoningTokens: (ordinary?.reasoningTokens ?? 0) + (compaction?.reasoningTokens ?? 0),
+      unknownCalls: (ordinary?.unknownCalls ?? 0) + (compaction?.unknownCalls ?? 0),
+      providerCalls: records.filter(
+        (record) =>
+          record.schemaVersion === 3 &&
+          (record.record.type === "provider_attempt_started" ||
+            record.record.type === "context_compaction_started"),
+      ).length,
+    },
+    ...(stalled
+      ? {
+          error: {
+            code: "managed_agent_stalled",
+            message: "The managed turn stalled without causal progress.",
+          },
+        }
+      : result.status === "failed"
+        ? { error: { code: result.error.code, message: result.error.message } }
+        : result.status === "incomplete"
+          ? {
+              error: {
+                code: result.reason,
+                message: "The managed turn did not produce a complete response.",
+              },
+            }
+          : {}),
+  };
+}

--- a/packages/agent/src/managed-agent-store.ts
+++ b/packages/agent/src/managed-agent-store.ts
@@ -1,8 +1,8 @@
 import { createHash } from "node:crypto";
 import { constants } from "node:fs";
-import { chmod, mkdir, open, readFile, realpath } from "node:fs/promises";
+import { chmod, mkdir, open, readdir, readFile, realpath } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import {
   type ManagedAgentRecord,
@@ -10,6 +10,269 @@ import {
   ManagedAgentStoreError,
   validateManagedAgentRecord,
 } from "./managed-agent.js";
+import {
+  type ManagedControlRecord,
+  type ManagedControlStore,
+  validateManagedControlRecord,
+} from "./managed-agent-folds.js";
+
+export function createInMemoryManagedAgentControlStore(): ManagedControlStore {
+  const partitions = new Map<string, ManagedControlRecord[]>();
+  const scoped = (parentSessionId?: string): ManagedControlStore => ({
+    forParent(id) {
+      assertParentScope(parentSessionId, id);
+      return scoped(id);
+    },
+    async preflight() {},
+    async readLegacy() {
+      return [];
+    },
+    async read() {
+      return structuredClone(
+        parentSessionId === undefined
+          ? [...partitions.entries()]
+              .sort(([a], [b]) => a.localeCompare(b))
+              .flatMap(([, records]) => records)
+          : (partitions.get(parentSessionId) ?? []),
+      );
+    },
+    async append(record) {
+      if (typeof record !== "object" || record === null)
+        throw new ManagedAgentStoreError("managed_agent_log_invalid");
+      assertParentScope(parentSessionId, record.parentSessionId);
+      const records = partitions.get(record.parentSessionId) ?? [];
+      records.push(validateManagedControlRecord(record, records));
+      partitions.set(record.parentSessionId, records);
+    },
+    async appendNext(input) {
+      if (typeof input !== "object" || input === null)
+        throw new ManagedAgentStoreError("managed_agent_log_invalid");
+      assertParentScope(parentSessionId, input.parentSessionId);
+      const records = partitions.get(input.parentSessionId) ?? [];
+      const record = validateManagedControlRecord(
+        { ...input, sequence: records.length + 1 },
+        records,
+      );
+      records.push(record);
+      partitions.set(input.parentSessionId, records);
+      return structuredClone(record);
+    },
+  });
+  return scoped();
+}
+
+function assertParentScope(bound: string | undefined, requested: string): void {
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u.test(requested) ||
+    (bound !== undefined && bound !== requested)
+  )
+    throw new ManagedAgentStoreError("managed_agent_log_invalid");
+}
+
+/** Parent journals share the project writer, while corruption stays in the attributable parent. */
+export async function createJsonlManagedAgentControlStore(options: {
+  readonly workspaceRoot: string;
+  readonly stateRoot?: string;
+}): Promise<ManagedControlStore> {
+  const workspace = await realpath(options.workspaceRoot);
+  const projectKey = createHash("sha256").update(workspace).digest("hex");
+  const stateRoot = resolve(options.stateRoot ?? defaultManagedAgentStateRoot());
+  const projects = join(stateRoot, "projects");
+  const project = join(projects, projectKey);
+  const directory = join(project, "managed-agents");
+  const legacyPath = join(directory, "events-v1.jsonl");
+  const backupPath = join(directory, "events-v1.pre-v3.jsonl");
+  const prepared = new Set<string>();
+  const assertDirectories = async () => {
+    for (const path of [stateRoot, projects, project, directory]) {
+      try {
+        if ((await realpath(path)) !== path)
+          throw new Error("Managed control directory identity changed.");
+      } catch (error) {
+        if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+        throw error;
+      }
+    }
+  };
+  const readBytes = async (path: string): Promise<string> => {
+    await assertDirectories();
+    let file: Awaited<ReturnType<typeof open>>;
+    try {
+      file = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK);
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return "";
+      throw error;
+    }
+    try {
+      const stats = await file.stat();
+      if (!stats.isFile()) throw new Error("Managed control journal is not a regular file.");
+      if (stats.size > maximumManagedAgentLogBytes)
+        throw new ManagedAgentStoreError("managed_agent_log_too_large");
+      return await file.readFile("utf8");
+    } finally {
+      await file.close();
+    }
+  };
+  const parseLines = (text: string): readonly unknown[] => {
+    if (text === "") return [];
+    if (!text.endsWith("\n")) throw new ManagedAgentStoreError("managed_agent_log_invalid");
+    try {
+      return text
+        .slice(0, -1)
+        .split("\n")
+        .map((line) => JSON.parse(line) as unknown);
+    } catch {
+      throw new ManagedAgentStoreError("managed_agent_log_invalid");
+    }
+  };
+  const readLegacy = async () => {
+    const records: ManagedAgentRecord[] = [];
+    for (const value of parseLines(await readBytes(legacyPath)))
+      records.push(validateManagedAgentRecord(value, records).record);
+    return records;
+  };
+  const readPartition = async (path: string, parent: string) => {
+    const memory = createInMemoryManagedAgentControlStore().forParent(parent);
+    for (const value of parseLines(await readBytes(path)))
+      await memory.append(value as ManagedControlRecord);
+    return memory.read();
+  };
+  const scoped = (parentSessionId?: string): ManagedControlStore => {
+    const path =
+      parentSessionId === undefined
+        ? undefined
+        : join(directory, `events-v3-${parentSessionId}.jsonl`);
+    const appendStored = (
+      input: Omit<ManagedControlRecord, "sequence">,
+      allocate: boolean,
+    ): Promise<ManagedControlRecord> => {
+      assertParentScope(parentSessionId, input.parentSessionId);
+      if (path === undefined || parentSessionId === undefined || !prepared.has(parentSessionId))
+        return Promise.reject(new ManagedAgentStoreError("managed_agent_log_invalid"));
+      return enqueueManagedAgentAppend(path, async () => {
+        const records = await readPartition(path, parentSessionId);
+        const record = validateManagedControlRecord(
+          allocate ? { ...input, sequence: records.length + 1 } : input,
+          records,
+        );
+        const text = `${JSON.stringify(record)}\n`;
+        const storedBytes = records.reduce(
+          (sum, entry) => sum + Buffer.byteLength(JSON.stringify(entry), "utf8") + 1,
+          0,
+        );
+        if (storedBytes + Buffer.byteLength(text, "utf8") > maximumManagedAgentLogBytes)
+          throw new ManagedAgentStoreError("managed_agent_log_too_large");
+        const file = await open(
+          path,
+          constants.O_APPEND | constants.O_WRONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+        );
+        try {
+          if (!(await file.stat()).isFile())
+            throw new Error("Managed control journal is not a regular file.");
+          await file.writeFile(text, "utf8");
+          await file.sync();
+        } finally {
+          await file.close();
+        }
+        return record;
+      });
+    };
+    const store: ManagedControlStore = {
+      forParent(id) {
+        assertParentScope(parentSessionId, id);
+        return scoped(id);
+      },
+      readLegacy,
+      async read() {
+        if (path !== undefined && parentSessionId !== undefined) {
+          await (managedAgentAppendQueues.get(path) ?? Promise.resolve());
+          return readPartition(path, parentSessionId);
+        }
+        await assertDirectories();
+        let names: string[];
+        try {
+          names = await readdir(directory);
+        } catch (error) {
+          if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+          throw error;
+        }
+        const records: ManagedControlRecord[] = [];
+        for (const name of names.filter((name) => name.startsWith("events-v3-")).sort()) {
+          const match = /^events-v3-([0-9a-f-]{36})\.jsonl$/u.exec(name);
+          if (match?.[1] === undefined)
+            throw new Error("Managed control journal identity is unavailable.");
+          records.push(...(await scoped(match[1]).read()));
+        }
+        return records;
+      },
+      preflight() {
+        return enqueueManagedAgentAppend(backupPath, async () => {
+          if (prepared.has(parentSessionId ?? "all")) return;
+          await readLegacy();
+          await store.read();
+          const legacyBytes = await readBytes(legacyPath);
+          for (const entry of [stateRoot, projects, project, directory]) {
+            await mkdir(entry, { recursive: true, mode: 0o700 });
+            if ((await realpath(entry)) !== entry)
+              throw new Error("Managed control directory identity changed.");
+            await chmod(entry, 0o700);
+          }
+          let backup: Awaited<ReturnType<typeof open>> | undefined;
+          try {
+            backup = await open(
+              backupPath,
+              constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
+              0o600,
+            );
+          } catch (error) {
+            if (!(error instanceof Error && "code" in error && error.code === "EEXIST"))
+              throw error;
+            if ((await readBytes(backupPath)) !== legacyBytes)
+              throw new ManagedAgentStoreError("managed_agent_log_invalid");
+          }
+          if (backup !== undefined) {
+            try {
+              await backup.writeFile(legacyBytes, "utf8");
+              await backup.sync();
+            } finally {
+              await backup.close();
+            }
+          }
+          if (path !== undefined) await ensureManagedAgentLogFile(path);
+          const directoryFile = await open(
+            directory,
+            constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+          );
+          try {
+            await directoryFile.sync();
+          } finally {
+            await directoryFile.close();
+          }
+          prepared.add(parentSessionId ?? "all");
+        });
+      },
+      async append(record) {
+        if (parentSessionId === undefined) {
+          const target = scoped(record.parentSessionId);
+          await target.preflight();
+          await target.append(record);
+          return;
+        }
+        await appendStored(record, false);
+      },
+      async appendNext(record) {
+        if (parentSessionId === undefined) {
+          const target = scoped(record.parentSessionId);
+          await target.preflight();
+          return target.appendNext(record);
+        }
+        return appendStored(record, true);
+      },
+    };
+    return store;
+  };
+  return scoped();
+}
 
 const maximumManagedAgentLogBytes = 32 * 1024 * 1024;
 const managedAgentAppendQueues = new Map<string, Promise<void>>();
@@ -131,7 +394,7 @@ async function readManagedAgentLog(path: string): Promise<readonly ManagedAgentR
   return records;
 }
 
-function enqueueManagedAgentAppend(path: string, operation: () => Promise<void>): Promise<void> {
+function enqueueManagedAgentAppend<T>(path: string, operation: () => Promise<T>): Promise<T> {
   const previous = managedAgentAppendQueues.get(path) ?? Promise.resolve();
   const queued = previous.then(operation, operation);
   const settled = queued.then(

--- a/packages/agent/src/managed-agent.ts
+++ b/packages/agent/src/managed-agent.ts
@@ -2072,6 +2072,7 @@ export function validateManagedAgentRecord(
 }
 
 export type ManagedAgentSummary = {
+  readonly readOnly?: true;
   readonly agentId: string;
   readonly attemptId: string;
   readonly profile: BuiltInManagedAgentProfileId;
@@ -2769,7 +2770,7 @@ export type ManagedAgentInactivityScheduler = {
   schedule(delayMilliseconds: number, onInactivity: () => void): { cancel(): void };
 };
 
-const nodeManagedAgentDeadlineScheduler: ManagedAgentDeadlineScheduler = {
+export const nodeManagedAgentDeadlineScheduler: ManagedAgentDeadlineScheduler = {
   schedule(delayMilliseconds, onDeadline) {
     const timer = setTimeout(onDeadline, delayMilliseconds);
     timer.unref();
@@ -5432,16 +5433,20 @@ export function createAgentManager(options: {
   return manager;
 }
 
-export function createManagedAgentToolRegistry(options: {
-  readonly manager: AgentManager;
-  readonly profile?:
-    | "managed-agent-tools.a1.v1"
-    | "managed-agent-tools.a2-long-lived.v1"
-    | "managed-agent-tools.a3-long-lived.v1"
-    | "managed-agent-tools.a1.v2"
-    | "managed-agent-tools.a2-long-lived.v2"
-    | "managed-agent-tools.a3-long-lived.v2";
-}): ToolRegistry {
+export function createManagedAgentToolRegistry(
+  options: {
+    readonly profile?:
+      | "managed-agent-tools.a1.v1"
+      | "managed-agent-tools.a2-long-lived.v1"
+      | "managed-agent-tools.a3-long-lived.v1"
+      | "managed-agent-tools.a1.v2"
+      | "managed-agent-tools.a2-long-lived.v2"
+      | "managed-agent-tools.a3-long-lived.v2";
+  } & (
+    | { readonly manager: AgentManager; readonly readOnly?: false }
+    | { readonly readOnly: true; readonly manager?: never }
+  ),
+): ToolRegistry {
   const profile = options.profile ?? "managed-agent-tools.a1.v1";
   const current = profile.endsWith(".v2");
   const a3 = profile.includes(".a3-long-lived.");
@@ -5494,6 +5499,11 @@ export function createManagedAgentToolRegistry(options: {
         if (!parsed.success) {
           return toolFailure("invalid_tool_input", "Tool input is invalid.");
         }
+        if (options.readOnly === true)
+          return toolFailure(
+            "managed_agent_unavailable",
+            "Historical agent controls are read-only. Start a new current Session to delegate work.",
+          );
         const a3Input = a3
           ? current
             ? managedAgentA3SpawnSchemaV2.parse(parsed.data)
@@ -5604,6 +5614,11 @@ export function createManagedAgentToolRegistry(options: {
         if (!parsed.success) {
           return toolFailure("invalid_tool_input", "Tool input is invalid.");
         }
+        if (options.readOnly === true)
+          return toolFailure(
+            "managed_agent_unavailable",
+            "Historical agent controls are read-only. Start a new current Session to delegate work.",
+          );
         return {
           status: "ready",
           permissionSubject: {
@@ -5640,6 +5655,11 @@ export function createManagedAgentToolRegistry(options: {
         if (!parsed.success) {
           return toolFailure("invalid_tool_input", "Tool input is invalid.");
         }
+        if (options.readOnly === true)
+          return toolFailure(
+            "managed_agent_unavailable",
+            "Historical agent controls are read-only. Start a new current Session to delegate work.",
+          );
         return {
           status: "ready",
           permissionSubject: {
@@ -5676,6 +5696,11 @@ export function createManagedAgentToolRegistry(options: {
         if (!parsed.success || new Set(parsed.data.agentIds).size !== parsed.data.agentIds.length) {
           return toolFailure("invalid_tool_input", "Tool input is invalid.");
         }
+        if (options.readOnly === true)
+          return toolFailure(
+            "managed_agent_unavailable",
+            "Historical agent controls are read-only. Start a new current Session to delegate work.",
+          );
         return {
           status: "ready",
           permissionSubject: {
@@ -5712,6 +5737,11 @@ export function createManagedAgentToolRegistry(options: {
         if (!parsed.success) {
           return toolFailure("invalid_tool_input", "Tool input is invalid.");
         }
+        if (options.readOnly === true)
+          return toolFailure(
+            "managed_agent_unavailable",
+            "Historical agent controls are read-only. Start a new current Session to delegate work.",
+          );
         return {
           status: "ready",
           permissionSubject: {
@@ -5757,6 +5787,11 @@ export function createManagedAgentToolRegistry(options: {
         ) {
           return toolFailure("invalid_tool_input", "Tool input is invalid.");
         }
+        if (options.readOnly === true)
+          return toolFailure(
+            "managed_agent_unavailable",
+            "Historical agent controls are read-only. Start a new current Session to delegate work.",
+          );
         return {
           status: "ready",
           permissionSubject: {

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -101,6 +101,9 @@ import {
 export const presentationHydrationBarrier = Symbol("adam-agent.presentation-hydration-barrier");
 export const presentationHistoryPageSize = Symbol("adam-agent.presentation-history-page-size");
 export const presentationCatalogPageSize = Symbol("adam-agent.presentation-catalog-page-size");
+
+import { sessionManagedControl } from "./session-lifecycle.js";
+
 export const presentationManagedAgentTranscriptPageSize = Symbol(
   "adam-agent.presentation-managed-agent-transcript-page-size",
 );
@@ -651,6 +654,9 @@ export async function createPresentationSession(
     }
     const listeners = new Set<() => void>();
     let closed = false;
+    let controlObserver: AbortController | undefined;
+    let controlObserverParent: string | undefined;
+    let controlObservation = Promise.resolve();
     const publishStateChange = (): void => {
       for (const listener of listeners) {
         try {
@@ -660,6 +666,33 @@ export async function createPresentationSession(
         }
       }
     };
+    const observeManagedControl = async (parentSessionId: string) => {
+      if (controlObserverParent === parentSessionId) return;
+      controlObserver?.abort();
+      const observer = new AbortController();
+      controlObserver = observer;
+      controlObserverParent = parentSessionId;
+      const control = await options.lifecycle[sessionManagedControl](parentSessionId);
+      if (control === undefined || observer.signal.aborted) return;
+      controlObservation = (async () => {
+        for await (const frame of control.observe({ parentSessionId, signal: observer.signal })) {
+          if (
+            closed ||
+            observer.signal.aborted ||
+            state.authoritative.active?.session.id !== parentSessionId
+          )
+            return;
+          state = {
+            ...state,
+            revision: state.revision + 1,
+            authoritative: { ...state.authoritative, managedControl: frame.snapshot },
+          };
+          publishStateChange();
+        }
+      })();
+      void controlObservation.catch(() => undefined);
+    };
+    if (created !== undefined) await observeManagedControl(created.sessionId);
     type TargetConnection = NonNullable<
       AuthoritativePresentationSnapshot["targets"]["items"][number]["connection"]
     >;
@@ -2279,6 +2312,31 @@ export async function createPresentationSession(
           message: "The presentation session is closed.",
         };
       }
+      if (command.type === "managed_control") {
+        const parentSessionId = command.command.parentSessionId;
+        if (state.authoritative.active?.session.id !== parentSessionId)
+          return {
+            status: "rejected",
+            code: "stale_revision",
+            message: "The selected parent Session is no longer active.",
+          };
+        const control = await options.lifecycle[sessionManagedControl](parentSessionId);
+        if (control === undefined)
+          return {
+            status: "rejected",
+            code: "action_unavailable",
+            message: "Managed control is unavailable for this Session.",
+          };
+        await observeManagedControl(parentSessionId);
+        const receipt = await control.dispatch(command.command);
+        if (receipt.status === "rejected") return receipt;
+        return {
+          status: "admitted",
+          commandId: command.commandId,
+          resource: null,
+          control: receipt,
+        };
+      }
       if (
         command.type === "refresh_managed_agents" ||
         command.type === "cancel_managed_agent" ||
@@ -2343,7 +2401,12 @@ export async function createPresentationSession(
             resource: null,
             ...(managedAgentControl === undefined ? {} : { managedAgentControl }),
           };
-        } catch {
+        } catch (error) {
+          if (
+            error instanceof SessionLifecycleError &&
+            error.code === "session_managed_control_read_only"
+          )
+            return { status: "rejected", code: "action_unavailable", message: error.message };
           return {
             status: "rejected",
             code: "authority_rejected",
@@ -4790,6 +4853,8 @@ export async function createPresentationSession(
         }
         await persistSettledCurrentTurnDraft();
         closed = true;
+        controlObserver?.abort();
+        await controlObservation;
         activeRun?.controller.abort();
         const connectionSettlements = [...activeConnectionTests.values()].flatMap((active) =>
           active.settlement === undefined ? [] : [active.settlement],

--- a/packages/agent/src/project-execution-domain.ts
+++ b/packages/agent/src/project-execution-domain.ts
@@ -42,7 +42,21 @@ export type ProjectExecutionRootClaim = {
   release(): Promise<void>;
 };
 
+export type ProjectExecutionScope =
+  | {
+      readonly kind: "main_run" | "control" | "reviewer";
+      readonly sessionId: string;
+      readonly identity: string;
+    }
+  | {
+      readonly kind: "child_attempt";
+      readonly sessionId: string;
+      readonly threadId: string;
+      readonly identity: string;
+    };
+
 export type ProjectExecutionDomain = {
+  claimScope(input: ProjectExecutionScope): Promise<ProjectExecutionChildClaim>;
   claimRoot(input: { readonly rootId: string }): Promise<ProjectExecutionRootClaim>;
   runRoot<T>(input: { readonly rootId: string }, operation: () => Promise<T>): Promise<T>;
   close(): Promise<void>;
@@ -61,6 +75,7 @@ export function createProjectExecutionDomain(options: {
   let closePromise: Promise<void> | undefined;
   let resolveClose: (() => void) | undefined;
   let rejectClose: ((error: unknown) => void) | undefined;
+  const scopes = new Map<string, symbol>();
 
   const releaseClaim = async () => {
     claimCount -= 1;
@@ -96,12 +111,43 @@ export function createProjectExecutionDomain(options: {
   };
 
   const domain: ProjectExecutionDomain = {
+    async claimScope(input) {
+      const key = JSON.stringify(
+        input.kind === "child_attempt"
+          ? [input.kind, input.sessionId, input.threadId]
+          : input.kind === "main_run"
+            ? [input.kind, input.sessionId]
+            : [input.kind, input.sessionId, input.identity],
+      );
+      if (scopes.has(key)) throw new ProjectExecutionDomainError("root_conflict");
+      const identity = Symbol(input.identity);
+      scopes.set(key, identity);
+      let root: ProjectExecutionRootClaim;
+      try {
+        root = await domain.claimRoot({ rootId: projectRuntimeRootId });
+      } catch (error) {
+        if (scopes.get(key) === identity) scopes.delete(key);
+        throw error;
+      }
+      let release: Promise<void> | undefined;
+      return {
+        childId: input.identity,
+        release() {
+          release ??= (async () => {
+            await root.release();
+            if (scopes.get(key) === identity) scopes.delete(key);
+          })();
+          return release;
+        },
+      };
+    },
     async claimRoot({ rootId }) {
       if (closed) {
         throw new ProjectExecutionDomainError("domain_closed");
       }
       if (finalReleasePromise !== undefined) {
-        throw new ProjectExecutionDomainError("root_conflict");
+        await finalReleasePromise;
+        if (closed) throw new ProjectExecutionDomainError("domain_closed");
       }
       if (activeRootId !== undefined && activeRootId !== rootId) {
         throw new ProjectExecutionDomainError("root_conflict");

--- a/packages/agent/src/session-history-replay.ts
+++ b/packages/agent/src/session-history-replay.ts
@@ -8,6 +8,7 @@ import { SessionLifecycleError } from "./session-lifecycle-error.js";
 import type {
   SessionLogicalRunStartedRecord,
   SessionModelResponseField,
+  SessionProviderAttemptStartedRecord,
   SessionRecord,
 } from "./session-store.js";
 import {
@@ -56,6 +57,18 @@ export function modelMessagesFromCanonicalRecords(
 ): ModelMessage[] {
   const messages: ModelMessage[] = [];
   for (const record of currentRecords) {
+    if (
+      record.record.type === "provider_attempt_started" &&
+      record.record.managedAgentDeliveryVersion === 3
+    ) {
+      messages.push(
+        ...managedDeliveryMessagesFromReceipt(
+          currentRecords,
+          record as SessionProviderAttemptStartedRecord,
+        ),
+      );
+      continue;
+    }
     if (record.record.type === "logical_run_started") {
       messages.push(createLogicalRunUserMessageV1(record.record));
       continue;
@@ -101,6 +114,28 @@ export function modelMessagesFromCanonicalRecords(
     }
   }
   return messages;
+}
+
+export function managedDeliveryMessagesFromReceipt(
+  records: readonly SessionRecord[],
+  receipt: SessionProviderAttemptStartedRecord,
+): ModelMessage[] {
+  if (receipt.record.managedAgentDeliveryVersion !== 3) return [];
+  const deliveries = receipt.record.managedAgentDeliveries ?? [];
+  return deliveries.map((delivery, index) => {
+    const message = records.find(
+      (record) => record.sequence === receipt.sequence - deliveries.length + index,
+    );
+    if (
+      message?.schemaVersion !== 3 ||
+      message.record.type !== "runtime_event" ||
+      message.record.event.type !== "user_message" ||
+      message.record.runId !== receipt.record.runId ||
+      !message.record.event.text.startsWith(`Parent message (${delivery.id}): `)
+    )
+      throw new SessionLifecycleError("session_invalid");
+    return { role: "user", content: message.record.event.text };
+  });
 }
 
 export function createLogicalRunUserMessageV1(

--- a/packages/agent/src/session-history-validation.ts
+++ b/packages/agent/src/session-history-validation.ts
@@ -132,6 +132,33 @@ export function validateCurrentSessionHistory(
     throw new SessionLifecycleError("session_invalid");
   }
   const currentRecords = records.filter((record) => record.schemaVersion === 3);
+  const managedDeliveryMessageSequences = new Set<number>();
+  const managedDeliveryIds = new Set<string>();
+  for (const [index, entry] of currentRecords.entries()) {
+    if (
+      entry.record.type !== "provider_attempt_started" ||
+      entry.record.managedAgentDeliveryVersion !== 3
+    )
+      continue;
+    const deliveries = entry.record.managedAgentDeliveries ?? [];
+    if (deliveries.length === 0 || deliveries.length > 32 || index < deliveries.length)
+      throw new SessionLifecycleError("session_invalid");
+    for (const [offset, delivery] of deliveries.entries()) {
+      const message = currentRecords[index - deliveries.length + offset];
+      if (
+        message?.record.type !== "runtime_event" ||
+        message.record.runId !== entry.record.runId ||
+        message.record.event.type !== "user_message" ||
+        !message.record.event.text.startsWith(`Parent message (${delivery.id}): `) ||
+        delivery.messageDigest !==
+          `sha256:${createHash("sha256").update(message.record.event.text, "utf8").digest("hex")}` ||
+        managedDeliveryIds.has(delivery.id)
+      )
+        throw new SessionLifecycleError("session_invalid");
+      managedDeliveryIds.add(delivery.id);
+      managedDeliveryMessageSequences.add(message.sequence);
+    }
+  }
   let run: SessionLogicalRunStartedRecord["record"] | undefined;
   let attemptState: ValidatedAttemptState | undefined;
   let sawUserMessage = false;
@@ -1649,6 +1676,11 @@ export function validateCurrentSessionHistory(
     }
     const event = record.event;
     if (event.type === "user_message") {
+      if (managedDeliveryMessageSequences.has(entry.sequence)) {
+        if (!sawUserMessage || terminalIntent !== undefined || attemptState?.status === "started")
+          throw new SessionLifecycleError("session_invalid");
+        continue;
+      }
       if (
         terminalIntent !== undefined ||
         sawUserMessage ||

--- a/packages/agent/src/session-lifecycle-error.ts
+++ b/packages/agent/src/session-lifecycle-error.ts
@@ -2,6 +2,7 @@ export class SessionLifecycleError extends Error {
   readonly code:
     | "session_branch_boundary_invalid"
     | "session_invalid"
+    | "session_managed_control_read_only"
     | "session_model_target_incompatible"
     | "session_model_target_unavailable"
     | "session_user_configuration_invalid"
@@ -70,6 +71,8 @@ function sessionLifecycleErrorMessage(code: SessionLifecycleError["code"]): stri
       return "The OS-backed project lifecycle owner is unavailable.";
     case "session_branch_boundary_invalid":
       return "The requested branch position is not a complete session boundary.";
+    case "session_managed_control_read_only":
+      return "Historical agent controls are read-only. Start a new current Session to delegate work.";
     case "session_invalid":
       return "The session history is invalid.";
     case "session_model_target_incompatible":

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -3,7 +3,11 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { z } from "zod";
-import { AgentSession, managedAgentPromptSummary } from "./agent-session.js";
+import {
+  AgentSession,
+  managedAgentPromptSummary,
+  managedAgentRequestBoundary,
+} from "./agent-session.js";
 import type {
   ModelDriver,
   ModelMessage,
@@ -49,9 +53,15 @@ import {
   type ManagedAgentResearchContext,
   type ManagedAgentSnapshot,
   type ManagedAgentStore,
+  managedAgentSnapshotFromRecords,
   managedAgentSnapshotWithChildHistories,
   recoverInterruptedManagedAgents,
 } from "./managed-agent.js";
+import {
+  createManagedAgentControl,
+  type ManagedAgentControl,
+  managedControlMainRequestBoundary,
+} from "./managed-agent-control.js";
 import { createJsonlManagedAgentStore } from "./managed-agent-store.js";
 import {
   createMcpRuntimeHost,
@@ -169,6 +179,7 @@ import {
 import {
   createLogicalRunUserMessageV1,
   inlineModelResponseField,
+  managedDeliveryMessagesFromReceipt,
   modelMessagesFromCompleteRecords,
 } from "./session-history-replay.js";
 import {
@@ -429,7 +440,14 @@ export type WorkspaceMcpLeaseTransitionBarrier = {
   waitingForRelease(): Promise<void> | void;
 };
 
+/** Internal candidate composition; the default entry remains unchanged until cutover. */
+export const sessionManagedControl = Symbol("adam-agent.session-managed-control");
+
 export type SessionLifecycleOptions = {
+  readonly [sessionManagedControl]?: {
+    readonly store: import("./managed-agent-folds.js").ManagedControlStore;
+    readonly childSessionStores: SessionStoreDirectory<SessionRecord>;
+  };
   readonly extensionHost?: ExtensionHost;
   readonly modelTargets?: ModelTargets;
   readonly managedAgentTools?:
@@ -723,6 +741,9 @@ export type SessionCommand =
   | McpConfigurationCommand;
 
 export interface SessionLifecycle {
+  readonly [sessionManagedControl]: (
+    sessionId: string,
+  ) => Promise<import("./managed-agent-control.js").ManagedAgentControl | undefined>;
   readonly [sessionManagedAgentTranscriptReader]: (input: {
     readonly sessionId: string;
     readonly agentId: string;
@@ -1171,9 +1192,13 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
   };
   const managedAgentStore: ManagedAgentStore = {
     async append(record) {
+      if (options[sessionManagedControl] !== undefined)
+        throw new SessionLifecycleError("session_managed_control_read_only");
       return (await resolveManagedAgentStore()).append(record);
     },
     async read() {
+      if (options[sessionManagedControl] !== undefined)
+        return options[sessionManagedControl].store.readLegacy();
       return (await resolveManagedAgentStore()).read();
     },
   };
@@ -1182,6 +1207,63 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     stateRoot: join(effectiveSessionStateRoot(options.stateRoot), "managed-child-sessions"),
   });
   const activeAgentManagers = new Map<string, AgentManager>();
+  const managedControls = new Map<string, Promise<ManagedAgentControl | undefined>>();
+  const resolveManagedControl = async (
+    sessionId: string,
+  ): Promise<ManagedAgentControl | undefined> => {
+    const composition = options[sessionManagedControl];
+    if (composition === undefined || lifecycleClosing) return undefined;
+    let pending = managedControls.get(sessionId);
+    if (pending === undefined) {
+      pending = (async () => {
+        const snapshot = await inspectSession({ sessionId });
+        const records = await readSessionRecords(options, sessionId);
+        const genesis = records[0];
+        if (
+          snapshot.schemaVersion !== 3 ||
+          genesis === undefined ||
+          !isGenesisRecord(genesis) ||
+          options.modelTargets === undefined
+        )
+          throw new SessionLifecycleError("session_invalid");
+        if (genesis.record.managedAgentTools !== undefined) return undefined;
+        const resolved = await options.modelTargets.resolve({
+          targetId: snapshot.targetIdentity.targetId,
+          targetIdentity: snapshot.targetIdentity,
+          allowExperimental: snapshot.targetIdentity.certification === "experimental",
+          signal: new AbortController().signal,
+        });
+        const contextProfile = historicalContextProfile(
+          genesis,
+          contextSnapshotFromRecords(records)?.profile,
+          resolved.contextProfile,
+        );
+        if (
+          !sameModelTargetIdentity(resolved.identity, snapshot.targetIdentity) ||
+          !isHistoricalContextProfileSupported(resolved.contextProfile, contextProfile)
+        )
+          throw new SessionLifecycleError("session_model_target_incompatible");
+        return createManagedAgentControl({
+          parentSessionId: sessionId,
+          projectId: snapshot.projectId as `sha256:${string}`,
+          workspaceRoot: options.workspaceRoot,
+          targetIdentity: snapshot.targetIdentity,
+          contextProfile,
+          model: resolved.driver,
+          permissions: options.permissions ?? createPermissionPolicy({ allowedEffects: [] }),
+          executionDomain,
+          store: composition.store,
+          childSessionStores: composition.childSessionStores,
+          parentSessionStore: await openSessionStore(options, sessionId),
+        });
+      })();
+      managedControls.set(sessionId, pending);
+      void pending.catch(() => {
+        if (managedControls.get(sessionId) === pending) managedControls.delete(sessionId);
+      });
+    }
+    return pending;
+  };
   const toolsForSession = async (
     sessionId: string,
     targetIdentity: ModelTargetIdentity,
@@ -1242,6 +1324,11 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       }
       return baseWithWeb;
     }
+    if (options[sessionManagedControl] !== undefined)
+      return combineToolRegistries(
+        baseWithWeb,
+        createManagedAgentToolRegistry({ readOnly: true, profile: managedAgentTools }),
+      );
     const managerRouter: AgentManager = {
       parentRootId: `session:${sessionId}`,
       parentSessionId: sessionId,
@@ -1527,16 +1614,34 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     rootId = projectRuntimeRootId,
   ): Promise<T> => {
     const active = coordinatingOwnerOperation;
-    if (active !== undefined && (kind === "title" || active.kind === "title")) {
+    if (
+      active !== undefined &&
+      (kind === "title" ||
+        (active.kind === "title" && options[sessionManagedControl] === undefined))
+    ) {
       await active.settlement;
     }
-    const operationPromise = executionDomain.claimRoot({ rootId }).then(async (rootClaim) => {
-      try {
-        return await operation(rootClaim);
-      } finally {
-        await rootClaim.release();
-      }
-    });
+    const managedMain =
+      options[sessionManagedControl] !== undefined &&
+      kind === "ordinary" &&
+      rootId.startsWith("session:");
+    const operationPromise = executionDomain
+      .claimRoot({ rootId: managedMain ? projectRuntimeRootId : rootId })
+      .then(async (rootClaim) => {
+        let mainClaim: Awaited<ReturnType<typeof executionDomain.claimScope>> | undefined;
+        try {
+          if (managedMain)
+            mainClaim = await executionDomain.claimScope({
+              kind: "main_run",
+              sessionId: rootId.slice("session:".length),
+              identity: randomUUID(),
+            });
+          return await operation(rootClaim);
+        } finally {
+          await mainClaim?.release();
+          await rootClaim.release();
+        }
+      });
     const tracked = {
       kind,
       settlement: operationPromise.then(
@@ -3023,6 +3128,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
   };
 
   return {
+    [sessionManagedControl]: resolveManagedControl,
     async admit(input) {
       const runId = input.runId ?? randomUUID();
       if (
@@ -3509,6 +3615,21 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           throw new SessionLifecycleError("project_owner_unavailable");
         }
         activeAgentManagers.clear();
+        const controlSettlements = await Promise.allSettled(
+          [...managedControls].map(
+            async ([parentSessionId, control]) =>
+              (await control)?.dispatch({ type: "close", parentSessionId }) ?? {
+                status: "closed" as const,
+              },
+          ),
+        );
+        if (
+          controlSettlements.some(
+            (result) => result.status === "rejected" || result.value.status !== "closed",
+          )
+        )
+          throw new SessionLifecycleError("project_owner_unavailable");
+        managedControls.clear();
         await Promise.allSettled(pendingMcpCatalogDurability.values());
         for (const timer of mcpIdleTimers.values()) {
           timer.cancel();
@@ -3676,6 +3797,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             throw new SessionLifecycleError("session_recovery_required");
         }
         if (
+          options[sessionManagedControl] === undefined &&
           options.managedAgentTools !== undefined &&
           !(
             isLongLivedManagedAgentTools(options.managedAgentTools) &&
@@ -4280,7 +4402,16 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           first.record.managedAgentTools,
           first.record.webEvidence,
         );
+        const managedControl = await resolveManagedControl(input.sessionId);
         const sessionDependencies = {
+          ...(managedControl === undefined
+            ? {}
+            : {
+                [managedAgentRequestBoundary]: managedControlMainRequestBoundary(
+                  managedControl,
+                  input.sessionId,
+                ),
+              }),
           artifactStore,
           model: resolved.driver,
           store: store as unknown as SessionStore,
@@ -4423,68 +4554,70 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         });
         const existingAgentManager = activeAgentManagers.get(input.sessionId);
         const agentManager =
-          isLongLivedManagedAgentTools(first.record.managedAgentTools) &&
-          existingAgentManager !== undefined
-            ? existingAgentManager
-            : createAgentManager({
-                artifactStore,
-                childContextProfile: resolved.contextProfile,
-                childModel: resolved.driver,
-                builtInProfileVersion: managedAgentToolsVersion(first.record.managedAgentTools),
-                childSessionStores: managedChildSessionStores,
-                managedStore: managedAgentStore,
-                ...(options[sessionManagedAgentInactivityScheduler] === undefined
-                  ? {}
-                  : {
-                      inactivityScheduler: options[sessionManagedAgentInactivityScheduler],
-                    }),
-                parentPermissions:
-                  options.permissions ?? createPermissionPolicy({ allowedEffects: [] }),
-                ...(hasManagedAgentCoordination(first.record.managedAgentTools)
-                  ? {
-                      parentCoordination: {
-                        interactive: () => managedAgentEventListeners.size > 0,
-                      },
-                      onChildPermissionEvent(event) {
-                        for (const listener of listeners) {
-                          listener(event);
-                        }
-                        publishManagedAgentNotification({
-                          type: "runtime_event",
-                          parentSessionId: input.sessionId,
-                          event,
-                        });
-                      },
-                    }
-                  : {}),
-                onManagedAgentStateChanged() {
-                  publishManagedAgentNotification({
-                    type: "state_changed",
-                    parentSessionId: input.sessionId,
-                  });
-                },
-                onChildRuntimeEvent(event) {
-                  publishManagedAgentNotification({
-                    type: "child_runtime_event",
-                    parentSessionId: input.sessionId,
-                    ...event,
-                  });
-                },
-                parentRoot,
-                parentSessionId: input.sessionId,
-                projectId: resumed.snapshot.projectId as `sha256:${string}`,
-                ...(activePromptContext === undefined
-                  ? {}
-                  : { repository: activePromptContext.repository }),
-                targetIdentity: resumed.snapshot.targetIdentity,
-                ...(effectiveThinkingPolicy === undefined
-                  ? {}
-                  : { thinkingPolicy: effectiveThinkingPolicy }),
-                workspaceRoot: options.workspaceRoot,
-              });
-        agentManager.rebindParentRoot(parentRoot);
-        agentManager.rebindResearchContext(researchContext);
-        await agentManager.snapshot();
+          options[sessionManagedControl] !== undefined
+            ? undefined
+            : isLongLivedManagedAgentTools(first.record.managedAgentTools) &&
+                existingAgentManager !== undefined
+              ? existingAgentManager
+              : createAgentManager({
+                  artifactStore,
+                  childContextProfile: resolved.contextProfile,
+                  childModel: resolved.driver,
+                  builtInProfileVersion: managedAgentToolsVersion(first.record.managedAgentTools),
+                  childSessionStores: managedChildSessionStores,
+                  managedStore: managedAgentStore,
+                  ...(options[sessionManagedAgentInactivityScheduler] === undefined
+                    ? {}
+                    : {
+                        inactivityScheduler: options[sessionManagedAgentInactivityScheduler],
+                      }),
+                  parentPermissions:
+                    options.permissions ?? createPermissionPolicy({ allowedEffects: [] }),
+                  ...(hasManagedAgentCoordination(first.record.managedAgentTools)
+                    ? {
+                        parentCoordination: {
+                          interactive: () => managedAgentEventListeners.size > 0,
+                        },
+                        onChildPermissionEvent(event) {
+                          for (const listener of listeners) {
+                            listener(event);
+                          }
+                          publishManagedAgentNotification({
+                            type: "runtime_event",
+                            parentSessionId: input.sessionId,
+                            event,
+                          });
+                        },
+                      }
+                    : {}),
+                  onManagedAgentStateChanged() {
+                    publishManagedAgentNotification({
+                      type: "state_changed",
+                      parentSessionId: input.sessionId,
+                    });
+                  },
+                  onChildRuntimeEvent(event) {
+                    publishManagedAgentNotification({
+                      type: "child_runtime_event",
+                      parentSessionId: input.sessionId,
+                      ...event,
+                    });
+                  },
+                  parentRoot,
+                  parentSessionId: input.sessionId,
+                  projectId: resumed.snapshot.projectId as `sha256:${string}`,
+                  ...(activePromptContext === undefined
+                    ? {}
+                    : { repository: activePromptContext.repository }),
+                  targetIdentity: resumed.snapshot.targetIdentity,
+                  ...(effectiveThinkingPolicy === undefined
+                    ? {}
+                    : { thinkingPolicy: effectiveThinkingPolicy }),
+                  workspaceRoot: options.workspaceRoot,
+                });
+        agentManager?.rebindParentRoot(parentRoot);
+        agentManager?.rebindResearchContext(researchContext);
+        await agentManager?.snapshot();
         const session = new AgentSession(sessionDependencies);
         let resolveSessionSettlement = () => {};
         const sessionSettlement = new Promise<void>((resolve) => {
@@ -4515,7 +4648,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         });
         activeSession = session;
         activeSessionSettlement = sessionSettlement;
-        if (first.record.managedAgentTools !== undefined) {
+        if (first.record.managedAgentTools !== undefined && agentManager !== undefined) {
           activeAgentManagers.set(input.sessionId, agentManager);
         }
         try {
@@ -5266,6 +5399,20 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       return inspectSession(input);
     },
     async inspectManagedAgents(input) {
+      if (options[sessionManagedControl] !== undefined) {
+        const snapshot = managedAgentSnapshotFromRecords(
+          await managedAgentStore.read(),
+          input.sessionId,
+        );
+        const agents = snapshot.agents.map((agent) => ({
+          ...agent,
+          readOnly: true as const,
+          ...(isManagedAgentActiveStatus(agent.status)
+            ? { status: "recovery_required" as const, phase: "terminal" as const }
+            : {}),
+        }));
+        return { agents, counts: { active: 0, terminal: agents.length, attention: 0 } };
+      }
       const manager = activeAgentManagers.get(input.sessionId);
       if (manager !== undefined) {
         return manager.snapshot();
@@ -5320,6 +5467,8 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       });
     },
     async cancelManagedAgent(input) {
+      if (options[sessionManagedControl] !== undefined)
+        throw new SessionLifecycleError("session_managed_control_read_only");
       const manager = activeAgentManagers.get(input.sessionId);
       if (manager === undefined) {
         throw new SessionLifecycleError("session_invalid");
@@ -5334,6 +5483,8 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       };
     },
     async sendManagedAgentMessage(input) {
+      if (options[sessionManagedControl] !== undefined)
+        throw new SessionLifecycleError("session_managed_control_read_only");
       const manager = activeAgentManagers.get(input.sessionId);
       const sessionRecords = await readSessionRecords(options, input.sessionId);
       const genesis = sessionRecords[0];
@@ -5364,9 +5515,13 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       };
     },
     async followUpManagedAgent(input) {
+      if (options[sessionManagedControl] !== undefined)
+        throw new SessionLifecycleError("session_managed_control_read_only");
       return continueManagedAgent(input, "follow_up");
     },
     async recoverManagedAgent(input) {
+      if (options[sessionManagedControl] !== undefined)
+        throw new SessionLifecycleError("session_managed_control_read_only");
       return continueManagedAgent(input, "recovery");
     },
     async [sessionManagedAgentTranscriptReader](input) {
@@ -5929,57 +6084,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         await appendDanglingAttemptInterruption(options, snapshot);
         const records = await readSessionRecords(options, input.sessionId);
         const store = await openSessionStore(options, input.sessionId);
-        let sequence = records.length + 1;
-        for (const entry of records) {
-          if (
-            entry.schemaVersion !== 3 ||
-            entry.record.type !== "runtime_event" ||
-            entry.record.runId !== input.runId ||
-            entry.record.event.type !== "tool_requested"
-          )
-            continue;
-          const call = entry.record.event;
-          if (
-            records.some(
-              (later) =>
-                later.sequence > entry.sequence &&
-                later.schemaVersion === 3 &&
-                later.record.type === "runtime_event" &&
-                later.record.runId === input.runId &&
-                (later.record.event.type === "tool_completed" ||
-                  later.record.event.type === "tool_failed") &&
-                later.record.event.callId === call.callId,
-            )
-          )
-            continue;
-          await store.append({
-            schemaVersion: 3,
-            sequence: sequence++,
-            record: {
-              type: "runtime_event",
-              runId: input.runId,
-              event: {
-                type: "tool_failed",
-                callId: call.callId,
-                name: call.name,
-                error: {
-                  code: "tool_effect_indeterminate",
-                  reason: "process_restart",
-                  message: "The interrupted tool was cancelled without replay.",
-                },
-              },
-            },
-          });
-        }
-        await store.append({
-          schemaVersion: 3,
-          sequence,
-          record: {
-            type: "runtime_event",
-            runId: input.runId,
-            event: { type: "session_interrupted", reason: "cancelled" },
-          },
-        });
+        await appendInterruptedToolCancellation(records, store, input.runId);
         snapshot = await inspectSession(input);
         if (snapshot.schemaVersion !== 3) throw new SessionLifecycleError("session_invalid");
         await settleInterruptedCancellation(options, snapshot);
@@ -6799,7 +6904,9 @@ async function validatePromptProjectionDigests(
     }
     const skillContext = skillContextRecordFromRecords(genesis, prefix);
     const activeSkillContents = await materializeActiveSkillContents(options, skillContext);
-    const ownMessages = modelMessagesFromCompleteRecords(prefix);
+    const ownMessages = modelMessagesFromCompleteRecords(
+      entry.record.managedAgentDeliveryVersion === 3 ? [...prefix, entry] : prefix,
+    );
     const transcript = prefix.some(
       (candidate) =>
         candidate.schemaVersion === 3 && candidate.record.type === "context_compaction_committed",
@@ -7524,7 +7631,7 @@ function isExactToolIntent(
   );
 }
 
-function createAgentResumeState(
+export function createAgentResumeState(
   records: readonly SessionRecord[],
   tools: ToolRegistry,
   snapshot: CurrentSessionSnapshot,
@@ -7635,6 +7742,19 @@ function createAgentResumeState(
         ),
     );
   for (const responseRecord of currentRecords) {
+    if (
+      responseRecord.record.type === "provider_attempt_started" &&
+      responseRecord.record.runId === runId &&
+      responseRecord.record.managedAgentDeliveryVersion === 3 &&
+      (contextCheckpointRecord === undefined ||
+        responseRecord.sequence > contextCheckpointRecord.sourceThrough)
+    )
+      messages.push(
+        ...managedDeliveryMessagesFromReceipt(
+          currentRecords,
+          responseRecord as import("./session-store.js").SessionProviderAttemptStartedRecord,
+        ),
+      );
     if (
       responseRecord.record.type !== "model_response_completed" ||
       responseRecord.record.runId !== runId ||
@@ -9026,4 +9146,109 @@ function draftRunLimitsAreValid(limits: RunOptions["limits"]): boolean {
     (limits?.maxTokens === undefined ||
       (Number.isSafeInteger(limits.maxTokens) && limits.maxTokens > 0))
   );
+}
+
+async function appendInterruptedToolCancellation(
+  records: readonly SessionRecord[],
+  store: SessionStore<SessionRecord>,
+  runId: string,
+): Promise<void> {
+  let sequence = records.length + 1;
+  for (const entry of records) {
+    if (
+      entry.schemaVersion !== 3 ||
+      entry.record.type !== "runtime_event" ||
+      entry.record.runId !== runId ||
+      entry.record.event.type !== "tool_requested"
+    )
+      continue;
+    const call = entry.record.event;
+    if (
+      records.some(
+        (later) =>
+          later.sequence > entry.sequence &&
+          later.schemaVersion === 3 &&
+          later.record.type === "runtime_event" &&
+          later.record.runId === runId &&
+          (later.record.event.type === "tool_completed" ||
+            later.record.event.type === "tool_failed") &&
+          later.record.event.callId === call.callId,
+      )
+    )
+      continue;
+    await store.append({
+      schemaVersion: 3,
+      sequence: sequence++,
+      record: {
+        type: "runtime_event",
+        runId: runId,
+        event: {
+          type: "tool_failed",
+          callId: call.callId,
+          name: call.name,
+          error: {
+            code: "tool_effect_indeterminate",
+            reason: "process_restart",
+            message: "The interrupted tool was cancelled without replay.",
+          },
+        },
+      },
+    });
+  }
+  await store.append({
+    schemaVersion: 3,
+    sequence,
+    record: {
+      type: "runtime_event",
+      runId: runId,
+      event: { type: "session_interrupted", reason: "cancelled" },
+    },
+  });
+}
+
+/** Package-private child cancellation, called only under the project's current control claim. */
+export async function cancelManagedChildSessionRecords(input: {
+  readonly workspaceRoot: string;
+  readonly sessionId: string;
+  readonly childSessionStores: SessionStoreDirectory<SessionRecord>;
+}): Promise<readonly SessionRecord[]> {
+  const options: SessionLifecycleOptions = {
+    workspaceRoot: input.workspaceRoot,
+    [sessionStoreDirectory]: input.childSessionStores,
+  };
+  const records = await readSessionRecords(options, input.sessionId);
+  const genesis = records[0];
+  if (genesis === undefined || !isGenesisRecord(genesis))
+    throw new SessionLifecycleError("session_invalid");
+  validateCurrentSessionHistory(genesis, records, input.workspaceRoot);
+  const snapshot = snapshotFromRecords(genesis, records);
+  if (snapshot.status === "idle" && snapshot.run === undefined) return records;
+  if (snapshot.run?.result?.status === "cancelled") return records;
+  if (snapshot.status !== "interrupted" || snapshot.run === undefined)
+    throw new SessionLifecycleError("session_invalid");
+  await appendDanglingAttemptInterruption(options, snapshot);
+  const latest = await readSessionRecords(options, input.sessionId);
+  const store = await openSessionStore(options, input.sessionId);
+  await appendInterruptedToolCancellation(latest, store, snapshot.run.runId);
+  await settleInterruptedCancellation(options, snapshot);
+  return readSessionRecords(options, input.sessionId);
+}
+
+/** Reconcile a recorded child terminal intent under the caller's existing control claim. */
+export async function settleManagedChildTerminalIntent(input: {
+  readonly workspaceRoot: string;
+  readonly sessionId: string;
+  readonly childSessionStores: SessionStoreDirectory<SessionRecord>;
+}): Promise<readonly SessionRecord[]> {
+  const options: SessionLifecycleOptions = {
+    workspaceRoot: input.workspaceRoot,
+    [sessionStoreDirectory]: input.childSessionStores,
+  };
+  const records = await readSessionRecords(options, input.sessionId);
+  const genesis = records[0];
+  if (genesis === undefined || !isGenesisRecord(genesis))
+    throw new SessionLifecycleError("session_invalid");
+  validateCurrentSessionHistory(genesis, records, input.workspaceRoot);
+  await settleRunTerminalIntent(options, snapshotFromRecords(genesis, records));
+  return readSessionRecords(options, input.sessionId);
 }

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -764,9 +764,11 @@ export type SessionProviderAttemptStartedRecord = {
     readonly turn: number;
     readonly attempt: number;
     readonly targetIdentity: ModelTargetIdentity;
+    readonly managedAgentDeliveryVersion?: 3;
     readonly managedAgentDeliveries?: readonly {
       readonly id: Sha256Digest;
       readonly digest: Sha256Digest;
+      readonly messageDigest?: Sha256Digest;
     }[];
     readonly promptProjection?: {
       readonly version: 1;
@@ -777,6 +779,13 @@ export type SessionProviderAttemptStartedRecord = {
     };
     readonly projectedContent?: ProjectedContentUsageV1;
   };
+};
+
+export type SessionPartialOutputV1 = {
+  readonly version: 1;
+  readonly text: string;
+  readonly byteCount: number;
+  readonly truncated: boolean;
 };
 
 export type SessionProviderAttemptInterruptedRecord = {
@@ -790,7 +799,11 @@ export type SessionProviderAttemptInterruptedRecord = {
   } & (
     | { readonly reason: "process_restart"; readonly result?: never }
     | { readonly reason: "context_overflow"; readonly result?: never }
-    | { readonly reason: "run_terminal"; readonly result: RunResult }
+    | {
+        readonly reason: "run_terminal";
+        readonly result: RunResult;
+        readonly partialOutput?: SessionPartialOutputV1;
+      }
   );
 };
 
@@ -2925,38 +2938,53 @@ const sessionV3RecordSchema = z.union([
       height: z.number().int().positive().max(4_096),
     }),
   }),
-  z.strictObject({
-    type: z.literal("provider_attempt_started"),
-    runId: z.uuid(),
-    turn: z.number().int().positive(),
-    attempt: z.number().int().positive(),
-    targetIdentity: modelTargetIdentitySchema,
-    managedAgentDeliveries: z
-      .array(
-        z.strictObject({
-          id: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
-          digest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
-        }),
-      )
-      .max(5)
-      .optional(),
-    promptProjection: z
-      .strictObject({
-        version: z.literal(1),
-        assemblyIdentityDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
-        requestProjectionDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
-        managedAgentSummary: z
-          .string()
-          .refine((value) => Buffer.byteLength(value, "utf8") <= 1024)
-          .optional(),
-        approvedPlanProjectionDigest: z
-          .string()
-          .regex(/^sha256:[0-9a-f]{64}$/u)
-          .optional(),
-      })
-      .optional(),
-    projectedContent: projectedContentUsageV1Schema.optional(),
-  }),
+  z
+    .strictObject({
+      type: z.literal("provider_attempt_started"),
+      runId: z.uuid(),
+      turn: z.number().int().positive(),
+      attempt: z.number().int().positive(),
+      targetIdentity: modelTargetIdentitySchema,
+      managedAgentDeliveryVersion: z.literal(3).optional(),
+      managedAgentDeliveries: z
+        .array(
+          z.strictObject({
+            id: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+            digest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+            messageDigest: z
+              .string()
+              .regex(/^sha256:[0-9a-f]{64}$/u)
+              .optional(),
+          }),
+        )
+        .max(32)
+        .optional(),
+      promptProjection: z
+        .strictObject({
+          version: z.literal(1),
+          assemblyIdentityDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+          requestProjectionDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),
+          managedAgentSummary: z
+            .string()
+            .refine((value) => Buffer.byteLength(value, "utf8") <= 1024)
+            .optional(),
+          approvedPlanProjectionDigest: z
+            .string()
+            .regex(/^sha256:[0-9a-f]{64}$/u)
+            .optional(),
+        })
+        .optional(),
+      projectedContent: projectedContentUsageV1Schema.optional(),
+    })
+    .refine((record) =>
+      record.managedAgentDeliveryVersion === 3
+        ? (record.managedAgentDeliveries?.length ?? 0) > 0 &&
+          record.managedAgentDeliveries?.every((delivery) => delivery.messageDigest !== undefined)
+        : (record.managedAgentDeliveries?.length ?? 0) <= 5 &&
+          record.managedAgentDeliveries?.every(
+            (delivery) => delivery.messageDigest === undefined,
+          ) !== false,
+    ),
   z.strictObject({
     type: z.literal("repository_instructions_committed"),
     recordVersion: z.literal(1),
@@ -2990,14 +3018,29 @@ const sessionV3RecordSchema = z.union([
       })
       .optional(),
   }),
-  z.strictObject({
-    type: z.literal("provider_attempt_interrupted"),
-    runId: z.uuid(),
-    turn: z.number().int().positive(),
-    attempt: z.number().int().positive(),
-    reason: z.enum(["process_restart", "context_overflow", "run_terminal"]),
-    result: runResultSchema.optional(),
-  }),
+  z
+    .strictObject({
+      type: z.literal("provider_attempt_interrupted"),
+      runId: z.uuid(),
+      turn: z.number().int().positive(),
+      attempt: z.number().int().positive(),
+      reason: z.enum(["process_restart", "context_overflow", "run_terminal"]),
+      result: runResultSchema.optional(),
+      partialOutput: z
+        .strictObject({
+          version: z.literal(1),
+          text: z.string().refine((text) => Buffer.byteLength(text, "utf8") <= 16 * 1024),
+          byteCount: z.number().int().nonnegative(),
+          truncated: z.boolean(),
+        })
+        .refine(
+          (partial) =>
+            partial.byteCount >= Buffer.byteLength(partial.text, "utf8") &&
+            partial.truncated === partial.byteCount > Buffer.byteLength(partial.text, "utf8"),
+        )
+        .optional(),
+    })
+    .refine((record) => record.partialOutput === undefined || record.reason === "run_terminal"),
   z.strictObject({
     type: z.literal("model_response_completed"),
     runId: z.uuid(),

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -922,6 +922,7 @@ export type TurnComposerDisplay = {
 };
 
 export type AuthoritativePresentationSnapshot = {
+  readonly managedControl?: ManagedWorkspaceSnapshot;
   readonly schemaVersion: 1;
   readonly continuity:
     | {
@@ -942,6 +943,7 @@ export type AuthoritativePresentationSnapshot = {
       readonly attention: number;
     };
     readonly agents: readonly {
+      readonly readOnly?: true;
       readonly agentId: string;
       readonly attemptId: string;
       readonly profile: "scout.v1" | "scout.v2" | "research.v1" | "research.v2";
@@ -1154,6 +1156,7 @@ export type CommandReceipt =
       readonly draftText?: string;
       readonly todo?: TodoPageResource | TodoEntityResource;
       readonly managedAgentTranscript?: ManagedAgentTranscriptPageResource;
+      readonly control?: ManagedControlReceipt;
       readonly managedAgentControl?: {
         readonly action: "message" | "reply" | "cancel" | "follow_up" | "recovery";
         readonly agentId: string;
@@ -1176,6 +1179,11 @@ export type CommandReceipt =
         | "conflict"
         | "invalid_command"
         | "authority_rejected"
+        | "stale_revision"
+        | "authority_busy"
+        | "action_unavailable"
+        | "recovery_required"
+        | "runtime_unavailable"
         | "persistence_failed"
         | "presentation_closed";
       readonly message: string;
@@ -1229,6 +1237,11 @@ export type ManagedAgentTranscriptPageResource = {
 };
 
 export type PresentationCommand =
+  | {
+      readonly type: "managed_control";
+      readonly commandId: string;
+      readonly command: ManagedControlCommand;
+    }
   | { readonly type: "refresh_managed_agents"; readonly sessionId: string }
   | {
       readonly type: "read_managed_agent_transcript";
@@ -1610,3 +1623,143 @@ export function reconcilePresentationUpdate(
     },
   };
 }
+
+export type ManagedControlIdentity = {
+  readonly parentSessionId: string;
+  readonly threadId: string;
+  readonly turnId: string;
+  readonly attemptId: string;
+  readonly childSessionId: string;
+};
+
+export type ManagedControlLink = {
+  readonly sequence: number;
+  readonly digest: `sha256:${string}`;
+};
+
+export type ManagedControlOutcome = {
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+    readonly reasoningTokens: number;
+    readonly providerCalls: number;
+    readonly unknownCalls: number;
+  };
+  readonly type: "outcome";
+  readonly status: "completed" | "failed" | "cancelled" | "interrupted";
+  readonly summary: string;
+  readonly transcript: ManagedControlLink;
+  readonly error?: { readonly code: string; readonly message: string };
+};
+
+export type ManagedControlThread = {
+  readonly parentSessionId: string;
+  readonly lifecycle: "open" | "closed";
+  readonly displayName: string;
+  readonly handle: string;
+  readonly residency: "live" | "unloaded";
+  readonly threadId: string;
+  readonly role: "builtin:explore";
+  readonly description: string;
+  readonly turn: {
+    readonly turnId: string;
+    readonly attemptId: string;
+    readonly childSessionId: string;
+    readonly phase: "starting" | "executing" | "settling" | "idle" | "waiting";
+    readonly waitReason: "none" | "suspended";
+    readonly ownerPhase: "waiting" | "claimed" | "releasing" | "released";
+    readonly lastOutcome: "none" | "completed" | "failed" | "cancelled" | "interrupted";
+    readonly label: string;
+    readonly recovery: "none" | "required";
+    readonly health: "healthy" | "stalled";
+    readonly watchdog?: {
+      readonly deadlineId: string;
+      readonly maximumInactivityMilliseconds: 300_000;
+      readonly lastProgressAtUnixMilliseconds: number;
+      readonly transcript: ManagedControlLink;
+      readonly state: "running" | "stopped" | "stalled";
+    };
+    readonly diagnostic?: string;
+    readonly outcome?: ManagedControlOutcome;
+  };
+};
+
+export type ManagedWorkspaceSnapshot = {
+  readonly completions: readonly {
+    readonly id: `sha256:${string}`;
+    readonly threadId: string;
+    readonly turnId: string;
+    readonly receipt: ManagedControlLink;
+    readonly outcome: ManagedControlOutcome;
+    readonly consumption: "pending" | "consumed";
+  }[];
+  readonly status: "ready" | "recovery_required" | "runtime_unavailable";
+  readonly diagnostic?: string;
+  readonly parentSessionId: string;
+  readonly revision: number;
+  readonly threads: readonly ManagedControlThread[];
+};
+
+export type ManagedControlCommand =
+  | { readonly type: "prepare_main_delivery"; readonly parentSessionId: string }
+  | {
+      readonly type: "acknowledge_main_delivery";
+      readonly parentSessionId: string;
+      readonly deliveries: readonly {
+        readonly id: `sha256:${string}`;
+        readonly digest: `sha256:${string}`;
+      }[];
+    }
+  | {
+      readonly type: "cancel_turn";
+      readonly parentSessionId: string;
+      readonly threadId: string;
+      readonly expectedTurnId: string;
+    }
+  | {
+      readonly type: "start_thread";
+      readonly parentSessionId: string;
+      readonly role: "builtin:explore";
+      readonly task: string;
+      readonly description: string;
+    }
+  | {
+      readonly type: "next_turn";
+      readonly parentSessionId: string;
+      readonly threadId: string;
+      readonly expectedTurnId: string;
+      readonly task: string;
+    }
+  | {
+      readonly type: "recover_turn";
+      readonly parentSessionId: string;
+      readonly threadId: string;
+      readonly expectedTurnId: string;
+    }
+  | { readonly type: "close"; readonly parentSessionId: string };
+
+export type ManagedControlReceipt =
+  | {
+      readonly status: "delivery";
+      readonly messages: readonly { readonly id: `sha256:${string}`; readonly text: string }[];
+      readonly deliveries: readonly {
+        readonly id: `sha256:${string}`;
+        readonly digest: `sha256:${string}`;
+      }[];
+    }
+  | { readonly status: "acknowledged" }
+  | { readonly status: "cancelled"; readonly turnId: string }
+  | ({ readonly status: "accepted" } & ManagedControlIdentity)
+  | { readonly status: "closed" }
+  | { readonly status: "recovered" }
+  | {
+      readonly status: "rejected";
+      readonly code:
+        | "stale_revision"
+        | "authority_busy"
+        | "action_unavailable"
+        | "recovery_required"
+        | "persistence_failed"
+        | "runtime_unavailable";
+      readonly message: string;
+    };

--- a/packages/testkit/src/managed-agent-control-owner.fixture.ts
+++ b/packages/testkit/src/managed-agent-control-owner.fixture.ts
@@ -1,0 +1,195 @@
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { AgentSession, createPermissionPolicy, ModelDriverError } from "@adam-agent/agent";
+import {
+  createJsonlManagedAgentControlStore,
+  createJsonlSessionStoreDirectory,
+  createManagedAgentControl,
+  createProjectExecutionDomain,
+  createProjectLifecycleOwner,
+  createPromptContextV1,
+  managedAgentRecordBarrier,
+  managedAgentRequestBoundary,
+  managedControlMainRequestBoundary,
+  type SessionStore,
+  sessionDurableContext,
+  sessionRecordCommittedBarrier,
+} from "@adam-agent/agent/internal-testing";
+
+const { ADAM_CONTROL_FIXTURE_ROOT: workspaceRoot, ADAM_CONTROL_FIXTURE_PHASE: phase } = process.env;
+if (workspaceRoot === undefined || phase === undefined)
+  throw new Error("Missing fixture configuration.");
+const stateRoot = join(workspaceRoot, "state");
+const domain = createProjectExecutionDomain({
+  lifecycleOwner: createProjectLifecycleOwner({ workspaceRoot, stateRoot }),
+});
+const parentSessionId = "123e4567-e89b-42d3-a456-426614174601";
+let expireInactivity: (() => void) | undefined;
+const parentStore =
+  phase === "main_receipt" || phase === "consumed"
+    ? await createJsonlSessionStoreDirectory({
+        workspaceRoot,
+        stateRoot: join(workspaceRoot, "parents"),
+      }).create(parentSessionId)
+    : undefined;
+const controlOptions: Parameters<typeof createManagedAgentControl>[0] = {
+  parentSessionId: "123e4567-e89b-42d3-a456-426614174601",
+  projectId: `sha256:${createHash("sha256").update(workspaceRoot).digest("hex")}`,
+  workspaceRoot,
+  targetIdentity: {
+    targetId: "deepseek-v4-flash.direct",
+    vendor: "deepseek",
+    modelId: "deepseek-v4-flash",
+    route: "direct",
+    profileVersion: 1,
+    certification: "certified",
+  },
+  contextProfile: {
+    version: 1,
+    contextWindowTokens: 128_000,
+    maximumOutputTokens: 4096,
+    compactAtTokens: 96_000,
+    postCompactTargetTokens: 32_000,
+    retainedTargetTokens: 8000,
+    estimatorVersion: 1,
+  },
+  model: {
+    async *stream(request) {
+      if (phase === "stalled_terminal") {
+        yield { type: "text_delta", text: "Partial crash evidence." };
+        await new Promise<void>((resolve) => {
+          request.signal.addEventListener("abort", () => resolve(), { once: true });
+          expireInactivity?.();
+        });
+        return;
+      }
+      if (phase === "tool_started") {
+        yield { type: "tool_call_start", id: "read-crash", name: "read_file" };
+        yield { type: "tool_call_delta", id: "read-crash", json: '{"path":"evidence.txt"}' };
+        yield { type: "tool_call_end", id: "read-crash" };
+        yield { type: "usage", inputTokens: 20, outputTokens: 5 };
+        yield { type: "finish", reason: "tool_calls" };
+        return;
+      }
+      yield { type: "text_delta", text: "Crash-retained evidence." };
+      if (phase === "provider_attempt_interrupted")
+        throw new ModelDriverError("transport", "External fixture disconnected.", {
+          cause: undefined,
+        });
+      yield { type: "usage", inputTokens: 20, outputTokens: 5 };
+      yield { type: "finish", reason: "stop" };
+    },
+  },
+  permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+  executionDomain: domain,
+  ...(phase === "stalled_terminal"
+    ? {
+        inactivityScheduler: {
+          schedule(_milliseconds: number, expire: () => void) {
+            expireInactivity = expire;
+            return { cancel() {} };
+          },
+        },
+      }
+    : {}),
+  store: await createJsonlManagedAgentControlStore({ workspaceRoot, stateRoot }),
+  childSessionStores: createJsonlSessionStoreDirectory({
+    workspaceRoot,
+    stateRoot: join(workspaceRoot, "children"),
+  }),
+  ...(parentStore === undefined ? {} : { parentSessionStore: parentStore }),
+  [managedAgentRecordBarrier]: async (record) => {
+    if (record.event.type !== (phase.startsWith("cancel_") ? phase.slice(7) : phase)) return;
+    process.send?.({ phase, threadId: record.threadId, turnId: record.turnId });
+    await new Promise<void>(() => {});
+  },
+  [sessionRecordCommittedBarrier]: async (record) => {
+    if (record.schemaVersion !== 3) return;
+    const kind =
+      record.record.type === "runtime_event" ? record.record.event.type : record.record.type;
+    if (kind !== (phase === "stalled_terminal" ? "session_settled" : phase)) return;
+    const records = await (
+      await createJsonlManagedAgentControlStore({ workspaceRoot, stateRoot })
+    ).read();
+    const admission = records[0];
+    process.send?.({ phase, threadId: admission?.threadId, turnId: admission?.turnId });
+    await new Promise<void>(() => {});
+  },
+};
+const control = createManagedAgentControl(controlOptions);
+const observation = new AbortController();
+const childCompleted =
+  parentStore === undefined
+    ? undefined
+    : (async () => {
+        for await (const frame of control.observe({ parentSessionId, signal: observation.signal }))
+          if (frame.snapshot.completions.length > 0) return;
+      })();
+if (phase.startsWith("cancel_")) {
+  const admission = (await controlOptions.store.read())[0];
+  if (admission === undefined) throw new Error("Missing cancelled admission.");
+  await control.dispatch({
+    type: "cancel_turn",
+    parentSessionId,
+    threadId: admission.threadId,
+    expectedTurnId: admission.turnId,
+  });
+} else
+  await control.dispatch({
+    type: "start_thread",
+    parentSessionId: "123e4567-e89b-42d3-a456-426614174601",
+    role: "builtin:explore",
+    task: "Retain crash evidence.",
+    description: "Crash evidence",
+  });
+if (parentStore !== undefined) {
+  await childCompleted;
+  observation.abort();
+  const claim = await domain.claimScope({
+    kind: "main_run",
+    sessionId: parentSessionId,
+    identity: "main-request",
+  });
+  const promptContext = createPromptContextV1(undefined);
+  await parentStore.append({
+    schemaVersion: 3,
+    sequence: 1,
+    record: {
+      type: "session_genesis",
+      recordVersion: 2,
+      sessionId: parentSessionId,
+      projectId: controlOptions.projectId,
+      targetIdentity: controlOptions.targetIdentity,
+      contextProfile: controlOptions.contextProfile,
+      promptContext,
+    },
+  });
+  const dependencies = {
+    model: controlOptions.model,
+    contextProfile: controlOptions.contextProfile,
+    store: parentStore as SessionStore,
+    [sessionDurableContext]: {
+      nextSequence: 2,
+      sessionId: parentSessionId,
+      projectId: controlOptions.projectId,
+      targetIdentity: controlOptions.targetIdentity,
+      promptContext,
+    },
+    [managedAgentRequestBoundary]: managedControlMainRequestBoundary(control, parentSessionId),
+    [sessionRecordCommittedBarrier]: async (
+      record: import("@adam-agent/agent/internal-testing").SessionRecord,
+    ) => {
+      if (
+        phase !== "main_receipt" ||
+        record.schemaVersion !== 3 ||
+        record.record.type !== "provider_attempt_started"
+      )
+        return;
+      const admission = (await controlOptions.store.read())[0];
+      process.send?.({ phase, threadId: admission?.threadId, turnId: admission?.turnId });
+      await new Promise<void>(() => {});
+    },
+  };
+  await new AgentSession(dependencies).run({ text: "Use the pending completion." });
+  await claim.release();
+}

--- a/packages/testkit/src/managed-agent-control.os.test.ts
+++ b/packages/testkit/src/managed-agent-control.os.test.ts
@@ -1,0 +1,947 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createPermissionPolicy,
+  createPresentationSession,
+  createReadToolRegistry,
+  createSessionLifecycle,
+} from "@adam-agent/agent";
+
+import {
+  createJsonlManagedAgentControlStore,
+  createJsonlManagedAgentStore,
+  createJsonlSessionStoreDirectory,
+  createManagedAgentControl,
+  createProjectExecutionDomain,
+  createProjectLifecycleOwner,
+  createTrustedWorkspaceTrustForTesting,
+  scoutManagedAgentProfileV1,
+  sessionAutomaticTitlesEnabled,
+  sessionManagedControl,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+import { withManagedFailureGuard } from "./managed-agent-test-support.js";
+
+test("ManagedAgentStore v3 preflight preserves and backs up exact legacy bytes before first admission", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "adam-control-preflight-"));
+  const options = { workspaceRoot: directory, stateRoot: join(directory, "state") };
+  try {
+    const legacy = await createJsonlManagedAgentStore(options);
+    await legacy.append(legacyAdmission());
+    const logDirectory = join(
+      options.stateRoot,
+      "projects",
+      createHash("sha256").update(directory).digest("hex"),
+      "managed-agents",
+    );
+    const before = await readFile(join(logDirectory, "events-v1.jsonl"));
+    const store = await createJsonlManagedAgentControlStore(options);
+    await store.preflight();
+    expect(await readFile(join(logDirectory, "events-v1.pre-v3.jsonl"))).toEqual(before);
+    expect(await readFile(join(logDirectory, "events-v1.jsonl"))).toEqual(before);
+    expect(await store.read()).toEqual([]);
+    expect(await store.readLegacy()).toMatchObject([
+      { type: "managed_agent_admitted", profile: "scout.v1" },
+    ]);
+    await writeFile(join(logDirectory, "events-v1.jsonl"), "invalid\n");
+    const reopened = await createJsonlManagedAgentControlStore(options);
+    await expect(reopened.preflight()).rejects.toMatchObject({ code: "managed_agent_log_invalid" });
+    expect(await readFile(join(logDirectory, "events-v1.pre-v3.jsonl"))).toEqual(before);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test.each(["provider_attempt_interrupted", "session_settled", "outcome", "settled", "completion"])(
+  "ManagedAgentControl recovers a real process crash after %s without replay or duplicate completion",
+  async (phase) => {
+    const directory = await mkdtemp(join(tmpdir(), `adam-control-crash-${phase}-`));
+    const parentSessionId = "123e4567-e89b-42d3-a456-426614174601";
+    const fixture = spawn(
+      process.execPath,
+      [fileURLToPath(new URL("../dist/managed-agent-control-owner.fixture.js", import.meta.url))],
+      {
+        env: {
+          ...process.env,
+          ADAM_CONTROL_FIXTURE_ROOT: directory,
+          ADAM_CONTROL_FIXTURE_PHASE: phase,
+        },
+        stdio: ["ignore", "ignore", "pipe", "ipc"],
+      },
+    );
+    const closed = new Promise<void>((resolve) => fixture.once("close", () => resolve()));
+    const ready = new Promise<{ threadId: string; turnId: string }>((resolve, reject) => {
+      fixture.once("error", reject);
+      fixture.once("close", () => reject(new Error("Fixture closed before its durable barrier.")));
+      fixture.on("message", (message: unknown) => {
+        if (
+          typeof message === "object" &&
+          message !== null &&
+          "phase" in message &&
+          message.phase === phase &&
+          "threadId" in message &&
+          typeof message.threadId === "string" &&
+          "turnId" in message &&
+          typeof message.turnId === "string"
+        )
+          resolve({ threadId: message.threadId, turnId: message.turnId });
+      });
+    });
+    const stateRoot = join(directory, "state");
+    const domain = createProjectExecutionDomain({
+      lifecycleOwner: createProjectLifecycleOwner({ workspaceRoot: directory, stateRoot }),
+    });
+    const store = await createJsonlManagedAgentControlStore({
+      workspaceRoot: directory,
+      stateRoot,
+    });
+    const control = createManagedAgentControl({
+      parentSessionId,
+      projectId: `sha256:${createHash("sha256").update(directory).digest("hex")}`,
+      workspaceRoot: directory,
+      targetIdentity: {
+        targetId: "deepseek-v4-flash.direct",
+        vendor: "deepseek",
+        modelId: "deepseek-v4-flash",
+        route: "direct",
+        profileVersion: 1,
+        certification: "certified",
+      },
+      contextProfile: {
+        version: 1,
+        contextWindowTokens: 128_000,
+        maximumOutputTokens: 4096,
+        compactAtTokens: 96_000,
+        postCompactTargetTokens: 32_000,
+        retainedTargetTokens: 8000,
+        estimatorVersion: 1,
+      },
+      model: {
+        stream() {
+          throw new Error("Settled recovery cannot resend a provider request.");
+        },
+      },
+      permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      executionDomain: domain,
+      store,
+      childSessionStores: createJsonlSessionStoreDirectory({
+        workspaceRoot: directory,
+        stateRoot: join(directory, "children"),
+      }),
+    });
+    try {
+      const identity = await withManagedFailureGuard(ready, `durable ${phase} IPC`);
+      const before = await store.read();
+      expect((await control.inspect({ parentSessionId })).threads).toHaveLength(1);
+      expect(
+        await control.dispatch({
+          type: "recover_turn",
+          parentSessionId,
+          threadId: identity.threadId,
+          expectedTurnId: identity.turnId,
+        }),
+      ).toMatchObject({ status: "rejected", code: "authority_busy" });
+      expect(await store.read()).toEqual(before);
+      fixture.kill("SIGKILL");
+      await withManagedFailureGuard(closed, "crashed owner close");
+      const command = {
+        type: "recover_turn" as const,
+        parentSessionId,
+        threadId: identity.threadId,
+        expectedTurnId: identity.turnId,
+      };
+      expect(await control.dispatch(command)).toMatchObject({ status: "recovered" });
+      expect(await control.dispatch(command)).toMatchObject({ status: "recovered" });
+      expect(
+        (await store.read()).filter((record) => record.event.type === "completion"),
+      ).toHaveLength(1);
+      expect((await control.inspect({ parentSessionId })).threads[0]?.turn.outcome?.summary).toBe(
+        "Crash-retained evidence.",
+      );
+    } finally {
+      fixture.kill("SIGKILL");
+      await withManagedFailureGuard(closed, "fixture close");
+      await control.dispatch({ type: "close", parentSessionId });
+      await domain.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+);
+
+test("ManagedAgentControl isolates a corrupted JSONL child while another thread remains inspectable and continuable", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "adam-control-corruption-"));
+  const parentSessionId = "123e4567-e89b-42d3-a456-426614174601";
+  const projectKey = createHash("sha256").update(directory).digest("hex");
+  const childRoot = join(directory, "children");
+  const { control, domain } = await jsonlControlFixture(directory);
+  const subscription = new AbortController();
+  const settled = (async () => {
+    for await (const frame of control.observe({ parentSessionId, signal: subscription.signal })) {
+      if (
+        frame.snapshot.threads.length === 2 &&
+        frame.snapshot.threads.every((thread) => thread.turn.phase === "idle")
+      )
+        return frame.snapshot.threads;
+    }
+    throw new Error("Missing two settled children.");
+  })();
+  try {
+    expect(
+      await control.dispatch({
+        type: "start_thread",
+        parentSessionId,
+        role: "builtin:explore",
+        task: "First evidence.",
+        description: "First evidence",
+      }),
+    ).toMatchObject({ status: "accepted" });
+    expect(
+      await control.dispatch({
+        type: "start_thread",
+        parentSessionId,
+        role: "builtin:explore",
+        task: "Second evidence.",
+        description: "Second evidence",
+      }),
+    ).toMatchObject({ status: "accepted" });
+    const threads = await withManagedFailureGuard(settled, "two JSONL child settlements");
+    const first = threads[0];
+    const second = threads[1];
+    if (first === undefined || second === undefined) throw new Error("Missing child identities.");
+    await writeFile(
+      join(childRoot, "projects", projectKey, "sessions", `${first.turn.childSessionId}.jsonl`),
+      "corrupt\n",
+    );
+    const snapshot = await control.inspect({ parentSessionId });
+    expect(snapshot.threads[0]?.turn).toMatchObject({
+      recovery: "required",
+      diagnostic: "Child history is unavailable. Inspect durable state.",
+    });
+    expect(snapshot.threads[1]?.turn.recovery).toBe("none");
+    expect(
+      await control.dispatch({
+        type: "next_turn",
+        parentSessionId,
+        threadId: second.threadId,
+        expectedTurnId: second.turn.turnId,
+        task: "Continue intact evidence.",
+      }),
+    ).toMatchObject({ status: "accepted" });
+  } finally {
+    subscription.abort();
+    await control.dispatch({ type: "close", parentSessionId });
+    await domain.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+async function jsonlControlFixture(directory: string) {
+  const stateRoot = join(directory, "state");
+  const parentSessionId = "123e4567-e89b-42d3-a456-426614174601";
+  const projectKey = createHash("sha256").update(directory).digest("hex");
+  const childRoot = join(directory, "children");
+  const domain = createProjectExecutionDomain({
+    lifecycleOwner: createProjectLifecycleOwner({ workspaceRoot: directory, stateRoot }),
+  });
+  const store = await createJsonlManagedAgentControlStore({ workspaceRoot: directory, stateRoot });
+  const controlOptions = {
+    parentSessionId,
+    projectId: `sha256:${projectKey}` as const,
+    workspaceRoot: directory,
+    targetIdentity: {
+      targetId: "deepseek-v4-flash.direct",
+      vendor: "deepseek",
+      modelId: "deepseek-v4-flash",
+      route: "direct" as const,
+      profileVersion: 1,
+      certification: "certified" as const,
+    },
+    contextProfile: {
+      version: 1,
+      contextWindowTokens: 128_000,
+      maximumOutputTokens: 4096,
+      compactAtTokens: 96_000,
+      postCompactTargetTokens: 32_000,
+      retainedTargetTokens: 8000,
+      estimatorVersion: 1 as const,
+    },
+    model: {
+      async *stream() {
+        yield { type: "text_delta" as const, text: "Retained child evidence." };
+        yield { type: "finish" as const, reason: "stop" as const };
+      },
+    },
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    executionDomain: domain,
+    store,
+    childSessionStores: createJsonlSessionStoreDirectory({
+      workspaceRoot: directory,
+      stateRoot: childRoot,
+    }),
+  };
+  const control = createManagedAgentControl(controlOptions);
+  return { control, domain, store, controlOptions };
+}
+
+test.each(["session_genesis", "started", "tool_started"])(
+  "ManagedAgentControl explicitly resumes a real process stopped at %s using its exact safe boundary",
+  async (phase) => {
+    const directory = await mkdtemp(join(tmpdir(), "adam-control-safe-recovery-"));
+    await writeFile(join(directory, "evidence.txt"), "BEFORE_CRASH_READ");
+    const fixture = startControlCrashFixture(directory, phase);
+    const harness = await jsonlControlFixture(directory);
+    const parentSessionId = harness.controlOptions.parentSessionId;
+    const subscription = new AbortController();
+    let calls = 0;
+    const control = createManagedAgentControl({
+      ...harness.controlOptions,
+      model: {
+        async *stream(request) {
+          calls += 1;
+          if (phase === "tool_started")
+            expect(JSON.stringify(request.messages)).toContain("AFTER_CRASH_READ");
+          yield { type: "text_delta", text: "Explicit safe recovery." };
+          yield { type: "finish", reason: "stop" };
+        },
+      },
+    });
+    try {
+      const identity = await withManagedFailureGuard(fixture.ready, `durable ${phase} barrier`);
+      fixture.process.kill("SIGKILL");
+      await withManagedFailureGuard(fixture.closed, "safe recovery process close");
+      await writeFile(join(directory, "evidence.txt"), "AFTER_CRASH_READ");
+      expect((await control.inspect({ parentSessionId })).threads[0]?.turn.recovery).toBe(
+        "required",
+      );
+      expect(calls).toBe(0);
+      const settled = (async () => {
+        for await (const frame of control.observe({
+          parentSessionId,
+          signal: subscription.signal,
+        })) {
+          if (frame.snapshot.threads[0]?.turn.phase === "idle") return frame.snapshot.threads[0];
+        }
+        throw new Error("Missing safe recovered settlement.");
+      })();
+      void settled.catch(() => undefined);
+      expect(
+        await control.dispatch({
+          type: "recover_turn",
+          parentSessionId,
+          threadId: identity.threadId,
+          expectedTurnId: identity.turnId,
+        }),
+      ).toMatchObject({ status: "accepted", turnId: identity.turnId });
+      expect(
+        (await withManagedFailureGuard(settled, "safe recovered settlement")).turn.outcome?.summary,
+      ).toBe("Explicit safe recovery.");
+      expect(calls).toBe(1);
+    } finally {
+      fixture.process.kill("SIGKILL");
+      await withManagedFailureGuard(fixture.closed, "safe fixture cleanup");
+      subscription.abort();
+      await control.dispatch({ type: "close", parentSessionId });
+      await harness.control.dispatch({ type: "close", parentSessionId });
+      await harness.domain.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+);
+
+test.each(["admitted", "session_genesis"])(
+  "ManagedAgentControl cancels a pre-provider crash at %s without inventing a logical run",
+  async (phase) => {
+    const directory = await mkdtemp(join(tmpdir(), "adam-control-admitted-crash-"));
+    const fixture = startControlCrashFixture(directory, phase);
+    const harness = await jsonlControlFixture(directory);
+    const parentSessionId = harness.controlOptions.parentSessionId;
+    try {
+      const identity = await withManagedFailureGuard(
+        fixture.ready,
+        "durable admission before genesis",
+      );
+      fixture.process.kill("SIGKILL");
+      await withManagedFailureGuard(fixture.closed, "admitted process close");
+      expect(
+        await harness.control.dispatch({
+          type: "cancel_turn",
+          parentSessionId,
+          threadId: identity.threadId,
+          expectedTurnId: identity.turnId,
+        }),
+      ).toMatchObject({ status: "cancelled", turnId: identity.turnId });
+      const snapshot = await harness.control.inspect({ parentSessionId });
+      expect(snapshot.threads[0]?.turn).toMatchObject({
+        phase: "idle",
+        recovery: "none",
+        outcome: { status: "cancelled", transcript: { sequence: phase === "admitted" ? 0 : 1 } },
+      });
+      expect(await harness.controlOptions.childSessionStores.listSessionEntries()).toHaveLength(
+        phase === "admitted" ? 0 : 1,
+      );
+    } finally {
+      fixture.process.kill("SIGKILL");
+      await withManagedFailureGuard(fixture.closed, "admitted fixture cleanup");
+      await harness.control.dispatch({ type: "close", parentSessionId });
+      await harness.domain.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+);
+
+function startControlCrashFixture(directory: string, phase: string) {
+  const child = spawn(
+    process.execPath,
+    [fileURLToPath(new URL("../dist/managed-agent-control-owner.fixture.js", import.meta.url))],
+    {
+      env: {
+        ...process.env,
+        ADAM_CONTROL_FIXTURE_ROOT: directory,
+        ADAM_CONTROL_FIXTURE_PHASE: phase,
+      },
+      stdio: ["ignore", "ignore", "pipe", "ipc"],
+    },
+  );
+  let stderr = "";
+  child.stderr?.on("data", (chunk: Buffer) => {
+    stderr = (stderr + chunk.toString("utf8")).slice(-4096);
+  });
+  const closed = new Promise<void>((resolve) => child.once("close", () => resolve()));
+  const ready = new Promise<{ threadId: string; turnId: string }>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", () => reject(new Error(`Fixture closed before ${phase}: ${stderr}`)));
+    child.on("message", (message: unknown) => {
+      if (
+        typeof message === "object" &&
+        message !== null &&
+        "phase" in message &&
+        message.phase === phase &&
+        "threadId" in message &&
+        typeof message.threadId === "string" &&
+        "turnId" in message &&
+        typeof message.turnId === "string"
+      )
+        resolve({ threadId: message.threadId, turnId: message.turnId });
+    });
+  });
+  return { process: child, closed, ready };
+}
+
+test("ManagedAgentControl never resends a durably acknowledged provider request and explicitly cancels its interrupted turn", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "adam-control-provider-recovery-"));
+  const fixture = startControlCrashFixture(directory, "provider_attempt_started");
+  const harness = await jsonlControlFixture(directory);
+  const parentSessionId = harness.controlOptions.parentSessionId;
+  let calls = 0;
+  const control = createManagedAgentControl({
+    ...harness.controlOptions,
+    model: {
+      stream() {
+        calls += 1;
+        throw new Error("An acknowledged request must not be resent.");
+      },
+    },
+  });
+  try {
+    const identity = await withManagedFailureGuard(fixture.ready, "acknowledged provider request");
+    fixture.process.kill("SIGKILL");
+    await withManagedFailureGuard(fixture.closed, "acknowledged provider process close");
+    const before = await harness.store.read();
+    expect(
+      await control.dispatch({
+        type: "recover_turn",
+        parentSessionId,
+        threadId: identity.threadId,
+        expectedTurnId: identity.turnId,
+      }),
+    ).toMatchObject({ status: "rejected", code: "recovery_required" });
+    expect(await harness.store.read()).toEqual(before);
+    expect(
+      await control.dispatch({
+        type: "cancel_turn",
+        parentSessionId,
+        threadId: identity.threadId,
+        expectedTurnId: identity.turnId,
+      }),
+    ).toMatchObject({ status: "cancelled", turnId: identity.turnId });
+    expect((await control.inspect({ parentSessionId })).threads[0]?.turn).toMatchObject({
+      phase: "idle",
+      outcome: { status: "cancelled" },
+    });
+    expect(calls).toBe(0);
+  } finally {
+    fixture.process.kill("SIGKILL");
+    await withManagedFailureGuard(fixture.closed, "provider fixture cleanup");
+    await control.dispatch({ type: "close", parentSessionId });
+    await harness.control.dispatch({ type: "close", parentSessionId });
+    await harness.domain.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test.each(["main_receipt", "consumed"])(
+  "ManagedAgentControl reconciles a real process crash after %s from the exact Main receipt",
+  async (phase) => {
+    const directory = await mkdtemp(join(tmpdir(), "adam-control-main-receipt-"));
+    const fixture = startControlCrashFixture(directory, phase);
+    const harness = await jsonlControlFixture(directory);
+    const parentSessionId = harness.controlOptions.parentSessionId;
+    try {
+      await withManagedFailureGuard(fixture.ready, `durable ${phase}`);
+      fixture.process.kill("SIGKILL");
+      await withManagedFailureGuard(fixture.closed, "Main receipt owner close");
+      const parentStore = await createJsonlSessionStoreDirectory({
+        workspaceRoot: directory,
+        stateRoot: join(directory, "parents"),
+      }).open(parentSessionId);
+      if (parentStore === undefined) throw new Error("Missing canonical Main store.");
+      const before = await parentStore.read();
+      const control = createManagedAgentControl({
+        ...harness.controlOptions,
+        parentSessionStore: parentStore,
+      });
+      expect(
+        await control.dispatch({ type: "prepare_main_delivery", parentSessionId }),
+      ).toMatchObject({ status: "delivery", messages: [], deliveries: [] });
+      expect(
+        await control.dispatch({ type: "prepare_main_delivery", parentSessionId }),
+      ).toMatchObject({ status: "delivery", messages: [], deliveries: [] });
+      expect(
+        (await harness.store.read()).filter((record) => record.event.type === "consumed"),
+      ).toHaveLength(1);
+      expect(await parentStore.read()).toEqual(before);
+      await control.dispatch({ type: "close", parentSessionId });
+    } finally {
+      fixture.process.kill("SIGKILL");
+      await withManagedFailureGuard(fixture.closed, "Main receipt fixture cleanup");
+      await harness.control.dispatch({ type: "close", parentSessionId });
+      await harness.domain.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+);
+
+test("ManagedAgentControl exposes Fleet recovery and refuses mutation without rewriting a corrupted control journal", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "adam-control-fleet-invalid-"));
+  const { control, store, domain } = await jsonlControlFixture(directory);
+  const parentSessionId = "123e4567-e89b-42d3-a456-426614174601";
+  try {
+    await store.preflight();
+    const path = join(
+      directory,
+      "state",
+      "projects",
+      createHash("sha256").update(directory).digest("hex"),
+      "managed-agents",
+      `events-v3-${parentSessionId}.jsonl`,
+    );
+    await writeFile(path, "corrupt\n");
+    expect(await control.inspect({ parentSessionId })).toMatchObject({
+      status: "recovery_required",
+      diagnostic: "Managed history is unavailable. Inspect durable state.",
+    });
+    expect(
+      await control.dispatch({
+        type: "start_thread",
+        parentSessionId,
+        role: "builtin:explore",
+        task: "No mutation.",
+        description: "No mutation",
+      }),
+    ).toMatchObject({ status: "rejected", code: "recovery_required" });
+    expect(await readFile(path, "utf8")).toBe("corrupt\n");
+  } finally {
+    await control.dispatch({ type: "close", parentSessionId });
+    await domain.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("SessionLifecycle keeps ordinary Main conversation usable when its v3 Fleet journal is corrupt", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "adam-main-fleet-corrupt-"));
+  const harness = await jsonlControlFixture(directory);
+  const { targetIdentity, contextProfile, model: driver } = harness.controlOptions;
+  const lifecycle = createSessionLifecycle({
+    workspaceTrust: createTrustedWorkspaceTrustForTesting(directory),
+    workspaceRoot: directory,
+    stateRoot: join(directory, "parents"),
+    modelTargets: {
+      async resolve() {
+        return { identity: targetIdentity, contextProfile, driver };
+      },
+      async snapshot() {
+        return {
+          targets: [
+            {
+              identity: targetIdentity,
+              contextProfile,
+              readiness: { status: "available", credentialSource: "external fixture" },
+            },
+          ],
+        };
+      },
+    },
+    [sessionAutomaticTitlesEnabled]: false,
+    [sessionManagedControl]: {
+      store: harness.store,
+      childSessionStores: harness.controlOptions.childSessionStores,
+    },
+  });
+  try {
+    const parent = await lifecycle.create({ targetIdentity });
+    await harness.store.preflight();
+    const path = join(
+      directory,
+      "state",
+      "projects",
+      createHash("sha256").update(directory).digest("hex"),
+      "managed-agents",
+      `events-v3-${parent.sessionId}.jsonl`,
+    );
+    await writeFile(path, "corrupt\n");
+    const control = await lifecycle[sessionManagedControl](parent.sessionId);
+    expect(await control?.inspect({ parentSessionId: parent.sessionId })).toMatchObject({
+      status: "recovery_required",
+    });
+    expect(
+      (
+        await lifecycle.continue({
+          sessionId: parent.sessionId,
+          input: { text: "Ordinary Main conversation." },
+        })
+      ).result.status,
+    ).toBe("completed");
+    expect(await readFile(path, "utf8")).toBe("corrupt\n");
+  } finally {
+    await lifecycle.close();
+    await harness.control.dispatch({
+      type: "close",
+      parentSessionId: harness.controlOptions.parentSessionId,
+    });
+    await harness.domain.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("ManagedAgentStore isolates an attributable parent journal corruption from another parent under one project owner", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "adam-control-parent-isolation-"));
+  const harness = await jsonlControlFixture(directory);
+  const firstParent = harness.controlOptions.parentSessionId;
+  const secondParent = "123e4567-e89b-42d3-a456-426614174699";
+  const second = createManagedAgentControl({
+    ...harness.controlOptions,
+    parentSessionId: secondParent,
+  });
+  const subscription = new AbortController();
+  const completed = (control: typeof second, parentSessionId: string) =>
+    (async () => {
+      for await (const frame of control.observe({ parentSessionId, signal: subscription.signal }))
+        if (frame.snapshot.completions.length > 0) return;
+      throw new Error("Missing isolated parent completion.");
+    })();
+  const firstDone = completed(harness.control, firstParent);
+  const secondDone = completed(second, secondParent);
+  void firstDone.catch(() => undefined);
+  void secondDone.catch(() => undefined);
+  try {
+    await harness.control.dispatch({
+      type: "start_thread",
+      parentSessionId: firstParent,
+      role: "builtin:explore",
+      task: "First parent.",
+      description: "First parent",
+    });
+    await second.dispatch({
+      type: "start_thread",
+      parentSessionId: secondParent,
+      role: "builtin:explore",
+      task: "Second parent.",
+      description: "Second parent",
+    });
+    await withManagedFailureGuard(Promise.all([firstDone, secondDone]), "both parent completions");
+    const logDirectory = join(
+      directory,
+      "state",
+      "projects",
+      createHash("sha256").update(directory).digest("hex"),
+      "managed-agents",
+    );
+    const paths = (await readdir(logDirectory)).filter(
+      (name) => name.startsWith("events-v3") && name.endsWith(".jsonl"),
+    );
+    let corrupted = false;
+    for (const name of paths) {
+      const path = join(logDirectory, name);
+      const contents = await readFile(path, "utf8");
+      if (!contents.includes(firstParent)) continue;
+      await writeFile(path, contents.replace('"role":"builtin:explore"', '"role":"invalid:role"'));
+      corrupted = true;
+      break;
+    }
+    expect(corrupted).toBe(true);
+    expect(await harness.control.inspect({ parentSessionId: firstParent })).toMatchObject({
+      status: "recovery_required",
+    });
+    expect(await second.inspect({ parentSessionId: secondParent })).toMatchObject({
+      status: "ready",
+    });
+    expect(
+      await second.dispatch({
+        type: "start_thread",
+        parentSessionId: secondParent,
+        role: "builtin:explore",
+        task: "Continue unaffected parent.",
+        description: "Unaffected parent",
+      }),
+    ).toMatchObject({ status: "accepted" });
+  } finally {
+    subscription.abort();
+    await second.dispatch({ type: "close", parentSessionId: secondParent });
+    await harness.control.dispatch({ type: "close", parentSessionId: firstParent });
+    await harness.domain.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function legacyAdmission(
+  parentSessionId = "123e4567-e89b-42d3-a456-426614174601",
+): Extract<
+  import("@adam-agent/agent/internal-testing").ManagedAgentRecord,
+  { type: "managed_agent_admitted" }
+> {
+  return {
+    schemaVersion: 1,
+    sequence: 1,
+    type: "managed_agent_admitted",
+    agentId: "123e4567-e89b-42d3-a456-426614174602",
+    attemptId: "123e4567-e89b-42d3-a456-426614174603",
+    childSessionId: "123e4567-e89b-42d3-a456-426614174604",
+    parentSessionId,
+    parentToolCallId: "legacy-spawn",
+    parentRootId: "project-runtime",
+    projectId: `sha256:${"d".repeat(64)}`,
+    profile: "scout.v1",
+    profileDigest: scoutManagedAgentProfileV1.digest,
+    limits: { maximumTokens: 128_000, maximumTurns: 8, maximumDeadlineMilliseconds: 600_000 },
+    admittedAtUnixMilliseconds: 1_900_000_000_000,
+    taskDigest: `sha256:${"a".repeat(64)}`,
+    childInputDigest: `sha256:${"b".repeat(64)}`,
+    targetIdentity: {
+      targetId: "deepseek-v4-flash.direct",
+      vendor: "deepseek",
+      modelId: "deepseek-v4-flash",
+      route: "direct",
+      profileVersion: 1,
+      certification: "certified",
+    },
+  };
+}
+
+test("PresentationSession exposes historical managed history read-only through the new candidate without legacy writes", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "adam-control-legacy-view-"));
+  const harness = await jsonlControlFixture(directory);
+  const { targetIdentity, contextProfile, model: driver } = harness.controlOptions;
+  const modelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, contextProfile, driver };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            contextProfile,
+            readiness: { status: "available" as const, credentialSource: "external fixture" },
+          },
+        ],
+      };
+    },
+  };
+  const options = {
+    workspaceRoot: directory,
+    stateRoot: join(directory, "parents"),
+    workspaceTrust: createTrustedWorkspaceTrustForTesting(directory),
+    modelTargets,
+    tools: createReadToolRegistry({ workspaceRoot: directory }),
+    [sessionAutomaticTitlesEnabled]: false,
+  };
+  const old = createSessionLifecycle({
+    ...options,
+    managedAgentTools: "managed-agent-tools.a1.v1",
+  });
+  const parent = await old.create({ targetIdentity });
+  await old.close();
+  const legacy = await createJsonlManagedAgentStore({
+    workspaceRoot: directory,
+    stateRoot: join(directory, "state"),
+  });
+  const admission = legacyAdmission(parent.sessionId);
+  await legacy.append(admission);
+  const before = await legacy.read();
+  const lifecycle = createSessionLifecycle({
+    ...options,
+    [sessionManagedControl]: {
+      store: harness.store,
+      childSessionStores: harness.controlOptions.childSessionStores,
+    },
+  });
+  let presentation: Awaited<ReturnType<typeof createPresentationSession>> | undefined;
+  try {
+    presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      workspaceRoot: directory,
+      stateRoot: options.stateRoot,
+      projectLabel: "Legacy history",
+      sessionId: parent.sessionId,
+    });
+    const agent = presentation.getState().authoritative.managedAgents.agents[0];
+    expect(agent).toMatchObject({
+      agentId: admission.agentId,
+      profile: "scout.v1",
+      status: "recovery_required",
+      readOnly: true,
+    });
+    if (agent === undefined) throw new Error("Missing legacy projection.");
+    expect(
+      await presentation.dispatch({
+        type: "cancel_managed_agent",
+        sessionId: parent.sessionId,
+        agentId: agent.agentId,
+        expectedRevision: agent.revision,
+      }),
+    ).toMatchObject({ status: "rejected", code: "action_unavailable" });
+    expect(await legacy.read()).toEqual(before);
+    expect(await harness.store.read()).toEqual([]);
+  } finally {
+    await presentation?.close();
+    await lifecycle.close();
+    await harness.control.dispatch({
+      type: "close",
+      parentSessionId: harness.controlOptions.parentSessionId,
+    });
+    await harness.domain.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test.each(["outcome", "settled"])(
+  "ManagedAgentControl recovers a pre-genesis cancellation crash after %s with its empty transcript receipt",
+  async (phase) => {
+    const directory = await mkdtemp(join(tmpdir(), "adam-control-empty-cancel-"));
+    const admitted = startControlCrashFixture(directory, "admitted");
+    const harness = await jsonlControlFixture(directory);
+    const parentSessionId = harness.controlOptions.parentSessionId;
+    let cancelled: ReturnType<typeof startControlCrashFixture> | undefined;
+    try {
+      const identity = await withManagedFailureGuard(admitted.ready, "empty child admission");
+      admitted.process.kill("SIGKILL");
+      await withManagedFailureGuard(admitted.closed, "empty admission process close");
+      cancelled = startControlCrashFixture(directory, `cancel_${phase}`);
+      await withManagedFailureGuard(cancelled.ready, `cancelled ${phase}`);
+      cancelled.process.kill("SIGKILL");
+      await withManagedFailureGuard(cancelled.closed, "cancelled process close");
+      expect(
+        await harness.control.dispatch({
+          type: "recover_turn",
+          parentSessionId,
+          threadId: identity.threadId,
+          expectedTurnId: identity.turnId,
+        }),
+      ).toMatchObject({ status: "recovered" });
+      expect(
+        (await harness.store.read()).filter((record) => record.event.type === "completion"),
+      ).toHaveLength(1);
+      expect(await harness.controlOptions.childSessionStores.listSessionEntries()).toEqual([]);
+    } finally {
+      admitted.process.kill("SIGKILL");
+      cancelled?.process.kill("SIGKILL");
+      await withManagedFailureGuard(admitted.closed, "first cancellation fixture close");
+      if (cancelled !== undefined)
+        await withManagedFailureGuard(cancelled.closed, "second cancellation fixture close");
+      await harness.control.dispatch({ type: "close", parentSessionId });
+      await harness.domain.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+);
+
+test("ManagedAgentControl preserves durable stall classification and partial output after child terminal but before outcome", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "adam-control-stalled-terminal-"));
+  const fixture = startControlCrashFixture(directory, "stalled_terminal");
+  const harness = await jsonlControlFixture(directory);
+  const parentSessionId = harness.controlOptions.parentSessionId;
+  try {
+    const identity = await withManagedFailureGuard(fixture.ready, "stalled child terminal receipt");
+    fixture.process.kill("SIGKILL");
+    await withManagedFailureGuard(fixture.closed, "stalled owner close");
+    expect(
+      await harness.control.dispatch({
+        type: "recover_turn",
+        parentSessionId,
+        threadId: identity.threadId,
+        expectedTurnId: identity.turnId,
+      }),
+    ).toMatchObject({ status: "recovered" });
+    expect(
+      (await harness.control.inspect({ parentSessionId })).threads[0]?.turn.outcome,
+    ).toMatchObject({
+      status: "failed",
+      error: { code: "managed_agent_stalled" },
+      summary: "Partial crash evidence.",
+    });
+  } finally {
+    fixture.process.kill("SIGKILL");
+    await withManagedFailureGuard(fixture.closed, "stall fixture cleanup");
+    await harness.control.dispatch({ type: "close", parentSessionId });
+    await harness.domain.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("ManagedAgentControl publishes a reset when child filesystem setup fails after durable admission", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "adam-control-setup-failure-"));
+  const harness = await jsonlControlFixture(directory);
+  const parentSessionId = harness.controlOptions.parentSessionId;
+  await writeFile(join(directory, "children"), "not a directory");
+  const subscription = new AbortController();
+  const reset = (async () => {
+    for await (const frame of harness.control.observe({
+      parentSessionId,
+      signal: subscription.signal,
+    })) {
+      if (frame.type === "reset" && frame.snapshot.threads[0]?.turn.recovery === "required")
+        return frame;
+    }
+    throw new Error("Missing setup failure reset.");
+  })();
+  void reset.catch(() => undefined);
+  try {
+    expect(
+      await harness.control.dispatch({
+        type: "start_thread",
+        parentSessionId,
+        role: "builtin:explore",
+        task: "Cannot open child store.",
+        description: "Setup failure",
+      }),
+    ).toMatchObject({ status: "accepted" });
+    expect(await harness.control.dispatch({ type: "close", parentSessionId })).toMatchObject({
+      status: "rejected",
+      code: "recovery_required",
+    });
+    expect(
+      (await withManagedFailureGuard(reset, "failure reset at unchanged control revision")).snapshot
+        .threads[0]?.turn,
+    ).toMatchObject({ phase: "waiting", recovery: "required" });
+  } finally {
+    subscription.abort();
+    await harness.control.dispatch({ type: "close", parentSessionId });
+    await harness.domain.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/packages/testkit/src/managed-agent-control.test.ts
+++ b/packages/testkit/src/managed-agent-control.test.ts
@@ -1,0 +1,1253 @@
+import {
+  createPermissionPolicy,
+  createPresentationSession,
+  type ModelDriver,
+  ModelDriverError,
+} from "@adam-agent/agent";
+import {
+  createInMemoryManagedAgentControlStore,
+  createInMemorySessionStore,
+  createInMemorySessionStoreDirectory,
+  createManagedAgentControl,
+  createManagedAgentToolRegistry,
+  createProjectExecutionDomain,
+  managedAgentRecordBarrier,
+  managedAgentSettlementBarrier,
+  presentationSessionRecordReader,
+  type SessionRecord,
+  sessionManagedControl,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+import { createInMemorySessionLifecycleHarness } from "./index.js";
+import { withManagedFailureGuard } from "./managed-agent-test-support.js";
+
+const parentSessionId = "00000000-0000-4000-8000-000000000001";
+const projectId = `sha256:${"d".repeat(64)}` as const;
+const targetIdentity = {
+  targetId: "deepseek-v4-flash.direct",
+  vendor: "deepseek",
+  modelId: "deepseek-v4-flash",
+  route: "direct",
+  profileVersion: 1,
+  certification: "certified",
+} as const;
+const contextProfile = {
+  version: 1,
+  contextWindowTokens: 128_000,
+  maximumOutputTokens: 4_096,
+  compactAtTokens: 96_000,
+  postCompactTargetTokens: 32_000,
+  retainedTargetTokens: 8_000,
+  estimatorVersion: 1,
+} as const;
+
+test("ManagedAgentStore rejects settlement without its exact outcome receipt", async () => {
+  const store = createInMemoryManagedAgentControlStore();
+  const identity = {
+    schemaVersion: 3 as const,
+    parentSessionId,
+    threadId: "00000000-0000-4000-8000-000000000002",
+    turnId: "00000000-0000-4000-8000-000000000003",
+    attemptId: "00000000-0000-4000-8000-000000000004",
+    childSessionId: "00000000-0000-4000-8000-000000000005",
+  };
+  await store.append({
+    ...identity,
+    sequence: 1,
+    event: {
+      type: "admitted",
+      role: "builtin:explore",
+      task: "Inspect evidence.",
+      description: "Inspect evidence",
+    },
+  });
+  await expect(
+    store.append({
+      ...identity,
+      sequence: 2,
+      event: { type: "settled", outcome: { sequence: 1, digest: `sha256:${"a".repeat(64)}` } },
+    }),
+  ).rejects.toMatchObject({ code: "managed_agent_log_invalid" });
+  expect(await store.read()).toHaveLength(1);
+});
+
+test("ManagedAgentControl retains typed failure and bounded partial output with the exact child transcript", async () => {
+  const model: ModelDriver = {
+    async *stream() {
+      yield { type: "text_delta", text: "Partial evidence before provider failure." };
+      throw new ModelDriverError("transport", "External fixture disconnected.", {
+        cause: undefined,
+      });
+    },
+  };
+  const harness = await controlHarness(model);
+  const subscription = new AbortController();
+  const terminal = (async () => {
+    for await (const frame of harness.control.observe({
+      parentSessionId,
+      signal: subscription.signal,
+    })) {
+      if (frame.snapshot.threads[0]?.turn.phase === "idle") return frame.snapshot.threads[0];
+    }
+    throw new Error("Missing failed settlement.");
+  })();
+  try {
+    await harness.control.dispatch({
+      type: "start_thread",
+      parentSessionId,
+      role: "builtin:explore",
+      task: "Inspect evidence.",
+      description: "Inspect evidence",
+    });
+    const thread = await withManagedFailureGuard(terminal, "failed settled receipt");
+    expect(thread.turn.outcome).toMatchObject({
+      status: "failed",
+      summary: "Partial evidence before provider failure.",
+      error: { code: "model_request_failed" },
+    });
+    expect(thread.turn.outcome?.transcript.sequence).toBeGreaterThan(1);
+    expect(thread.turn.outcome?.transcript.digest).toMatch(/^sha256:[a-f0-9]{64}$/u);
+  } finally {
+    subscription.abort();
+    await harness.close();
+  }
+});
+
+async function controlHarness(model: ModelDriver) {
+  const domain = createProjectExecutionDomain({
+    lifecycleOwner: {
+      async acquire() {
+        return { async release() {} };
+      },
+      async run(operation) {
+        return operation();
+      },
+    },
+  });
+  const root = await domain.claimRoot({ rootId: "project-runtime" });
+  const store = createInMemoryManagedAgentControlStore();
+  const childSessionStores = createInMemorySessionStoreDirectory<SessionRecord>();
+  const options = {
+    parentSessionId,
+    projectId,
+    workspaceRoot: process.cwd(),
+    targetIdentity,
+    contextProfile,
+    model,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    executionDomain: domain,
+    store,
+    childSessionStores,
+  };
+  const control = createManagedAgentControl(options);
+  return {
+    control,
+    options,
+    root,
+    domain,
+    async close() {
+      await control.dispatch({ type: "close", parentSessionId });
+      await root.release();
+      await domain.close();
+    },
+  };
+}
+
+test("ManagedAgentControl refuses admission before writing when its project claim is released", async () => {
+  const harness = await controlHarness({
+    stream() {
+      throw new Error("No provider dispatch is authorized.");
+    },
+  });
+  try {
+    await harness.root.release();
+    await harness.domain.close();
+    expect(
+      await harness.control.dispatch({
+        type: "start_thread",
+        parentSessionId,
+        role: "builtin:explore",
+        task: "Inspect evidence.",
+        description: "Inspect evidence",
+      }),
+    ).toMatchObject({ status: "rejected", code: "runtime_unavailable" });
+    expect(await harness.options.store.read()).toEqual([]);
+  } finally {
+    await harness.close();
+  }
+});
+
+test("ManagedAgentControl cold outcome recovery settles and completes once without dispatching another provider", async () => {
+  const harness = await controlHarness({
+    async *stream() {
+      yield { type: "text_delta", text: "Retained outcome." };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  const subscription = new AbortController();
+  const terminal = (async () => {
+    for await (const frame of harness.control.observe({
+      parentSessionId,
+      signal: subscription.signal,
+    })) {
+      if (frame.snapshot.threads[0]?.turn.phase === "idle") return frame.snapshot.threads[0];
+    }
+    throw new Error("Missing outcome.");
+  })();
+  try {
+    await harness.control.dispatch({
+      type: "start_thread",
+      parentSessionId,
+      role: "builtin:explore",
+      task: "Inspect evidence.",
+      description: "Inspect evidence",
+    });
+    const thread = await withManagedFailureGuard(terminal, "original outcome");
+    await harness.control.dispatch({ type: "close", parentSessionId });
+    const store = createInMemoryManagedAgentControlStore();
+    for (const record of await harness.options.store.read()) {
+      if (record.event.type === "settled" || record.event.type === "completion") break;
+      await store.append(record);
+    }
+    const cold = createManagedAgentControl({
+      ...harness.options,
+      store,
+      model: {
+        stream() {
+          throw new Error("Recovery must never replay this provider.");
+        },
+      },
+    });
+    expect((await cold.inspect({ parentSessionId })).threads[0]?.turn).toMatchObject({
+      phase: "settling",
+      recovery: "required",
+    });
+    const command = {
+      type: "recover_turn" as const,
+      parentSessionId,
+      threadId: thread.threadId,
+      expectedTurnId: thread.turn.turnId,
+    };
+    expect(await cold.dispatch(command)).toMatchObject({ status: "recovered" });
+    expect(await cold.dispatch(command)).toMatchObject({ status: "recovered" });
+    expect((await store.read()).map((record) => record.event.type)).toEqual([
+      "admitted",
+      "started",
+      "execution_progress",
+      "outcome",
+      "settled",
+      "completion",
+    ]);
+    expect((await cold.inspect({ parentSessionId })).threads[0]?.turn).toMatchObject({
+      phase: "idle",
+      recovery: "none",
+    });
+    await cold.dispatch({ type: "close", parentSessionId });
+  } finally {
+    subscription.abort();
+    await harness.close();
+  }
+});
+
+test("ManagedAgentControl refuses continuation through a changed target instead of rebinding the thread", async () => {
+  const harness = await controlHarness({
+    async *stream() {
+      yield { type: "text_delta", text: "Frozen target evidence." };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  const subscription = new AbortController();
+  const terminal = (async () => {
+    for await (const frame of harness.control.observe({
+      parentSessionId,
+      signal: subscription.signal,
+    })) {
+      if (frame.snapshot.threads[0]?.turn.phase === "idle") return frame.snapshot.threads[0];
+    }
+    throw new Error("Missing frozen thread.");
+  })();
+  try {
+    await harness.control.dispatch({
+      type: "start_thread",
+      parentSessionId,
+      role: "builtin:explore",
+      task: "Inspect evidence.",
+      description: "Inspect evidence",
+    });
+    const thread = await withManagedFailureGuard(terminal, "frozen thread settlement");
+    await harness.control.dispatch({ type: "close", parentSessionId });
+    const before = await harness.options.store.read();
+    const cold = createManagedAgentControl({
+      ...harness.options,
+      targetIdentity: {
+        ...targetIdentity,
+        targetId: "deepseek-v4-pro.direct",
+        modelId: "deepseek-v4-pro",
+      },
+    });
+    expect(
+      await cold.dispatch({
+        type: "next_turn",
+        parentSessionId,
+        threadId: thread.threadId,
+        expectedTurnId: thread.turn.turnId,
+        task: "Continue.",
+      }),
+    ).toMatchObject({ status: "rejected", code: "action_unavailable" });
+    expect(await harness.options.store.read()).toEqual(before);
+    await cold.dispatch({ type: "close", parentSessionId });
+  } finally {
+    subscription.abort();
+    await harness.close();
+  }
+});
+
+test("ManagedAgentControl refuses a historical spawn command without writing either control format", async () => {
+  const harness = await controlHarness({
+    stream() {
+      throw new Error("Legacy control cannot execute.");
+    },
+  });
+  try {
+    const command = { type: "spawn_agent", parentSessionId, task: "Legacy request." };
+    expect(await harness.control.dispatch(command as never)).toMatchObject({
+      status: "rejected",
+      code: "action_unavailable",
+      message:
+        "Historical agent controls are read-only. Start a new current Session to delegate work.",
+    });
+    expect(await harness.options.store.read()).toEqual([]);
+    expect(await harness.options.store.readLegacy()).toEqual([]);
+  } finally {
+    await harness.close();
+  }
+});
+
+test("ManagedAgentControl old attempt cleanup preserves cancellation of the immediately admitted next turn", async () => {
+  const secondStarted = Promise.withResolvers<void>();
+  const secondClosed = Promise.withResolvers<void>();
+  let calls = 0;
+  const harness = await controlHarness({
+    async *stream(request) {
+      calls += 1;
+      if (calls === 2) {
+        secondStarted.resolve();
+        try {
+          await new Promise<void>((resolve) => {
+            if (request.signal.aborted) resolve();
+            else request.signal.addEventListener("abort", () => resolve(), { once: true });
+          });
+        } finally {
+          secondClosed.resolve();
+        }
+        return;
+      }
+      yield { type: "text_delta", text: "First completed boundary." };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  const subscription = new AbortController();
+  const continuation = (async () => {
+    for await (const frame of harness.control.observe({
+      parentSessionId,
+      signal: subscription.signal,
+    })) {
+      const thread = frame.snapshot.threads[0];
+      if (thread?.turn.phase === "idle")
+        return harness.control.dispatch({
+          type: "next_turn",
+          parentSessionId,
+          threadId: thread.threadId,
+          expectedTurnId: thread.turn.turnId,
+          task: "Next turn.",
+        });
+    }
+    throw new Error("Missing continuation.");
+  })();
+  try {
+    await harness.control.dispatch({
+      type: "start_thread",
+      parentSessionId,
+      role: "builtin:explore",
+      task: "First turn.",
+      description: "Inspect evidence",
+    });
+    expect(await withManagedFailureGuard(continuation, "immediate continuation")).toMatchObject({
+      status: "accepted",
+    });
+    await withManagedFailureGuard(secondStarted.promise, "second provider start");
+    await withManagedFailureGuard(
+      harness.control.dispatch({ type: "close", parentSessionId }),
+      "second turn cancellation settlement",
+    );
+    await withManagedFailureGuard(secondClosed.promise, "second provider closure");
+    expect(
+      (await harness.control.inspect({ parentSessionId })).threads[0]?.turn.outcome?.status,
+    ).toBe("cancelled");
+  } finally {
+    subscription.abort();
+    await harness.close();
+  }
+});
+
+test("SessionLifecycle admits and continues a settled v3 child while its automatic title provider is still active", async () => {
+  const titleStarted = Promise.withResolvers<void>();
+  const titleRelease = Promise.withResolvers<void>();
+  const driver: ModelDriver = {
+    async *stream(request) {
+      if (request.purpose === "title") {
+        titleStarted.resolve();
+        await titleRelease.promise;
+      }
+      yield {
+        type: "text_delta",
+        text: request.purpose === "title" ? "Evidence inspection" : "Settled evidence.",
+      };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const lifecycle = harness.createLifecycle({
+    workspaceRoot: process.cwd(),
+    modelTargets: {
+      async resolve() {
+        return { identity: targetIdentity, driver, contextProfile };
+      },
+      async snapshot() {
+        return {
+          targets: [
+            {
+              identity: targetIdentity,
+              contextProfile,
+              readiness: { status: "available", credentialSource: "external fixture" },
+            },
+          ],
+        };
+      },
+    },
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    [sessionManagedControl]: {
+      store: createInMemoryManagedAgentControlStore(),
+      childSessionStores: createInMemorySessionStoreDirectory<SessionRecord>(),
+    },
+  });
+  const subscription = new AbortController();
+  let title: Promise<unknown> | undefined;
+  try {
+    const created = await lifecycle.create({ targetIdentity });
+    await lifecycle.continue({
+      sessionId: created.sessionId,
+      input: { text: "Inspect evidence." },
+    });
+    lifecycle.enableAutomaticTitles();
+    title = lifecycle.ensureAutomaticTitle({ sessionId: created.sessionId });
+    await withManagedFailureGuard(titleStarted.promise, "automatic title provider start");
+    const control = await lifecycle[sessionManagedControl](created.sessionId);
+    if (control === undefined) throw new Error("Missing new control composition.");
+    const settled = (async () => {
+      for await (const frame of control.observe({
+        parentSessionId: created.sessionId,
+        signal: subscription.signal,
+      })) {
+        const thread = frame.snapshot.threads[0];
+        if (thread?.turn.phase === "idle") return thread;
+      }
+      throw new Error("Missing settled child.");
+    })();
+    expect(
+      await control.dispatch({
+        type: "start_thread",
+        parentSessionId: created.sessionId,
+        role: "builtin:explore",
+        task: "Inspect child evidence.",
+        description: "Inspect evidence",
+      }),
+    ).toMatchObject({ status: "accepted" });
+    const thread = await withManagedFailureGuard(settled, "settled child while title is active");
+    expect(
+      await control.dispatch({
+        type: "next_turn",
+        parentSessionId: created.sessionId,
+        threadId: thread.threadId,
+        expectedTurnId: thread.turn.turnId,
+        task: "Continue child evidence.",
+      }),
+    ).toMatchObject({ status: "accepted", threadId: thread.threadId });
+  } finally {
+    titleRelease.resolve();
+    subscription.abort();
+    await title;
+    await lifecycle.close();
+  }
+});
+
+test("PresentationSession dispatches v3 child controls and observes settlement without refreshing or blocking Main", async () => {
+  const driver: ModelDriver = {
+    async *stream() {
+      yield { type: "text_delta", text: "Visible child evidence." };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const modelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, driver, contextProfile };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            contextProfile,
+            readiness: { status: "available" as const, credentialSource: "external fixture" },
+          },
+        ],
+      };
+    },
+  };
+  const lifecycle = harness.createLifecycle({
+    workspaceRoot: process.cwd(),
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    [sessionManagedControl]: {
+      store: createInMemoryManagedAgentControlStore(),
+      childSessionStores: createInMemorySessionStoreDirectory<SessionRecord>(),
+    },
+  });
+  const parent = await lifecycle.create({ targetIdentity });
+  const presentation = await createPresentationSession({
+    lifecycle,
+    modelTargets,
+    workspaceRoot: process.cwd(),
+    projectLabel: "Managed control",
+    sessionId: parent.sessionId,
+    [presentationSessionRecordReader]: async (sessionId) =>
+      (await (await harness.sessions.open(sessionId))?.read()) ?? [],
+  });
+  const settled = Promise.withResolvers<void>();
+  const unsubscribe = presentation.subscribe(() => {
+    if (presentation.getState().authoritative.managedControl?.threads[0]?.turn.phase === "idle")
+      settled.resolve();
+  });
+  try {
+    expect(
+      await presentation.dispatch({
+        type: "managed_control",
+        commandId: "start-child",
+        command: {
+          type: "start_thread",
+          parentSessionId: parent.sessionId,
+          role: "builtin:explore",
+          task: "Inspect evidence.",
+          description: "Visible evidence",
+        },
+      }),
+    ).toMatchObject({ status: "admitted", control: { status: "accepted" } });
+    await withManagedFailureGuard(settled.promise, "Presentation settled child frame");
+    expect(
+      presentation.getState().authoritative.managedControl?.threads[0]?.turn.outcome?.summary,
+    ).toBe("Visible child evidence.");
+    expect(
+      (
+        await lifecycle.continue({
+          sessionId: parent.sessionId,
+          input: { text: "Ordinary Main input." },
+        })
+      ).result.status,
+    ).toBe("completed");
+  } finally {
+    unsubscribe();
+    await presentation.close();
+    await lifecycle.close();
+  }
+});
+
+test("ManagedAgentControl observers register before their initial read and remain independent after one aborts", async () => {
+  const harness = await controlHarness({
+    async *stream() {
+      yield { type: "text_delta", text: "Observed evidence." };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  const firstAbort = new AbortController();
+  const secondAbort = new AbortController();
+  const first = harness.control
+    .observe({ parentSessionId, signal: firstAbort.signal })
+    [Symbol.asyncIterator]();
+  const second = harness.control
+    .observe({ parentSessionId, signal: secondAbort.signal })
+    [Symbol.asyncIterator]();
+  try {
+    const initialFirst = first.next();
+    const initialSecond = second.next();
+    const admission = harness.control.dispatch({
+      type: "start_thread",
+      parentSessionId,
+      role: "builtin:explore",
+      task: "Observe.",
+      description: "Observed evidence",
+    });
+    const initial = await initialSecond;
+    expect((await initialFirst).value?.type).toBe("snapshot");
+    expect(initial.value?.type).toBe("snapshot");
+    expect(await admission).toMatchObject({ status: "accepted" });
+    firstAbort.abort();
+    expect(await first.next()).toMatchObject({ done: true });
+    const revisions = [initial.value?.snapshot.revision ?? -1];
+    await withManagedFailureGuard(
+      (async () => {
+        while (true) {
+          const frame = await second.next();
+          if (frame.done) throw new Error("Second subscription ended unexpectedly.");
+          revisions.push(frame.value.snapshot.revision);
+          if (frame.value.snapshot.threads[0]?.turn.phase === "idle") break;
+        }
+      })(),
+      "independent second subscriber settlement",
+    );
+    expect(
+      revisions.every(
+        (revision, index) => index === 0 || revision === (revisions[index - 1] ?? -1) + 1,
+      ),
+    ).toBe(true);
+  } finally {
+    firstAbort.abort();
+    secondAbort.abort();
+    await first.return?.();
+    await second.return?.();
+    await harness.close();
+  }
+});
+
+test("ManagedAgentControl resumes a validated pre-provider start only after explicit recovery", async () => {
+  const harness = await controlHarness({
+    async *stream() {
+      yield { type: "text_delta", text: "Explicitly resumed evidence." };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  const reached = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const original = createManagedAgentControl({
+    ...harness.options,
+    [managedAgentRecordBarrier]: async (record) => {
+      if (record.event.type === "started") {
+        reached.resolve();
+        await release.promise;
+      }
+    },
+  });
+  const subscription = new AbortController();
+  try {
+    await original.dispatch({
+      type: "start_thread",
+      parentSessionId,
+      role: "builtin:explore",
+      task: "Resume this exact task.",
+      description: "Resume evidence",
+    });
+    await withManagedFailureGuard(reached.promise, "pre-provider start barrier");
+    const frozen = await harness.options.store.read();
+    const admission = frozen[0];
+    if (admission === undefined) throw new Error("Missing admission.");
+    const childRecords = await (
+      await harness.options.childSessionStores.open(admission.childSessionId)
+    )?.read();
+    if (childRecords === undefined) throw new Error("Missing prepared child.");
+    const coldStore = createInMemoryManagedAgentControlStore();
+    for (const record of frozen) await coldStore.append(record);
+    const childStores = createInMemorySessionStoreDirectory<SessionRecord>();
+    const restoredChild = await childStores.create(admission.childSessionId);
+    for (const record of childRecords) await restoredChild.append(record);
+    release.resolve();
+    await original.dispatch({ type: "close", parentSessionId });
+    const cold = createManagedAgentControl({
+      ...harness.options,
+      store: coldStore,
+      childSessionStores: childStores,
+    });
+    expect((await cold.inspect({ parentSessionId })).threads[0]?.turn.recovery).toBe("required");
+    expect(await restoredChild.read()).toEqual(childRecords);
+    const settled = (async () => {
+      for await (const frame of cold.observe({ parentSessionId, signal: subscription.signal })) {
+        if (frame.snapshot.threads[0]?.turn.phase === "idle") return frame.snapshot.threads[0];
+      }
+      throw new Error("Missing resumed turn.");
+    })();
+    expect(
+      await cold.dispatch({
+        type: "recover_turn",
+        parentSessionId,
+        threadId: admission.threadId,
+        expectedTurnId: admission.turnId,
+      }),
+    ).toMatchObject({ status: "accepted", turnId: admission.turnId });
+    expect(
+      (await withManagedFailureGuard(settled, "resumed pre-provider turn")).turn.outcome?.summary,
+    ).toBe("Explicitly resumed evidence.");
+    await cold.dispatch({ type: "close", parentSessionId });
+  } finally {
+    release.resolve();
+    subscription.abort();
+    await original.dispatch({ type: "close", parentSessionId });
+    await harness.close();
+  }
+});
+
+test("ManagedAgentControl persists causal watchdog identity and retains a stalled partial outcome without per-token control writes", async () => {
+  const waiting = Promise.withResolvers<void>();
+  const callbacks: (() => void)[] = [];
+  const harness = await controlHarness({
+    async *stream(request) {
+      yield { type: "text_delta", text: "Partial " };
+      yield { type: "text_delta", text: "evidence." };
+      waiting.resolve();
+      await new Promise<void>((resolve) => {
+        if (request.signal.aborted) resolve();
+        else request.signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+    },
+  });
+  const control = createManagedAgentControl({
+    ...harness.options,
+    now: () => 1_900_000_000_000,
+    inactivityScheduler: {
+      schedule(milliseconds, callback) {
+        expect(milliseconds).toBe(300_000);
+        callbacks.push(callback);
+        return { cancel() {} };
+      },
+    },
+  });
+  const subscription = new AbortController();
+  const terminal = (async () => {
+    for await (const frame of control.observe({ parentSessionId, signal: subscription.signal })) {
+      if (frame.snapshot.threads[0]?.turn.phase === "idle") return frame.snapshot.threads[0];
+    }
+    throw new Error("Missing stalled outcome.");
+  })();
+  void terminal.catch(() => undefined);
+  try {
+    await control.dispatch({
+      type: "start_thread",
+      parentSessionId,
+      role: "builtin:explore",
+      task: "Inspect evidence.",
+      description: "Stall evidence",
+    });
+    await withManagedFailureGuard(waiting.promise, "stream waiting after causal deltas");
+    const snapshot = await control.inspect({ parentSessionId });
+    expect(snapshot.threads[0]?.turn.watchdog).toMatchObject({
+      maximumInactivityMilliseconds: 300_000,
+      lastProgressAtUnixMilliseconds: 1_900_000_000_000,
+    });
+    expect((await harness.options.store.read()).map((record) => record.event.type)).toEqual([
+      "admitted",
+      "started",
+      "execution_progress",
+    ]);
+    const expire = callbacks.at(-1);
+    if (expire === undefined) throw new Error("Missing executing watchdog.");
+    expire();
+    expect((await withManagedFailureGuard(terminal, "stalled settlement")).turn).toMatchObject({
+      health: "stalled",
+      outcome: {
+        status: "failed",
+        summary: "Partial evidence.",
+        error: { code: "managed_agent_stalled" },
+      },
+    });
+  } finally {
+    subscription.abort();
+    await control.dispatch({ type: "close", parentSessionId });
+    await harness.close();
+  }
+});
+
+test("SessionLifecycle accepts a v3 completion once into canonical Main request history before acknowledging consumption", async () => {
+  const driver: ModelDriver = {
+    async *stream() {
+      yield { type: "text_delta", text: "Canonical completion evidence." };
+      yield { type: "usage", inputTokens: 20, outputTokens: 5 };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const harness = createInMemorySessionLifecycleHarness();
+  const controlStore = createInMemoryManagedAgentControlStore();
+  const lifecycle = harness.createLifecycle({
+    workspaceRoot: process.cwd(),
+    modelTargets: {
+      async resolve() {
+        return { identity: targetIdentity, driver, contextProfile };
+      },
+      async snapshot() {
+        return {
+          targets: [
+            {
+              identity: targetIdentity,
+              contextProfile,
+              readiness: { status: "available", credentialSource: "external fixture" },
+            },
+          ],
+        };
+      },
+    },
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    [sessionManagedControl]: {
+      store: controlStore,
+      childSessionStores: createInMemorySessionStoreDirectory<SessionRecord>(),
+    },
+  });
+  const subscription = new AbortController();
+  try {
+    const parent = await lifecycle.create({ targetIdentity });
+    const control = await lifecycle[sessionManagedControl](parent.sessionId);
+    if (control === undefined) throw new Error("Missing control.");
+    const completed = (async () => {
+      for await (const frame of control.observe({
+        parentSessionId: parent.sessionId,
+        signal: subscription.signal,
+      })) {
+        if (frame.snapshot.threads[0]?.turn.phase === "idle") return;
+      }
+      throw new Error("Missing child completion.");
+    })();
+    void completed.catch(() => undefined);
+    await control.dispatch({
+      type: "start_thread",
+      parentSessionId: parent.sessionId,
+      role: "builtin:explore",
+      task: "Inspect evidence.",
+      description: "Completion evidence",
+    });
+    await withManagedFailureGuard(completed, "completion before Main request");
+    expect(
+      (
+        await lifecycle.continue({
+          sessionId: parent.sessionId,
+          input: { text: "Use the completed evidence." },
+        })
+      ).result.status,
+    ).toBe("completed");
+    expect(
+      (
+        await lifecycle.continue({
+          sessionId: parent.sessionId,
+          input: { text: "One further Main request." },
+        })
+      ).result.status,
+    ).toBe("completed");
+    const records = await (await harness.sessions.open(parent.sessionId))?.read();
+    const deliveries =
+      records?.flatMap((record) =>
+        record.schemaVersion === 3 && record.record.type === "provider_attempt_started"
+          ? (record.record.managedAgentDeliveries ?? [])
+          : [],
+      ) ?? [];
+    expect(deliveries).toHaveLength(1);
+    expect(
+      (await control.inspect({ parentSessionId: parent.sessionId })).completions[0]?.consumption,
+    ).toBe("consumed");
+    expect(
+      (await controlStore.read()).filter((record) => record.event.type === "consumed"),
+    ).toHaveLength(1);
+  } finally {
+    subscription.abort();
+    await lifecycle.close();
+  }
+});
+
+test("ManagedAgentStore serializes concurrent parent admissions and outcomes in one shared control journal", async () => {
+  const release = Promise.withResolvers<void>();
+  const started = Promise.withResolvers<void>();
+  let calls = 0;
+  const harness = await controlHarness({
+    async *stream() {
+      if (++calls === 2) started.resolve();
+      await release.promise;
+      yield { type: "text_delta", text: "Concurrent evidence." };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  const secondParent = "00000000-0000-4000-8000-000000000099";
+  const second = createManagedAgentControl({ ...harness.options, parentSessionId: secondParent });
+  const subscription = new AbortController();
+  const observeTerminal = async (control: typeof second, parent: string) => {
+    for await (const frame of control.observe({
+      parentSessionId: parent,
+      signal: subscription.signal,
+    }))
+      if (frame.snapshot.threads[0]?.turn.phase === "idle") return;
+    throw new Error("Missing concurrent terminal.");
+  };
+  const terminals = Promise.all([
+    observeTerminal(harness.control, parentSessionId),
+    observeTerminal(second, secondParent),
+  ]);
+  void terminals.catch(() => undefined);
+  try {
+    const receipts = await Promise.all([
+      harness.control.dispatch({
+        type: "start_thread",
+        parentSessionId,
+        role: "builtin:explore",
+        task: "First parent.",
+        description: "First evidence",
+      }),
+      second.dispatch({
+        type: "start_thread",
+        parentSessionId: secondParent,
+        role: "builtin:explore",
+        task: "Second parent.",
+        description: "Second evidence",
+      }),
+    ]);
+    expect(receipts.map((receipt) => receipt.status)).toEqual(["accepted", "accepted"]);
+    await withManagedFailureGuard(started.promise, "both concurrent providers");
+    release.resolve();
+    await withManagedFailureGuard(terminals, "both concurrent outcomes");
+    const records = await harness.options.store.read();
+    expect(records.filter((record) => record.event.type === "outcome")).toHaveLength(2);
+  } finally {
+    release.resolve();
+    subscription.abort();
+    await second.dispatch({ type: "close", parentSessionId: secondParent });
+    await harness.close();
+  }
+});
+
+test("ManagedAgentControl keeps a cold thread suspended in later frames after unrelated admission", async () => {
+  const harness = await controlHarness({
+    async *stream() {
+      yield { type: "text_delta", text: "Unrelated evidence." };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  const identity = {
+    schemaVersion: 3 as const,
+    parentSessionId,
+    threadId: "00000000-0000-4000-8000-000000000012",
+    turnId: "00000000-0000-4000-8000-000000000013",
+    attemptId: "00000000-0000-4000-8000-000000000014",
+    childSessionId: "00000000-0000-4000-8000-000000000015",
+  };
+  await harness.options.store.append({
+    ...identity,
+    sequence: 1,
+    event: {
+      type: "admitted",
+      role: "builtin:explore",
+      task: "Cold task.",
+      description: "Cold evidence",
+    },
+  });
+  await harness.options.store.append({ ...identity, sequence: 2, event: { type: "started" } });
+  const subscription = new AbortController();
+  const frames = harness.control
+    .observe({ parentSessionId, signal: subscription.signal })
+    [Symbol.asyncIterator]();
+  try {
+    expect((await frames.next()).value?.snapshot.threads[0]).toMatchObject({
+      residency: "unloaded",
+      turn: { phase: "waiting", recovery: "required" },
+    });
+    await harness.control.dispatch({
+      type: "start_thread",
+      parentSessionId,
+      role: "builtin:explore",
+      task: "Unrelated task.",
+      description: "Unrelated evidence",
+    });
+    expect((await frames.next()).value?.snapshot.threads[0]).toMatchObject({
+      residency: "unloaded",
+      turn: { phase: "waiting", recovery: "required", waitReason: "suspended" },
+    });
+  } finally {
+    subscription.abort();
+    await frames.return?.();
+    await harness.close();
+  }
+});
+
+test("ManagedAgentControl refuses consumption from an orphan legacy Main receipt even when completion IDs match", async () => {
+  const harness = await controlHarness({
+    async *stream() {
+      yield { type: "text_delta", text: "Unconsumed evidence." };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  const subscription = new AbortController();
+  const ready = (async () => {
+    for await (const frame of harness.control.observe({
+      parentSessionId,
+      signal: subscription.signal,
+    }))
+      if (frame.snapshot.completions[0] !== undefined) return frame.snapshot.completions[0];
+    throw new Error("Missing pending completion.");
+  })();
+  void ready.catch(() => undefined);
+  try {
+    await harness.control.dispatch({
+      type: "start_thread",
+      parentSessionId,
+      role: "builtin:explore",
+      task: "Inspect evidence.",
+      description: "Pending evidence",
+    });
+    const completion = await withManagedFailureGuard(
+      ready,
+      "pending completion for receipt validation",
+    );
+    await harness.control.dispatch({ type: "close", parentSessionId });
+    const parentStore = createInMemorySessionStore<SessionRecord>();
+    const deliveries = [{ id: completion.id, digest: completion.receipt.digest }];
+    await parentStore.append({
+      schemaVersion: 3,
+      sequence: 1,
+      record: {
+        type: "provider_attempt_started",
+        runId: "00000000-0000-4000-8000-000000000055",
+        turn: 1,
+        attempt: 1,
+        targetIdentity,
+        managedAgentDeliveries: deliveries,
+      },
+    });
+    const cold = createManagedAgentControl({ ...harness.options, parentSessionStore: parentStore });
+    expect(
+      await cold.dispatch({ type: "acknowledge_main_delivery", parentSessionId, deliveries }),
+    ).toMatchObject({ status: "rejected", code: "recovery_required" });
+    expect((await cold.inspect({ parentSessionId })).completions[0]?.consumption).toBe("pending");
+    await cold.dispatch({ type: "close", parentSessionId });
+  } finally {
+    subscription.abort();
+    await harness.close();
+  }
+});
+
+test("ManagedAgentControl reports a cleanup deadline and incomplete close while retaining settlement authority", async () => {
+  const cleanupEntered = Promise.withResolvers<void>();
+  const cleanupRelease = Promise.withResolvers<void>();
+  const closeTimer = Promise.withResolvers<() => void>();
+  const callbacks: (() => void)[] = [];
+  const harness = await controlHarness({
+    async *stream() {
+      yield { type: "text_delta", text: "Retain outcome during cleanup." };
+      yield { type: "usage", inputTokens: 20, outputTokens: 5 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  const control = createManagedAgentControl({
+    ...harness.options,
+    cleanupScheduler: {
+      schedule(milliseconds, expire) {
+        expect(milliseconds).toBe(10_000);
+        callbacks.push(expire);
+        if (callbacks.length === 2) closeTimer.resolve(expire);
+        return { cancel() {} };
+      },
+    },
+    [managedAgentSettlementBarrier]: async () => {
+      cleanupEntered.resolve();
+      await cleanupRelease.promise;
+    },
+  });
+  const subscription = new AbortController();
+  const settled = (async () => {
+    for await (const frame of control.observe({ parentSessionId, signal: subscription.signal }))
+      if (frame.snapshot.threads[0]?.turn.phase === "idle") return;
+    throw new Error("Missing late cleanup settlement.");
+  })();
+  void settled.catch(() => undefined);
+  try {
+    await control.dispatch({
+      type: "start_thread",
+      parentSessionId,
+      role: "builtin:explore",
+      task: "Inspect evidence.",
+      description: "Cleanup evidence",
+    });
+    await withManagedFailureGuard(cleanupEntered.promise, "cleanup entry");
+    const expire = callbacks[0];
+    if (expire === undefined) throw new Error("Missing cleanup deadline.");
+    expire();
+    expect((await control.inspect({ parentSessionId })).threads[0]?.turn).toMatchObject({
+      phase: "settling",
+      recovery: "required",
+      diagnostic: "Cleanup has not settled. Inspect durable state.",
+    });
+    const closing = control.dispatch({ type: "close", parentSessionId });
+    (await withManagedFailureGuard(closeTimer.promise, "bounded close deadline"))();
+    expect(await closing).toMatchObject({ status: "rejected", code: "recovery_required" });
+    cleanupRelease.resolve();
+    await withManagedFailureGuard(settled, "late causal cleanup settlement");
+    expect(await control.dispatch({ type: "close", parentSessionId })).toMatchObject({
+      status: "closed",
+    });
+  } finally {
+    cleanupRelease.resolve();
+    subscription.abort();
+    await control.dispatch({ type: "close", parentSessionId });
+    await harness.close();
+  }
+});
+
+test.each(["managed-agent-tools.a1.v1", "managed-agent-tools.a1.v2"] as const)(
+  "Historical %s decodes its exact schema and refuses new execution without a manager",
+  (profile) => {
+    const registry = createManagedAgentToolRegistry({ readOnly: true, profile });
+    expect(registry.resolve("spawn_agents")).toBeUndefined();
+    expect(registry.resolve("spawn_agent")?.prepare('{"task":"Inspect evidence."}')).toMatchObject({
+      status: "failed",
+      error: { code: "managed_agent_unavailable" },
+    });
+    expect(registry.resolve("spawn_agent")?.prepare('{"task":5}')).toMatchObject({
+      status: "failed",
+      error: { code: "invalid_tool_input" },
+    });
+  },
+);
+
+test("ManagedAgentControl cannot inspect cancel or recover another parent's live turn", async () => {
+  const started = Promise.withResolvers<void>();
+  const harness = await controlHarness({
+    async *stream(request) {
+      started.resolve();
+      await new Promise<void>((resolve) =>
+        request.signal.addEventListener("abort", () => resolve(), { once: true }),
+      );
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  const parent = "00000000-0000-4000-8000-000000000099";
+  const second = createManagedAgentControl({ ...harness.options, parentSessionId: parent });
+  try {
+    const receipt = await second.dispatch({
+      type: "start_thread",
+      parentSessionId: parent,
+      role: "builtin:explore",
+      task: "Other parent's work.",
+      description: "Other parent",
+    });
+    if (receipt.status !== "accepted") throw new Error("Missing foreign turn.");
+    await withManagedFailureGuard(started.promise, "foreign provider start");
+    const before = await harness.options.store.forParent(parent).read();
+    for (const type of ["cancel_turn", "recover_turn"] as const)
+      expect(
+        await harness.control.dispatch({
+          type,
+          parentSessionId,
+          threadId: receipt.threadId,
+          expectedTurnId: receipt.turnId,
+        }),
+      ).toMatchObject({ status: "rejected", code: "stale_revision" });
+    await expect(harness.control.inspect({ parentSessionId: parent })).rejects.toBeInstanceOf(
+      TypeError,
+    );
+    expect(await harness.options.store.forParent(parent).read()).toEqual(before);
+  } finally {
+    await second.dispatch({ type: "close", parentSessionId: parent });
+    await harness.close();
+  }
+});
+
+test("ManagedAgentControl keeps outcome Settling until cleanup and admits immediate continuation under the live project root", async () => {
+  const cleanupEntered = Promise.withResolvers<void>();
+  const cleanupRelease = Promise.withResolvers<void>();
+  const model: ModelDriver = {
+    async *stream() {
+      yield { type: "text_delta", text: "Exact child evidence." };
+      yield { type: "usage", inputTokens: 20, outputTokens: 5 };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const domain = createProjectExecutionDomain({
+    lifecycleOwner: {
+      async acquire() {
+        return { async release() {} };
+      },
+      async run(operation) {
+        return operation();
+      },
+    },
+  });
+  const root = await domain.claimRoot({ rootId: "project-runtime" });
+  const control = createManagedAgentControl({
+    parentSessionId,
+    projectId,
+    workspaceRoot: process.cwd(),
+    targetIdentity,
+    contextProfile,
+    model,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    executionDomain: domain,
+    store: createInMemoryManagedAgentControlStore(),
+    childSessionStores: createInMemorySessionStoreDirectory<SessionRecord>(),
+    [managedAgentSettlementBarrier]: async () => {
+      cleanupEntered.resolve();
+      await cleanupRelease.promise;
+    },
+  });
+  const subscription = new AbortController();
+  const frames = control.observe({ parentSessionId, signal: subscription.signal });
+  const settled = (async () => {
+    for await (const frame of frames) {
+      if (frame.snapshot.threads[0]?.turn.phase === "idle") return frame.snapshot.threads[0];
+    }
+    throw new Error("Missing settled thread.");
+  })();
+  try {
+    const admitted = await control.dispatch({
+      type: "start_thread",
+      parentSessionId,
+      role: "builtin:explore",
+      task: "Find exact evidence.",
+      description: "Inspect evidence",
+    });
+    expect(admitted.status).toBe("accepted");
+    await withManagedFailureGuard(cleanupEntered.promise, "outcome cleanup entry");
+    const thread = (await control.inspect({ parentSessionId })).threads[0];
+    expect(thread).toMatchObject({
+      parentSessionId,
+      lifecycle: "open",
+      handle: "@explore-1",
+      displayName: "Explore",
+      residency: "live",
+      turn: {
+        phase: "settling",
+        label: "Settling",
+        ownerPhase: "releasing",
+        health: "healthy",
+        waitReason: "none",
+        lastOutcome: "completed",
+      },
+    });
+    if (thread === undefined) throw new Error("Missing admitted thread.");
+    expect(
+      await control.dispatch({
+        type: "next_turn",
+        parentSessionId,
+        threadId: thread.threadId,
+        expectedTurnId: thread.turn.turnId,
+        task: "Continue exact evidence.",
+      }),
+    ).toMatchObject({ status: "rejected", code: "authority_busy" });
+    cleanupRelease.resolve();
+    const terminal = await withManagedFailureGuard(settled, "settled observation");
+    expect(
+      await control.dispatch({
+        type: "next_turn",
+        parentSessionId,
+        threadId: terminal.threadId,
+        expectedTurnId: terminal.turn.turnId,
+        task: "Continue exact evidence.",
+      }),
+    ).toMatchObject({ status: "accepted", threadId: terminal.threadId });
+  } finally {
+    cleanupRelease.resolve();
+    subscription.abort();
+    await control.dispatch({ type: "close", parentSessionId });
+    await root.release();
+    await domain.close();
+  }
+});

--- a/packages/testkit/src/project-execution-domain-topology.test.ts
+++ b/packages/testkit/src/project-execution-domain-topology.test.ts
@@ -9,12 +9,15 @@ const agentSourceRoot = fileURLToPath(new URL("../../agent/src/", import.meta.ur
 test("ProjectExecutionDomain is the sole production caller of ProjectLifecycleOwner", async () => {
   const sources = await productionAgentSources();
   const ownerMethodCalls = sources.flatMap(({ path, source }) =>
-    [...source.matchAll(/\b([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\.(acquire|run)\(/gu)].map(
-      (match) => ({ call: `${match[1]}.${match[2]}`, path }),
-    ),
+    [
+      ...source.matchAll(
+        /\b([A-Za-z_$][\w$]*(?:\s*\.\s*[A-Za-z_$][\w$]*)*)\s*\.\s*(acquire|run)\s*\(/gu,
+      ),
+    ].map((match) => ({ call: `${match[1]?.replace(/\s+/gu, "")}.${match[2]}`, path })),
   );
 
   expect(ownerMethodCalls).toEqual([
+    { call: "child.run", path: "managed-agent-control.ts" },
     { call: "child.run", path: "managed-agent.ts" },
     { call: "options.lifecycleOwner.acquire", path: "project-execution-domain.ts" },
     { call: "session.run", path: "session-lifecycle.ts" },

--- a/packages/testkit/src/project-execution-domain.test.ts
+++ b/packages/testkit/src/project-execution-domain.test.ts
@@ -9,6 +9,68 @@ import {
 } from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
 
+test("ProjectExecutionDomain admits Main child and control scopes beneath title while fencing the same child thread", async () => {
+  let acquisitions = 0;
+  const domain = createProjectExecutionDomain({
+    lifecycleOwner: {
+      async acquire() {
+        acquisitions += 1;
+        return { async release() {} };
+      },
+      async run(operation) {
+        return operation();
+      },
+    },
+  });
+  const title = await domain.claimRoot({ rootId: "project-runtime" });
+  const main = await domain.claimScope({ kind: "main_run", sessionId: "parent", identity: "run" });
+  const child = await domain.claimScope({
+    kind: "child_attempt",
+    sessionId: "parent",
+    threadId: "thread",
+    identity: "attempt-1",
+  });
+  const control = await domain.claimScope({
+    kind: "control",
+    sessionId: "parent",
+    identity: "command",
+  });
+  try {
+    await expect(
+      domain.claimScope({
+        kind: "child_attempt",
+        sessionId: "parent",
+        threadId: "thread",
+        identity: "attempt-2",
+      }),
+    ).rejects.toMatchObject({ code: "root_conflict" });
+    expect(acquisitions).toBe(1);
+    await child.release();
+    const next = await domain.claimScope({
+      kind: "child_attempt",
+      sessionId: "parent",
+      threadId: "thread",
+      identity: "attempt-2",
+    });
+    await child.release();
+    await expect(
+      domain.claimScope({
+        kind: "child_attempt",
+        sessionId: "parent",
+        threadId: "thread",
+        identity: "attempt-3",
+      }),
+    ).rejects.toMatchObject({ code: "root_conflict" });
+    await next.release();
+  } finally {
+    await control.release();
+    await child.release();
+    await main.release();
+    await title.release();
+    await domain.close();
+  }
+});
+
 test("ProjectExecutionDomain retains one owner for a subordinate claim and the same root", async () => {
   let acquisitions = 0;
   let releases = 0;


### PR DESCRIPTION
Managed turns need an authoritative settlement barrier before continuation becomes available. This adds an internal managed-control composition with stable thread/turn identities, parent-scoped v3 journals, hierarchical project claims, and explicit recovery through the existing AgentSession and SessionLifecycle owners.

Outcome, claim cleanup, settlement, completion, and Main consumption have distinct durable receipts. Recovery retains typed failure/stall evidence and bounded canonical partial output, reconstructs missing outcomes or acknowledgements without resending a provider request, and isolates attributable child or parent-journal corruption. Historical managed schemas remain readable and refuse new execution through the candidate composition.

The new path is wired through an internal test entry. Default CLI/TUI activation is a later change.

Validation:

- Complete `pnpm quality:check`: 1,899 tests passed, 18 existing opt-in skips; code, Markdown, TypeScript and browser checks passed.
- Independent Standards and Specification reviews completed with their findings repaired and rechecked.
- Real JSONL/process crash coverage across admission, genesis, provider receipt/terminal intent, child terminal, outcome, settlement, completion and Main receipt/ack boundaries; title concurrency, cancellation, corruption isolation and observer failure/reset regressions.
- Existing timeout, worker, assertion and skip settings retained. OS contracts passed with the permissions required for FIFO/socket/process tests.
