### PR TITLE
Add managed-agent workspace and conversation controls

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -416,3 +416,31 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ```
+
+## pi-subagents UI adaptation
+
+AgentWidget, AgentFleet and AgentConversationViewer adapt UI layout and focus behavior from tintinweb/pi-subagents 0.19.0, commit `4f572eaa04c09d3dbc16e4a5f13a16b295e84e14`, source files `src/ui/agent-widget.ts`, `src/ui/fleet-list.ts`, `src/ui/conversation-viewer.ts` and `src/ui/viewer-keys.ts`. Adam retains its own execution, permission, persistence and input-delivery owners.
+
+```text
+MIT License
+
+Copyright (c) 2026 tintinweb
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/apps/tui/src/agent-conversation-viewer.ts
+++ b/apps/tui/src/agent-conversation-viewer.ts
@@ -1,0 +1,1404 @@
+/**
+ * Conversation focus and keys adapted from tintinweb/pi-subagents
+ * src/ui/conversation-viewer.ts and src/ui/viewer-keys.ts
+ * at 4f572eaa04c09d3dbc16e4a5f13a16b295e84e14 (MIT). See THIRD_PARTY_NOTICES.md.
+ * The independent editor never transfers input to the Main editor.
+ */
+import { randomUUID } from "node:crypto";
+import type {
+  AgentExportField,
+  ArtifactChunk,
+  ArtifactRange,
+  ArtifactReference,
+  CommandReceipt,
+  ManagedAgentExport,
+  ManagedAgentTranscriptPageResource,
+  ManagedComposerDraft,
+  ManagedControlCommand,
+  ManagedControlThread,
+  ManagedWorkspaceSnapshot,
+  PresentationDisplayState,
+  TranscriptItem,
+} from "@adam-agent/presentation";
+import {
+  agentExportFields,
+  nextAgentViewerMode,
+  presentationArtifactPageMaximumBytes,
+} from "@adam-agent/presentation";
+import {
+  type Component,
+  getKeybindings,
+  Input,
+  isKeyRelease,
+  isKeyRepeat,
+  Markdown,
+  matchesKey,
+  truncateToWidth,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import { agentElapsedLabel } from "./agent-widget.js";
+import { safeTerminalText } from "./safe-terminal-text.js";
+import type { AdamTuiTheme } from "./theme.js";
+import { ToolPreview } from "./tool-preview.js";
+
+const viewerKeys = {
+  up: (data: string) => getKeybindings().matches(data, "tui.select.up") || matchesKey(data, "k"),
+  down: (data: string) =>
+    getKeybindings().matches(data, "tui.select.down") || matchesKey(data, "j"),
+  pageUp: (data: string) =>
+    getKeybindings().matches(data, "tui.select.pageUp") || matchesKey(data, "shift+up"),
+  pageDown: (data: string) =>
+    getKeybindings().matches(data, "tui.select.pageDown") || matchesKey(data, "shift+down"),
+};
+
+type ConversationPage = {
+  readonly items: readonly TranscriptItem[];
+  readonly liveText: string | undefined;
+  readonly liveOmittedBytes: number;
+  readonly cursor: string | null;
+  readonly olderCursor: string | null;
+};
+
+export type AgentConversationResource =
+  | { readonly kind: "input"; readonly inputId: string; readonly label: string }
+  | { readonly kind: "reasoning" | "tool"; readonly itemId: string; readonly label: string }
+  | { readonly kind: "artifact"; readonly artifact: ArtifactReference; readonly label: string };
+
+type ResourceView = {
+  readonly thread: ManagedControlThread;
+  readonly entries: readonly AgentConversationResource[];
+  selected: number;
+  visible: ReadonlySet<number>;
+  page: ArtifactChunk | undefined;
+  previousOffsets: number[];
+  scroll: number;
+  maximumScroll: number;
+  pending: boolean;
+  generation: number;
+  notice: string;
+  restoreArmed?: boolean;
+  inputOnly?: boolean;
+};
+
+type ExportView = {
+  readonly thread: ManagedControlThread;
+  readonly completion: ManagedWorkspaceSnapshot["completions"][number];
+  readonly fields: Set<AgentExportField>;
+  selected: number;
+  visible: ReadonlySet<number>;
+  phase: "fields" | "confirm" | "pending" | "ready";
+  confirmRendered: boolean;
+  result: ManagedAgentExport | undefined;
+  notice: string;
+};
+
+export class AgentConversationViewer implements Component {
+  #thread: ManagedControlThread;
+  #completion: ManagedWorkspaceSnapshot["completions"][number] | undefined;
+  readonly #seenAttempts = new Set<string>();
+  #suppressTarget: ManagedWorkspaceSnapshot["completions"][number] | undefined;
+  #suppressPending = false;
+  #exports: readonly ManagedAgentExport[] = [];
+  #exportView: ExportView | undefined;
+  readonly #composer = new Input();
+  #composing = false;
+  #focused = false;
+  #activity: NonNullable<PresentationDisplayState["managedAgentActivity"]>[number] | undefined;
+  #liveText: string | undefined;
+  #liveOmittedBytes = 0;
+  #items: readonly TranscriptItem[] = [];
+  #olderCursor: string | null = null;
+  #currentCursor: string | null = null;
+  #manualPage: ConversationPage | undefined;
+  #newerCursors: (string | null)[] = [];
+  #pageReadPending = false;
+  #pageGeneration = 0;
+  #readKey = "";
+  #readGeneration = 0;
+  #closed = false;
+  #details = false;
+  #detailScroll = 0;
+  #detailMaximumScroll = 0;
+  #notice = "";
+  #scrollOffset = 0;
+  #followTail = true;
+  #maximumScroll = 0;
+  #bodyHeight = 1;
+  #composeTarget:
+    | Pick<ManagedComposerDraft, "parentSessionId" | "threadId" | "expectedTurnId" | "attentionId">
+    | undefined;
+  #retargetPending = false;
+  #mode: "cooperative" | "interrupt" | "new_turn" | "reply" = "cooperative";
+  #sending = false;
+  #inputNotice = "";
+  #lastInputId: string | undefined;
+  #submission:
+    | { readonly id: string; readonly text: string; readonly mode: string; readonly turnId: string }
+    | undefined;
+  #renderMode: "raw" | "assistant" | "full" = "assistant";
+  readonly #markdown = new Map<
+    string,
+    { readonly component: Markdown; text: string; failed: boolean }
+  >();
+  #resources: ResourceView | undefined;
+  #cancelTarget:
+    | {
+        readonly parentSessionId: string;
+        readonly threadId: string;
+        readonly expectedTurnId: string;
+      }
+    | undefined;
+  #cancelling = false;
+  constructor(
+    private readonly options: {
+      readonly thread: ManagedControlThread;
+      readonly completion?: ManagedWorkspaceSnapshot["completions"][number] | undefined;
+      readonly exports?: readonly ManagedAgentExport[] | undefined;
+      readonly onExport: (
+        thread: ManagedControlThread,
+        completion: ManagedWorkspaceSnapshot["completions"][number],
+        fields: readonly AgentExportField[],
+      ) => Promise<CommandReceipt>;
+      readonly onSeen: (
+        completion: ManagedWorkspaceSnapshot["completions"][number],
+      ) => Promise<CommandReceipt>;
+      readonly onSuppress: (
+        completion: ManagedWorkspaceSnapshot["completions"][number],
+      ) => Promise<CommandReceipt>;
+      readonly renderMode?: "raw" | "assistant" | "full";
+      readonly onRenderMode?: (mode: "raw" | "assistant" | "full") => Promise<CommandReceipt>;
+      readonly drafts: Map<string, ManagedComposerDraft>;
+      readonly theme: AdamTuiTheme;
+      readonly activity?:
+        | NonNullable<PresentationDisplayState["managedAgentActivity"]>[number]
+        | undefined;
+      readonly maximumLines: () => number;
+      readonly onRead: (
+        thread: ManagedControlThread,
+        cursor: string | null,
+      ) => Promise<ManagedAgentTranscriptPageResource>;
+      readonly onSend: (command: ManagedControlCommand) => Promise<CommandReceipt>;
+      readonly onSaveDraft: (draft: ManagedComposerDraft) => Promise<void>;
+      readonly onClearDraft: (draft: ManagedComposerDraft) => Promise<boolean>;
+      readonly onReadResource: (
+        thread: ManagedControlThread,
+        resource: AgentConversationResource,
+        range: ArtifactRange,
+      ) => Promise<ArtifactChunk>;
+      readonly onChange: () => void;
+      readonly onClose: () => void;
+    },
+  ) {
+    this.#thread = options.thread;
+    this.#completion = options.completion;
+    this.#exports = options.exports ?? [];
+    this.#renderMode = options.renderMode ?? "assistant";
+    const draft = options.drafts.get(options.thread.threadId);
+    if (draft?.parentSessionId === options.thread.parentSessionId) {
+      this.#composer.setValue(draft.text);
+      this.#composeTarget = {
+        parentSessionId: draft.parentSessionId,
+        threadId: draft.threadId,
+        expectedTurnId: draft.expectedTurnId,
+        ...(draft.attentionId === undefined ? {} : { attentionId: draft.attentionId }),
+      };
+      this.#mode = draft.mode;
+      if (draft.inputId !== undefined)
+        this.#submission = {
+          id: draft.inputId,
+          text: draft.text,
+          mode: draft.mode,
+          turnId: draft.expectedTurnId,
+        };
+    }
+    this.#composer.onSubmit = (text) => {
+      void this.submit(text);
+    };
+    this.#activity = options.activity;
+    this.#liveText = options.activity?.assistant?.text;
+    this.#liveOmittedBytes = options.activity?.assistant?.omittedBytes ?? 0;
+    this.refresh();
+  }
+  get focused(): boolean {
+    return this.#focused;
+  }
+  set focused(value: boolean) {
+    this.#focused = value;
+    this.#composer.focused = value && this.#composing;
+  }
+  setExports(exports: readonly ManagedAgentExport[]): void {
+    this.#exports = exports;
+  }
+  setCompletion(completion: ManagedWorkspaceSnapshot["completions"][number] | undefined): void {
+    this.#completion = completion;
+  }
+  setThread(thread: ManagedControlThread): void {
+    if (this.#thread.turn.turnId !== thread.turn.turnId) {
+      this.#items = [];
+      this.#olderCursor = null;
+      this.#liveText = undefined;
+      this.#liveOmittedBytes = 0;
+      this.#manualPage = undefined;
+      this.#currentCursor = null;
+      this.#newerCursors = [];
+      this.#pageGeneration += 1;
+      this.#pageReadPending = false;
+      this.#markdown.clear();
+    }
+    this.#thread = thread;
+    if (
+      this.#composing &&
+      !this.#sending &&
+      this.#composer.getValue().length === 0 &&
+      this.canCompose() &&
+      (!thread.actions?.includes(this.#mode) ||
+        this.#composeTarget?.expectedTurnId !== thread.turn.turnId ||
+        (this.#mode === "reply" && this.#composeTarget?.attentionId !== thread.turn.attention?.id))
+    )
+      this.selectCurrentTarget();
+    this.refresh();
+  }
+  setActivity(activity: PresentationDisplayState["managedAgentActivity"]): void {
+    this.#activity = activity?.find(
+      (entry) =>
+        entry.agentId === this.#thread.threadId && entry.attemptId === this.#thread.turn.attemptId,
+    );
+    if (this.#activity?.assistant !== undefined) {
+      this.#liveText = this.#activity.assistant.text;
+      this.#liveOmittedBytes = this.#activity.assistant.omittedBytes ?? 0;
+    }
+    this.refresh();
+  }
+  private refresh(): void {
+    const thread = this.#thread;
+    const key = `${thread.turn.turnId}:${thread.turn.phase}:${thread.turn.outcome?.transcript.sequence ?? ""}:${this.#activity?.activity ?? ""}:${this.#activity?.tool?.callId ?? ""}:${this.#activity?.tool?.status ?? ""}`;
+    if (key === this.#readKey || this.#closed) return;
+    this.#readKey = key;
+    if (
+      !thread.turn.hasStarted &&
+      thread.turn.outcome?.status === "cancelled" &&
+      thread.turn.outcome.transcript.sequence === 0
+    ) {
+      this.#items = [];
+      this.#notice = "No agent session was started.";
+      return;
+    }
+    const generation = ++this.#readGeneration;
+    void this.options
+      .onRead(thread, null)
+      .then((page) => {
+        if (this.#closed || generation !== this.#readGeneration) return;
+        if (
+          page.agentId !== thread.threadId ||
+          page.turnId !== thread.turn.turnId ||
+          page.childSessionId !== thread.turn.childSessionId
+        )
+          throw new Error("The exact agent transcript changed.");
+        this.#items = page.items;
+        this.#olderCursor = page.olderCursor;
+        this.#currentCursor = page.cursor ?? null;
+        if (this.#activity?.assistant === undefined) {
+          this.#liveText = undefined;
+          this.#liveOmittedBytes = 0;
+        }
+        this.pruneMarkdown();
+        this.#notice = "";
+        this.options.onChange();
+      })
+      .catch((error: unknown) => {
+        if (this.#closed || generation !== this.#readGeneration) return;
+        this.#notice =
+          error instanceof Error ? error.message : "The bounded agent transcript is unavailable.";
+        this.options.onChange();
+      });
+  }
+  dispose(): void {
+    this.#closed = true;
+    this.#readGeneration += 1;
+    this.#pageGeneration += 1;
+    this.#markdown.clear();
+  }
+  private freezePage(): void {
+    if (this.#manualPage === undefined)
+      this.#manualPage = {
+        items: this.#items,
+        liveText: this.#liveText,
+        liveOmittedBytes: this.#liveOmittedBytes,
+        cursor: this.#currentCursor,
+        olderCursor: this.#olderCursor,
+      };
+    this.#followTail = false;
+  }
+  private followTail(): void {
+    this.#manualPage = undefined;
+    this.#newerCursors = [];
+    this.#followTail = true;
+    this.#pageGeneration += 1;
+    this.#pageReadPending = false;
+    this.#readKey = "";
+    this.refresh();
+  }
+  private loadPage(cursor: string | null, direction: "older" | "newer"): void {
+    if (this.#pageReadPending) return;
+    this.freezePage();
+    const previous = this.#manualPage;
+    const thread = this.#thread;
+    const generation = ++this.#pageGeneration;
+    this.#pageReadPending = true;
+    this.#notice = "Loading transcript page…";
+    void this.options
+      .onRead(thread, cursor)
+      .then((page) => {
+        if (this.#closed || generation !== this.#pageGeneration) return;
+        if (
+          page.agentId !== thread.threadId ||
+          page.turnId !== thread.turn.turnId ||
+          page.childSessionId !== thread.turn.childSessionId
+        )
+          throw new Error("The exact transcript page changed.");
+        if (direction === "older") this.#newerCursors.push(previous?.cursor ?? null);
+        else this.#newerCursors.pop();
+        this.#manualPage = {
+          items: page.items,
+          liveText: undefined,
+          liveOmittedBytes: 0,
+          cursor: page.cursor ?? null,
+          olderCursor: page.olderCursor,
+        };
+        this.#scrollOffset = 0;
+        this.#notice = "";
+        this.pruneMarkdown();
+      })
+      .catch((error: unknown) => {
+        if (!this.#closed && generation === this.#pageGeneration)
+          this.#notice =
+            error instanceof Error ? error.message : "The transcript page is unavailable.";
+      })
+      .finally(() => {
+        if (!this.#closed && generation === this.#pageGeneration) {
+          this.#pageReadPending = false;
+          this.options.onChange();
+        }
+      });
+  }
+  private pruneMarkdown(): void {
+    const retained = new Set(
+      [...this.#items, ...(this.#manualPage?.items ?? [])].map((item) => item.id),
+    );
+    retained.add(`live:${this.#thread.turn.attemptId}`);
+    retained.add(`outcome:${this.#thread.turn.turnId}`);
+    for (const key of this.#markdown.keys()) if (!retained.has(key)) this.#markdown.delete(key);
+  }
+  private async submit(text: string): Promise<void> {
+    if (this.#sending || this.#closed) return;
+    if (text.trim().length === 0) {
+      this.back();
+      return;
+    }
+    const target = this.#composeTarget;
+    if (target === undefined) return;
+    if (
+      this.#submission?.text !== text ||
+      this.#submission.mode !== this.#mode ||
+      this.#submission.turnId !== target.expectedTurnId
+    )
+      this.#submission = {
+        id: randomUUID(),
+        text,
+        mode: this.#mode,
+        turnId: target.expectedTurnId,
+      };
+    const inputId = this.#submission.id;
+    const submittedDraft: ManagedComposerDraft = { ...target, mode: this.#mode, inputId, text };
+    const common = {
+      parentSessionId: target.parentSessionId,
+      threadId: target.threadId,
+      expectedTurnId: target.expectedTurnId,
+      inputId,
+      text,
+    };
+    const command: ManagedControlCommand =
+      this.#mode === "reply"
+        ? { ...common, type: "reply_agent", attentionId: target.attentionId ?? "" }
+        : { ...common, type: "post_agent", mode: this.#mode };
+    this.#sending = true;
+    this.#inputNotice = "Accepting exact input…";
+    this.options.onChange();
+    let acceptanceRecorded = false;
+    try {
+      await this.saveLocalDraft();
+      const receipt = await this.options.onSend(command);
+      if (receipt.status === "rejected") this.#inputNotice = receipt.message;
+      else if (
+        receipt.control?.status === "input_accepted" ||
+        receipt.control?.status === "accepted"
+      ) {
+        acceptanceRecorded = true;
+        this.#lastInputId = inputId;
+        this.#inputNotice = "Accepted";
+        if (this.#composer.getValue() === text) {
+          const cleared = await this.options.onClearDraft(submittedDraft);
+          const current = this.options.drafts.get(target.threadId);
+          if (
+            cleared &&
+            current?.inputId === inputId &&
+            current.text === text &&
+            current.expectedTurnId === target.expectedTurnId &&
+            current.mode === submittedDraft.mode &&
+            current.attentionId === submittedDraft.attentionId
+          ) {
+            this.#composer.setValue("");
+            this.options.drafts.delete(target.threadId);
+            if (this.#submission?.id === inputId) this.#submission = undefined;
+          }
+        }
+        if (
+          receipt.control.status === "accepted" &&
+          this.#thread.turn.turnId === receipt.control.turnId
+        ) {
+          this.selectCurrentTarget();
+        }
+      } else this.#inputNotice = "The exact input was not accepted. Your draft is retained.";
+    } catch {
+      this.#inputNotice = acceptanceRecorded
+        ? "Accepted; the private draft could not be cleared. Your text is retained."
+        : "Input acceptance could not be confirmed. Your draft is retained.";
+    } finally {
+      this.#sending = false;
+      if (!this.#closed) this.options.onChange();
+    }
+  }
+  private selectCurrentTarget(): boolean {
+    const thread = this.#thread;
+    const mode = thread.actions?.includes("reply")
+      ? "reply"
+      : thread.actions?.includes("new_turn")
+        ? "new_turn"
+        : thread.actions?.includes("cooperative")
+          ? "cooperative"
+          : undefined;
+    if (mode === undefined) {
+      this.#inputNotice = "Input is unavailable for the current agent state.";
+      return false;
+    }
+    this.#mode = mode;
+    this.#composeTarget = {
+      parentSessionId: thread.parentSessionId,
+      threadId: thread.threadId,
+      expectedTurnId: thread.turn.turnId,
+      ...(this.#mode === "reply" && thread.turn.attention !== undefined
+        ? { attentionId: thread.turn.attention.id }
+        : {}),
+    };
+    this.#submission = undefined;
+    return true;
+  }
+  private saveLocalDraft(): Promise<void> {
+    const target = this.#composeTarget;
+    if (target === undefined) return Promise.resolve();
+    const text = this.#composer.getValue();
+    const draft = {
+      ...target,
+      mode: this.#mode,
+      text,
+      ...(this.#submission?.text === text ? { inputId: this.#submission.id } : {}),
+    };
+    if (text.length === 0) this.options.drafts.delete(target.threadId);
+    else this.options.drafts.set(target.threadId, draft);
+    return this.options.onSaveDraft(draft).catch((error: unknown) => {
+      this.#inputNotice = "The private child draft could not be saved. Your text is retained.";
+      if (!this.#closed) this.options.onChange();
+      throw error;
+    });
+  }
+  back(): void {
+    if (this.#exportView !== undefined) {
+      if (this.#exportView.phase === "confirm") this.#exportView.phase = "fields";
+      else this.#exportView = undefined;
+    } else if (this.#suppressTarget !== undefined) {
+      this.#suppressTarget = undefined;
+    } else if (this.#details) {
+      this.#details = false;
+    } else if (this.#resources !== undefined) {
+      this.#resources.generation += 1;
+      this.#resources.pending = false;
+      if (this.#resources.page !== undefined) {
+        this.#resources.page = undefined;
+        this.#resources.previousOffsets = [];
+      } else this.#resources = undefined;
+    } else if (this.#composing) {
+      this.#composing = false;
+      this.#composer.focused = false;
+    } else this.options.onClose();
+    this.options.onChange();
+  }
+  handleInput(data: string): void {
+    if (isKeyRelease(data)) return;
+    if (!isKeyRepeat(data) && !matchesKey(data, "x")) this.#cancelTarget = undefined;
+    if (matchesKey(data, "enter") && isKeyRepeat(data)) return;
+    if (this.#exportView !== undefined) {
+      this.handleExportInput(data, this.#exportView);
+      this.options.onChange();
+      return;
+    }
+    if (this.#details) {
+      if ((matchesKey(data, "escape") || data === "?") && !isKeyRepeat(data)) this.#details = false;
+      else if (matchesKey(data, "home")) this.#detailScroll = 0;
+      else if (matchesKey(data, "end")) this.#detailScroll = this.#detailMaximumScroll;
+      else if (viewerKeys.up(data) || viewerKeys.pageUp(data))
+        this.#detailScroll = Math.max(
+          0,
+          this.#detailScroll -
+            (viewerKeys.up(data) ? 1 : Math.max(1, this.options.maximumLines() - 2)),
+        );
+      else if (viewerKeys.down(data) || viewerKeys.pageDown(data))
+        this.#detailScroll = Math.min(
+          this.#detailMaximumScroll,
+          this.#detailScroll +
+            (viewerKeys.down(data) ? 1 : Math.max(1, this.options.maximumLines() - 2)),
+        );
+      this.options.onChange();
+      return;
+    }
+    if (!this.#composing && data === "?" && !isKeyRepeat(data)) {
+      this.#details = true;
+      this.#detailScroll = 0;
+      this.options.onChange();
+      return;
+    }
+    if (this.#resources !== undefined) {
+      this.handleResourceInput(data);
+      this.options.onChange();
+      return;
+    }
+    if (
+      !this.#composing &&
+      !this.#retargetPending &&
+      matchesKey(data, "e") &&
+      !isKeyRepeat(data) &&
+      this.#completion !== undefined
+    ) {
+      this.#suppressTarget = undefined;
+      this.#exportView = {
+        thread: this.#thread,
+        completion: this.#completion,
+        fields: new Set(["summary", "result"]),
+        selected: 0,
+        visible: new Set(),
+        phase: "fields",
+        confirmRendered: false,
+        result: undefined,
+        notice: "",
+      };
+      this.options.onChange();
+      return;
+    }
+    if (!this.#composing && !this.#retargetPending && matchesKey(data, "s")) {
+      if (isKeyRepeat(data) || this.#suppressPending) return;
+      const completion = this.#completion;
+      if (completion?.consumption !== "pending") return;
+      const target = this.#suppressTarget;
+      this.#suppressTarget = undefined;
+      if (target === undefined) this.#suppressTarget = completion;
+      else if (target.id !== completion.id || target.receipt.digest !== completion.receipt.digest)
+        this.#inputNotice = "The completion changed. Select it again.";
+      else {
+        this.#suppressPending = true;
+        this.#inputNotice = "Suppressing the exact completion…";
+        void this.options
+          .onSuppress(target)
+          .then(
+            (receipt) => {
+              this.#inputNotice =
+                receipt.status === "rejected"
+                  ? receipt.message
+                  : "Suppressed from automatic Main delivery.";
+            },
+            () => {
+              this.#inputNotice = "Suppression could not be confirmed.";
+            },
+          )
+          .finally(() => {
+            this.#suppressPending = false;
+            if (!this.#closed) this.options.onChange();
+          });
+      }
+      this.options.onChange();
+      return;
+    }
+    if (!matchesKey(data, "escape")) this.#suppressTarget = undefined;
+    if (!this.#composing && !this.#retargetPending && matchesKey(data, "x")) {
+      if (isKeyRepeat(data) || this.#cancelling) return;
+      const target = this.#cancelTarget;
+      this.#cancelTarget = undefined;
+      if (target !== undefined && target.expectedTurnId !== this.#thread.turn.turnId)
+        this.#inputNotice = "The turn changed. Start a new x x confirmation.";
+      else if (this.#thread.actions?.includes("cancel")) {
+        if (target === undefined)
+          this.#cancelTarget = {
+            parentSessionId: this.#thread.parentSessionId,
+            threadId: this.#thread.threadId,
+            expectedTurnId: this.#thread.turn.turnId,
+          };
+        else {
+          this.#cancelling = true;
+          void this.options
+            .onSend({ ...target, type: "cancel_turn" })
+            .then(
+              (receipt) => {
+                this.#inputNotice = receipt.status === "rejected" ? receipt.message : "Cancelled";
+              },
+              () => {
+                this.#inputNotice = "Cancellation could not be confirmed. Inspect durable state.";
+              },
+            )
+            .finally(() => {
+              this.#cancelling = false;
+              if (!this.#closed) this.options.onChange();
+            });
+        }
+      }
+      this.options.onChange();
+      return;
+    }
+    if (!matchesKey(data, "x")) this.#cancelTarget = undefined;
+    if (this.#retargetPending) {
+      if (matchesKey(data, "enter")) {
+        if (this.selectCurrentTarget()) {
+          void this.saveLocalDraft().catch(() => undefined);
+          this.#inputNotice = "Draft retargeted to the current turn.";
+        }
+        this.#retargetPending = false;
+      } else if (matchesKey(data, "escape")) this.#retargetPending = false;
+      this.options.onChange();
+      return;
+    }
+    if (matchesKey(data, "escape")) {
+      if (!isKeyRepeat(data)) this.back();
+      return;
+    }
+    if (this.#composing) {
+      if (this.#sending) return;
+      if (
+        matchesKey(data, "tab") &&
+        this.#thread.actions?.includes("interrupt") &&
+        (this.#mode === "cooperative" || this.#mode === "interrupt")
+      ) {
+        this.#mode = this.#mode === "cooperative" ? "interrupt" : "cooperative";
+        this.#submission = undefined;
+        void this.saveLocalDraft().catch(() => undefined);
+        this.options.onChange();
+        return;
+      }
+      const before = this.#composer.getValue();
+      this.#composer.handleInput(data);
+      if (this.#composer.getValue() !== before) void this.saveLocalDraft().catch(() => undefined);
+    } else if (matchesKey(data, "enter") && !isKeyRepeat(data)) {
+      if (this.#sending) return;
+      if (!this.canCompose()) {
+        this.#inputNotice = "Input is unavailable until this turn can accept it.";
+        this.options.onChange();
+        return;
+      }
+      if (
+        (this.#composer.getValue().length === 0 || this.#composeTarget === undefined) &&
+        !this.selectCurrentTarget()
+      ) {
+        this.options.onChange();
+        return;
+      }
+      this.#composing = true;
+      this.#composer.focused = this.#focused;
+    } else if (matchesKey(data, "d") && !isKeyRepeat(data) && this.#composer.getValue()) {
+      this.#composer.setValue("");
+      void this.saveLocalDraft().catch(() => undefined);
+      this.#composeTarget = undefined;
+      this.#submission = undefined;
+    } else if (matchesKey(data, "t") && !isKeyRepeat(data) && this.#composer.getValue()) {
+      this.#retargetPending = true;
+    } else if ((matchesKey(data, "v") || matchesKey(data, "i")) && !isKeyRepeat(data)) {
+      this.#resources = {
+        thread: this.#thread,
+        entries: this.resourceEntries().filter(
+          (entry) => !matchesKey(data, "i") || entry.kind === "input",
+        ),
+        inputOnly: matchesKey(data, "i"),
+        selected: 0,
+        visible: new Set(),
+        page: undefined,
+        previousOffsets: [],
+        scroll: 0,
+        maximumScroll: 0,
+        pending: false,
+        generation: 0,
+        notice: "",
+      };
+    } else if (matchesKey(data, "m") && !isKeyRepeat(data)) {
+      this.#renderMode = nextAgentViewerMode(this.#renderMode);
+      void this.options.onRenderMode?.(this.#renderMode).then(
+        (receipt) => {
+          if (receipt.status === "rejected") {
+            this.#notice = receipt.message;
+            this.options.onChange();
+          }
+        },
+        () => {
+          this.#notice = "Viewer preference could not be saved.";
+          this.options.onChange();
+        },
+      );
+    } else if (matchesKey(data, "home")) {
+      this.freezePage();
+      this.#scrollOffset = 0;
+    } else if (matchesKey(data, "end")) {
+      this.followTail();
+    } else if (viewerKeys.up(data) || viewerKeys.pageUp(data)) {
+      this.freezePage();
+      if (viewerKeys.pageUp(data) && this.#scrollOffset === 0 && this.#manualPage?.olderCursor)
+        this.loadPage(this.#manualPage.olderCursor, "older");
+      else
+        this.#scrollOffset = Math.max(
+          0,
+          this.#scrollOffset - (viewerKeys.pageUp(data) ? this.#bodyHeight : 1),
+        );
+    } else if (viewerKeys.down(data) || viewerKeys.pageDown(data)) {
+      if (this.#scrollOffset >= this.#maximumScroll && this.#newerCursors.length > 0)
+        this.loadPage(this.#newerCursors.at(-1) ?? null, "newer");
+      else {
+        this.#scrollOffset = Math.min(
+          this.#maximumScroll,
+          this.#scrollOffset + (viewerKeys.pageDown(data) ? this.#bodyHeight : 1),
+        );
+        if (this.#scrollOffset >= this.#maximumScroll && this.#newerCursors.length === 0)
+          this.followTail();
+      }
+    }
+    this.options.onChange();
+  }
+  invalidate(): void {}
+  private canCompose(): boolean {
+    return (
+      this.#thread.actions?.some(
+        (action) =>
+          action === "cooperative" ||
+          action === "interrupt" ||
+          action === "new_turn" ||
+          action === "reply",
+      ) ?? false
+    );
+  }
+  private textLines(
+    id: string,
+    text: string,
+    width: number,
+    kind: "assistant" | "tool" | "literal" = "assistant",
+  ): string[] {
+    const bytes = Buffer.from(text, "utf8");
+    let end = Math.min(bytes.byteLength, presentationArtifactPageMaximumBytes);
+    while (end > 0 && end < bytes.byteLength && ((bytes[end] ?? 0) & 0xc0) === 0x80) end -= 1;
+    const safe = safeTerminalText(bytes.subarray(0, end).toString("utf8"));
+    const omission =
+      end < bytes.byteLength
+        ? [truncateToWidth(`… ${bytes.byteLength - end} bytes omitted · v resources`, width)]
+        : [];
+    if (
+      this.#renderMode === "raw" ||
+      kind === "literal" ||
+      (kind === "tool" && this.#renderMode !== "full") ||
+      /^(?:diff --git |@@ |--- |\+\+\+ |#!|\$ |\d{4}-\d\d-\d\d[T ])/mu.test(safe)
+    )
+      return [...wrapTextWithAnsi(safe, width), ...omission];
+    let entry = this.#markdown.get(id);
+    if (entry === undefined) {
+      entry = {
+        component: new Markdown(safe, 0, 0, this.options.theme.markdown, undefined, {
+          preserveOrderedListMarkers: true,
+          preserveBackslashEscapes: true,
+        }),
+        text: safe,
+        failed: false,
+      };
+      this.#markdown.set(id, entry);
+    } else if (entry.text !== safe) {
+      if (!safe.startsWith(entry.text)) entry.failed = false;
+      entry.text = safe;
+      entry.component.setText(safe);
+    }
+    if (!entry.failed) {
+      try {
+        return [...entry.component.render(width), ...omission];
+      } catch {
+        entry.failed = true;
+      }
+    }
+    return [...wrapTextWithAnsi(safe, width), ...omission];
+  }
+  private handleExportInput(data: string, state: ExportView): void {
+    if (matchesKey(data, "escape")) {
+      if (!isKeyRepeat(data)) this.back();
+      return;
+    }
+    if (state.phase === "pending") return;
+    if (state.phase === "ready") {
+      if (matchesKey(data, "v") && !isKeyRepeat(data) && state.result !== undefined) {
+        this.#exportView = undefined;
+        this.#resources = {
+          thread: state.thread,
+          entries: [
+            { kind: "artifact", artifact: state.result.artifact, label: "Confirmed export" },
+          ],
+          selected: 0,
+          visible: new Set([0]),
+          page: undefined,
+          previousOffsets: [],
+          scroll: 0,
+          maximumScroll: 0,
+          pending: false,
+          generation: 0,
+          notice: "",
+        };
+        this.readResource(
+          { offset: 0, maximumBytes: presentationArtifactPageMaximumBytes },
+          "first",
+        );
+      }
+      return;
+    }
+    if (state.phase === "confirm") {
+      if (!matchesKey(data, "enter") || isKeyRepeat(data) || !state.confirmRendered) return;
+      state.phase = "pending";
+      const fields = agentExportFields.filter((field) => state.fields.has(field));
+      void this.options.onExport(state.thread, state.completion, fields).then(
+        (receipt) => {
+          if (this.#closed || this.#exportView !== state) return;
+          if (receipt.status === "rejected" || receipt.agentExport === undefined) {
+            state.phase = "fields";
+            state.notice =
+              receipt.status === "rejected"
+                ? receipt.message
+                : "The export receipt is unavailable.";
+          } else {
+            state.result = receipt.agentExport;
+            state.phase = "ready";
+          }
+          this.options.onChange();
+        },
+        () => {
+          if (!this.#closed && this.#exportView === state) {
+            state.phase = "fields";
+            state.notice = "The selected fields could not be exported.";
+            this.options.onChange();
+          }
+        },
+      );
+      return;
+    }
+    if (matchesKey(data, "home")) state.selected = 0;
+    else if (matchesKey(data, "end")) state.selected = agentExportFields.length - 1;
+    else if (viewerKeys.up(data)) state.selected = Math.max(0, state.selected - 1);
+    else if (viewerKeys.down(data))
+      state.selected = Math.min(agentExportFields.length - 1, state.selected + 1);
+    else if (matchesKey(data, "space") && !isKeyRepeat(data) && state.visible.has(state.selected)) {
+      const field = agentExportFields[state.selected];
+      if (field !== undefined && !state.fields.delete(field)) state.fields.add(field);
+    } else if (matchesKey(data, "enter") && !isKeyRepeat(data)) {
+      if (state.fields.size === 0) state.notice = "Choose at least one field.";
+      else {
+        state.phase = "confirm";
+        state.confirmRendered = false;
+        state.notice = "";
+      }
+    }
+  }
+  private renderExport(width: number, state: ExportView): string[] {
+    const maximum = this.options.maximumLines();
+    if (state.phase === "pending")
+      return [
+        "Exporting confirmed fields…",
+        `${state.thread.handle} · ${state.thread.turn.turnId.slice(0, 8)}`,
+        "Esc close",
+      ].map((line) => truncateToWidth(line, width));
+    if (state.phase === "ready" && state.result !== undefined)
+      return [
+        this.options.theme.primary(`Export ready · ${state.thread.handle}`),
+        `${state.result.artifact.byteCount} bytes · JSON`,
+        ...wrapTextWithAnsi(state.result.artifact.id, width),
+        "v open export · Esc back",
+      ].map((line) => truncateToWidth(line, width));
+    if (state.phase === "confirm") {
+      const lines = [
+        this.options.theme.primary("Confirm export"),
+        `${state.thread.handle} · turn ${state.thread.turn.turnId.slice(0, 8)}`,
+        ...wrapTextWithAnsi(
+          `Fields: ${agentExportFields.filter((field) => state.fields.has(field)).join(", ")}`,
+          width,
+        ),
+        state.fields.has("reasoning") ? "Reasoning INCLUDED" : "Reasoning excluded",
+        "Enter export · Esc fields",
+      ];
+      state.confirmRendered = lines.length <= maximum;
+      return lines.map((line) => truncateToWidth(line, width));
+    }
+    const labels: Record<AgentExportField, string> = {
+      summary: "Summary",
+      conversation: "Conversation (assistant)",
+      tools: "Tool records",
+      result: "Result",
+      reasoning: "Reasoning (separate opt-in)",
+    };
+    const count = Math.max(1, maximum - 3 - Number(Boolean(state.notice)));
+    const start = Math.max(0, state.selected - count + 1);
+    const visible = agentExportFields.slice(start, start + count);
+    state.visible = new Set(visible.map((_, index) => start + index));
+    return [
+      this.options.theme.primary(`Export agent · ${state.thread.handle}`),
+      `16 KiB / 32 items · ${agentExportFields.length - visible.length} hidden`,
+      ...visible.map(
+        (field, index) =>
+          `${start + index === state.selected ? "●" : "○"} [${state.fields.has(field) ? "x" : " "}] ${labels[field]}`,
+      ),
+      ...(state.notice ? [safeTerminalText(state.notice)] : []),
+      "Space toggle · Enter review · Esc back",
+    ].map((line) => truncateToWidth(line, width));
+  }
+  private resourceEntries(): readonly AgentConversationResource[] {
+    const entries: AgentConversationResource[] = [];
+    const artifacts = new Set<string>();
+    const addArtifact = (artifact: ArtifactReference, label = "Artifact") => {
+      if (artifacts.has(artifact.id)) return;
+      artifacts.add(artifact.id);
+      entries.push({ kind: "artifact", artifact, label: `${label} · ${artifact.byteCount} bytes` });
+    };
+    for (const item of this.#manualPage?.items ?? this.#items) {
+      if (item.type === "reasoning_block")
+        entries.push({ kind: "reasoning", itemId: item.id, label: `Reasoning · ${item.status}` });
+      else if (item.type === "tool_call") {
+        entries.push({
+          kind: "tool",
+          itemId: item.id,
+          label: `Tool · ${item.qualifiedName} · ${item.status}`,
+        });
+        for (const artifact of item.artifacts) addArtifact(artifact);
+      } else if (item.type === "assistant_message" && item.artifact !== null)
+        addArtifact(item.artifact, "Assistant output");
+    }
+    const result = this.#thread.turn.outcome?.artifact;
+    if (result !== undefined)
+      addArtifact({ ...result, source: "model_response" }, "Result artifact");
+    for (const input of this.#thread.inputs ?? []) {
+      if (input.turnId === this.#thread.turn.turnId)
+        entries.push({
+          kind: "input",
+          inputId: input.id,
+          label: `${input.status === "undelivered" ? "Undelivered" : input.status === "delivered" ? "Delivered" : "Accepted"}${input.reason === undefined ? "" : ` · ${input.reason}`} · ${input.id.slice(0, 8)}`,
+        });
+    }
+    for (const exported of this.#exports)
+      addArtifact(exported.artifact, `Export · ${exported.fields.join(", ")}`);
+    return entries;
+  }
+  private readResource(range: ArtifactRange, direction: "first" | "next" | "previous"): void {
+    const state = this.#resources;
+    const entry = state?.entries[state.selected];
+    if (state === undefined || entry === undefined || state.pending) return;
+    state.pending = true;
+    state.notice = "Loading bounded resource…";
+    const generation = ++state.generation;
+    void this.options
+      .onReadResource(state.thread, entry, range)
+      .then((page) => {
+        if (this.#closed || this.#resources !== state || state.generation !== generation) return;
+        if (direction === "next" && state.page !== undefined)
+          state.previousOffsets.push(state.page.offset);
+        else if (direction === "previous") state.previousOffsets.pop();
+        else state.previousOffsets = [];
+        state.page = page;
+        state.scroll = 0;
+        state.notice = "";
+      })
+      .catch((error: unknown) => {
+        if (!this.#closed && this.#resources === state && state.generation === generation)
+          state.notice = error instanceof Error ? error.message : "The resource is unavailable.";
+      })
+      .finally(() => {
+        if (!this.#closed && this.#resources === state && state.generation === generation) {
+          state.pending = false;
+          this.options.onChange();
+        }
+      });
+  }
+  private handleResourceInput(data: string): void {
+    const state = this.#resources;
+    if (state === undefined) return;
+    if (matchesKey(data, "escape")) {
+      if (!isKeyRepeat(data)) this.back();
+      return;
+    }
+    if (state.pending) return;
+    if (state.page === undefined) {
+      if (viewerKeys.down(data))
+        state.selected = Math.min(state.entries.length - 1, state.selected + 1);
+      else if (viewerKeys.up(data)) state.selected = Math.max(0, state.selected - 1);
+      else if (matchesKey(data, "home")) state.selected = 0;
+      else if (matchesKey(data, "end")) state.selected = Math.max(0, state.entries.length - 1);
+      else if (matchesKey(data, "enter") && state.visible.has(state.selected))
+        this.readResource(
+          { offset: 0, maximumBytes: presentationArtifactPageMaximumBytes },
+          "first",
+        );
+      return;
+    }
+    const entry = state.entries[state.selected];
+    if (!matchesKey(data, "b")) state.restoreArmed = false;
+    if (
+      matchesKey(data, "b") &&
+      !isKeyRepeat(data) &&
+      entry?.kind === "input" &&
+      state.page.offset === 0 &&
+      state.page.eof
+    ) {
+      if (!this.canCompose() || this.#thread.turn.turnId !== state.thread.turn.turnId) {
+        state.notice = "The selected turn changed or cannot accept a draft.";
+        return;
+      }
+      if (!state.restoreArmed) {
+        state.restoreArmed = true;
+        state.notice = `Return input as draft · b confirm${this.#composer.getValue() ? " · replaces current child draft" : ""}`;
+        return;
+      }
+      if (!this.selectCurrentTarget()) return;
+      this.#composer.setValue(state.page.text);
+      this.#submission = undefined;
+      this.#composing = false;
+      this.#composer.focused = false;
+      this.#resources = undefined;
+      this.#inputNotice = "Input restored as a draft. Nothing sent.";
+      void this.saveLocalDraft().catch(() => undefined);
+      return;
+    }
+    if (matchesKey(data, "n") && !isKeyRepeat(data) && state.page.nextRange !== null)
+      this.readResource(state.page.nextRange, "next");
+    else if (matchesKey(data, "p") && !isKeyRepeat(data) && state.previousOffsets.length > 0)
+      this.readResource(
+        {
+          offset: state.previousOffsets.at(-1) ?? 0,
+          maximumBytes: presentationArtifactPageMaximumBytes,
+        },
+        "previous",
+      );
+    else if (matchesKey(data, "home")) state.scroll = 0;
+    else if (matchesKey(data, "end")) state.scroll = state.maximumScroll;
+    else if (viewerKeys.up(data) || viewerKeys.pageUp(data))
+      state.scroll = Math.max(
+        0,
+        state.scroll - (viewerKeys.up(data) ? 1 : Math.max(1, this.options.maximumLines() - 4)),
+      );
+    else if (viewerKeys.down(data) || viewerKeys.pageDown(data))
+      state.scroll = Math.min(
+        state.maximumScroll,
+        state.scroll + (viewerKeys.down(data) ? 1 : Math.max(1, this.options.maximumLines() - 4)),
+      );
+  }
+  private renderResources(width: number, state: ResourceView): string[] {
+    const maximum = Math.max(4, this.options.maximumLines());
+    if (state.page === undefined) {
+      const count = Math.max(1, maximum - 4);
+      const start = Math.max(0, state.selected - count + 1);
+      const entries = state.entries.slice(start, start + count);
+      state.visible = new Set(entries.map((_, index) => start + index));
+      return [
+        this.options.theme.primary(
+          `${state.inputOnly ? "Input receipts" : "Conversation resources"} · ${state.thread.handle}`,
+        ),
+        ...entries.map(
+          (entry, index) =>
+            `${start + index === state.selected ? "●" : "○"} ${safeTerminalText(entry.label)}`,
+        ),
+        ...(entries.length === 0 ? ["No resources on this transcript page."] : []),
+        ...(start > 0 || start + entries.length < state.entries.length
+          ? [`↑ ${start} hidden · ↓ ${state.entries.length - start - entries.length} hidden`]
+          : []),
+        ...(state.notice ? [safeTerminalText(state.notice)] : []),
+        "Enter open · Esc conversation",
+      ].map((line) => truncateToWidth(line, width));
+    }
+    const entry = state.entries[state.selected];
+    const page = state.page;
+    const body = wrapTextWithAnsi(safeTerminalText(page.text), width);
+    const footer = [
+      ...(entry?.kind === "input" &&
+      state.thread.turn.turnId === this.#thread.turn.turnId &&
+      this.canCompose() &&
+      page.offset === 0 &&
+      page.eof
+        ? ["b return to draft"]
+        : []),
+      ...(state.notice ? [safeTerminalText(state.notice)] : []),
+      `${page.nextRange === null ? "End of resource" : "n next"}${state.previousOffsets.length > 0 ? " · p previous" : ""} · Esc resources`,
+    ];
+    const height = Math.max(1, maximum - footer.length - 2);
+    state.maximumScroll = Math.max(0, body.length - height);
+    state.scroll = Math.min(state.scroll, state.maximumScroll);
+    return [
+      this.options.theme.primary(
+        `${entry?.kind === "reasoning" ? "Reasoning" : entry?.kind === "tool" ? "Tool" : entry?.kind === "input" ? "Input" : "Artifact"} page · ${state.thread.handle} · literal`,
+      ),
+      `Bytes ${page.offset}-${page.offset + page.byteCount} of ${page.totalByteCount}`,
+      ...body.slice(state.scroll, state.scroll + height),
+      ...footer,
+    ].map((line) => truncateToWidth(line, width));
+  }
+  render(width: number): string[] {
+    const completion = this.#completion;
+    if (
+      this.#focused &&
+      completion !== undefined &&
+      completion.turnId === this.#thread.turn.turnId &&
+      !completion.userSeen &&
+      !this.#seenAttempts.has(completion.id)
+    ) {
+      this.#seenAttempts.add(completion.id);
+      void this.options.onSeen(completion).then(
+        (receipt) => {
+          if (receipt.status === "rejected") {
+            this.#notice = receipt.message;
+            this.options.onChange();
+          }
+        },
+        () => {
+          this.#notice = "The Seen state could not be recorded.";
+          this.options.onChange();
+        },
+      );
+    }
+    if (this.#exportView !== undefined) return this.renderExport(width, this.#exportView);
+    if (this.#resources !== undefined) return this.renderResources(width, this.#resources);
+    const thread = this.#thread;
+    const config = thread.turn.configuration;
+    const olderCursor =
+      this.#manualPage === undefined ? this.#olderCursor : this.#manualPage.olderCursor;
+    const liveOmittedBytes =
+      this.#manualPage === undefined ? this.#liveOmittedBytes : this.#manualPage.liveOmittedBytes;
+    const header = [
+      this.options.theme.primary(`Conversation · ${thread.handle} · ${thread.displayName}`),
+      safeTerminalText(thread.description),
+      config === undefined
+        ? "Recorded target unavailable"
+        : `${safeTerminalText(config.targetId)} · thinking ${safeTerminalText(config.thinking)}`,
+      `${config?.contextWindowTokens ?? "unknown"} context · ${thread.budget?.knownUsed ?? 0} used · ${thread.budget?.outstandingReserved ?? 0} reserved`,
+      ...(thread.budget === undefined
+        ? []
+        : [
+            `${thread.budget.unknownReserved} unknown reserved · ${thread.budget.available} available`,
+          ]),
+      `${thread.turn.label}${agentElapsedLabel(thread)}`,
+      ...(thread.turn.diagnostic === undefined
+        ? []
+        : wrapTextWithAnsi(safeTerminalText(thread.turn.diagnostic), width)),
+      ...(thread.turn.attention?.question === undefined
+        ? []
+        : wrapTextWithAnsi(safeTerminalText(thread.turn.attention.question), width)),
+    ];
+    const footer = [
+      ...(completion === undefined
+        ? []
+        : [
+            `${completion.userSeen ? "Seen" : "Unseen"} · Main ${completion.consumption}`,
+            ...(!this.#composing ? ["e export"] : []),
+          ]),
+      ...(this.#suppressTarget !== undefined
+        ? [
+            "Suppress from Main? s confirm · Esc cancel",
+            "Skip automatic delivery of this completion.",
+          ]
+        : completion?.consumption === "pending" && !this.#composing
+          ? ["s Suppress from Main"]
+          : []),
+      ...(this.#cancelTarget === undefined
+        ? !this.#composing && thread.actions?.includes("cancel")
+          ? ["x x cancel"]
+          : []
+        : [`x again to cancel ${thread.handle}`]),
+      ...(this.#retargetPending
+        ? ["Retarget draft to the current turn? Enter confirm · Esc cancel"]
+        : []),
+      ...(this.#composeTarget !== undefined &&
+      this.#composer.getValue() &&
+      this.#composeTarget.expectedTurnId !== thread.turn.turnId
+        ? ["Draft targets an earlier turn · d discard · t retarget"]
+        : []),
+      `${this.#followTail ? "Following tail" : "Manual scroll · End tail"} · m ${this.#renderMode === "raw" ? "raw" : `${this.#renderMode} Markdown`}`,
+      ...(olderCursor === null ? [] : ["PgUp at top: older transcript page"]),
+      ...(this.#newerCursors.length === 0 ? [] : ["PgDown at bottom: newer page · End latest"]),
+      ...(this.#notice ? [safeTerminalText(this.#notice)] : []),
+      ...(liveOmittedBytes > 0 ? [`Live preview · ${liveOmittedBytes} bytes omitted`] : []),
+      ...(this.resourceEntries().length > 0 ? ["v resources · i input receipts"] : []),
+      ...(() => {
+        const input =
+          thread.inputs?.find((entry) => entry.id === this.#lastInputId) ??
+          thread.inputs?.findLast(
+            (entry) => entry.turnId === thread.turn.turnId && entry.status === "undelivered",
+          );
+        const text =
+          input?.status === "delivered"
+            ? "Delivered"
+            : input?.status === "undelivered"
+              ? `Undelivered · ${input.reason ?? "delivery unavailable"} · Inspect before sending again`
+              : this.#inputNotice;
+        return text ? [safeTerminalText(text)] : [];
+      })(),
+      ...(this.#composing
+        ? [
+            `To ${thread.handle} · ${thread.displayName} · ${thread.turn.label} · ${this.#mode === "new_turn" ? "New turn" : this.#mode === "reply" ? "Reply to parent input" : this.#mode === "interrupt" ? "Interrupt after current effect" : "Cooperative"}`,
+            ...this.#composer.render(width),
+            this.#mode === "cooperative" || this.#mode === "interrupt"
+              ? "Enter send · Tab delivery mode · Esc viewer"
+              : "Enter send · Esc viewer",
+          ]
+        : [
+            ...(this.#composer.getValue() ? [`Draft to ${thread.handle}`] : []),
+            this.canCompose()
+              ? "Enter compose · Esc back"
+              : this.#thread.turn.phase === "settling"
+                ? "Settling · input available after cleanup · Esc back"
+                : "Input unavailable · Esc back",
+          ]),
+    ];
+    const body = (this.#manualPage?.items ?? this.#items).flatMap((item) => {
+      if (item.type === "assistant_message")
+        return this.textLines(item.id, item.text ?? "Assistant output in artifact", width);
+      if (item.type === "tool_call") {
+        const lines = wrapTextWithAnsi(
+          safeTerminalText(
+            `Tool · ${item.label} · ${item.status}${item.resultSummary === null ? "" : ` · ${item.resultSummary}`}`,
+          ),
+          width,
+        );
+        if (item.preview?.kind === "read_text") {
+          const preview = item.preview;
+          lines.push(
+            ...this.textLines(
+              `${item.id}:result`,
+              preview.lines.map((line) => line.text).join("\n"),
+              width,
+              preview.language === null ||
+                preview.language === "text" ||
+                preview.language === "markdown"
+                ? "tool"
+                : "literal",
+            ),
+          );
+          if (preview.omittedBytes > 0)
+            lines.push(`… ${preview.omittedBytes} bytes omitted · v resources`);
+          if (preview.sourceTruncated) lines.push("Tool output truncated at source");
+        } else if (item.preview !== null)
+          lines.push(...new ToolPreview(item.preview, true, this.options.theme).render(width));
+        return lines;
+      }
+      if (item.type === "reasoning_block") return [`Reasoning · ${item.status}`];
+      if (item.type === "session_notice") return [`Session · ${item.status}`];
+      if (item.type === "compaction_marker") return ["Context compacted"];
+      return [];
+    });
+    const liveText = this.#manualPage === undefined ? this.#liveText : this.#manualPage.liveText;
+    if (liveText) body.push(...this.textLines(`live:${thread.turn.attemptId}`, liveText, width));
+    if (body.length === 0 && this.#manualPage === undefined && thread.turn.outcome !== undefined)
+      body.push(
+        ...this.textLines(`outcome:${thread.turn.turnId}`, thread.turn.outcome.summary, width),
+      );
+    const maximum = this.options.maximumLines();
+    if (this.#details) {
+      const details = [
+        ...header.slice(1),
+        `Rendering: ${this.#renderMode} · m cycles raw/assistant/full`,
+        "Enter: focus the independent child editor",
+        "Esc: editor to viewer to Fleet to Main",
+        "x x: cancel the exact turn",
+        "v: bounded resources · i: exact input receipts",
+        "d: discard retained draft · t: confirm retarget",
+        "Home/End: scroll start/follow tail",
+        "j/k or configured arrows: scroll",
+        "PgUp/PgDown or Shift+arrows: page and bounded transcript",
+      ].flatMap((line) => wrapTextWithAnsi(safeTerminalText(line), width));
+      const height = Math.max(1, maximum - 2);
+      this.#detailMaximumScroll = Math.max(0, details.length - height);
+      this.#detailScroll = Math.min(this.#detailScroll, this.#detailMaximumScroll);
+      return [
+        this.options.theme.primary(`Conversation details · ${thread.handle}`),
+        ...details.slice(this.#detailScroll, this.#detailScroll + height),
+        `↑↓ scroll · ${details.length - Math.min(height, details.length)} hidden · Esc back`,
+      ].map((line) => truncateToWidth(line, width));
+    }
+    if (header.length + footer.length + 1 > maximum) {
+      const mode =
+        this.#mode === "new_turn"
+          ? "New turn"
+          : this.#mode === "reply"
+            ? "Reply"
+            : this.#mode === "interrupt"
+              ? "Interrupt"
+              : "Cooperative";
+      const input =
+        thread.inputs?.find((entry) => entry.id === this.#lastInputId) ??
+        thread.inputs?.findLast(
+          (entry) => entry.turnId === thread.turn.turnId && entry.status === "undelivered",
+        );
+      const notice =
+        input?.status === "delivered"
+          ? "Delivered"
+          : input?.status === "undelivered"
+            ? `Undelivered · ${input.reason ?? "unavailable"}`
+            : this.#inputNotice ||
+              this.#notice ||
+              (completion === undefined
+                ? ""
+                : `${completion.userSeen ? "Seen" : "Unseen"} · Main ${completion.consumption}`);
+      const essential = this.#composing
+        ? [
+            ...(notice ? [safeTerminalText(notice)] : []),
+            `To ${thread.handle} · ${mode}`,
+            ...this.#composer.render(width),
+            `Enter send${this.#mode === "cooperative" || this.#mode === "interrupt" ? " · Tab" : ""} · Esc viewer`,
+          ]
+        : [
+            ...(this.#composer.getValue() ? [`Draft to ${thread.handle} · d/t`] : []),
+            ...(this.#suppressTarget !== undefined
+              ? ["Suppress from Main? s confirm", "Esc cancel · skip automatic delivery"]
+              : this.#retargetPending
+                ? ["Retarget draft? Enter confirm · Esc cancel"]
+                : notice
+                  ? [safeTerminalText(notice)]
+                  : []),
+            ...(this.#cancelTarget === undefined ? [] : [`x again to cancel ${thread.handle}`]),
+            `${this.canCompose() ? "Enter compose" : "Input unavailable"}${completion?.consumption === "pending" ? " · s" : ""}${completion === undefined ? "" : " · e export"}${thread.actions?.includes("cancel") ? " · x x" : ""}${this.resourceEntries().length > 0 ? " · v/i" : ""} · Esc back`,
+          ];
+      const compactBody = body.length === 0 ? [thread.turn.label] : body;
+      this.#bodyHeight = Math.max(0, maximum - 2 - essential.length);
+      this.#maximumScroll = Math.max(0, compactBody.length - this.#bodyHeight);
+      this.#scrollOffset = this.#followTail
+        ? this.#maximumScroll
+        : Math.min(this.#scrollOffset, this.#maximumScroll);
+      const hidden =
+        header.length -
+        1 +
+        Math.max(0, footer.length - essential.length) +
+        Math.max(0, compactBody.length - this.#bodyHeight);
+      return [
+        this.options.theme.primary(`Conversation · ${thread.handle}`),
+        `${hidden} lines hidden · m ${this.#renderMode} · ?`,
+        ...compactBody.slice(this.#scrollOffset, this.#scrollOffset + this.#bodyHeight),
+        ...essential,
+      ].map((line) => truncateToWidth(line, width));
+    }
+    this.#bodyHeight = Math.max(1, this.options.maximumLines() - header.length - footer.length);
+    this.#maximumScroll = Math.max(0, body.length - this.#bodyHeight);
+    this.#scrollOffset = this.#followTail
+      ? this.#maximumScroll
+      : Math.min(this.#scrollOffset, this.#maximumScroll);
+    return [
+      ...header,
+      ...body.slice(this.#scrollOffset, this.#scrollOffset + this.#bodyHeight),
+      ...footer,
+    ].map((line) => truncateToWidth(line, width));
+  }
+}

--- a/apps/tui/src/agent-fleet.os.test.ts
+++ b/apps/tui/src/agent-fleet.os.test.ts
@@ -41,7 +41,7 @@ test("owner-private child draft survives a cold TUI and Lifecycle rebuild separa
       }),
     ).toMatchObject({ status: "admitted" });
     await started.promise;
-    await h.terminal.nextSynchronizedFrameContaining("Draft persistence");
+    await h.terminal.nextSynchronizedFrameContaining("@explore-1 · Explore · Running");
     await h.press("\u001b[B\u001b[B\r", "Conversation");
     await h.press("\r", "Cooperative");
     await h.press("Child draft survives restart.", "Child draft survives restart.");

--- a/apps/tui/src/agent-fleet.os.test.ts
+++ b/apps/tui/src/agent-fleet.os.test.ts
@@ -1,0 +1,680 @@
+import { mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createPresentationPreferences, type ModelDriver } from "@adam-agent/agent";
+import { type AgentUiSettings, defaultAgentUiSettings } from "@adam-agent/presentation";
+import { expect, test } from "vitest";
+import { startManagedTui } from "./agent-fleet.test-support.js";
+
+test("owner-private child draft survives a cold TUI and Lifecycle rebuild separately from Main", async () => {
+  const started = Promise.withResolvers<void>();
+  let calls = 0;
+  const driver: ModelDriver = {
+    async *stream(request) {
+      calls += 1;
+      started.resolve();
+      await new Promise<void>((resolve) => {
+        if (request.signal.aborted) resolve();
+        else request.signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const h = await startManagedTui(driver, { draftPersistencePolicy: "recoverable" });
+  let cold: Awaited<ReturnType<typeof startManagedTui>> | undefined;
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "durable-draft",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            {
+              role: "builtin:explore",
+              task: "Inspect evidence.",
+              description: "Draft persistence",
+            },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await started.promise;
+    await h.terminal.nextSynchronizedFrameContaining("Draft persistence");
+    await h.press("\u001b[B\u001b[B\r", "Conversation");
+    await h.press("\r", "Cooperative");
+    await h.press("Child draft survives restart.", "Child draft survives restart.");
+    await h.press("\u001b", "Enter compose · Esc back");
+    await h.press("\u001b", "Esc Main");
+    await h.press("\u001b", "Fleet · ↓ navigate");
+    await h.press("Separate Main draft.", "Separate Main draft.");
+    await h.stop();
+    cold = await startManagedTui(driver, {
+      restore: h.storage,
+      draftPersistencePolicy: "recoverable",
+    });
+    await cold.terminal.nextSynchronizedFrameContaining("Separate Main draft.");
+    expect(cold.presentation.getState().composer.renderedText).toBe("Separate Main draft.");
+    cold.terminal.input("\u0001\u000b");
+    await cold.press("/agents\r", "Agents workspace");
+    await cold.press("\r", "Conversation");
+    await cold.press("\r", "Child draft survives restart.");
+    expect(cold.conversationText()).toContain("Cooperative");
+    expect(cold.presentation.getState().composer.renderedText).not.toContain("Child draft");
+    expect(calls).toBe(1);
+  } finally {
+    await (cold ?? h).close();
+  }
+});
+
+test("explicit child resources page private reasoning, exact tool records and immutable output with UTF-8 boundaries", async () => {
+  const reasoning = `PRIVATE_REASONING\n${"r".repeat(16364)}界界\nREASONING_END`;
+  const answer = `RESULT_START\n${"a".repeat(16369)}界界\nRESULT_END`;
+  let calls = 0;
+  const h = await startManagedTui({
+    async *stream() {
+      if (++calls === 1) {
+        yield {
+          type: "reasoning_start",
+          id: "provider-reasoning-0",
+          artifactType: "provider_reasoning",
+        };
+        yield { type: "reasoning_delta", id: "provider-reasoning-0", text: reasoning };
+        yield { type: "reasoning_end", id: "provider-reasoning-0" };
+        yield { type: "tool_call_start", id: "resource-read", name: "read_file" };
+        yield { type: "tool_call_delta", id: "resource-read", json: '{"path":"package.json"}' };
+        yield { type: "tool_call_end", id: "resource-read" };
+        yield { type: "usage", inputTokens: 20, outputTokens: 10, reasoningTokens: 5 };
+        yield { type: "finish", reason: "tool_calls" };
+      } else {
+        yield { type: "text_delta", text: answer };
+        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+      }
+    },
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "private-resources",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            {
+              role: "builtin:explore",
+              task: "Private task bytes.",
+              description: "Bounded resources",
+            },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await h.terminal.nextSynchronizedFrameContaining("Completed");
+    const thread = h.presentation.getState().authoritative.managedControl?.threads[0];
+    if (thread === undefined) throw new Error("Missing child");
+    expect(JSON.stringify(h.presentation.getState())).not.toContain("PRIVATE_REASONING");
+    expect(JSON.stringify(h.presentation.getState())).not.toContain("Private task bytes.");
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\r", "Conversation");
+    expect(h.conversationText()).not.toContain("PRIVATE_REASONING");
+    await h.press("v", "Conversation resources");
+    await h.press("\r", "Reasoning page");
+    expect(h.terminal.lines().join("\n")).toContain("PRIVATE_REASONING");
+    await h.press("n", "REASONING_END");
+    expect(h.terminal.lines().join("\n")).not.toContain("�");
+    await h.press("\u001b", "Conversation resources");
+    await h.press("\u001b[B\r", "Tool page");
+    expect(h.terminal.lines().join("\n")).toContain("package.json");
+    await h.press("\u001b", "Conversation resources");
+    await h.press("\u001b[F\r", "Artifact page");
+    expect(h.terminal.lines().join("\n")).toContain("RESULT_START");
+    await h.press("n", "RESULT_END");
+    expect(h.terminal.lines().join("\n")).not.toContain("�");
+    const artifact = thread.turn.outcome?.artifact;
+    if (artifact === undefined) throw new Error("Missing output artifact");
+    expect(
+      await h.presentation.dispatch({
+        type: "read_agent_artifact",
+        sessionId: thread.parentSessionId,
+        threadId: thread.threadId,
+        expectedTurnId: thread.turn.turnId,
+        artifact: { ...artifact, source: "model_response", id: `sha256:${"0".repeat(64)}` },
+        range: { offset: 0, maximumBytes: 16384 },
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      h.presentation.getState().authoritative.managedControl?.completions[0]?.consumption,
+    ).toBe("pending");
+    expect(calls).toBe(2);
+  } finally {
+    await h.close();
+  }
+});
+
+test("full Markdown renders an actual read-file prose result while assistant mode keeps it literal", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-tool-markdown-"));
+  await writeFile(
+    join(workspaceRoot, "fixture.md"),
+    "# TOOL HEADING\n\n**literal tool text**\n\n3) first\n7) seventh\n",
+  );
+  let calls = 0;
+  const h = await startManagedTui(
+    {
+      async *stream() {
+        if (++calls === 1) {
+          yield { type: "tool_call_start", id: "markdown-read", name: "read_file" };
+          yield { type: "tool_call_delta", id: "markdown-read", json: '{"path":"fixture.md"}' };
+          yield { type: "tool_call_end", id: "markdown-read" };
+        } else yield { type: "text_delta", text: "Tool read completed." };
+        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+        yield { type: "finish", reason: calls === 1 ? "tool_calls" : "stop" };
+      },
+    },
+    { workspaceRoot },
+  );
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "tool-markdown",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            { role: "builtin:explore", task: "Read fixture.md.", description: "Tool Markdown" },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await h.terminal.nextSynchronizedFrameContaining("Completed");
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\r", "Conversation");
+    await h.press("\u001b[H", "Manual scroll");
+    expect(h.conversationText()).toContain("**literal tool text**");
+    await h.press("m", "m full Markdown");
+    expect(h.conversationText()).toContain("literal tool text");
+    expect(h.conversationText()).not.toContain("**literal tool text**");
+    expect(h.conversationText()).toContain("3) first");
+    expect(h.conversationText()).toContain("7) seventh");
+    await h.press("\u001b", "Agents workspace");
+    await h.press("s", "Viewer · full Markdown");
+    await h.press("\r", "Widget · all");
+    expect(h.presentation.getState().agentUiSettings?.viewerMode).toBe("full");
+  } finally {
+    await h.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("Agents settings persist privately and Reset restores concrete defaults without execution changes", async () => {
+  const configRoot = await mkdtemp(join(tmpdir(), "adam-agent-ui-settings-"));
+  const preferences = createPresentationPreferences({
+    environment: { XDG_CONFIG_HOME: configRoot },
+  });
+  const h = await startManagedTui(
+    {
+      async *stream() {
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    { preferences },
+  );
+  try {
+    await h.presentation.dispatch({
+      type: "managed_control",
+      commandId: "settings-init",
+      command: { type: "list_agents", parentSessionId: h.parent.sessionId },
+    });
+    const before = h.presentation.getState().authoritative;
+    await h.press("/agents settings\r", "Agent settings");
+    await h.press("\r", "Widget · all");
+    await h.press("\r", "Widget · off");
+    await h.press("\u001b[B\r", "Fleet · disabled");
+    await h.press("\u001b[B\r", "Model/thinking · shown");
+    await h.press("\u001b[B\r", "Viewer · full Markdown");
+    await h.press("\u001b[B\r", "Mentions · off");
+    const path = join(configRoot, "adam-agent", "ui.json");
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({
+      schemaVersion: 1,
+      widgetMode: "off",
+      fleetEnabled: false,
+      showModel: true,
+      viewerMode: "full",
+      mentions: "off",
+    });
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    expect(h.presentation.getState().authoritative).toEqual(before);
+    await h.press("\u001b", "Fleet fixture");
+    await h.press("/agents settings\r", "Widget · off");
+    await h.press("\u001b[F\r", "Defaults restored");
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({
+      schemaVersion: 1,
+      widgetMode: "background",
+      fleetEnabled: true,
+      showModel: false,
+      viewerMode: "assistant",
+      mentions: "direct",
+    });
+    expect(await preferences.load()).toMatchObject({ defaultTargetId: null, diagnostic: null });
+  } finally {
+    await h.close();
+    await rm(configRoot, { recursive: true, force: true });
+  }
+});
+
+test.each([{}, { columns: 40, rows: 12 }])(
+  "cold Agents workspace resumes one selected queued turn then the exact remaining set without automatic replay %j",
+  async (viewport) => {
+    let stopping = false;
+    let calls = 0;
+    const four = Promise.withResolvers<void>();
+    const driver: ModelDriver = {
+      async *stream(request) {
+        calls += 1;
+        if (calls === 4) four.resolve();
+        if (!stopping)
+          await new Promise<void>((resolve) =>
+            request.signal.addEventListener("abort", () => resolve(), { once: true }),
+          );
+        else yield { type: "text_delta", text: "Resumed queued evidence" };
+        yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+      },
+    };
+    const h = await startManagedTui(driver);
+    let cold: Awaited<ReturnType<typeof startManagedTui>> | undefined;
+    try {
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "cold-queued",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: Array.from({ length: 7 }, (_, index) => ({
+            role: "builtin:explore" as const,
+            task: `Inspect item ${index}`,
+            description: `Cold item ${index}`,
+          })),
+        },
+      });
+      await four.promise;
+      stopping = true;
+      await h.stop();
+      cold = await startManagedTui(driver, { restore: h.storage, ...viewport });
+      expect(cold.terminal.lines().join("\n")).not.toContain("3 running");
+      await cold.press("/agents\r", "Agents workspace");
+      expect(calls).toBe(4);
+      await cold.press("\u001b[F", "@explore-7");
+      await cold.press("u", "@explore-7");
+      expect(cold.terminal.lines().join("\n")).toContain("u again to resume 1");
+      await cold.press("u", "Completed");
+      expect(calls).toBe(5);
+      await cold.press("U", "u again to resume 2");
+      await cold.press("u", "Resumed 2");
+      const restarted = cold;
+      await new Promise<void>((resolve) => {
+        const check = () => {
+          if (
+            restarted.presentation
+              .getState()
+              .authoritative.managedControl?.threads.filter(
+                (entry) => entry.turn.label === "Completed",
+              ).length === 3
+          ) {
+            unsubscribe();
+            resolve();
+          }
+        };
+        const unsubscribe = restarted.presentation.subscribe(check);
+        check();
+      });
+      expect(calls).toBe(7);
+      expect(
+        cold.presentation
+          .getState()
+          .authoritative.managedControl?.threads.filter(
+            (entry) => entry.turn.label === "Completed",
+          ),
+      ).toHaveLength(3);
+    } finally {
+      await (cold ?? h).close();
+    }
+  },
+);
+
+test("cold undelivered input remains private and can be explicitly inspected and returned to a new-turn draft", async () => {
+  const started = Promise.withResolvers<void>();
+  const finish = Promise.withResolvers<void>();
+  let calls = 0;
+  const driver: ModelDriver = {
+    async *stream() {
+      if (++calls === 1) {
+        started.resolve();
+        await finish.promise;
+      }
+      yield { type: "text_delta", text: "Input evidence finished" };
+      yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const h = await startManagedTui(driver, { draftPersistencePolicy: "recoverable" });
+  let cold: Awaited<ReturnType<typeof startManagedTui>> | undefined;
+  try {
+    await h.presentation.dispatch({
+      type: "managed_control",
+      commandId: "cold-input",
+      command: {
+        type: "spawn_agents",
+        parentSessionId: h.parent.sessionId,
+        entries: [{ role: "builtin:explore", task: "Inspect", description: "Private receipts" }],
+      },
+    });
+    await started.promise;
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\r", "Conversation");
+    await h.press("\r", "Cooperative");
+    await h.press("PRIVATE_UNDELIVERED_MESSAGE\r", "Accepted");
+    const offset = h.terminal.output().length;
+    finish.resolve();
+    await h.terminal.nextSynchronizedFrameContaining("Undelivered · settled", offset);
+    await h.stop();
+    cold = await startManagedTui(driver, {
+      restore: h.storage,
+      draftPersistencePolicy: "recoverable",
+    });
+    expect(JSON.stringify(cold.presentation.getState())).not.toContain(
+      "PRIVATE_UNDELIVERED_MESSAGE",
+    );
+    await cold.press("/agents\r", "Agents workspace");
+    await cold.press("\r", "Undelivered · settled");
+    await cold.press("i", "Input receipts");
+    await cold.press("\r", "PRIVATE_UNDELIVERED_MESSAGE");
+    expect(calls).toBe(1);
+    await cold.press("b", "Return input as draft");
+    await cold.press("b", "Draft to @explore-1");
+    expect(cold.conversationText()).not.toContain("To @explore-1");
+    await cold.press("\r", "New turn");
+    expect(cold.conversationText()).toContain("PRIVATE_UNDELIVERED_MESSAGE");
+    await cold.press("\u001b", "Draft to @explore-1");
+    await cold.press("d", "Enter compose · Esc back");
+    expect(cold.conversationText()).not.toContain("Draft to @explore-1");
+    expect(calls).toBe(1);
+    expect(
+      cold.presentation.getState().authoritative.managedControl?.completions[0]?.consumption,
+    ).toBe("pending");
+  } finally {
+    finish.resolve();
+    await (cold ?? h).close();
+  }
+});
+
+test("confirmed bounded exports persist selected fields privately with a separate reasoning opt-in and no completion consumption", async () => {
+  const reasoning = `PRIVATE_REASONING_EXPORT\n${"r".repeat(16356)}界界\nREASONING_END`;
+  const answer = `PUBLIC_RESULT_EXPORT\n${"a".repeat(19000)}界界\nRESULT_END`;
+  let calls = 0;
+  const h = await startManagedTui({
+    async *stream() {
+      if (++calls === 1) {
+        yield {
+          type: "reasoning_start",
+          id: "provider-reasoning-0",
+          artifactType: "provider_reasoning",
+        };
+        yield { type: "reasoning_delta", id: "provider-reasoning-0", text: reasoning };
+        yield { type: "reasoning_end", id: "provider-reasoning-0" };
+        yield { type: "tool_call_start", id: "export-tool", name: "read_file" };
+        yield { type: "tool_call_delta", id: "export-tool", json: '{"path":"package.json"}' };
+        yield { type: "tool_call_end", id: "export-tool" };
+        yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+        yield { type: "finish", reason: "tool_calls" };
+      } else {
+        yield { type: "text_delta", text: answer };
+        yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+      }
+    },
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "explicit-export",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            { role: "builtin:explore", task: "PRIVATE_TASK_EXPORT", description: "Export subject" },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await h.terminal.nextSynchronizedFrameContaining("Completed");
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\r", "Seen · Main pending");
+    const artifactsBefore = await readdir(join(h.storage.stateRoot, "artifacts"));
+    await h.press("e", "Export agent");
+    await h.press("\u001b", "Seen · Main pending");
+    expect((await h.store.read()).some((record) => record.event.type === "exported")).toBe(false);
+    expect(await readdir(join(h.storage.stateRoot, "artifacts"))).toEqual(artifactsBefore);
+    await h.press("e", "Export agent");
+    await h.press("\r", "Confirm export");
+    await h.press("\u001b", "Export agent");
+    expect((await h.store.read()).some((record) => record.event.type === "exported")).toBe(false);
+    await h.press("\r", "Confirm export");
+    await h.press("\r", "Export ready");
+    const first = h.presentation.getState().authoritative.managedControl?.exports?.[0];
+    if (first === undefined) throw new Error("Missing first export");
+    const path = join(h.storage.stateRoot, "artifacts", first.artifact.id.slice("sha256:".length));
+    const firstText = await readFile(path, "utf8");
+    const firstData = JSON.parse(firstText);
+    expect(Object.keys(firstData.fields)).toEqual(["summary", "result"]);
+    expect(firstData.fields.result.text).toContain("PUBLIC_RESULT_EXPORT");
+    expect(firstData.fields.result.omittedBytes).toBeGreaterThan(0);
+    expect(firstText).not.toContain("PRIVATE_REASONING_EXPORT");
+    expect(firstText).not.toContain("PRIVATE_TASK_EXPORT");
+    expect(firstText).not.toContain("argumentsJson");
+    expect((await stat(path)).mode & 0o777).toBe(0o400);
+    await h.press("\u001b", "Seen · Main pending");
+    await h.press("e", "Export agent");
+    await h.press("\u001b[B\u001b[B\u001b[B\u001b[B ", "[x] Reasoning");
+    await h.press("\r", "Confirm export");
+    await h.press("\r", "Export ready");
+    const second = h.presentation.getState().authoritative.managedControl?.exports?.[1];
+    if (second === undefined) throw new Error("Missing reasoning export");
+    const secondText = await readFile(
+      join(h.storage.stateRoot, "artifacts", second.artifact.id.slice("sha256:".length)),
+      "utf8",
+    );
+    const secondData = JSON.parse(secondText);
+    expect(secondData.fields.reasoning.items[0].text).toContain("PRIVATE_REASONING_EXPORT");
+    expect(secondData.fields.reasoning.items[0].omittedBytes).toBeGreaterThan(0);
+    expect(secondText).not.toContain("�");
+    await h.press("v", "Artifact page");
+    expect(h.terminal.lines().join("\n")).toContain("adam.agent-export.v1");
+    const thread = h.presentation.getState().authoritative.managedControl?.threads[0];
+    if (thread === undefined) throw new Error("Missing export identity");
+    expect(
+      await h.presentation.dispatch({
+        type: "read_agent_artifact",
+        sessionId: thread.parentSessionId,
+        threadId: thread.threadId,
+        expectedTurnId: thread.turn.turnId,
+        artifact: { ...second.artifact, id: `sha256:${"0".repeat(64)}` },
+        range: { offset: 0, maximumBytes: 16384 },
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(h.presentation.getState().authoritative.managedControl?.completions[0]).toMatchObject({
+      userSeen: true,
+      consumption: "pending",
+    });
+    expect(calls).toBe(2);
+    await h.press("\u001b", "Conversation resources");
+    await h.press("\u001b", "Seen · Main pending");
+    await h.press("e", "Export agent");
+    await h.press("\u001b[B ", "[x] Conversation");
+    await h.press("\u001b[B ", "[x] Tool records");
+    await h.press("\r", "Confirm export");
+    await h.press("\r", "Export ready");
+    const third = h.presentation.getState().authoritative.managedControl?.exports?.[2];
+    if (third === undefined) throw new Error("Missing selected resource export");
+    const thirdText = await readFile(
+      join(h.storage.stateRoot, "artifacts", third.artifact.id.slice("sha256:".length)),
+      "utf8",
+    );
+    const thirdData = JSON.parse(thirdText);
+    expect(thirdData.fields.tools.items[0].text).toContain("argumentsJson");
+    expect(thirdData.fields.tools.items[0].text).toContain("package.json");
+    expect(thirdData.fields.conversation.items[0].text).toContain("PUBLIC_RESULT_EXPORT");
+    expect(thirdText).not.toContain("PRIVATE_REASONING_EXPORT");
+    expect(thirdText).not.toContain("PRIVATE_TASK_EXPORT");
+    const completion = h.presentation.getState().authoritative.managedControl?.completions[0];
+    if (completion === undefined) throw new Error("Missing export receipt");
+    const exportRequest = {
+      type: "export_agent" as const,
+      confirmed: true as const,
+      sessionId: thread.parentSessionId,
+      threadId: thread.threadId,
+      expectedTurnId: thread.turn.turnId,
+      completion: completion.receipt,
+      fields: ["summary"] as const,
+    };
+    expect(
+      await h.presentation.dispatch({
+        ...exportRequest,
+        completion: { ...completion.receipt, digest: `sha256:${"0".repeat(64)}` },
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      await h.presentation.dispatch({ ...exportRequest, fields: ["reasoning", "reasoning"] }),
+    ).toMatchObject({ status: "rejected" });
+    await h.stop();
+    const cold = await startManagedTui(
+      {
+        stream() {
+          throw new Error("Export inspection must not start a provider.");
+        },
+      },
+      { restore: h.storage },
+    );
+    try {
+      await cold.press("/agents\r", "Agents workspace");
+      await cold.press("\r", "Seen · Main pending");
+      await cold.press("v", "Conversation resources");
+      await cold.press("\u001b[F\r", "Artifact page");
+      expect(cold.terminal.lines().join("\n")).toContain("adam.agent-export.v1");
+      expect(cold.presentation.getState().authoritative.managedControl?.exports).toHaveLength(3);
+      expect(
+        cold.presentation.getState().authoritative.managedControl?.completions[0]?.consumption,
+      ).toBe("pending");
+    } finally {
+      await cold.stop();
+    }
+  } finally {
+    await h.close();
+  }
+});
+
+test.each([
+  [40, 12],
+  [80, 24],
+  [120, 40],
+])(
+  "%i×%i export requires a rendered confirmation and exposes every selected field",
+  async (columns, rows) => {
+    const h = await startManagedTui(
+      {
+        async *stream() {
+          yield {
+            type: "reasoning_start",
+            id: "provider-reasoning-0",
+            artifactType: "provider_reasoning",
+          };
+          yield {
+            type: "reasoning_delta",
+            id: "provider-reasoning-0",
+            text: "MIN_PRIVATE_REASONING",
+          };
+          yield { type: "reasoning_end", id: "provider-reasoning-0" };
+          yield { type: "text_delta", text: "MIN_EXPORT" };
+          yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+          yield { type: "finish", reason: "stop" };
+        },
+      },
+      { columns, rows },
+    );
+    try {
+      expect(
+        await h.presentation.dispatch({
+          type: "managed_control",
+          commandId: "rendered-export-confirm",
+          command: {
+            type: "spawn_agents",
+            parentSessionId: h.parent.sessionId,
+            entries: [{ role: "builtin:explore", task: "Inspect", description: "Export viewport" }],
+          },
+        }),
+      ).toMatchObject({ status: "admitted" });
+      await h.terminal.nextSynchronizedFrameContaining("Completed");
+      await h.press("/agents\r", "Agents workspace");
+      await h.press("\r", "Seen · Main pending");
+      await h.press("e", "Export agent");
+      await h.press("\r\r", "Confirm export");
+      expect(h.presentation.getState().authoritative.managedControl?.exports).toEqual([]);
+      await h.press("\u001b", "Export agent");
+      await h.press("\u001b[B", "Conversation");
+      await h.press(" ", "[x] Conversation");
+      await h.press("\u001b[B", "Tool records");
+      await h.press(" ", "[x] Tool records");
+      await h.press("\u001b[F", "Reasoning");
+      await h.press(" ", "[x] Reasoning");
+      await h.press("\r", "Reasoning INCLUDED");
+      expect(h.terminal.lines().join("\n")).toContain("Enter export");
+      await h.press("\r", "Export ready");
+      const exported = h.presentation.getState().authoritative.managedControl?.exports?.[0];
+      if (exported === undefined) throw new Error("Missing viewport export");
+      const data = JSON.parse(
+        await readFile(
+          join(h.storage.stateRoot, "artifacts", exported.artifact.id.slice("sha256:".length)),
+          "utf8",
+        ),
+      );
+      expect(Object.keys(data.fields)).toEqual([
+        "summary",
+        "conversation",
+        "tools",
+        "result",
+        "reasoning",
+      ]);
+      expect(data.fields.reasoning.items[0].text).toBe("MIN_PRIVATE_REASONING");
+      expect(
+        h.presentation.getState().authoritative.managedControl?.completions[0]?.consumption,
+      ).toBe("pending");
+    } finally {
+      await h.close();
+    }
+  },
+);
+
+test.each(["widgetMode", "viewerMode", "mentions"] as const)(
+  "UI settings reject non-string %s values on load and write",
+  async (field) => {
+    const root = await mkdtemp(join(tmpdir(), "adam-ui-settings-invalid-"));
+    const preferences = createPresentationPreferences({ environment: { XDG_CONFIG_HOME: root } });
+    try {
+      await preferences.setAgentUi?.(defaultAgentUiSettings);
+      const path = join(root, "adam-agent", "ui.json");
+      const malformed = { ...defaultAgentUiSettings, [field]: [defaultAgentUiSettings[field]] };
+      await writeFile(path, JSON.stringify({ schemaVersion: 1, ...malformed }));
+      await expect(preferences.loadAgentUi?.()).rejects.toThrow("Agent UI settings are invalid");
+      await expect(
+        preferences.setAgentUi?.(malformed as unknown as AgentUiSettings),
+      ).rejects.toThrow("Agent UI settings are invalid");
+      expect(JSON.parse(await readFile(path, "utf8"))[field]).toEqual(malformed[field]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/apps/tui/src/agent-fleet.test-support.ts
+++ b/apps/tui/src/agent-fleet.test-support.ts
@@ -1,0 +1,290 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createPermissionPolicy,
+  createPresentationSession,
+  createSessionLifecycle,
+  type ModelDriver,
+  type ModelTargets,
+} from "@adam-agent/agent";
+import {
+  createInMemoryManagedAgentControlStore,
+  createInMemorySessionStoreDirectory,
+  createTrustedWorkspaceTrustForTesting,
+  managedAgentRecordBarrier,
+  managedAgentSettlementBarrier,
+  presentationManagedControlReceiptBarrier,
+  presentationSessionRecordReader,
+  type SessionRecord,
+  sessionAutomaticTitlesEnabled,
+  sessionManagedControl,
+  sessionProjectLifecycleOwner,
+  sessionRecordCommittedBarrier,
+  sessionStoreDirectory,
+} from "@adam-agent/agent/internal-testing";
+import type {
+  ManagedAttentionItem,
+  ManagedControlCommand,
+  ManagedControlReceipt,
+} from "@adam-agent/presentation";
+import { onTestFailed } from "vitest";
+import { type DeadlineScheduler, runTui } from "./tui-app.js";
+import { VirtualTerminal } from "./virtual-terminal.test-support.js";
+
+const identity = {
+  targetId: "deepseek-v4-flash.direct",
+  vendor: "deepseek",
+  modelId: "deepseek-v4-flash",
+  route: "direct",
+  profileVersion: 1,
+  certification: "certified",
+} as const;
+const contextProfile = {
+  version: 1,
+  contextWindowTokens: 128_000,
+  maximumOutputTokens: 4096,
+  compactAtTokens: 96_000,
+  postCompactTargetTokens: 32_000,
+  retainedTargetTokens: 8000,
+  estimatorVersion: 1,
+} as const;
+
+export type ManagedTuiStorage = {
+  readonly stateRoot: string;
+  readonly sessions: ReturnType<typeof createInMemorySessionStoreDirectory<SessionRecord>>;
+  readonly children: ReturnType<typeof createInMemorySessionStoreDirectory<SessionRecord>>;
+  readonly store: ReturnType<typeof createInMemoryManagedAgentControlStore>;
+  readonly sessionId: string;
+};
+
+export type ManagedTuiFixture = {
+  readonly parent: { readonly sessionId: string };
+  readonly destination?: { readonly sessionId: string };
+  readonly presentation: Awaited<ReturnType<typeof createPresentationSession>>;
+  readonly terminal: VirtualTerminal;
+  readonly lifecycle: ReturnType<typeof createSessionLifecycle>;
+  readonly store: ManagedTuiStorage["store"];
+  readonly sessions: ManagedTuiStorage["sessions"];
+  readonly children: ManagedTuiStorage["children"];
+  readonly storage: ManagedTuiStorage;
+  conversationText(): string;
+  press(data: string, frame: string): Promise<void>;
+  close(): Promise<void>;
+  stop(): Promise<void>;
+  waitForAttention(
+    predicate: (items: readonly ManagedAttentionItem[]) => boolean,
+  ): Promise<readonly ManagedAttentionItem[]>;
+};
+
+export async function startManagedTui(
+  driver: ModelDriver,
+  viewport: {
+    readonly preferences?: Parameters<typeof createPresentationSession>[0]["preferences"];
+    readonly rows?: number;
+    readonly columns?: number;
+    readonly deadlineScheduler?: DeadlineScheduler;
+    readonly draftPersistencePolicy?: "process_only" | "recoverable";
+    readonly restore?: ManagedTuiStorage;
+    readonly withDestination?: boolean;
+    readonly controlReceiptBarrier?: (
+      command: ManagedControlCommand,
+      receipt: ManagedControlReceipt,
+    ) => Promise<void>;
+    readonly settlementBarrier?: () => Promise<void>;
+    readonly controlRecordBarrier?: (
+      record: Awaited<ReturnType<ManagedTuiStorage["store"]["read"]>>[number],
+    ) => Promise<void>;
+    readonly childRecordBarrier?: (record: SessionRecord) => Promise<void>;
+    readonly workspaceRoot?: string;
+    readonly permissions?: NonNullable<Parameters<typeof createSessionLifecycle>[0]["permissions"]>;
+  } = {},
+): Promise<ManagedTuiFixture> {
+  const stateRoot =
+    viewport.restore?.stateRoot ?? (await mkdtemp(join(tmpdir(), "adam-fleet-ui-")));
+  const workspaceRoot = viewport.workspaceRoot ?? process.cwd();
+  const sessions =
+    viewport.restore?.sessions ?? createInMemorySessionStoreDirectory<SessionRecord>();
+  const children =
+    viewport.restore?.children ?? createInMemorySessionStoreDirectory<SessionRecord>();
+  const store = viewport.restore?.store ?? createInMemoryManagedAgentControlStore();
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity, contextProfile, driver };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity,
+            contextProfile,
+            readiness: { status: "available", credentialSource: "test" },
+          },
+        ],
+      };
+    },
+  };
+  let held = false;
+  const acquire = async () => {
+    if (held) throw new Error("Test project already has an owner");
+    held = true;
+    return {
+      async release() {
+        held = false;
+      },
+    };
+  };
+  const lifecycle = createSessionLifecycle({
+    workspaceRoot,
+    stateRoot,
+    modelTargets,
+    permissions:
+      viewport.permissions ?? createPermissionPolicy({ allowedEffects: ["read", "delegate"] }),
+    workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
+    [sessionAutomaticTitlesEnabled]: false,
+    [sessionStoreDirectory]: sessions,
+    [sessionProjectLifecycleOwner]: {
+      acquire,
+      async run(operation) {
+        const lease = await acquire();
+        try {
+          return await operation();
+        } finally {
+          await lease.release();
+        }
+      },
+    },
+    [sessionManagedControl]: {
+      store,
+      childSessionStores: children,
+      ...(viewport.controlRecordBarrier === undefined
+        ? {}
+        : { [managedAgentRecordBarrier]: viewport.controlRecordBarrier }),
+      ...(viewport.settlementBarrier === undefined
+        ? {}
+        : { [managedAgentSettlementBarrier]: viewport.settlementBarrier }),
+      ...(viewport.childRecordBarrier === undefined
+        ? {}
+        : { [sessionRecordCommittedBarrier]: viewport.childRecordBarrier }),
+    },
+  });
+  const parent =
+    viewport.restore === undefined
+      ? await lifecycle.create({ targetIdentity: identity })
+      : { sessionId: viewport.restore.sessionId };
+  if (viewport.restore === undefined)
+    await lifecycle.setSessionManualName({ sessionId: parent.sessionId, name: "Fleet fixture" });
+  if (viewport.withDestination)
+    await lifecycle.continue({
+      sessionId: parent.sessionId,
+      input: { text: "Seed the source Session." },
+    });
+  const destination = viewport.withDestination
+    ? await lifecycle.create({ targetIdentity: identity })
+    : undefined;
+  if (destination !== undefined) {
+    await lifecycle.setSessionManualName({
+      sessionId: destination.sessionId,
+      name: "Destination fixture",
+    });
+    await lifecycle.continue({
+      sessionId: destination.sessionId,
+      input: { text: "Seed the destination Session." },
+    });
+  }
+  const presentation = await createPresentationSession({
+    lifecycle,
+    modelTargets,
+    workspaceRoot,
+    stateRoot,
+    ...(viewport.preferences === undefined ? {} : { preferences: viewport.preferences }),
+    sessionId: parent.sessionId,
+    projectLabel: "Fleet fixture",
+    draftPersistencePolicy: viewport.draftPersistencePolicy ?? "process_only",
+    ...(viewport.controlReceiptBarrier === undefined
+      ? {}
+      : { [presentationManagedControlReceiptBarrier]: viewport.controlReceiptBarrier }),
+    [presentationSessionRecordReader]: async (sessionId) =>
+      (await (await sessions.open(sessionId))?.read()) ?? [],
+  });
+  const terminal = new VirtualTerminal({ columns: 80, rows: 32, ...viewport });
+  let waitingForFrame = "initial frame";
+  onTestFailed(() =>
+    console.error(
+      `Fleet screen at failure (${waitingForFrame}):\n${terminal.lines().join("\n")}\nPending transition: ${JSON.stringify(presentation.getState().authoritative.managedTransition)}\nAttention: ${JSON.stringify(presentation.getState().managedAttention)}\nControl: ${JSON.stringify(presentation.getState().authoritative.managedControl?.threads.map((thread) => ({ handle: thread.handle, phase: thread.turn.phase, label: thread.turn.label, diagnostic: thread.turn.diagnostic, attention: thread.turn.attention, actions: thread.actions })))}`,
+    ),
+  );
+  const running = runTui({
+    terminal,
+    presentation,
+    ...(viewport.deadlineScheduler === undefined
+      ? {}
+      : { deadlineScheduler: viewport.deadlineScheduler }),
+    closeRuntime: async () => {
+      await presentation.close();
+      await lifecycle.close();
+    },
+  });
+  // The selected target remains visible when the minimum-height layout compresses the title.
+  await terminal.nextSynchronizedFrameContaining(identity.targetId);
+  return {
+    parent,
+    ...(destination === undefined ? {} : { destination }),
+    presentation,
+    terminal,
+    lifecycle,
+    store,
+    sessions,
+    children,
+    storage: {
+      stateRoot,
+      sessions,
+      children,
+      store,
+      sessionId: parent.sessionId,
+    } satisfies ManagedTuiStorage,
+    conversationText() {
+      const lines = terminal.lines();
+      const title = lines.find((line) => line.includes("Conversation ·"));
+      if (title === undefined) return "";
+      const left = title.indexOf("│");
+      const right = title.lastIndexOf("│");
+      return lines
+        .filter((line) => line[left] === "│" && line[right] === "│")
+        .map((line) => line.slice(left + 1, right))
+        .join("\n");
+    },
+    async press(data: string, frame: string) {
+      waitingForFrame = frame;
+      const offset = terminal.output().length;
+      terminal.input(data);
+      await terminal.nextSynchronizedFrameContaining(frame, offset);
+      waitingForFrame = "next test action";
+    },
+    async close() {
+      if (terminal.running()) terminal.input("\u0011");
+      try {
+        await running;
+      } finally {
+        await rm(stateRoot, { recursive: true, force: true });
+      }
+    },
+    async stop() {
+      if (terminal.running()) terminal.input("\u0011");
+      await running;
+    },
+    waitForAttention(predicate) {
+      return new Promise((resolve) => {
+        const check = () => {
+          const items = presentation.getState().managedAttention ?? [];
+          if (predicate(items)) {
+            unsubscribe();
+            resolve(items);
+          }
+        };
+        const unsubscribe = presentation.subscribe(check);
+        check();
+      });
+    },
+  };
+}

--- a/apps/tui/src/agent-fleet.test.ts
+++ b/apps/tui/src/agent-fleet.test.ts
@@ -1,0 +1,2886 @@
+import { createPermissionPolicy, type ModelRequest } from "@adam-agent/agent";
+import {
+  createInMemoryManagedAgentControlStore,
+  createInMemorySessionStoreDirectory,
+  type SessionRecord,
+} from "@adam-agent/agent/internal-testing";
+import { defaultAgentUiSettings } from "@adam-agent/presentation";
+import {
+  getKeybindings,
+  KeybindingsManager,
+  setKeybindings,
+  TUI_KEYBINDINGS,
+} from "@earendil-works/pi-tui";
+import { expect, test } from "vitest";
+import { startManagedTui } from "./agent-fleet.test-support.js";
+import { AgentWidget } from "./agent-widget.js";
+import { createAdamTuiTheme } from "./theme.js";
+import type { DeadlineScheduler } from "./tui-app.js";
+
+test("running Explore has Widget and Fleet, layered Enter and Esc preserve independent drafts and Main", async () => {
+  const started = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  let mainCalls = 0;
+  const h = await startManagedTui({
+    async *stream(request) {
+      if (
+        request.messages.some(
+          (message) =>
+            message.role === "user" &&
+            typeof message.content === "string" &&
+            message.content.includes("Inspect U0 evidence."),
+        )
+      ) {
+        yield { type: "text_delta", text: "Inspecting the repository." };
+        started.resolve();
+        await Promise.race([
+          release.promise,
+          new Promise<void>((resolve) => {
+            if (request.signal.aborted) resolve();
+            else request.signal.addEventListener("abort", () => resolve(), { once: true });
+          }),
+        ]);
+      } else {
+        mainCalls += 1;
+        yield { type: "text_delta", text: "Ordinary Main completed." };
+      }
+      yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  const unsubscribe = h.presentation.subscribe(() => {
+    const thread = h.presentation.getState().authoritative.managedControl?.threads[0];
+    if (thread?.turn.phase === "idle")
+      started.reject(new Error(JSON.stringify(thread.turn.outcome)));
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "u0-start",
+        command: {
+          type: "start_thread",
+          parentSessionId: h.parent.sessionId,
+          role: "builtin:explore",
+          task: "Inspect U0 evidence.",
+          description: "Map public API",
+        },
+      }),
+    ).toMatchObject({ status: "admitted", control: { status: "accepted" } });
+    await started.promise;
+    h.terminal.input("Main draft");
+    await h.terminal.nextSynchronizedFrameContaining("Main draft");
+    const screen = h.terminal.lines().join("\n");
+    expect(screen).toContain("Map public API");
+    expect(screen).toContain("Agents");
+    expect(screen).toContain("Fleet ·");
+    expect(screen).toContain("Main");
+    expect(screen.indexOf("Agents")).toBeLessThan(screen.indexOf("Main draft"));
+    expect(screen.indexOf("Main draft")).toBeLessThan(screen.indexOf("Fleet ·"));
+    h.terminal.input("\u001b[D");
+    expect(h.presentation.getState().composer.renderedText).not.toContain("Draft to");
+    h.terminal.input("\u0001\u000b");
+    // Pi Fleet first activates Main, then moves down to the openable child.
+    await h.press("\u001b[B\u001b[B\r", "Conversation");
+    await h.press("\r", "To @explore-1");
+    await h.press("Child draft", "Child draft");
+    await h.press("\u001b", "Enter compose · Esc back");
+    expect(h.terminal.lines().join("\n")).toContain("Draft to @explore-1");
+    await h.press("\u001b", "Esc Main");
+    expect(h.terminal.lines().join("\n")).not.toContain("Conversation ·");
+    await h.press("\u001b", "Fleet · ↓ navigate");
+    await h.press("Ordinary Main input.\r", "Ordinary Main completed.");
+    expect(mainCalls).toBe(1);
+    expect(h.presentation.getState().authoritative.managedControl?.threads[0]?.turn.phase).toBe(
+      "executing",
+    );
+  } finally {
+    unsubscribe();
+    release.resolve();
+    await h.close();
+  }
+});
+
+test("background spawn cards settle to Started and Queued with frozen identities while Main returns", async () => {
+  let mainCalls = 0;
+  let preparedCount = 0;
+  let childCalls = 0;
+  const prepared = Promise.withResolvers<void>();
+  const releaseStart = Promise.withResolvers<void>();
+  const fourStarted = Promise.withResolvers<void>();
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        if (!request.tools.some((tool) => tool.name === "spawn_agents")) {
+          yield { type: "text_delta", text: "Reading batch evidence." };
+          if (++childCalls === 4) fourStarted.resolve();
+          await new Promise<void>((resolve) => {
+            if (request.signal.aborted) resolve();
+            else request.signal.addEventListener("abort", () => resolve(), { once: true });
+          });
+        } else if (++mainCalls === 1) {
+          yield { type: "tool_call_start", id: "batch", name: "spawn_agents" };
+          yield {
+            type: "tool_call_delta",
+            id: "batch",
+            json: JSON.stringify({
+              entries: Array.from({ length: 5 }, (_, index) => ({
+                role: "builtin:explore",
+                task: `Read evidence ${index + 1}`,
+                description: `Inspect item ${index + 1}`,
+              })),
+            }),
+          };
+          yield { type: "tool_call_end", id: "batch" };
+          yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+          yield { type: "finish", reason: "tool_calls" };
+          return;
+        } else yield { type: "text_delta", text: "Batch admitted; Main ready." };
+        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    {
+      rows: 48,
+      childRecordBarrier: async (record) => {
+        if (record.schemaVersion === 3 && record.record.type === "session_genesis") {
+          if (++preparedCount === 4) prepared.resolve();
+          await releaseStart.promise;
+        }
+      },
+    },
+  );
+  try {
+    await h.press("Inspect these five items.\r", "Allow");
+    await h.press("\r", "Batch admitted; Main ready.");
+    await prepared.promise;
+    await h.terminal.nextSynchronizedFrameContaining("Starting · 0 used");
+    const screen = h.terminal.lines().join("\n");
+    expect(screen).toContain("Started @explore-1 · Explore · Inspect item 1");
+    expect(screen).toContain("Queued @explore-5 · Explore · Inspect item 5");
+    expect(
+      h.presentation
+        .getState()
+        .authoritative.managedControl?.threads.filter((thread) => thread.turn.phase === "starting"),
+    ).toHaveLength(4);
+    expect(
+      h.presentation
+        .getState()
+        .authoritative.managedControl?.threads.filter((thread) => thread.turn.phase === "queued"),
+    ).toHaveLength(1);
+    releaseStart.resolve();
+    await fourStarted.promise;
+    await h.terminal.nextSynchronizedFrameContaining("@explore-4 · Explore · Running");
+    const state = h.presentation.getState();
+    expect(
+      state.authoritative.managedControl?.threads.filter(
+        (thread) => thread.turn.phase === "executing",
+      ),
+    ).toHaveLength(4);
+    expect(
+      state.authoritative.managedControl?.threads.filter(
+        (thread) => thread.turn.phase === "queued",
+      ),
+    ).toHaveLength(1);
+    expect(
+      state.authoritative.active?.transcript.items.find(
+        (item) => item.type === "tool_call" && item.qualifiedName === "spawn_agents",
+      ),
+    ).toMatchObject({ status: "completed" });
+    expect(screen.slice(screen.indexOf("Fleet ·"))).not.toContain("@explore-5");
+    expect(mainCalls).toBe(2);
+  } finally {
+    releaseStart.resolve();
+    await h.close();
+  }
+});
+
+test("Widget projects live child activity and individually frozen queued configuration and budget", async () => {
+  const fourStarted = Promise.withResolvers<void>();
+  let calls = 0;
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        yield { type: "text_delta", text: "Inspecting exact repository evidence." };
+        if (++calls === 4) fourStarted.resolve();
+        await new Promise<void>((resolve) => {
+          if (request.signal.aborted) resolve();
+          else request.signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    { columns: 120, rows: 48 },
+  );
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "visible-five",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: Array.from({ length: 5 }, (_, index) => ({
+            role: "builtin:explore",
+            task: `Read item ${index + 1}`,
+            description: `Evidence ${index + 1}`,
+          })),
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await fourStarted.promise;
+    await h.press("Independent Main draft", "Independent Main draft");
+    const screen = h.terminal.lines().join("\n");
+    expect(screen).toContain("Inspecting exact repository evidence.");
+    expect(screen).toContain("Queued @explore-5 · Explore · Evidence 5");
+    expect(screen).toContain("deepseek-v4-flash.direct · thinking default");
+    expect(screen).toContain("0 used · 0 reserved");
+    const queued = h.presentation.getState().authoritative.managedControl?.threads[4];
+    expect(queued?.turn.configuration).toMatchObject({
+      targetId: "deepseek-v4-flash.direct",
+      thinking: "default",
+      contextWindowTokens: 128000,
+    });
+    expect(queued?.budget).toMatchObject({
+      knownUsed: 0,
+      outstandingReserved: 0,
+      unknownReserved: 0,
+      available: 128000,
+    });
+    expect(calls).toBe(4);
+  } finally {
+    await h.close();
+  }
+});
+
+test("thirty-two admitted agents compress truthfully without hiding the Main editor", async () => {
+  const fourStarted = Promise.withResolvers<void>();
+  const firstFinish = Promise.withResolvers<void>();
+  const fifthStarted = Promise.withResolvers<void>();
+  let calls = 0;
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        const call = ++calls;
+        if (call === 4) fourStarted.resolve();
+        if (call === 5) fifthStarted.resolve();
+        await Promise.race([
+          call === 1 ? firstFinish.promise : new Promise<void>(() => {}),
+          new Promise<void>((resolve) => {
+            if (request.signal.aborted) resolve();
+            else request.signal.addEventListener("abort", () => resolve(), { once: true });
+          }),
+        ]);
+        yield { type: "text_delta", text: "Finished this evidence item." };
+        yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    {
+      columns: 40,
+      rows: 16,
+      deadlineScheduler: {
+        schedule() {
+          return { cancel() {} };
+        },
+      },
+    },
+  );
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "visible-thirty-two",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: Array.from({ length: 32 }, (_, index) => ({
+            role: "builtin:explore",
+            task: `Read item ${index + 1}`,
+            description: `Evidence ${index + 1}`,
+          })),
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await fourStarted.promise;
+    await h.press("Main draft", "");
+    const screen = h.terminal.lines().join("\n");
+    expect(screen).toContain("Main draft");
+    expect(screen).toContain("28 queued");
+    expect(screen).toContain("… hidden 3 run/28 queued/1 line");
+    expect(screen).toContain("Fleet");
+    expect(h.presentation.getState().authoritative.managedControl?.threads).toHaveLength(32);
+    const beforeFinish = h.terminal.output().length;
+    firstFinish.resolve();
+    await fifthStarted.promise;
+    await h.terminal.nextSynchronizedFrameContaining(
+      "… hidden 3 run/27 queued/1 done/1 line",
+      beforeFinish,
+    );
+    const mixed = h.terminal.lines().join("\n");
+    expect(mixed).toContain("Main draft");
+    expect(mixed).toContain("Fleet");
+  } finally {
+    firstFinish.resolve();
+    await h.close();
+  }
+});
+
+test("queued agents stay individually inspectable and exact cancellation never opens a dead Fleet row", async () => {
+  const fourStarted = Promise.withResolvers<void>();
+  let calls = 0;
+  const h = await startManagedTui({
+    async *stream(request) {
+      if (++calls === 4) fourStarted.resolve();
+      await new Promise<void>((resolve) => {
+        if (request.signal.aborted) resolve();
+        else request.signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "queued-inspection",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: Array.from({ length: 5 }, (_, index) => ({
+            role: "builtin:explore",
+            task: `Private task ${index + 1}`,
+            description: `Queued evidence ${index + 1}`,
+          })),
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await fourStarted.promise;
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\u001b[F", "@explore-5");
+    await h.press("\r", "Queued tasks are immutable.");
+    const detail = h.terminal.lines().join("\n");
+    expect(detail).toContain("deepseek-v4-flash.direct");
+    expect(detail).toContain("thinking default");
+    expect(detail).toContain("128000 available");
+    expect(detail).not.toContain("Private task 5");
+    await h.press("x", "x again to cancel");
+    await h.press("x", "Cancelled");
+    expect(h.presentation.getState().authoritative.managedControl?.threads[4]?.turn).toMatchObject({
+      phase: "idle",
+      lastOutcome: "cancelled",
+    });
+    expect(calls).toBe(4);
+    await h.press("\u001b", "Agents workspace");
+    await h.press("\u001b", "Fleet");
+    expect(
+      h.terminal.lines().join("\n").slice(h.terminal.lines().join("\n").indexOf("Fleet ·")),
+    ).not.toContain("@explore-5");
+  } finally {
+    await h.close();
+  }
+});
+
+test("terminal Widget and Fleet linger expires without removing the full agent history", async () => {
+  const started = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const deadlines = new Map<object, { readonly milliseconds: number; readonly fire: () => void }>();
+  const scheduler: DeadlineScheduler = {
+    schedule(milliseconds, fire) {
+      const key = {};
+      deadlines.set(key, { milliseconds, fire });
+      return {
+        cancel() {
+          deadlines.delete(key);
+        },
+      };
+    },
+  };
+  const h = await startManagedTui(
+    {
+      async *stream() {
+        started.resolve();
+        await release.promise;
+        yield { type: "text_delta", text: "Retained history evidence." };
+        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    { deadlineScheduler: scheduler },
+  );
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "linger",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            { role: "builtin:explore", task: "Inspect evidence.", description: "Linger evidence" },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await started.promise;
+    await h.terminal.nextSynchronizedFrameContaining("Linger evidence");
+    const before = h.terminal.output().length;
+    release.resolve();
+    await h.terminal.nextSynchronizedFrameContaining("Completed", before);
+    expect(h.terminal.lines().join("\n")).toContain("Linger evidence");
+    const timers = [...deadlines.values()].filter((entry) => entry.milliseconds === 4000);
+    expect(timers).toHaveLength(1);
+    const beforeExpiry = h.terminal.output().length;
+    for (const timer of timers) timer.fire();
+    await h.terminal.nextSynchronizedFrameContaining("", beforeExpiry);
+    expect(h.terminal.lines().join("\n")).not.toContain("Linger evidence");
+    expect(h.presentation.getState().authoritative.managedControl?.threads).toHaveLength(1);
+    await h.press("/agents\r", "Agents workspace");
+    expect(h.terminal.lines().join("\n")).toContain("Linger evidence");
+  } finally {
+    release.resolve();
+    await h.close();
+  }
+  expect(deadlines.size).toBe(0);
+});
+
+test("ConversationViewer follows live output, preserves manual scroll, and survives settlement", async () => {
+  const started = Promise.withResolvers<void>();
+  const releaseLines = Promise.withResolvers<void>();
+  const releaseNewest = Promise.withResolvers<void>();
+  const newestEmitted = Promise.withResolvers<void>();
+  const releaseFinish = Promise.withResolvers<void>();
+  const h = await startManagedTui({
+    async *stream() {
+      yield { type: "text_delta", text: "First live line.\n" };
+      started.resolve();
+      await releaseLines.promise;
+      yield {
+        type: "text_delta",
+        text: `${Array.from({ length: 50 }, (_, index) => `Live line ${index + 1}`).join("\n")}\n`,
+      };
+      await releaseNewest.promise;
+      yield { type: "text_delta", text: "Newest live tail." };
+      newestEmitted.resolve();
+      await releaseFinish.promise;
+      yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "live-viewer",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            {
+              role: "builtin:explore",
+              task: "Read viewer evidence.",
+              description: "Live viewer evidence",
+            },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await started.promise;
+    await h.terminal.nextSynchronizedFrameContaining("Live viewer evidence");
+    await h.press("\u001b[B\u001b[B\r", "Conversation");
+    expect(h.conversationText()).toContain("First live line.");
+    expect(h.conversationText()).toContain("deepseek-v4-flash.direct · thinking default");
+    expect(h.conversationText()).toContain("128000 context");
+    const beforeLines = h.terminal.output().length;
+    releaseLines.resolve();
+    await h.terminal.nextSynchronizedFrameContaining("Live line 50", beforeLines);
+    await h.press("k", "Manual scroll");
+    await h.press("j", "Following tail");
+    await h.press("\u001b[1;2A", "Manual scroll");
+    await h.press("\u001b[1;2B", "Following tail");
+    const previousKeys = getKeybindings();
+    try {
+      setKeybindings(
+        new KeybindingsManager(TUI_KEYBINDINGS, {
+          "tui.select.up": "ctrl+p",
+          "tui.select.down": "ctrl+n",
+          "tui.select.pageUp": "ctrl+b",
+          "tui.select.pageDown": "ctrl+f",
+        }),
+      );
+      await h.press("\u0010", "Manual scroll");
+      await h.press("\u000e", "Following tail");
+      await h.press("\u0002", "Manual scroll");
+      await h.press("\u0006", "Following tail");
+      await h.press("k", "Manual scroll");
+      await h.press("j", "Following tail");
+    } finally {
+      setKeybindings(previousKeys);
+    }
+    await h.press("\u001b[H", "First live line.");
+    releaseNewest.resolve();
+    await newestEmitted.promise;
+    await h.press("\u001b[A", "");
+    expect(h.conversationText()).toContain("First live line.");
+    expect(h.conversationText()).not.toContain("Newest live tail.");
+    await h.press("\u001b[F", "Newest live tail.");
+    const beforeFinish = h.terminal.output().length;
+    releaseFinish.resolve();
+    await h.terminal.nextSynchronizedFrameContaining("Completed", beforeFinish);
+    expect(h.terminal.lines().join("\n")).toContain("Conversation · @explore-1");
+    expect(h.conversationText()).toContain("Newest live tail.");
+    expect(h.presentation.getState().authoritative.managedControl?.threads[0]?.turn.phase).toBe(
+      "idle",
+    );
+  } finally {
+    releaseLines.resolve();
+    releaseNewest.resolve();
+    releaseFinish.resolve();
+    await h.close();
+  }
+});
+
+test("actual child Enter accepts one exact input, delivers at the read boundary, and starts a settled continuation", async () => {
+  const started = Promise.withResolvers<void>();
+  const releaseRead = Promise.withResolvers<void>();
+  const requests: ModelRequest[] = [];
+  let mainCalls = 0;
+  const h = await startManagedTui({
+    async *stream(request) {
+      if (request.tools.some((tool) => tool.name === "spawn_agents")) {
+        mainCalls += 1;
+        yield { type: "text_delta", text: "Main after child completed." };
+      } else {
+        requests.push(request);
+        if (requests.length === 1) {
+          yield { type: "text_delta", text: "Reading before the safe boundary." };
+          started.resolve();
+          await releaseRead.promise;
+          yield { type: "tool_call_start", id: "child-read", name: "read_file" };
+          yield { type: "tool_call_delta", id: "child-read", json: '{"path":"package.json"}' };
+          yield { type: "tool_call_end", id: "child-read" };
+          yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+          yield { type: "finish", reason: "tool_calls" };
+          return;
+        }
+        yield {
+          type: "text_delta",
+          text: requests.length === 2 ? "Child input delivered." : "Continuation completed.",
+        };
+      }
+      yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "enter-delivery",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            {
+              role: "builtin:explore",
+              task: "Inspect repository.",
+              description: "Delivery evidence",
+            },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await started.promise;
+    await h.terminal.nextSynchronizedFrameContaining("@explore-1 · Explore · Running");
+    await h.press("\u001b[B\u001b[B\r", "Conversation");
+    await h.press("\r", "To @explore-1");
+    await h.press("Use this exact later evidence.", "Use this exact later evidence.");
+    await h.press("\r", "Accepted");
+    const first = h.presentation.getState().authoritative.managedControl?.threads[0];
+    expect(first?.inputs).toMatchObject([{ status: "accepted", turnId: first?.turn.turnId }]);
+    expect(requests).toHaveLength(1);
+    expect(JSON.stringify(requests)).not.toContain("Use this exact later evidence.");
+    const beforeRead = h.terminal.output().length;
+    releaseRead.resolve();
+    await h.terminal.nextSynchronizedFrameContaining("Child input delivered.", beforeRead);
+    await h.terminal.nextSynchronizedFrameContaining("Completed", beforeRead);
+    expect(h.conversationText()).toContain("Delivered");
+    expect(JSON.stringify(requests[1]?.messages)).toContain("Use this exact later evidence.");
+    expect(
+      h.presentation.getState().authoritative.managedControl?.threads[0]?.inputs,
+    ).toMatchObject([{ status: "delivered", turnId: first?.turn.turnId }]);
+    expect(mainCalls).toBe(0);
+    await h.press("\u001b", "Enter compose · Esc back");
+    await h.press("\r", "New turn");
+    await h.press("Continue this exact thread.", "Continue this exact thread.");
+    await h.press("\r", "Continuation completed.");
+    expect(requests).toHaveLength(3);
+    expect(JSON.stringify(requests[2]?.messages)).toContain("Continue this exact thread.");
+    const next = h.presentation.getState().authoritative.managedControl?.threads[0];
+    expect(next?.threadId).toBe(first?.threadId);
+    expect(next?.turn.turnId).not.toBe(first?.turn.turnId);
+    expect(mainCalls).toBe(0);
+    await h.press("\u001b", "Enter compose · Esc back");
+    await h.press("\u001b", "Esc Main");
+    await h.press("\u001b", "Fleet · ↓ navigate");
+    await h.press("Main prompt.\r", "Main after child completed.");
+    expect(mainCalls).toBe(1);
+  } finally {
+    releaseRead.resolve();
+    await h.close();
+  }
+});
+
+test.each(["cooperative", "interrupt"] as const)(
+  "%s composer Enter reports the exact finishing-provider delivery outcome",
+  async (mode) => {
+    const started = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    let calls = 0;
+    const h = await startManagedTui({
+      async *stream() {
+        if (++calls === 1) {
+          started.resolve();
+          await release.promise;
+        }
+        yield { type: "text_delta", text: "Finishing provider evidence." };
+        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+      },
+    });
+    try {
+      expect(
+        await h.presentation.dispatch({
+          type: "managed_control",
+          commandId: `finishing-${mode}`,
+          command: {
+            type: "spawn_agents",
+            parentSessionId: h.parent.sessionId,
+            entries: [
+              {
+                role: "builtin:explore",
+                task: "Inspect evidence.",
+                description: "Finishing boundary",
+              },
+            ],
+          },
+        }),
+      ).toMatchObject({ status: "admitted" });
+      await started.promise;
+      await h.terminal.nextSynchronizedFrameContaining("Finishing boundary");
+      await h.press("\u001b[B\u001b[B\r", "Conversation");
+      await h.press("\r", "Cooperative");
+      if (mode === "interrupt") await h.press("\t", "Interrupt after current effect");
+      await h.press("Additional evidence.", "Additional evidence.");
+      await h.press("\r", "Accepted");
+      const before = h.terminal.output().length;
+      release.resolve();
+      await h.terminal.nextSynchronizedFrameContaining("Completed", before);
+      expect(h.conversationText()).toContain(
+        mode === "interrupt" ? "Delivered" : "Undelivered · settled",
+      );
+      expect(
+        h.presentation.getState().authoritative.managedControl?.threads[0]?.inputs,
+      ).toMatchObject([{ status: mode === "interrupt" ? "delivered" : "undelivered" }]);
+      expect(calls).toBe(mode === "interrupt" ? 2 : 1);
+    } finally {
+      release.resolve();
+      await h.close();
+    }
+  },
+);
+
+test("child composer answers the exact Parent input request without a Main turn", async () => {
+  const requests: ModelRequest[] = [];
+  const h = await startManagedTui({
+    async *stream(request) {
+      requests.push(request);
+      if (requests.length === 1) {
+        yield { type: "tool_call_start", id: "question", name: "request_parent_input" };
+        yield {
+          type: "tool_call_delta",
+          id: "question",
+          json: '{"question":"Which scope should I inspect?"}',
+        };
+        yield { type: "tool_call_end", id: "question" };
+        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+        yield { type: "finish", reason: "tool_calls" };
+      } else {
+        yield { type: "text_delta", text: "Exact parent reply received." };
+        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+      }
+    },
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "parent-input",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            { role: "builtin:explore", task: "Ask for a scope.", description: "Exact question" },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await h.terminal.nextSynchronizedFrameContaining("Waiting for you");
+    await h.terminal.nextSynchronizedFrameContaining("Attention Center");
+    await h.press("\u001b[27u", "Attention pending");
+    await h.press("\u001b[B\u001b[B\r", "Conversation");
+    expect(h.conversationText()).toContain("Which scope should I inspect?");
+    await h.press("\r", "Reply to parent input");
+    await h.press("Inspect the public interface.", "Inspect the public interface.");
+    await h.press("\r", "Exact parent reply received.");
+    expect(requests).toHaveLength(2);
+    expect(JSON.stringify(requests[1]?.messages)).toContain("Inspect the public interface.");
+    expect(
+      h.presentation
+        .getState()
+        .authoritative.active?.transcript.items.some((item) => item.type === "user_message"),
+    ).toBe(false);
+    expect(
+      h.presentation.getState().authoritative.managedControl?.threads[0]?.inputs,
+    ).toMatchObject([{ status: "delivered" }]);
+  } finally {
+    await h.close();
+  }
+});
+
+test("a retained child draft rejects after another turn starts without rebinding its target", async () => {
+  const started = Promise.withResolvers<void>();
+  const firstFinish = Promise.withResolvers<void>();
+  const secondStarted = Promise.withResolvers<void>();
+  let calls = 0;
+  const h = await startManagedTui({
+    async *stream(request) {
+      if (++calls === 1) {
+        started.resolve();
+        await firstFinish.promise;
+      } else {
+        secondStarted.resolve();
+        await new Promise<void>((resolve) => {
+          if (request.signal.aborted) resolve();
+          else request.signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      }
+      yield { type: "text_delta", text: "Exact turn finished." };
+      yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "stale-draft-start",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [{ role: "builtin:explore", task: "First task.", description: "Stable thread" }],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await started.promise;
+    await h.terminal.nextSynchronizedFrameContaining("@explore-1 · Explore · Running");
+    await h.press("\u001b[B\u001b[B\r", "Conversation");
+    await h.press("\r", "Cooperative");
+    await h.press("Draft for the first turn only.", "Draft for the first turn only.");
+    await h.press("\u001b", "Enter compose · Esc back");
+    await h.press("\u001b", "Esc Main");
+    const first = h.presentation.getState().authoritative.managedControl?.threads[0];
+    if (first === undefined) throw new Error("Missing first thread");
+    const before = h.terminal.output().length;
+    firstFinish.resolve();
+    await h.terminal.nextSynchronizedFrameContaining("Completed", before);
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "independent-next-turn",
+        command: {
+          type: "next_turn",
+          parentSessionId: first.parentSessionId,
+          threadId: first.threadId,
+          expectedTurnId: first.turn.turnId,
+          task: "A separately admitted next task.",
+        },
+      }),
+    ).toMatchObject({ status: "admitted", control: { status: "accepted" } });
+    await secondStarted.promise;
+    await h.terminal.nextSynchronizedFrameContaining("@explore-1 · Explore · Running", before);
+    await h.press("\u001b[B\r", "Conversation");
+    await h.press("\r", "Draft for the first turn only.");
+    await h.press("\r", "The selected turn changed.");
+    expect(h.conversationText()).toContain("Draft for the first turn only.");
+    expect(h.presentation.getState().authoritative.managedControl?.threads[0]?.inputs).toHaveLength(
+      0,
+    );
+    expect(calls).toBe(2);
+  } finally {
+    firstFinish.resolve();
+    await h.close();
+  }
+});
+
+test.each(["wait", "suspend"] as const)(
+  "Session picker offers Stay and %s before switching and preserves child draft scope",
+  async (decision) => {
+    const fourStarted = Promise.withResolvers<void>();
+    const finish = Promise.withResolvers<void>();
+    let calls = 0;
+    const h = await startManagedTui(
+      {
+        async *stream(request) {
+          if (request.tools.some((tool) => tool.name === "spawn_agents")) {
+            yield { type: "text_delta", text: "Destination is ready." };
+            yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+            yield { type: "finish", reason: "stop" };
+            return;
+          }
+          if (++calls === 4) fourStarted.resolve();
+          await Promise.race([
+            finish.promise,
+            new Promise<void>((resolve) => {
+              if (request.signal.aborted) resolve();
+              else request.signal.addEventListener("abort", () => resolve(), { once: true });
+            }),
+          ]);
+          yield { type: "text_delta", text: "Source evidence settled." };
+          yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+          yield { type: "finish", reason: "stop" };
+        },
+      },
+      { withDestination: true },
+    );
+    try {
+      expect(
+        h.presentation
+          .getState()
+          .authoritative.sessions.items.some((session) => session.id === h.destination?.sessionId),
+      ).toBe(true);
+      expect(
+        await h.presentation.dispatch({
+          type: "managed_control",
+          commandId: "switch-source",
+          command: {
+            type: "spawn_agents",
+            parentSessionId: h.parent.sessionId,
+            entries: Array.from({ length: 5 }, (_, index) => ({
+              role: "builtin:explore",
+              task: `Source ${index + 1}.`,
+              description: `Source item ${index + 1}`,
+            })),
+          },
+        }),
+      ).toMatchObject({ status: "admitted" });
+      await fourStarted.promise;
+      await h.terminal.nextSynchronizedFrameContaining("Source item 1");
+      await h.press("\u001b[B\u001b[B\r", "Conversation");
+      await h.press("\r", "Cooperative");
+      await h.press("Only the source child draft.", "Only the source child draft.");
+      await h.press("\u001b", "Enter compose · Esc back");
+      await h.press("\u001b", "Esc Main");
+      await h.press("\u001b", "Fleet · ↓ navigate");
+      await h.press("/resume\r", "Select a project session");
+      await h.press("Destination", "Search: Destination");
+      await h.press("\r", "Switch Session");
+      expect(h.presentation.getState().authoritative.active?.session.id).toBe(h.parent.sessionId);
+      const stayed = Promise.withResolvers<void>();
+      const unsubscribeStay = h.presentation.subscribe(() => {
+        if (h.presentation.getState().authoritative.managedTransition === undefined)
+          stayed.resolve();
+      });
+      await h.press("\u001b[27u", "Select a project session");
+      await stayed.promise;
+      unsubscribeStay();
+      expect(h.presentation.getState().authoritative.active?.session.id).toBe(h.parent.sessionId);
+      await h.press("\r", "Switch Session");
+      const beforeSwitch = h.terminal.output().length;
+      if (decision === "wait") {
+        await h.press("\u001b[B\r", "Waiting for agent work");
+        finish.resolve();
+      } else h.terminal.input("\u001b[B\u001b[B\r");
+      await h.terminal.nextSynchronizedFrameContaining("Adam · Destination fixture", beforeSwitch);
+      expect(h.presentation.getState().authoritative.active?.session.id).toBe(
+        h.destination?.sessionId,
+      );
+      expect(h.presentation.getState().managedDrafts).toHaveLength(0);
+      expect(h.presentation.getState().authoritative.managedControl?.threads).toHaveLength(0);
+      expect(calls).toBe(decision === "wait" ? 5 : 4);
+      await h.press("/resume\r", "Select a project session");
+      await h.press("Fleet fixture", "Search: Fleet fixture");
+      await h.press("\r", "Adam · Fleet fixture");
+      await h.press("/agents\r", "Agents workspace");
+      await h.press("\r", "Conversation");
+      await h.press("\r", "Only the source child draft.");
+      expect(h.conversationText()).toContain("Only the source child draft.");
+      expect(h.presentation.getState().composer.renderedText).not.toContain("source child");
+    } finally {
+      finish.resolve();
+      await h.close();
+    }
+  },
+);
+
+test("two deliberate Enter submissions with identical text admit two distinct child inputs", async () => {
+  const started = Promise.withResolvers<void>();
+  const h = await startManagedTui({
+    async *stream(request) {
+      started.resolve();
+      await new Promise<void>((resolve) => {
+        if (request.signal.aborted) resolve();
+        else request.signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "distinct-enter",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            { role: "builtin:explore", task: "Inspect evidence.", description: "Repeated input" },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await started.promise;
+    await h.terminal.nextSynchronizedFrameContaining("Repeated input");
+    await h.press("\u001b[B\u001b[B\r", "Conversation");
+    await h.press("\r", "Cooperative");
+    await h.press("Check again.", "Check again.");
+    await h.press("\r", "Accepted");
+    await h.press("Check again.", "Check again.");
+    await h.press("\r", "Accepted");
+    const inputs = h.presentation.getState().authoritative.managedControl?.threads[0]?.inputs;
+    expect(inputs).toHaveLength(2);
+    expect(inputs?.[0]?.id).not.toBe(inputs?.[1]?.id);
+    expect(inputs?.map((input) => input.status)).toEqual(["accepted", "accepted"]);
+  } finally {
+    await h.close();
+  }
+});
+
+test("late durable acceptance cannot clear a draft explicitly retargeted to a newer turn", async () => {
+  const started = Promise.withResolvers<void>();
+  const firstFinish = Promise.withResolvers<void>();
+  const secondStarted = Promise.withResolvers<void>();
+  const receiptReady = Promise.withResolvers<void>();
+  const returnReceipt = Promise.withResolvers<void>();
+  let calls = 0;
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        if (++calls === 1) {
+          started.resolve();
+          await firstFinish.promise;
+        } else {
+          secondStarted.resolve();
+          await new Promise<void>((resolve) => {
+            if (request.signal.aborted) resolve();
+            else request.signal.addEventListener("abort", () => resolve(), { once: true });
+          });
+        }
+        yield { type: "text_delta", text: "Original work completed." };
+        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    {
+      controlReceiptBarrier: async (command) => {
+        if (command.type === "post_agent") {
+          receiptReady.resolve();
+          await returnReceipt.promise;
+        }
+      },
+    },
+  );
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "late-acceptance",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            { role: "builtin:explore", task: "First work.", description: "Retargeted draft" },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await started.promise;
+    await h.terminal.nextSynchronizedFrameContaining("Retargeted draft");
+    await h.press("\u001b[B\u001b[B\r", "Conversation");
+    await h.press("\r", "Cooperative");
+    await h.press("Still the intended draft.", "Still the intended draft.");
+    h.terminal.input("\r");
+    await receiptReady.promise;
+    await h.press("\u001b", "Enter compose · Esc back");
+    const first = h.presentation.getState().authoritative.managedControl?.threads[0];
+    if (first === undefined) throw new Error("Missing first turn");
+    const beforeFinish = h.terminal.output().length;
+    firstFinish.resolve();
+    await h.terminal.nextSynchronizedFrameContaining("Completed", beforeFinish);
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "retarget-next",
+        command: {
+          type: "next_turn",
+          parentSessionId: first.parentSessionId,
+          threadId: first.threadId,
+          expectedTurnId: first.turn.turnId,
+          task: "The current work.",
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await secondStarted.promise;
+    await h.press("t", "Retarget draft to the current turn?");
+    await h.press("\r", "Draft retargeted to the current turn.");
+    const next = h.presentation.getState().authoritative.managedControl?.threads[0];
+    expect(next?.turn.turnId).not.toBe(first.turn.turnId);
+    const beforeReceipt = h.terminal.output().length;
+    returnReceipt.resolve();
+    await h.terminal.nextSynchronizedFrameContaining("Undelivered · settled", beforeReceipt);
+    await h.press("\r", "To @explore-1");
+    expect(h.conversationText()).toContain("Still the intended draft.");
+    expect(
+      await h.presentation.dispatch({
+        type: "read_agent_draft",
+        sessionId: first.parentSessionId,
+        threadId: first.threadId,
+      }),
+    ).toMatchObject({
+      status: "admitted",
+      managedDraft: { expectedTurnId: next?.turn.turnId, text: "Still the intended draft." },
+    });
+    expect(calls).toBe(2);
+  } finally {
+    firstFinish.resolve();
+    returnReceipt.resolve();
+    await h.close();
+  }
+});
+
+test("Settling exposes no input action until cleanup releases the exact turn", async () => {
+  const settling = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  let calls = 0;
+  const h = await startManagedTui(
+    {
+      async *stream() {
+        yield { type: "text_delta", text: `Settled evidence ${++calls}.` };
+        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    {
+      settlementBarrier: async () => {
+        settling.resolve();
+        await release.promise;
+      },
+    },
+  );
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "settling-input",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            { role: "builtin:explore", task: "Inspect evidence.", description: "Cleanup boundary" },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await settling.promise;
+    await h.terminal.nextSynchronizedFrameContaining("Settling");
+    await h.press("\u001b[B\u001b[B\r", "Conversation");
+    expect(h.conversationText()).not.toContain("Enter compose");
+    await h.press("\r", "Settling");
+    expect(h.conversationText()).not.toContain("To @explore-1");
+    expect(h.presentation.getState().authoritative.managedControl?.threads[0]?.inputs).toHaveLength(
+      0,
+    );
+    const before = h.terminal.output().length;
+    release.resolve();
+    await h.terminal.nextSynchronizedFrameContaining("Completed", before);
+    await h.press("\r", "New turn");
+    await h.press("Continue after cleanup.", "Continue after cleanup.");
+    await h.press("\r", "Settled evidence 2.");
+    expect(calls).toBe(2);
+  } finally {
+    release.resolve();
+    await h.close();
+  }
+});
+
+test("ordinary Main Enter completes while a real child read remains durably started", async () => {
+  const readStarted = Promise.withResolvers<void>();
+  const releaseRead = Promise.withResolvers<void>();
+  let mainCalls = 0;
+  let childCalls = 0;
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        if (request.tools.some((tool) => tool.name === "spawn_agents")) {
+          mainCalls += 1;
+          yield { type: "text_delta", text: "Main completed while child read is active." };
+        } else if (++childCalls === 1) {
+          yield { type: "tool_call_start", id: "held-read", name: "read_file" };
+          yield { type: "tool_call_delta", id: "held-read", json: '{"path":"package.json"}' };
+          yield { type: "tool_call_end", id: "held-read" };
+          yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+          yield { type: "finish", reason: "tool_calls" };
+          return;
+        } else {
+          expect(request.messages.findLast((message) => message.role === "tool")).toMatchObject({
+            role: "tool",
+            name: "read_file",
+            result: { status: "completed" },
+          });
+          yield { type: "text_delta", text: "Child read complete." };
+        }
+        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    {
+      childRecordBarrier: async (record) => {
+        if (
+          record.schemaVersion === 3 &&
+          record.record.type === "runtime_event" &&
+          record.record.event.type === "tool_started" &&
+          record.record.event.name === "read_file"
+        ) {
+          readStarted.resolve();
+          await releaseRead.promise;
+        }
+      },
+    },
+  );
+  const mainReady = Promise.withResolvers<number>();
+  const unsubscribe = h.presentation.subscribe(() => {
+    const state = h.presentation.getState();
+    if (
+      mainCalls === 1 &&
+      state.authoritative.active?.parentRun?.phase === "ready" &&
+      state.authoritative.active.transcript.items.some(
+        (item) =>
+          item.type === "assistant_message" &&
+          item.text === "Main completed while child read is active.",
+      )
+    )
+      mainReady.resolve(h.terminal.output().length);
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "main-during-read",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            {
+              role: "builtin:explore",
+              task: "Read the package manifest.",
+              description: "Actual child read",
+            },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await readStarted.promise;
+    await h.press("Main while child reads.\r", "Main completed while child read is active.");
+    const readyOffset = await mainReady.promise;
+    await h.terminal.nextSynchronizedFrameContaining(" · idle", readyOffset);
+    const child = h.presentation.getState().authoritative.managedControl?.threads[0];
+    if (child === undefined) throw new Error("Missing child");
+    const records = await (await h.children.open(child.turn.childSessionId))?.read();
+    expect(
+      records?.some(
+        (record) =>
+          record.schemaVersion === 3 &&
+          record.record.type === "runtime_event" &&
+          record.record.event.type === "tool_started" &&
+          record.record.event.name === "read_file",
+      ),
+    ).toBe(true);
+    expect(
+      records?.some(
+        (record) =>
+          record.schemaVersion === 3 &&
+          record.record.type === "runtime_event" &&
+          record.record.event.type === "tool_completed",
+      ),
+    ).toBe(false);
+    expect(mainCalls).toBe(1);
+    expect(childCalls).toBe(1);
+    const before = h.terminal.output().length;
+    releaseRead.resolve();
+    await h.terminal.nextSynchronizedFrameContaining("Completed", before);
+    expect(childCalls).toBe(2);
+  } finally {
+    unsubscribe();
+    releaseRead.resolve();
+    await h.close();
+  }
+});
+
+test("viewer cycles assistant Markdown, full Markdown and raw without rewriting literal markers", async () => {
+  const text = "# Evidence\n\n**Bold proof**\n\n3) first\n7) seventh\n\n\\*literal\\*";
+  const h = await startManagedTui({
+    async *stream() {
+      yield { type: "text_delta", text };
+      yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "markdown-viewer",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            { role: "builtin:explore", task: "Read evidence.", description: "Markdown evidence" },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await h.terminal.nextSynchronizedFrameContaining("Completed");
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\r", "Conversation");
+    expect(h.conversationText()).toContain("Bold proof");
+    expect(h.conversationText()).not.toContain("**Bold proof**");
+    expect(h.conversationText()).toContain("m assistant Markdown");
+    await h.press("m", "m full Markdown");
+    await h.press("m", "m raw");
+    expect(h.conversationText()).toContain("**Bold proof**");
+    expect(h.conversationText()).toContain("3) first");
+    expect(h.conversationText()).toContain("7) seventh");
+    expect(h.conversationText()).toContain("\\*literal\\*");
+    await h.press("m", "m assistant Markdown");
+    expect(h.conversationText()).toContain("3) first");
+    expect(h.conversationText()).toContain("7) seventh");
+  } finally {
+    await h.close();
+  }
+});
+
+test.each([
+  ["diff", "diff --git a/a b/a\n--- a/a\n+++ b/a\n@@ -1 +1 @@\n-**old**\n+**new**", "+**new**"],
+  ["shell", "#!/bin/sh\nprintf '**literal**\\n'", "**literal**"],
+  ["log", "2026-09-06T00:00:00Z INFO **literal log**", "**literal log**"],
+  ["parser failure", `${"> ".repeat(60)}deep evidence`, "> > > > >"],
+])("viewer retains %s content literally in full Markdown mode", async (_kind, text, literal) => {
+  const h = await startManagedTui({
+    async *stream() {
+      yield { type: "text_delta", text };
+      yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "literal-viewer",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            { role: "builtin:explore", task: "Read evidence.", description: "Literal evidence" },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await h.terminal.nextSynchronizedFrameContaining("Completed");
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\r", "Conversation");
+    await h.press("m", "m full Markdown");
+    expect(h.conversationText()).toContain(literal);
+    await h.press("m", "m raw");
+    expect(h.conversationText()).toContain(literal);
+  } finally {
+    await h.close();
+  }
+});
+
+test("viewer loads bounded older transcript pages and returns to the current tail without consumption", async () => {
+  let calls = 0;
+  const h = await startManagedTui({
+    async *stream() {
+      const number = ++calls;
+      yield {
+        type: "text_delta",
+        text: number === 13 ? "Newest evidence page." : `Page evidence ${number}.`,
+      };
+      if (number < 13) {
+        yield { type: "tool_call_start", id: `page-read-${number}`, name: "read_file" };
+        yield {
+          type: "tool_call_delta",
+          id: `page-read-${number}`,
+          json: '{"path":"package.json"}',
+        };
+        yield { type: "tool_call_end", id: `page-read-${number}` };
+      }
+      yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+      yield { type: "finish", reason: number < 13 ? "tool_calls" : "stop" };
+    },
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "paged-transcript",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            {
+              role: "builtin:explore",
+              task: "Read the evidence boundaries.",
+              description: "Paged evidence",
+            },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await h.terminal.nextSynchronizedFrameContaining("Completed");
+    const thread = h.presentation.getState().authoritative.managedControl?.threads[0];
+    if (thread === undefined) throw new Error("Missing thread");
+    await new Promise<void>((resolve) => {
+      const check = () => {
+        if (
+          h.presentation
+            .getState()
+            .authoritative.managedControl?.completions.some(
+              (completion) => completion.turnId === thread.turn.turnId,
+            )
+        ) {
+          unsubscribe();
+          resolve();
+        }
+      };
+      const unsubscribe = h.presentation.subscribe(check);
+      check();
+    });
+    const command = {
+      type: "read_agent_conversation" as const,
+      sessionId: thread.parentSessionId,
+      threadId: thread.threadId,
+      expectedTurnId: thread.turn.turnId,
+      cursor: null,
+    };
+    const receipt = await h.presentation.dispatch(command);
+    if (receipt.status !== "admitted" || receipt.managedAgentTranscript === undefined)
+      throw new Error("Missing bounded page");
+    expect(receipt.managedAgentTranscript.items.length).toBeLessThanOrEqual(20);
+    expect(receipt.managedAgentTranscript.olderCursor).not.toBeNull();
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\r", "Newest evidence page.");
+    expect(h.conversationText()).not.toContain("Page evidence 1.");
+    await h.press("\u001b[H", "Manual scroll");
+    await h.press("\u001b[5~", "Page evidence 1.");
+    await h.press("\u001b[F", "Newest evidence page.");
+    expect(
+      h.presentation.getState().authoritative.managedControl?.completions[0]?.consumption,
+    ).toBe("pending");
+    expect(
+      await h.presentation.dispatch({
+        ...command,
+        cursor:
+          receipt.managedAgentTranscript.olderCursor?.replace(
+            thread.threadId,
+            "00000000-0000-4000-8000-000000000001",
+          ) ?? "invalid",
+      }),
+    ).toMatchObject({ status: "rejected", code: "invalid_command" });
+    expect(calls).toBe(13);
+  } finally {
+    await h.close();
+  }
+});
+
+test("live transcript elision is counted separately from the bounded Markdown content", async () => {
+  const started = Promise.withResolvers<void>();
+  const finish = Promise.withResolvers<void>();
+  const text = `\x60\x60\x60text\n${"x".repeat(19992)}`;
+  const h = await startManagedTui({
+    async *stream() {
+      yield { type: "text_delta", text };
+      started.resolve();
+      await finish.promise;
+      yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "live-elision",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            {
+              role: "builtin:explore",
+              task: "Inspect evidence.",
+              description: "Bounded live preview",
+            },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await started.promise;
+    await h.terminal.nextSynchronizedFrameContaining("Bounded live preview");
+    await h.press("\u001b[B\u001b[B\r", "Conversation");
+    expect(h.presentation.getState().managedAgentActivity?.[0]?.assistant).toMatchObject({
+      totalByteCount: 20000,
+      omittedBytes: 3616,
+    });
+    expect(h.presentation.getState().managedAgentActivity?.[0]?.assistant?.text).not.toContain(
+      "bytes omitted",
+    );
+    expect(h.conversationText()).toContain("Live preview · 3616 bytes omitted");
+  } finally {
+    finish.resolve();
+    await h.close();
+  }
+});
+
+test("child permission preempts and restores the exact independent composer without capturing Main", async () => {
+  const started = Promise.withResolvers<void>();
+  const ask = Promise.withResolvers<void>();
+  let childCalls = 0;
+  let mainCalls = 0;
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        if (request.tools.some((tool) => tool.name === "spawn_agents")) {
+          mainCalls += 1;
+          yield { type: "text_delta", text: "Main after permission." };
+        } else if (++childCalls === 1) {
+          yield { type: "text_delta", text: "Child preparing an exact read." };
+          started.resolve();
+          await ask.promise;
+          yield { type: "tool_call_start", id: "permission-read", name: "read_file" };
+          yield { type: "tool_call_delta", id: "permission-read", json: '{"path":"package.json"}' };
+          yield { type: "tool_call_end", id: "permission-read" };
+          yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+          yield { type: "finish", reason: "tool_calls" };
+          return;
+        } else yield { type: "text_delta", text: "Child permission completed." };
+        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    {
+      permissions: createPermissionPolicy({ allowedEffects: ["delegate"], askedEffects: ["read"] }),
+    },
+  );
+  let sawAttention = false;
+  const restored = Promise.withResolvers<number>();
+  const unsubscribe = h.presentation.subscribe(() => {
+    const attention = h.presentation.getState().managedAttention ?? [];
+    if (attention.length > 0) sawAttention = true;
+    else if (sawAttention) restored.resolve(h.terminal.output().length);
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "permission-focus",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            {
+              role: "builtin:explore",
+              task: "Read only after permission.",
+              description: "Permission focus",
+            },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await started.promise;
+    await h.terminal.nextSynchronizedFrameContaining("Permission focus");
+    await h.press("\u001b[B\u001b[B\r", "Conversation");
+    await h.press("\r", "Cooperative");
+    await h.press("Kept child draft", "Kept child draft");
+    const beforeAsk = h.terminal.output().length;
+    ask.resolve();
+    await h.terminal.nextSynchronizedFrameContaining("Attention Center", beforeAsk);
+    await h.terminal.nextSynchronizedFrameContaining("package.json", beforeAsk);
+    expect(h.terminal.lines().join("\n")).toContain("Permissions");
+    expect(h.terminal.lines().join("\n")).toContain("Parent input");
+    h.terminal.input("a");
+    const restoreOffset = await restored.promise;
+    await h.terminal.nextSynchronizedFrameContaining("To @explore-1", restoreOffset);
+    await h.press(" remains", "Kept child draft remains");
+    expect(h.presentation.getState().composer.renderedText).toBe("");
+    expect(mainCalls).toBe(0);
+    await h.press("\u001b", "Enter compose · Esc back");
+    await h.press("\u001b", "Esc Main");
+    await h.press("\u001b", "Fleet · ↓ navigate");
+    await h.press("Main prompt.\r", "Main after permission.");
+    expect(mainCalls).toBe(1);
+  } finally {
+    unsubscribe();
+    ask.resolve();
+    await h.close();
+  }
+});
+
+test("viewer x x cancels the exact turn only on two presses and retains unknown usage", async () => {
+  const started = Promise.withResolvers<void>();
+  let aborts = 0;
+  const h = await startManagedTui({
+    async *stream(request) {
+      started.resolve();
+      await new Promise<void>((resolve) => {
+        const abort = () => {
+          aborts += 1;
+          resolve();
+        };
+        if (request.signal.aborted) abort();
+        else request.signal.addEventListener("abort", abort, { once: true });
+      });
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "kitty-cancel",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            {
+              role: "builtin:explore",
+              task: "Inspect evidence.",
+              description: "Exact cancellation",
+            },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await started.promise;
+    await h.terminal.nextSynchronizedFrameContaining("Exact cancellation");
+    await h.press("\u001b[B\u001b[B\r", "Conversation");
+    await h.press("\u001b[120;1:1u", "x again to cancel");
+    h.terminal.input("\u001b[120;1:2u\u001b[120;1:3u");
+    await h.press("m", "m full Markdown");
+    expect(aborts).toBe(0);
+    expect(h.presentation.getState().authoritative.managedControl?.threads[0]?.turn.phase).toBe(
+      "executing",
+    );
+    await h.press("\u001b[120;1:1u", "x again to cancel");
+    await h.press("\u001b[120;1:1u", "Cancelled");
+    expect(aborts).toBe(1);
+    expect(
+      h.presentation.getState().authoritative.managedControl?.threads[0]?.budget?.unknownReserved,
+    ).toBeGreaterThan(0);
+    expect(h.conversationText()).toContain("unknown reserved");
+  } finally {
+    await h.close();
+  }
+});
+
+test("Attention defaults to one exact permission and explicit multi-selection decides only selected calls", async () => {
+  const feedback: string[] = [];
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        const result = request.messages.findLast((message) => message.role === "tool");
+        if (result?.role === "tool") {
+          feedback.push(result.result.status);
+          yield { type: "text_delta", text: "Permission result handled." };
+        } else {
+          yield { type: "tool_call_start", id: "same-call-id", name: "read_file" };
+          yield { type: "tool_call_delta", id: "same-call-id", json: '{"path":"package.json"}' };
+          yield { type: "tool_call_end", id: "same-call-id" };
+        }
+        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+        yield { type: "finish", reason: result === undefined ? "tool_calls" : "stop" };
+      },
+    },
+    {
+      permissions: createPermissionPolicy({ allowedEffects: ["delegate"], askedEffects: ["read"] }),
+    },
+  );
+  const spawn = () =>
+    h.presentation.dispatch({
+      type: "managed_control",
+      commandId: "two-permissions",
+      command: {
+        type: "spawn_agents",
+        parentSessionId: h.parent.sessionId,
+        entries: [
+          { role: "builtin:explore", task: "Permission A", description: "Permission A" },
+          { role: "builtin:explore", task: "Permission B", description: "Permission B" },
+        ],
+      },
+    });
+  try {
+    expect(await spawn()).toMatchObject({ status: "admitted" });
+    const first = await h.waitForAttention(
+      (items) =>
+        items.length === 2 &&
+        items.every(
+          (item) => item.kind === "permission" && item.interaction !== null && item.available,
+        ),
+    );
+    await h.terminal.nextSynchronizedFrameContaining("read · package.json");
+    const checked = first.filter((item) =>
+      h.terminal.lines().join("\n").includes(`[x] ${item.handle}`),
+    );
+    expect(checked).toHaveLength(1);
+    h.terminal.input("a");
+    const remaining = await h.waitForAttention((items) => items.length === 1);
+    expect(remaining[0]?.id).not.toBe(checked[0]?.id);
+    await h.terminal.nextSynchronizedFrameContaining("Permissions · 1");
+    h.terminal.input("d");
+    await h.waitForAttention((items) => items.length === 0);
+    const denied = h.presentation
+      .getState()
+      .authoritative.managedControl?.threads.find(
+        (thread) => thread.threadId === remaining[0]?.threadId,
+      );
+    if (denied === undefined) throw new Error("Missing denied child");
+    const deniedRecords = await (await h.children.open(denied.turn.childSessionId))?.read();
+    expect(
+      deniedRecords?.some(
+        (record) =>
+          record.schemaVersion === 3 &&
+          record.record.type === "runtime_event" &&
+          record.record.event.type === "tool_started",
+      ),
+    ).toBe(false);
+    const before = h.terminal.output().length;
+    expect(await spawn()).toMatchObject({ status: "admitted" });
+    const next = await h.waitForAttention(
+      (items) =>
+        items.length === 2 &&
+        items.every(
+          (item) => item.kind === "permission" && item.interaction !== null && item.available,
+        ),
+    );
+    await h.terminal.nextSynchronizedFrameContaining("Permissions · 2", before);
+    const selectedIndex = next.findIndex((item) =>
+      h.terminal.lines().join("\n").includes(`[x] ${item.handle}`),
+    );
+    const other = next[selectedIndex === 0 ? 1 : 0];
+    if (other === undefined) throw new Error("Missing second permission");
+    await h.press(" ", "Space toggle");
+    await h.press(`${selectedIndex === 0 ? "\u001b[B" : "\u001b[A"} `, `[x] ${other.handle}`);
+    h.terminal.input("a");
+    await h.waitForAttention((items) => items.length === 0);
+    expect(h.presentation.getState().authoritative.managedControl?.threads).toHaveLength(4);
+    const targets =
+      h.presentation.getState().authoritative.managedControl?.threads.map((thread) => ({
+        threadId: thread.threadId,
+        expectedTurnId: thread.turn.turnId,
+      })) ?? [];
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "joined-permissions",
+        command: { type: "wait_agents", parentSessionId: h.parent.sessionId, mode: "all", targets },
+      }),
+    ).toMatchObject({ status: "admitted", control: { status: "completed" } });
+    expect(feedback.toSorted()).toEqual(["completed", "completed", "completed", "failed"]);
+  } finally {
+    await h.close();
+  }
+});
+
+test("Parent input in Attention cannot grant a separate child permission", async () => {
+  const replied = Promise.withResolvers<void>();
+  let mainCalls = 0;
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        if (request.tools.some((tool) => tool.name === "spawn_agents")) mainCalls += 1;
+        const questionChild = request.messages.some(
+          (message) =>
+            message.role === "user" &&
+            typeof message.content === "string" &&
+            message.content.includes("Ask the parent"),
+        );
+        const result = request.messages.findLast((message) => message.role === "tool");
+        if (result === undefined) {
+          const name = questionChild ? "request_parent_input" : "read_file";
+          yield { type: "tool_call_start", id: "exact-question-or-permission", name };
+          yield {
+            type: "tool_call_delta",
+            id: "exact-question-or-permission",
+            json: questionChild
+              ? '{"question":"Which response should I use?"}'
+              : '{"path":"package.json"}',
+          };
+          yield { type: "tool_call_end", id: "exact-question-or-permission" };
+        } else {
+          if (questionChild) {
+            expect(JSON.stringify(request.messages)).toContain("allow");
+            replied.resolve();
+          }
+          yield { type: "text_delta", text: "Exact attention result." };
+        }
+        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+        yield { type: "finish", reason: result === undefined ? "tool_calls" : "stop" };
+      },
+    },
+    {
+      permissions: createPermissionPolicy({ allowedEffects: ["delegate"], askedEffects: ["read"] }),
+    },
+  );
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "mixed-attention",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            {
+              role: "builtin:explore",
+              task: "Read with permission.",
+              description: "Read approval",
+            },
+            {
+              role: "builtin:explore",
+              task: "Ask the parent for text.",
+              description: "Parent question",
+            },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    const items = await h.waitForAttention(
+      (attention) => attention.length === 2 && attention.every((item) => item.available),
+    );
+    const permission = items.find((item) => item.kind === "permission");
+    await h.terminal.nextSynchronizedFrameContaining("Parent input · 1");
+    await h.press("\u001b[F\r", "Which response should I use?");
+    await h.press("allow", "> allow");
+    h.terminal.input("\r");
+    await replied.promise;
+    const remaining = await h.waitForAttention((attention) => attention.length === 1);
+    expect(remaining[0]).toMatchObject({ kind: "permission", id: permission?.id });
+    expect(mainCalls).toBe(0);
+    await h.terminal.nextSynchronizedFrameContaining("Permissions · 1");
+    h.terminal.input("d");
+    await h.waitForAttention((attention) => attention.length === 0);
+  } finally {
+    await h.close();
+  }
+});
+
+test("Agents history opens each exact turn and keeps closed threads inspectable without input actions", async () => {
+  let calls = 0;
+  const h = await startManagedTui({
+    async *stream() {
+      yield {
+        type: "text_delta",
+        text: ++calls === 1 ? "FIRST_TURN_EVIDENCE" : "SECOND_TURN_EVIDENCE",
+      };
+      yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    await h.presentation.dispatch({
+      type: "managed_control",
+      commandId: "history-start",
+      command: {
+        type: "spawn_agents",
+        parentSessionId: h.parent.sessionId,
+        entries: [{ role: "builtin:explore", task: "First task", description: "History subject" }],
+      },
+    });
+    await h.terminal.nextSynchronizedFrameContaining("Completed");
+    const first = h.presentation.getState().authoritative.managedControl?.threads[0];
+    if (first === undefined) throw new Error("Missing thread");
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\r", "FIRST_TURN_EVIDENCE");
+    await h.press("\r", "New turn");
+    await h.press("Second task\r", "SECOND_TURN_EVIDENCE");
+    await h.press("\u001b", "Enter compose · Esc back");
+    await h.press("\u001b", "Agents workspace");
+    await h.press("h", "Agents history");
+    await h.press("\u001b[H\r", "FIRST_TURN_EVIDENCE");
+    expect(h.conversationText()).not.toContain("SECOND_TURN_EVIDENCE");
+    await h.press("\r", "Input is unavailable");
+    expect(h.conversationText()).not.toContain("New turn");
+    await h.press("\u001b", "Agents history");
+    await h.press("h", "Agents workspace");
+    await h.press("c", "c again to close");
+    await h.press("c", "Closed");
+    await h.press("h", "Agents history");
+    await h.press("\u001b[F\r", "SECOND_TURN_EVIDENCE");
+    await h.press("\r", "Input is unavailable");
+    expect(calls).toBe(2);
+    expect(
+      h.presentation
+        .getState()
+        .authoritative.managedControl?.completions.map((entry) => entry.consumption),
+    ).toEqual(["pending", "pending"]);
+  } finally {
+    await h.close();
+  }
+});
+
+test.each([
+  [40, 12],
+  [67, 18],
+  [80, 24],
+  [120, 40],
+])(
+  "%i×%i keeps the focused child editor and layered return usable with grapheme input",
+  async (columns, rows) => {
+    const started = Promise.withResolvers<void>();
+    let mainCalls = 0;
+    const h = await startManagedTui(
+      {
+        async *stream(request) {
+          if (request.tools.some((tool) => tool.name === "spawn_agents")) {
+            mainCalls += 1;
+            yield { type: "text_delta", text: "MAIN_RESPONDED" };
+          } else {
+            started.resolve();
+            await new Promise<void>((resolve) =>
+              request.signal.addEventListener("abort", () => resolve(), { once: true }),
+            );
+          }
+          yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+          yield { type: "finish", reason: "stop" };
+        },
+      },
+      { columns, rows },
+    );
+    try {
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "viewport-spawn",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [{ role: "builtin:explore", task: "Inspect", description: "视图 é 👩‍💻" }],
+        },
+      });
+      await started.promise;
+      await h.terminal.nextSynchronizedFrameContaining("Fleet");
+      await h.press("\u001b[B", "Fleet");
+      await h.press("\u001b[B", "@explore-1");
+      await h.press("\r", "Conversation");
+      await h.press("\r", "To @explore-1");
+      await h.press("界é👩‍💻", "é👩‍💻");
+      const thread = h.presentation.getState().authoritative.managedControl?.threads[0];
+      if (thread === undefined) throw new Error("Missing viewport child");
+      expect(
+        await h.presentation.dispatch({
+          type: "read_agent_draft",
+          sessionId: thread.parentSessionId,
+          threadId: thread.threadId,
+        }),
+      ).toMatchObject({ managedDraft: { text: "界é👩‍💻" } });
+      expect(h.terminal.lines().join("\n")).not.toContain("�");
+      await h.press("\u001b[27u", "Draft");
+      await h.press("?", "Conversation details");
+      expect(h.terminal.lines().join("\n")).toContain("deepseek-v4-flash.direct");
+      await h.press("\u001b[27u", "Draft");
+      await h.press("\u001b[27u", "Fleet");
+      await h.press("\u001b[27u", "Fleet");
+      await h.press("Main remains usable\r", "MAIN_RESPONDED");
+      expect(mainCalls).toBe(1);
+      expect(h.presentation.getState().managedDrafts).toHaveLength(1);
+    } finally {
+      await h.close();
+    }
+  },
+);
+
+test("Widget and viewer expose owner-timed elapsed duration and actual compact model and usage preferences", async () => {
+  const started = Promise.withResolvers<void>();
+  const finish = Promise.withResolvers<void>();
+  const h = await startManagedTui(
+    {
+      async *stream() {
+        started.resolve();
+        await finish.promise;
+        yield { type: "text_delta", text: "Timed evidence" };
+        yield { type: "usage", inputTokens: 23, outputTokens: 17 };
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    { columns: 120, rows: 40 },
+  );
+  try {
+    const beforeStart = Date.now();
+    await h.presentation.dispatch({
+      type: "managed_control",
+      commandId: "timed-widget",
+      command: {
+        type: "spawn_agents",
+        parentSessionId: h.parent.sessionId,
+        entries: [{ role: "builtin:explore", task: "Inspect", description: "Timed child" }],
+      },
+    });
+    await started.promise;
+    await h.terminal.nextSynchronizedFrameContaining("elapsed");
+    await h.press("/agents settings\r", "Agent settings");
+    await h.press("\u001b[B\u001b[B\r", "Model/thinking · shown");
+    await h.press("\u001b", "thinking default");
+    expect(h.terminal.lines().join("\n")).toContain("0 used");
+    const offset = h.terminal.output().length;
+    finish.resolve();
+    await h.terminal.nextSynchronizedFrameContaining("40 used", offset);
+    const thread = h.presentation.getState().authoritative.managedControl?.threads[0];
+    expect(thread?.turn.startedAtUnixMilliseconds).toBeGreaterThanOrEqual(beforeStart);
+    expect(thread?.turn.outcome?.atUnixMilliseconds).toBeGreaterThanOrEqual(
+      thread?.turn.startedAtUnixMilliseconds ?? Infinity,
+    );
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\r", "elapsed");
+    expect(h.conversationText()).toContain("40 used");
+  } finally {
+    finish.resolve();
+    await h.close();
+  }
+});
+
+test("40×12 Attention default selection follows the visible exact request and preserves the other pending call", async () => {
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        if (!request.messages.some((message) => message.role === "tool")) {
+          yield { type: "tool_call_start", id: "narrow-permission", name: "read_file" };
+          yield {
+            type: "tool_call_delta",
+            id: "narrow-permission",
+            json: '{"path":"package.json"}',
+          };
+          yield { type: "tool_call_end", id: "narrow-permission" };
+          yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+          yield { type: "finish", reason: "tool_calls" };
+        } else {
+          yield { type: "text_delta", text: "NARROW_ALLOWED" };
+          yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+          yield { type: "finish", reason: "stop" };
+        }
+      },
+    },
+    {
+      columns: 40,
+      rows: 12,
+      permissions: createPermissionPolicy({ allowedEffects: ["delegate"], askedEffects: ["read"] }),
+    },
+  );
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "narrow-permissions",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [1, 2].map((index) => ({
+            role: "builtin:explore" as const,
+            task: "Read package.json",
+            description: `Permit ${index}`,
+          })),
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await h.waitForAttention(
+      (items) =>
+        items.length === 2 &&
+        items.every((item) => item.kind === "permission" && item.interaction?.canAllow === true),
+    );
+    await h.terminal.nextSynchronizedFrameContaining("Attention Center");
+    await h.press("\u001b[B", "@explore-2");
+    expect(h.terminal.lines().join("\n")).toContain("● [x] @explore-2");
+    await h.press("a", "@explore-1");
+    await h.waitForAttention((items) => items.length === 1 && items[0]?.handle === "@explore-1");
+    const threads = h.presentation.getState().authoritative.managedControl?.threads ?? [];
+    const first = threads.find((thread) => thread.handle === "@explore-1");
+    const second = threads.find((thread) => thread.handle === "@explore-2");
+    if (first === undefined || second === undefined) throw new Error("Missing exact children");
+    expect(
+      (await (await h.children.open(first.turn.childSessionId))?.read())?.some(
+        (record) =>
+          record.schemaVersion === 3 &&
+          record.record.type === "runtime_event" &&
+          record.record.event.type === "tool_started",
+      ),
+    ).toBe(false);
+    await h.press("\u001b[27u", "Fleet");
+    await h.press("/agents attention\r", "Attention Center");
+    await h.press("d", "Fleet");
+  } finally {
+    await h.close();
+  }
+});
+
+test("minimum-height Settings cannot activate an off-screen Reset before its selected row is rendered", async () => {
+  let calls = 0;
+  const h = await startManagedTui(
+    {
+      async *stream() {
+        calls += 1;
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    { columns: 40, rows: 12 },
+  );
+  try {
+    await h.presentation.dispatch({
+      type: "managed_control",
+      commandId: "settings-visible",
+      command: { type: "list_agents", parentSessionId: h.parent.sessionId },
+    });
+    await h.press("/agents settings\r", "Agent settings");
+    await h.press("\r", "Widget · all");
+    await h.press("\u001b[F\r", "Reset defaults");
+    expect(h.presentation.getState().agentUiSettings?.widgetMode).toBe("all");
+    await h.press("\r", "Defaults restored");
+    expect(h.presentation.getState().agentUiSettings?.widgetMode).toBe("background");
+    expect(calls).toBe(0);
+  } finally {
+    await h.close();
+  }
+});
+
+test("a cold acknowledged provider attempt offers inspection and cancellation without advertising safe replay", async () => {
+  const started = Promise.withResolvers<void>();
+  let calls = 0;
+  const driver = {
+    async *stream(request: ModelRequest) {
+      calls += 1;
+      started.resolve();
+      await new Promise<void>((resolve) =>
+        request.signal.addEventListener("abort", () => resolve(), { once: true }),
+      );
+      yield { type: "finish" as const, reason: "stop" as const };
+    },
+  };
+  const h = await startManagedTui(driver);
+  let cold: Awaited<ReturnType<typeof startManagedTui>> | undefined;
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "unsafe-cold",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            { role: "builtin:explore", task: "Inspect", description: "Acknowledged provider" },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await started.promise;
+    const thread = h.presentation.getState().authoritative.managedControl?.threads[0];
+    if (thread === undefined) throw new Error("Missing source thread");
+    const controlPrefix = await h.store.read();
+    const childPrefix = await (await h.children.open(thread.turn.childSessionId))?.read();
+    if (childPrefix === undefined) throw new Error("Missing committed child prefix");
+    await h.stop();
+    const store = createInMemoryManagedAgentControlStore();
+    for (const record of controlPrefix) await store.append(record);
+    const children = createInMemorySessionStoreDirectory<SessionRecord>();
+    const child = await children.create(thread.turn.childSessionId);
+    for (const record of childPrefix) await child.append(record);
+    cold = await startManagedTui(driver, { restore: { ...h.storage, store, children } });
+    await cold.press("/agents\r", "Agents workspace");
+    await cold.press("\r", "Conversation");
+    expect(cold.conversationText()).toContain("This interrupted effect cannot be replayed safely.");
+    expect(cold.conversationText()).not.toContain("Resume or cancel");
+    expect(
+      cold.presentation.getState().authoritative.managedControl?.threads[0]?.actions,
+    ).not.toContain("resume");
+    expect(calls).toBe(1);
+    await cold.press("x", "x again to cancel");
+    await cold.press("x", "Cancelled");
+    expect(calls).toBe(1);
+  } finally {
+    await (cold ?? h).close();
+  }
+});
+
+test("opening and cold-reopening a completed viewer marks Seen independently of one canonical Main consumption", async () => {
+  const requests: ModelRequest[] = [];
+  const driver = {
+    async *stream(request: ModelRequest) {
+      const main = request.tools.some((tool) => tool.name === "spawn_agents");
+      if (main) requests.push(request);
+      yield {
+        type: "text_delta" as const,
+        text: main ? `MAIN_SEEN_${requests.length}` : "SEEN_RESULT",
+      };
+      yield { type: "usage" as const, inputTokens: 10, outputTokens: 10 };
+      yield { type: "finish" as const, reason: "stop" as const };
+    },
+  };
+  const h = await startManagedTui(driver);
+  let cold: Awaited<ReturnType<typeof startManagedTui>> | undefined;
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "seen-start",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [{ role: "builtin:explore", task: "Inspect", description: "Seen subject" }],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await h.terminal.nextSynchronizedFrameContaining("Completed");
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\r", "Seen · Main pending");
+    expect(h.presentation.getState().authoritative.managedControl?.completions[0]).toMatchObject({
+      userSeen: true,
+      consumption: "pending",
+    });
+    expect(requests).toHaveLength(0);
+    await h.stop();
+    cold = await startManagedTui(driver, { restore: h.storage });
+    expect(cold.presentation.getState().authoritative.managedControl?.completions[0]).toMatchObject(
+      { userSeen: true, consumption: "pending" },
+    );
+    await cold.press("/agents\r", "Agents workspace");
+    await cold.press("\r", "Seen · Main pending");
+    await cold.press("\u001b", "Agents workspace");
+    await cold.press("\u001b", "Fleet fixture");
+    await cold.press("Consume seen completion.\r", "MAIN_SEEN_1");
+    const restarted = cold;
+    await new Promise<void>((resolve) => {
+      const check = () => {
+        if (restarted.presentation.getState().authoritative.active?.parentRun?.phase === "ready") {
+          unsubscribe();
+          resolve();
+        }
+      };
+      const unsubscribe = restarted.presentation.subscribe(check);
+      check();
+    });
+    await cold.press("Next Main input.\r", "MAIN_SEEN_2");
+    expect(requests).toHaveLength(2);
+    expect(cold.presentation.getState().authoritative.managedControl?.completions[0]).toMatchObject(
+      { userSeen: true, consumption: "consumed" },
+    );
+    const parentRecords = await (await cold.sessions.open(h.parent.sessionId))?.read();
+    expect(
+      parentRecords?.flatMap((record) =>
+        record.schemaVersion === 3 && record.record.type === "provider_attempt_started"
+          ? [record.record.managedAgentDeliveries?.length ?? 0]
+          : [],
+      ),
+    ).toEqual([1, 0]);
+    expect(
+      (await cold.store.read()).filter((record) => record.event.type === "consumed"),
+    ).toHaveLength(1);
+  } finally {
+    await (cold ?? h).close();
+  }
+});
+
+test("Suppress from Main requires exact confirmation, refuses active Main, and leaves the other completion deliverable", async () => {
+  const finishChildren = Promise.withResolvers<void>();
+  const finishMain = Promise.withResolvers<void>();
+  const requests: ModelRequest[] = [];
+  let childCalls = 0;
+  const h = await startManagedTui({
+    async *stream(request) {
+      if (request.tools.some((tool) => tool.name === "spawn_agents")) {
+        requests.push(request);
+        if (requests.length === 1) {
+          yield { type: "text_delta", text: "MAIN_ACTIVE" };
+          await finishMain.promise;
+        }
+        yield { type: "text_delta", text: `MAIN_FINISHED_${requests.length}` };
+      } else {
+        childCalls += 1;
+        const continuation = request.messages.some(
+          (message) =>
+            message.role === "user" &&
+            typeof message.content === "string" &&
+            message.content.includes("Continue after suppression"),
+        );
+        if (!continuation) await finishChildren.promise;
+        const suppress = request.messages.some(
+          (message) =>
+            message.role === "user" &&
+            typeof message.content === "string" &&
+            message.content.includes("Suppress task"),
+        );
+        yield {
+          type: "text_delta",
+          text: continuation
+            ? "CONTINUED_SUPPRESSED"
+            : suppress
+              ? "SUPPRESS_RESULT"
+              : "KEEP_RESULT",
+        };
+      }
+      yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "suppress-pair",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            { role: "builtin:explore", task: "Suppress task", description: "Suppress target" },
+            { role: "builtin:explore", task: "Keep task", description: "Keep target" },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await h.press("Main remains active.\r", "MAIN_ACTIVE");
+    const offset = h.terminal.output().length;
+    finishChildren.resolve();
+    await h.terminal.nextSynchronizedFrameContaining("Completed", offset);
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\r", "Seen · Main pending");
+    await h.press("s", "Suppress from Main");
+    await h.press("\u001b", "Seen · Main pending");
+    expect((await h.store.read()).some((record) => record.event.type === "suppressed")).toBe(false);
+    await h.press("s", "Suppress from Main");
+    await h.press("s", "Main is active");
+    finishMain.resolve();
+    await new Promise<void>((resolve) => {
+      const check = () => {
+        if (h.presentation.getState().authoritative.active?.parentRun?.phase === "ready") {
+          unsubscribe();
+          resolve();
+        }
+      };
+      const unsubscribe = h.presentation.subscribe(check);
+      check();
+    });
+    await h.press("s", "Suppress from Main");
+    await h.press("s", "Seen · Main suppressed");
+    const suppressed = h.presentation
+      .getState()
+      .authoritative.managedControl?.completions.find(
+        (entry) => entry.outcome.summary === "SUPPRESS_RESULT",
+      );
+    expect(suppressed).toMatchObject({ userSeen: true, consumption: "suppressed" });
+    await h.press("\u001b", "Agents workspace");
+    await h.press("\u001b", "Fleet fixture");
+    await h.press("Next Main input.\r", "MAIN_FINISHED_2");
+    expect(JSON.stringify(requests[1]?.messages)).not.toContain("SUPPRESS_RESULT");
+    expect(JSON.stringify(requests[1]?.messages)).toContain("KEEP_RESULT");
+    await new Promise<void>((resolve) => {
+      const check = () => {
+        if (h.presentation.getState().authoritative.active?.parentRun?.phase === "ready") {
+          unsubscribe();
+          resolve();
+        }
+      };
+      const unsubscribe = h.presentation.subscribe(check);
+      check();
+    });
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\r", "Seen · Main suppressed");
+    await h.press("\r", "New turn");
+    await h.press("Continue after suppression.\r", "CONTINUED_SUPPRESSED");
+    expect(childCalls).toBe(3);
+    expect(requests).toHaveLength(2);
+  } finally {
+    finishChildren.resolve();
+    finishMain.resolve();
+    await h.close();
+  }
+});
+
+test("a committed suppression holds the existing family admission until the concurrent Main request can exclude it", async () => {
+  const committed = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const requests: ModelRequest[] = [];
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        const main = request.tools.some((tool) => tool.name === "spawn_agents");
+        if (main) requests.push(request);
+        yield { type: "text_delta", text: main ? "RACE_MAIN_READY" : "RACE_SUPPRESSED_RESULT" };
+        yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    {
+      controlRecordBarrier: async (record) => {
+        if (record.event.type === "suppressed") {
+          committed.resolve();
+          await release.promise;
+        }
+      },
+    },
+  );
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "suppression-race",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [{ role: "builtin:explore", task: "Inspect", description: "Suppression race" }],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await h.terminal.nextSynchronizedFrameContaining("Completed");
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\r", "Seen · Main pending");
+    await h.press("s", "Suppress from Main");
+    h.terminal.input("s");
+    await committed.promise;
+    await h.press("\u001b", "Agents workspace");
+    await h.press("\u001b", "Fleet fixture");
+    const parentBefore = await (await h.sessions.open(h.parent.sessionId))?.read();
+    await h.press("Main after suppressed record.\r", "Working");
+    expect(requests).toHaveLength(0);
+    expect(await (await h.sessions.open(h.parent.sessionId))?.read()).toEqual(parentBefore);
+    const offset = h.terminal.output().length;
+    release.resolve();
+    await h.terminal.nextSynchronizedFrameContaining("RACE_MAIN_READY", offset);
+    expect(JSON.stringify(requests[0]?.messages)).not.toContain("RACE_SUPPRESSED_RESULT");
+    expect(
+      h.presentation.getState().authoritative.managedControl?.completions[0]?.consumption,
+    ).toBe("suppressed");
+  } finally {
+    release.resolve();
+    await h.close();
+  }
+});
+
+test("cold Seen and Suppress reconcile an already durable wait tool result before any visibility mutation can hide consumption", async () => {
+  const finish = Promise.withResolvers<void>();
+  let target: { readonly threadId: string; readonly expectedTurnId: string } | undefined;
+  let mainCalls = 0;
+  const driver = {
+    async *stream(request: ModelRequest) {
+      if (request.tools.some((tool) => tool.name === "spawn_agents")) {
+        if (++mainCalls === 1) {
+          yield { type: "tool_call_start" as const, id: "exact-wait", name: "wait_agents" };
+          yield {
+            type: "tool_call_delta" as const,
+            id: "exact-wait",
+            json: JSON.stringify({ targets: [target], mode: "all" }),
+          };
+          yield { type: "tool_call_end" as const, id: "exact-wait" };
+          yield { type: "usage" as const, inputTokens: 10, outputTokens: 10 };
+          yield { type: "finish" as const, reason: "tool_calls" as const };
+          return;
+        }
+        yield { type: "text_delta" as const, text: "TOOL_ACK_DONE" };
+      } else {
+        await finish.promise;
+        yield { type: "text_delta" as const, text: "DURABLE_WAIT_RESULT" };
+      }
+      yield { type: "usage" as const, inputTokens: 10, outputTokens: 10 };
+      yield { type: "finish" as const, reason: "stop" as const };
+    },
+  };
+  const h = await startManagedTui(driver);
+  let cold: Awaited<ReturnType<typeof startManagedTui>> | undefined;
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "cold-tool-ack",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [{ role: "builtin:explore", task: "Inspect", description: "Durable wait" }],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    const thread = h.presentation.getState().authoritative.managedControl?.threads[0];
+    if (thread === undefined) throw new Error("Missing wait target");
+    target = { threadId: thread.threadId, expectedTurnId: thread.turn.turnId };
+    await h.press("Wait for exact evidence.\r", "wait_agents");
+    const offset = h.terminal.output().length;
+    finish.resolve();
+    await h.terminal.nextSynchronizedFrameContaining("TOOL_ACK_DONE", offset);
+    await new Promise<void>((resolve) => {
+      const check = () => {
+        if (h.presentation.getState().authoritative.active?.parentRun?.phase === "ready") {
+          unsubscribe();
+          resolve();
+        }
+      };
+      const unsubscribe = h.presentation.subscribe(check);
+      check();
+    });
+    const records = await h.store.read();
+    expect(records.some((record) => record.event.type === "consumed")).toBe(true);
+    await h.stop();
+    const store = createInMemoryManagedAgentControlStore();
+    for (const record of records) {
+      if (record.event.type === "consumed") break;
+      await store.append(record);
+    }
+    cold = await startManagedTui(driver, { restore: { ...h.storage, store } });
+    await cold.press("/agents\r", "Agents workspace");
+    await cold.press("\r", "Seen · Main pending");
+    await cold.press("s", "Suppress from Main");
+    await cold.press("s", "Main has already consumed");
+    expect(cold.presentation.getState().authoritative.managedControl?.completions[0]).toMatchObject(
+      { consumption: "consumed", userSeen: true },
+    );
+    expect((await store.read()).filter((record) => record.event.type === "consumed")).toHaveLength(
+      1,
+    );
+    expect((await store.read()).some((record) => record.event.type === "suppressed")).toBe(false);
+    expect(mainCalls).toBe(2);
+  } finally {
+    finish.resolve();
+    await (cold ?? h).close();
+  }
+});
+
+test("a queued cancellation keeps per-thread export available without creating a child session or continuation action", async () => {
+  let calls = 0;
+  const fourStarted = Promise.withResolvers<void>();
+  const h = await startManagedTui({
+    async *stream(request) {
+      calls += 1;
+      if (calls === 4) fourStarted.resolve();
+      await new Promise<void>((resolve) =>
+        request.signal.addEventListener("abort", () => resolve(), { once: true }),
+      );
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "queued-export",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: Array.from({ length: 5 }, (_, index) => ({
+            role: "builtin:explore" as const,
+            task: "Inspect",
+            description: `Export queue ${index}`,
+          })),
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await fourStarted.promise;
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\u001b[F", "@explore-5");
+    await h.press("x", "x again to cancel");
+    await h.press("x", "Cancelled");
+    await h.press("\r", "e export");
+    expect(h.terminal.lines().join("\n")).toContain("e export");
+    await h.press("e", "Export agent");
+    await h.press("\r", "Confirm export");
+    await h.press("\r", "Export ready");
+    const thread = h.presentation.getState().authoritative.managedControl?.threads[4];
+    if (thread === undefined) throw new Error("Missing cancelled queue entry");
+    expect(thread.actions).not.toContain("new_turn");
+    expect(await h.children.open(thread.turn.childSessionId)).toBeUndefined();
+    expect(h.presentation.getState().authoritative.managedControl?.exports?.[0]?.turnId).toBe(
+      thread.turn.turnId,
+    );
+    expect(calls).toBe(4);
+  } finally {
+    await h.close();
+  }
+});
+
+test("viewer Help disarms an earlier x-x cancellation before returning to the same live turn", async () => {
+  const started = Promise.withResolvers<void>();
+  let aborts = 0;
+  const h = await startManagedTui({
+    async *stream(request) {
+      started.resolve();
+      await new Promise<void>((resolve) =>
+        request.signal.addEventListener(
+          "abort",
+          () => {
+            aborts += 1;
+            resolve();
+          },
+          { once: true },
+        ),
+      );
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "cancel-help",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [{ role: "builtin:explore", task: "Inspect", description: "Cancel target" }],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await started.promise;
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\r", "Conversation");
+    await h.press("x", "x again to cancel");
+    await h.press("?", "Conversation details");
+    await h.press("\u001b", "Conversation");
+    await h.press("x", "Conversation");
+    expect(h.conversationText()).toContain("x again to cancel");
+    expect(aborts).toBe(0);
+    await h.press("x", "Cancelled");
+    expect(aborts).toBe(1);
+  } finally {
+    await h.close();
+  }
+});
+
+test("40×12 child composer visibly distinguishes Accepted from Delivered across the real read boundary", async () => {
+  const release = Promise.withResolvers<void>();
+  const started = Promise.withResolvers<void>();
+  const delivered = Promise.withResolvers<ModelRequest>();
+  let calls = 0;
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        if (++calls === 1) {
+          started.resolve();
+          await release.promise;
+          yield { type: "tool_call_start", id: "compact-read", name: "read_file" };
+          yield { type: "tool_call_delta", id: "compact-read", json: '{"path":"package.json"}' };
+          yield { type: "tool_call_end", id: "compact-read" };
+          yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+          yield { type: "finish", reason: "tool_calls" };
+        } else {
+          delivered.resolve(request);
+          yield { type: "text_delta", text: "Read boundary done." };
+          yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+          yield { type: "finish", reason: "stop" };
+        }
+      },
+    },
+    { columns: 40, rows: 12 },
+  );
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "compact-delivery",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [{ role: "builtin:explore", task: "Read", description: "Compact input" }],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await started.promise;
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\r", "Conversation");
+    await h.press("\r", "To @explore-1");
+    await h.press("Exact input", "Exact input");
+    await h.press("\r", "Accepted");
+    expect(
+      h.presentation.getState().authoritative.managedControl?.threads[0]?.inputs?.[0]?.status,
+    ).toBe("accepted");
+    const offset = h.terminal.output().length;
+    release.resolve();
+    const request = await delivered.promise;
+    await h.terminal.nextSynchronizedFrameContaining("Delivered", offset);
+    expect(JSON.stringify(request.messages)).toContain("Exact input");
+    expect(h.conversationText()).not.toContain("Accepted");
+    expect(
+      h.presentation.getState().authoritative.managedControl?.threads[0]?.inputs?.[0]?.status,
+    ).toBe("delivered");
+  } finally {
+    release.resolve();
+    await h.close();
+  }
+});
+
+test.each([3, 4])(
+  "Widget spends actual visible line height and counts partial details at a %i-line limit",
+  async (maximum) => {
+    const count = maximum === 3 ? 1 : 3;
+    const started = Promise.withResolvers<void>();
+    const finish = Promise.withResolvers<void>();
+    let calls = 0;
+    const h = await startManagedTui({
+      async *stream() {
+        if (++calls === count) started.resolve();
+        await finish.promise;
+        yield { type: "text_delta", text: "Budgeted terminal evidence." };
+        yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+      },
+    });
+    const widget = new AgentWidget(createAdamTuiTheme(true), () => maximum, {
+      settings: () => ({ ...defaultAgentUiSettings, showModel: true }),
+      scheduler: {
+        schedule() {
+          return { cancel() {} };
+        },
+      },
+    });
+    try {
+      expect(
+        await h.presentation.dispatch({
+          type: "managed_control",
+          commandId: "widget-line-budget",
+          command: {
+            type: "spawn_agents",
+            parentSessionId: h.parent.sessionId,
+            entries: Array.from({ length: count }, (_, index) => ({
+              role: "builtin:explore" as const,
+              task: "Inspect",
+              description: `Budgeted ${index}`,
+            })),
+          },
+        }),
+      ).toMatchObject({ status: "admitted" });
+      await started.promise;
+      widget.setSnapshot(h.presentation.getState().authoritative.managedControl);
+      if (maximum === 4) {
+        finish.resolve();
+        const targets =
+          h.presentation.getState().authoritative.managedControl?.threads.map((thread) => ({
+            threadId: thread.threadId,
+            expectedTurnId: thread.turn.turnId,
+          })) ?? [];
+        expect(
+          await h.presentation.dispatch({
+            type: "managed_control",
+            commandId: "widget-settlement",
+            command: {
+              type: "wait_agents",
+              parentSessionId: h.parent.sessionId,
+              targets,
+              mode: "all",
+            },
+          }),
+        ).toMatchObject({ status: "admitted", control: { status: "completed" } });
+        widget.setSnapshot(h.presentation.getState().authoritative.managedControl);
+      }
+      const lines = widget.render(80);
+      expect(lines.length).toBeLessThanOrEqual(maximum);
+      expect(lines.join("\n")).toContain(
+        maximum === 3 ? "2 detail lines hidden" : "2 finished hidden",
+      );
+      expect(lines.join("\n")).not.toContain("…  hidden");
+    } finally {
+      widget.dispose();
+      finish.resolve();
+      await h.close();
+    }
+  },
+);
+
+test.each([false, true])(
+  "Fleet reconciles expired selection and retains the open viewer row (viewer=%s)",
+  async (openViewer) => {
+    const firstFinish = Promise.withResolvers<void>();
+    const started = Promise.withResolvers<void>();
+    let calls = 0;
+    const deadlines = new Map<object, { milliseconds: number; fire: () => void }>();
+    const h = await startManagedTui(
+      {
+        async *stream(request) {
+          if (++calls === 2) started.resolve();
+          const first = request.messages.some(
+            (message) =>
+              message.role === "user" &&
+              typeof message.content === "string" &&
+              message.content.includes("First linger"),
+          );
+          if (first) await firstFinish.promise;
+          else
+            await new Promise<void>((resolve) =>
+              request.signal.addEventListener("abort", () => resolve(), { once: true }),
+            );
+          yield { type: "text_delta", text: "Linger selection evidence." };
+          yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+          yield { type: "finish", reason: "stop" };
+        },
+      },
+      {
+        deadlineScheduler: {
+          schedule(milliseconds, fire) {
+            const key = {};
+            deadlines.set(key, { milliseconds, fire });
+            return {
+              cancel() {
+                deadlines.delete(key);
+              },
+            };
+          },
+        },
+      },
+    );
+    try {
+      expect(
+        await h.presentation.dispatch({
+          type: "managed_control",
+          commandId: "linger-selection",
+          command: {
+            type: "spawn_agents",
+            parentSessionId: h.parent.sessionId,
+            entries: [
+              { role: "builtin:explore", task: "First linger", description: "First selection" },
+              { role: "builtin:explore", task: "Second remains", description: "Second selection" },
+            ],
+          },
+        }),
+      ).toMatchObject({ status: "admitted" });
+      await started.promise;
+      await h.press("\u001b[B", "Fleet");
+      await h.press("\u001b[B", "● @explore-1");
+      if (openViewer) await h.press("\r", "Conversation");
+      const first = h.presentation.getState().authoritative.managedControl?.threads[0];
+      if (first === undefined) throw new Error("Missing selected thread");
+      firstFinish.resolve();
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "linger-first-settled",
+        command: {
+          type: "wait_agents",
+          parentSessionId: h.parent.sessionId,
+          mode: "all",
+          targets: [{ threadId: first.threadId, expectedTurnId: first.turn.turnId }],
+        },
+      });
+      const timers = [...deadlines.values()].filter((entry) => entry.milliseconds === 4000);
+      expect(timers).toHaveLength(1);
+      const offset = h.terminal.output().length;
+      for (const timer of timers) timer.fire();
+      await h.terminal.nextSynchronizedFrameContaining("Fleet", offset);
+      const fleet = () => {
+        const lines = h.terminal.lines();
+        return lines.slice(lines.findIndex((line) => line.startsWith("Fleet"))).join("\n");
+      };
+      if (openViewer) {
+        expect(fleet()).toContain("● @explore-1");
+        await h.press("\u001b[27u", "● Main");
+      }
+      expect(fleet()).toContain("● Main");
+      expect(fleet()).not.toContain("@explore-1");
+      expect(fleet()).toContain("@explore-2");
+      await h.press("\r", "Fleet · ↓ navigate");
+      expect(calls).toBe(2);
+    } finally {
+      firstFinish.resolve();
+      await h.close();
+    }
+  },
+);
+
+test("workspace Attention navigation disarms an earlier exact cancellation", async () => {
+  const started = Promise.withResolvers<void>();
+  let aborts = 0;
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        const permission = request.messages.some(
+          (message) =>
+            message.role === "user" &&
+            typeof message.content === "string" &&
+            message.content.includes("Permission partner"),
+        );
+        if (permission) {
+          yield { type: "tool_call_start", id: "attention-partner", name: "read_file" };
+          yield {
+            type: "tool_call_delta",
+            id: "attention-partner",
+            json: '{"path":"package.json"}',
+          };
+          yield { type: "tool_call_end", id: "attention-partner" };
+          yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+          yield { type: "finish", reason: "tool_calls" };
+        } else {
+          started.resolve();
+          await new Promise<void>((resolve) =>
+            request.signal.addEventListener(
+              "abort",
+              () => {
+                aborts += 1;
+                resolve();
+              },
+              { once: true },
+            ),
+          );
+          yield { type: "finish", reason: "stop" };
+        }
+      },
+    },
+    {
+      permissions: createPermissionPolicy({ allowedEffects: ["delegate"], askedEffects: ["read"] }),
+    },
+  );
+  try {
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "cancel-attention",
+        command: {
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            { role: "builtin:explore", task: "Running target", description: "Cancel target" },
+            {
+              role: "builtin:explore",
+              task: "Permission partner",
+              description: "Permission partner",
+            },
+          ],
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await started.promise;
+    await h.waitForAttention((items) => items.length === 1);
+    await h.terminal.nextSynchronizedFrameContaining("Attention Center");
+    await h.press("\u001b", "Fleet");
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("x", "x again to cancel");
+    await h.press("a", "Attention Center");
+    await h.press("\u001b", "Agents workspace");
+    await h.press("x", "x again to cancel");
+    expect(aborts).toBe(0);
+    expect(h.presentation.getState().authoritative.managedControl?.threads[0]?.turn.phase).toBe(
+      "executing",
+    );
+    await h.press("x", "Cancelled");
+    expect(aborts).toBe(1);
+  } finally {
+    await h.close();
+  }
+});

--- a/apps/tui/src/agent-fleet.test.ts
+++ b/apps/tui/src/agent-fleet.test.ts
@@ -487,7 +487,7 @@ test("ConversationViewer follows live output, preserves manual scroll, and survi
       }),
     ).toMatchObject({ status: "admitted" });
     await started.promise;
-    await h.terminal.nextSynchronizedFrameContaining("Live viewer evidence");
+    await h.terminal.nextSynchronizedFrameContaining("@explore-1 · Explore · Running");
     await h.press("\u001b[B\u001b[B\r", "Conversation");
     expect(h.conversationText()).toContain("First live line.");
     expect(h.conversationText()).toContain("deepseek-v4-flash.direct · thinking default");
@@ -668,7 +668,7 @@ test.each(["cooperative", "interrupt"] as const)(
         }),
       ).toMatchObject({ status: "admitted" });
       await started.promise;
-      await h.terminal.nextSynchronizedFrameContaining("Finishing boundary");
+      await h.terminal.nextSynchronizedFrameContaining("@explore-1 · Explore · Running");
       await h.press("\u001b[B\u001b[B\r", "Conversation");
       await h.press("\r", "Cooperative");
       if (mode === "interrupt") await h.press("\t", "Interrupt after current effect");
@@ -877,7 +877,7 @@ test.each(["wait", "suspend"] as const)(
         }),
       ).toMatchObject({ status: "admitted" });
       await fourStarted.promise;
-      await h.terminal.nextSynchronizedFrameContaining("Source item 1");
+      await h.terminal.nextSynchronizedFrameContaining("@explore-1 · Explore · Running");
       await h.press("\u001b[B\u001b[B\r", "Conversation");
       await h.press("\r", "Cooperative");
       await h.press("Only the source child draft.", "Only the source child draft.");
@@ -952,7 +952,7 @@ test("two deliberate Enter submissions with identical text admit two distinct ch
       }),
     ).toMatchObject({ status: "admitted" });
     await started.promise;
-    await h.terminal.nextSynchronizedFrameContaining("Repeated input");
+    await h.terminal.nextSynchronizedFrameContaining("@explore-1 · Explore · Running");
     await h.press("\u001b[B\u001b[B\r", "Conversation");
     await h.press("\r", "Cooperative");
     await h.press("Check again.", "Check again.");
@@ -1017,7 +1017,7 @@ test("late durable acceptance cannot clear a draft explicitly retargeted to a ne
       }),
     ).toMatchObject({ status: "admitted" });
     await started.promise;
-    await h.terminal.nextSynchronizedFrameContaining("Retargeted draft");
+    await h.terminal.nextSynchronizedFrameContaining("@explore-1 · Explore · Running");
     await h.press("\u001b[B\u001b[B\r", "Conversation");
     await h.press("\r", "Cooperative");
     await h.press("Still the intended draft.", "Still the intended draft.");
@@ -1448,7 +1448,7 @@ test("live transcript elision is counted separately from the bounded Markdown co
       }),
     ).toMatchObject({ status: "admitted" });
     await started.promise;
-    await h.terminal.nextSynchronizedFrameContaining("Bounded live preview");
+    await h.terminal.nextSynchronizedFrameContaining("@explore-1 · Explore · Running");
     await h.press("\u001b[B\u001b[B\r", "Conversation");
     expect(h.presentation.getState().managedAgentActivity?.[0]?.assistant).toMatchObject({
       totalByteCount: 20000,
@@ -1520,7 +1520,7 @@ test("child permission preempts and restores the exact independent composer with
       }),
     ).toMatchObject({ status: "admitted" });
     await started.promise;
-    await h.terminal.nextSynchronizedFrameContaining("Permission focus");
+    await h.terminal.nextSynchronizedFrameContaining("@explore-1 · Explore · Running");
     await h.press("\u001b[B\u001b[B\r", "Conversation");
     await h.press("\r", "Cooperative");
     await h.press("Kept child draft", "Kept child draft");
@@ -1584,7 +1584,7 @@ test("viewer x x cancels the exact turn only on two presses and retains unknown 
       }),
     ).toMatchObject({ status: "admitted" });
     await started.promise;
-    await h.terminal.nextSynchronizedFrameContaining("Exact cancellation");
+    await h.terminal.nextSynchronizedFrameContaining("@explore-1 · Explore · Running");
     await h.press("\u001b[B\u001b[B\r", "Conversation");
     await h.press("\u001b[120;1:1u", "x again to cancel");
     h.terminal.input("\u001b[120;1:2u\u001b[120;1:3u");

--- a/apps/tui/src/agent-fleet.ts
+++ b/apps/tui/src/agent-fleet.ts
@@ -1,0 +1,696 @@
+/**
+ * Fleet navigation adapted from tintinweb/pi-subagents src/ui/fleet-list.ts
+ * at 4f572eaa04c09d3dbc16e4a5f13a16b295e84e14 (MIT). See THIRD_PARTY_NOTICES.md.
+ * Stable selection and drafts are local UI state; Control owns threads and turns.
+ */
+import type {
+  AgentUiSettings,
+  CommandReceipt,
+  ManagedComposerDraft,
+  ManagedControlCommand,
+  ManagedControlThread,
+  ManagedSessionTransition,
+  ManagedWorkspaceSnapshot,
+} from "@adam-agent/presentation";
+import { defaultAgentUiSettings, nextAgentViewerMode } from "@adam-agent/presentation";
+import {
+  type Component,
+  isKeyRelease,
+  isKeyRepeat,
+  matchesKey,
+  SelectList,
+  truncateToWidth,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import { safeTerminalText } from "./safe-terminal-text.js";
+import type { AdamTuiTheme } from "./theme.js";
+
+export class AgentFleet implements Component {
+  #snapshot: ManagedWorkspaceSnapshot | undefined;
+  #threads: readonly ManagedControlThread[] = [];
+  #active = false;
+  #selected: string | null = null;
+  #visibleIds = new Set<string | null>();
+  readonly drafts = new Map<string, ManagedComposerDraft>();
+  constructor(
+    private readonly options: {
+      readonly theme: AdamTuiTheme;
+      readonly onChange: () => void;
+      readonly onOpen: (thread: ManagedControlThread) => void;
+      readonly maximumLines?: () => number;
+      readonly hasDraft?: (thread: ManagedControlThread) => boolean;
+    },
+  ) {}
+  setSnapshot(
+    snapshot: ManagedWorkspaceSnapshot | undefined,
+    visibleThreads: readonly ManagedControlThread[] = snapshot?.threads ?? [],
+  ): void {
+    if (this.#snapshot?.parentSessionId !== snapshot?.parentSessionId) {
+      this.#active = false;
+      this.#selected = null;
+    }
+    this.#snapshot = snapshot;
+    this.#threads = visibleThreads;
+    if (
+      this.#selected !== null &&
+      !this.rows().some((thread) => thread.threadId === this.#selected)
+    )
+      this.#selected = null;
+  }
+  private rows(): readonly ManagedControlThread[] {
+    return this.#threads.filter((thread) => thread.turn.hasStarted && thread.lifecycle === "open");
+  }
+  handleMainInput(data: string, empty: boolean): boolean {
+    if (this.#snapshot === undefined || this.rows().length === 0) return false;
+    if (isKeyRelease(data)) return this.#active;
+    if (!empty) {
+      this.#active = false;
+      return false;
+    }
+    if (!this.#active) {
+      if (!matchesKey(data, "down") && !matchesKey(data, "left")) return false;
+      this.#active = true;
+      this.#selected = null;
+    } else {
+      const rows = this.rows();
+      const index = rows.findIndex((thread) => thread.threadId === this.#selected);
+      if (matchesKey(data, "down"))
+        this.#selected = rows[Math.min(index + 1, rows.length - 1)]?.threadId ?? null;
+      else if (matchesKey(data, "up")) {
+        if (index < 0) this.#active = false;
+        this.#selected = rows[index - 1]?.threadId ?? null;
+      } else if (matchesKey(data, "escape")) this.#active = false;
+      else if (matchesKey(data, "enter")) {
+        if (isKeyRepeat(data)) return true;
+        const thread = rows.find((row) => row.threadId === this.#selected);
+        if (thread !== undefined && this.#visibleIds.has(thread.threadId))
+          this.options.onOpen(thread);
+        else this.#active = false;
+      } else {
+        this.#active = false;
+        this.options.onChange();
+        return false;
+      }
+    }
+    this.options.onChange();
+    return true;
+  }
+  invalidate(): void {}
+  render(width: number): string[] {
+    const rows = this.rows();
+    if (rows.length === 0) return [];
+    const maximum = this.options.maximumLines?.() ?? 7;
+    const entries = [
+      { id: null, text: "Main" },
+      ...rows.map((thread) => ({
+        id: thread.threadId,
+        text: `${thread.handle} · ${thread.displayName} · ${thread.turn.label}${this.drafts.get(thread.threadId)?.text || this.options.hasDraft?.(thread) ? ` · Draft to ${thread.handle}` : ""}`,
+      })),
+    ];
+    const selectedIndex = Math.max(
+      0,
+      entries.findIndex((entry) => entry.id === this.#selected),
+    );
+    if (maximum === 1) {
+      const entry = entries[this.#active ? selectedIndex : 0];
+      this.#visibleIds = new Set([entry?.id ?? null]);
+      return [
+        truncateToWidth(
+          `Fleet ${this.#active ? "●" : "○"} ${entry?.text.split(" · ")[0] ?? "Main"} · +${entries.length - 1} · ${this.#active ? "Enter/Esc" : "↓ navigate"}`,
+          width,
+        ),
+      ];
+    }
+    const body = Math.max(1, maximum - 1);
+    const start = Math.max(0, selectedIndex - body + 1);
+    const visible = entries.slice(start, start + body);
+    const below = entries.length - start - visible.length;
+    this.#visibleIds = new Set(visible.map((entry) => entry.id));
+    return [
+      this.options.theme.muted(
+        `${this.#active ? "Fleet · Enter open · Esc Main" : "Fleet · ↓ navigate"}${start ? ` · ↑${start}` : ""}${below ? ` · ↓${below}` : ""}`,
+      ),
+      ...visible.map(
+        (entry) => `${this.#active && this.#selected === entry.id ? "●" : "○"} ${entry.text}`,
+      ),
+    ].map((line) => truncateToWidth(line, width));
+  }
+}
+
+/** The full list retains individually addressable queued and historical threads. */
+export class AgentWorkspace implements Component {
+  #snapshot: ManagedWorkspaceSnapshot;
+  #settings: AgentUiSettings;
+  #settingsOpen = false;
+  #settingIndex = 0;
+  #visibleSettings = new Set<number>();
+  #selected: string | undefined;
+  #detail = false;
+  #detailScroll = 0;
+  #detailMaximumScroll = 0;
+  #history = false;
+  #resumeTargets:
+    | readonly { readonly threadId: string; readonly expectedTurnId: string }[]
+    | undefined;
+  #closeTarget: { readonly threadId: string; readonly turnId: string } | undefined;
+  #notice = "";
+  #armed: { readonly threadId: string; readonly turnId: string } | undefined;
+  #pending = false;
+  #visibleIds = new Set<string>();
+  constructor(
+    private readonly options: {
+      readonly snapshot: ManagedWorkspaceSnapshot;
+      readonly settings?: AgentUiSettings | undefined;
+      readonly initialView?: "workspace" | "settings" | "history";
+      readonly onSettings: (settings: AgentUiSettings | null) => Promise<CommandReceipt>;
+      readonly onAttention: () => void;
+      readonly theme: AdamTuiTheme;
+      readonly maximumLines: () => number;
+      readonly onChange: () => void;
+      readonly onClose: () => void;
+      readonly onOpen: (thread: ManagedControlThread, readOnly?: boolean) => void;
+      readonly onDispatch: (command: ManagedControlCommand) => Promise<CommandReceipt>;
+      readonly hasDraft?: (thread: ManagedControlThread) => boolean;
+    },
+  ) {
+    this.#snapshot = options.snapshot;
+    this.#settings = options.settings ?? defaultAgentUiSettings;
+    this.#settingsOpen = options.initialView === "settings";
+    this.#history = options.initialView === "history";
+    this.select(this.rows()[0]);
+  }
+  private select(thread: ManagedControlThread | undefined): void {
+    this.#selected = thread === undefined ? undefined : this.key(thread);
+  }
+  private key(thread: ManagedControlThread): string {
+    return this.#history ? thread.turn.turnId : thread.threadId;
+  }
+  private rows(): readonly ManagedControlThread[] {
+    return this.#history
+      ? this.#snapshot.threads.flatMap((thread) =>
+          [...(thread.previousTurns ?? []), thread.turn].map((turn) => ({
+            ...thread,
+            turn,
+            actions: [],
+          })),
+        )
+      : this.#snapshot.threads;
+  }
+  setSnapshot(snapshot: ManagedWorkspaceSnapshot, settings?: AgentUiSettings): void {
+    this.#snapshot = snapshot;
+    if (settings !== undefined) this.#settings = settings;
+    if (!this.rows().some((thread) => this.key(thread) === this.#selected))
+      this.select(this.rows()[0]);
+  }
+  back(): void {
+    this.#armed = undefined;
+    this.#closeTarget = undefined;
+    if (this.#settingsOpen && this.options.initialView !== "settings") this.#settingsOpen = false;
+    else if (this.#detail) this.#detail = false;
+    else this.options.onClose();
+    this.options.onChange();
+  }
+  handleInput(data: string): void {
+    if (isKeyRelease(data)) return;
+    if (!isKeyRepeat(data)) {
+      if (!matchesKey(data, "x")) this.#armed = undefined;
+      if (!matchesKey(data, "c")) this.#closeTarget = undefined;
+      if (!matchesKey(data, "u") && !matchesKey(data, "shift+u")) this.#resumeTargets = undefined;
+    }
+    if (matchesKey(data, "escape")) {
+      if (!isKeyRepeat(data)) this.back();
+      return;
+    }
+    if (this.#settingsOpen) {
+      if (this.#pending) return;
+      if (matchesKey(data, "down")) this.#settingIndex = Math.min(5, this.#settingIndex + 1);
+      else if (matchesKey(data, "up")) this.#settingIndex = Math.max(0, this.#settingIndex - 1);
+      else if (matchesKey(data, "home")) this.#settingIndex = 0;
+      else if (matchesKey(data, "end")) this.#settingIndex = 5;
+      else if (
+        matchesKey(data, "enter") &&
+        !isKeyRepeat(data) &&
+        this.#visibleSettings.has(this.#settingIndex)
+      ) {
+        const current = this.#settings;
+        const setting = this.#settingIndex;
+        const updated: AgentUiSettings | null =
+          setting === 5
+            ? null
+            : {
+                ...current,
+                ...(setting === 0
+                  ? {
+                      widgetMode:
+                        current.widgetMode === "background"
+                          ? "all"
+                          : current.widgetMode === "all"
+                            ? "off"
+                            : "background",
+                    }
+                  : {}),
+                ...(setting === 1 ? { fleetEnabled: !current.fleetEnabled } : {}),
+                ...(setting === 2 ? { showModel: !current.showModel } : {}),
+                ...(setting === 3
+                  ? {
+                      viewerMode: nextAgentViewerMode(current.viewerMode),
+                    }
+                  : {}),
+                ...(setting === 4
+                  ? { mentions: current.mentions === "direct" ? "off" : "direct" }
+                  : {}),
+              };
+        this.#pending = true;
+        void this.options
+          .onSettings(updated)
+          .then(
+            (receipt) => {
+              if (receipt.status === "rejected") this.#notice = receipt.message;
+              else {
+                this.#settings = updated ?? defaultAgentUiSettings;
+                this.#notice = updated === null ? "Defaults restored" : "Settings saved";
+              }
+            },
+            () => {
+              this.#notice = "Settings could not be saved.";
+            },
+          )
+          .finally(() => {
+            this.#pending = false;
+            this.options.onChange();
+          });
+      }
+      this.options.onChange();
+      return;
+    }
+    if (matchesKey(data, "s") && !isKeyRepeat(data)) {
+      this.#settingsOpen = true;
+      this.#notice = "";
+      this.options.onChange();
+      return;
+    }
+    if (matchesKey(data, "a") && !isKeyRepeat(data)) {
+      this.options.onAttention();
+      return;
+    }
+    if (matchesKey(data, "h") && !isKeyRepeat(data)) {
+      this.#history = !this.#history;
+      this.#detail = false;
+      this.#notice = "";
+      this.#armed = undefined;
+      this.#closeTarget = undefined;
+      this.select(this.rows()[0]);
+      this.options.onChange();
+      return;
+    }
+    const threads = this.rows();
+    const index = threads.findIndex((thread) => this.key(thread) === this.#selected);
+    const selected = threads[index];
+    if (!matchesKey(data, "u") && !matchesKey(data, "shift+u")) this.#resumeTargets = undefined;
+    if (
+      (matchesKey(data, "u") || matchesKey(data, "shift+u")) &&
+      !isKeyRepeat(data) &&
+      !this.#pending &&
+      !this.#history
+    ) {
+      if (this.#resumeTargets !== undefined && matchesKey(data, "u")) {
+        const targets = this.#resumeTargets;
+        this.#resumeTargets = undefined;
+        if (
+          targets.some(
+            (target) =>
+              !threads.some(
+                (thread) =>
+                  thread.threadId === target.threadId &&
+                  thread.turn.turnId === target.expectedTurnId &&
+                  (thread.actions?.includes("resume") || thread.actions?.includes("recover")),
+              ),
+          )
+        ) {
+          this.#notice = "The selected work changed. Select it again.";
+          this.options.onChange();
+          return;
+        }
+        this.#pending = true;
+        void this.options
+          .onDispatch({
+            type: "resume_agents",
+            parentSessionId: this.#snapshot.parentSessionId,
+            targets,
+          })
+          .then(
+            (receipt) => {
+              const failure =
+                receipt.status === "rejected"
+                  ? receipt
+                  : receipt.control?.status === "resumed"
+                    ? receipt.control.results.find((result) => result.status === "rejected")
+                    : undefined;
+              this.#notice =
+                failure?.status === "rejected" ? failure.message : `Resumed ${targets.length}`;
+            },
+            () => {
+              this.#notice = "Resume could not be confirmed. Inspect durable state.";
+            },
+          )
+          .finally(() => {
+            this.#pending = false;
+            this.options.onChange();
+          });
+      } else {
+        const candidates = matchesKey(data, "shift+u")
+          ? threads
+          : selected === undefined || !this.#visibleIds.has(this.key(selected))
+            ? []
+            : [selected];
+        const targets = candidates
+          .filter(
+            (thread) => thread.actions?.includes("resume") || thread.actions?.includes("recover"),
+          )
+          .map((thread) => ({ threadId: thread.threadId, expectedTurnId: thread.turn.turnId }));
+        this.#resumeTargets = targets.length === 0 ? undefined : targets;
+        this.#notice =
+          targets.length === 0
+            ? "No selected work can resume safely. Inspect or cancel it."
+            : `u again to resume ${targets.length} exact turn${targets.length === 1 ? "" : "s"} · any other key disarms`;
+      }
+      this.options.onChange();
+      return;
+    }
+    if (!matchesKey(data, "c")) this.#closeTarget = undefined;
+    if (
+      matchesKey(data, "c") &&
+      !isKeyRepeat(data) &&
+      !this.#pending &&
+      selected?.actions?.includes("close") &&
+      this.#visibleIds.has(this.key(selected))
+    ) {
+      if (
+        this.#closeTarget?.threadId !== selected.threadId ||
+        this.#closeTarget.turnId !== selected.turn.turnId
+      ) {
+        this.#closeTarget = { threadId: selected.threadId, turnId: selected.turn.turnId };
+        this.#notice = "c again to close the exact thread · history retained";
+      } else {
+        this.#closeTarget = undefined;
+        this.#pending = true;
+        void this.options
+          .onDispatch({
+            type: "close_thread",
+            parentSessionId: selected.parentSessionId,
+            threadId: selected.threadId,
+            expectedTurnId: selected.turn.turnId,
+          })
+          .then(
+            (receipt) => {
+              this.#notice =
+                receipt.status === "rejected" ? receipt.message : "Closed · history retained";
+            },
+            () => {
+              this.#notice = "Close could not be confirmed.";
+            },
+          )
+          .finally(() => {
+            this.#pending = false;
+            this.options.onChange();
+          });
+      }
+      this.options.onChange();
+      return;
+    }
+    if (matchesKey(data, "x")) {
+      if (
+        isKeyRepeat(data) ||
+        this.#pending ||
+        selected === undefined ||
+        !selected.actions?.includes("cancel") ||
+        (!this.#detail && !this.#visibleIds.has(this.key(selected)))
+      )
+        return;
+      if (
+        this.#armed?.threadId === selected.threadId &&
+        this.#armed.turnId === selected.turn.turnId
+      ) {
+        this.#armed = undefined;
+        this.#pending = true;
+        this.#notice = "Cancelling the exact turn…";
+        void this.options
+          .onDispatch({
+            type: "cancel_turn",
+            parentSessionId: selected.parentSessionId,
+            threadId: selected.threadId,
+            expectedTurnId: selected.turn.turnId,
+          })
+          .then(
+            (receipt) => {
+              this.#notice = receipt.status === "rejected" ? receipt.message : "Cancelled";
+            },
+            () => {
+              this.#notice = "Cancellation could not be confirmed. Inspect durable state.";
+            },
+          )
+          .finally(() => {
+            this.#pending = false;
+            this.options.onChange();
+          });
+      } else this.#armed = { threadId: selected.threadId, turnId: selected.turn.turnId };
+      this.options.onChange();
+      return;
+    }
+    this.#armed = undefined;
+    if (this.#detail) {
+      if (matchesKey(data, "home")) this.#detailScroll = 0;
+      else if (matchesKey(data, "end")) this.#detailScroll = this.#detailMaximumScroll;
+      else if (matchesKey(data, "up") || matchesKey(data, "pageUp"))
+        this.#detailScroll = Math.max(
+          0,
+          this.#detailScroll -
+            (matchesKey(data, "up") ? 1 : Math.max(1, this.options.maximumLines() - 3)),
+        );
+      else if (matchesKey(data, "down") || matchesKey(data, "pageDown"))
+        this.#detailScroll = Math.min(
+          this.#detailMaximumScroll,
+          this.#detailScroll +
+            (matchesKey(data, "down") ? 1 : Math.max(1, this.options.maximumLines() - 3)),
+        );
+    } else {
+      if (matchesKey(data, "down")) this.select(threads[Math.min(threads.length - 1, index + 1)]);
+      else if (matchesKey(data, "up")) this.select(threads[Math.max(0, index - 1)]);
+      else if (matchesKey(data, "home")) this.select(threads[0]);
+      else if (matchesKey(data, "end")) this.select(threads.at(-1));
+      else if (
+        matchesKey(data, "enter") &&
+        !isKeyRepeat(data) &&
+        selected !== undefined &&
+        this.#visibleIds.has(this.key(selected))
+      ) {
+        if (selected.turn.hasStarted || selected.turn.outcome !== undefined)
+          this.options.onOpen(
+            selected,
+            this.#history || selected.lifecycle === "closed" || !selected.turn.hasStarted,
+          );
+        else {
+          this.#detail = true;
+          this.#detailScroll = 0;
+        }
+      }
+    }
+    this.options.onChange();
+  }
+  invalidate(): void {}
+  render(width: number): string[] {
+    if (this.#settingsOpen) {
+      const settings = this.#settings;
+      const entries = [
+        `Widget · ${settings.widgetMode}`,
+        `Fleet · ${settings.fleetEnabled ? "enabled" : "disabled"}`,
+        `Model/thinking · ${settings.showModel ? "shown" : "hidden"}`,
+        `Viewer · ${settings.viewerMode === "raw" ? "raw" : `${settings.viewerMode} Markdown`}`,
+        `Mentions · ${settings.mentions}`,
+        "Reset defaults",
+      ];
+      const maximum = Math.max(1, this.options.maximumLines() - 3);
+      const start = Math.max(0, this.#settingIndex - maximum + 1);
+      this.#visibleSettings = new Set(
+        entries.slice(start, start + maximum).map((_, index) => start + index),
+      );
+      return [
+        this.options.theme.primary("Agent settings"),
+        ...entries
+          .slice(start, start + maximum)
+          .map((entry, index) => `${start + index === this.#settingIndex ? "●" : "○"} ${entry}`),
+        this.#pending ? "Saving…" : this.#notice || "User-local display preferences",
+        `↑↓ select · Enter change · Esc close${entries.length > maximum ? ` · ${entries.length - Math.min(maximum, entries.length)} hidden` : ""}`,
+      ].map((line) => truncateToWidth(line, width));
+    }
+    const thread = this.rows().find((entry) => this.key(entry) === this.#selected);
+    const lines: string[] = [];
+    if (this.#detail && thread !== undefined) {
+      const config = thread.turn.configuration;
+      const budget = thread.budget;
+      lines.push(
+        this.options.theme.primary(`${thread.turn.label} ${thread.handle} · ${thread.displayName}`),
+        safeTerminalText(thread.description),
+      );
+      if (config !== undefined)
+        lines.push(
+          `${safeTerminalText(config.targetId)} · thinking ${safeTerminalText(config.thinking)}`,
+          `${config.contextWindowTokens ?? "unknown"} context tokens`,
+        );
+      if (budget !== undefined)
+        lines.push(
+          `${budget.knownUsed} used · ${budget.outstandingReserved} reserved`,
+          `${budget.unknownReserved} unknown · ${budget.available} available`,
+        );
+      if (!thread.turn.hasStarted && thread.turn.outcome === undefined)
+        lines.push(
+          ...wrapTextWithAnsi(
+            "Queued tasks are immutable. Cancel and start a new agent to change the task.",
+            width,
+          ),
+        );
+      const title = lines.shift() ?? "Agent detail";
+      const details = lines.flatMap((line) => wrapTextWithAnsi(line, width));
+      const height = Math.max(
+        1,
+        this.options.maximumLines() -
+          3 -
+          Number(this.#armed !== undefined || Boolean(this.#notice)),
+      );
+      this.#detailMaximumScroll = Math.max(0, details.length - height);
+      this.#detailScroll = Math.min(this.#detailScroll, this.#detailMaximumScroll);
+      lines.splice(
+        0,
+        lines.length,
+        title,
+        `↑↓ detail · ${Math.max(0, details.length - height)} lines hidden`,
+        ...details.slice(this.#detailScroll, this.#detailScroll + height),
+        `${thread.actions?.includes("cancel") ? "x x cancel · " : ""}Esc list`,
+      );
+    } else {
+      const threads = this.rows();
+      const resumable =
+        !this.#history &&
+        threads.some(
+          (entry) => entry.actions?.includes("resume") || entry.actions?.includes("recover"),
+        );
+      const controls = [
+        ...(thread?.actions?.includes("close") ? ["c close"] : []),
+        ...(thread?.actions?.includes("cancel") ? ["x x cancel"] : []),
+        ...(resumable
+          ? [
+              thread?.actions?.some((action) => action === "resume" || action === "recover")
+                ? "u/U resume"
+                : "U resume all",
+            ]
+          : []),
+      ].join(" · ");
+      const hints = [
+        width < 72
+          ? "Enter inspect · h/s/a · Esc"
+          : "Enter inspect · h history · s settings · a attention · Esc back",
+        ...(controls ? [controls] : []),
+      ];
+      const maximum = Math.max(
+        1,
+        this.options.maximumLines() -
+          2 -
+          hints.length -
+          Number(this.#armed !== undefined || Boolean(this.#notice)),
+      );
+      const selectedIndex = Math.max(
+        0,
+        threads.findIndex((entry) => this.key(entry) === this.#selected),
+      );
+      const start = Math.max(0, selectedIndex - maximum + 1);
+      const visible = threads.slice(start, start + maximum);
+      this.#visibleIds = new Set(visible.map((entry) => this.key(entry)));
+      lines.push(
+        this.options.theme.primary(
+          `${this.#history ? "Agents history" : "Agents workspace"} · ${threads.length} ${this.#history ? "turns" : "threads"}`,
+        ),
+      );
+      lines.push(...hints);
+      lines.push(
+        ...visible.map(
+          (entry) =>
+            `${this.key(entry) === this.#selected ? "●" : "○"} ${entry.handle} · ${width < 48 ? `${entry.turn.label.split(" · ")[0]} · ${safeTerminalText(entry.description)}` : `${safeTerminalText(entry.displayName)} · ${safeTerminalText(entry.description)} · ${entry.turn.label}`}${entry.lifecycle === "closed" ? " · Closed" : ""}${this.#history ? ` · ${entry.turn.turnId.slice(0, 8)}` : ""}${this.options.hasDraft?.(entry) ? ` · Draft to ${entry.handle}` : ""}`,
+        ),
+      );
+      if (start > 0 || start + visible.length < threads.length)
+        lines.push(`↑ ${start} hidden · ↓ ${threads.length - start - visible.length} hidden`);
+      if (threads.length === 0)
+        lines.push(this.#snapshot.diagnostic ?? "No agents in this Session.");
+    }
+    if (this.#armed !== undefined)
+      lines.push(
+        this.options.theme.statusWarning(
+          "x again to cancel the exact turn · any other key disarms",
+        ),
+      );
+    else if (this.#notice)
+      lines.push(this.options.theme.statusInfo(safeTerminalText(this.#notice)));
+    return lines.map((line) => truncateToWidth(line, width));
+  }
+}
+
+export class AgentSessionTransition implements Component {
+  readonly #list: SelectList;
+  #pending: "wait" | "suspend" | undefined;
+  #notice = "";
+  constructor(
+    private readonly options: {
+      readonly transition: ManagedSessionTransition;
+      readonly theme: AdamTuiTheme;
+      readonly onDecision: (decision: "stay" | "wait" | "suspend") => void;
+    },
+  ) {
+    this.#list = new SelectList(
+      [
+        { value: "stay", label: "Stay" },
+        { value: "wait", label: "Wait then switch" },
+        { value: "suspend", label: "Suspend queued; stop running" },
+      ],
+      3,
+      options.theme.editor.selectList,
+    );
+    this.#list.onSelect = (item) => options.onDecision(item.value as "stay" | "wait" | "suspend");
+    this.#list.onCancel = () => this.cancel();
+  }
+  cancel(): void {
+    this.options.onDecision("stay");
+  }
+  setPending(decision: "stay" | "wait" | "suspend"): void {
+    this.#pending = decision === "stay" ? undefined : decision;
+  }
+  setError(message: string): void {
+    this.#pending = undefined;
+    this.#notice = safeTerminalText(message);
+  }
+  handleInput(data: string): void {
+    if (isKeyRelease(data) || (matchesKey(data, "enter") && isKeyRepeat(data))) return;
+    if (this.#pending !== undefined) {
+      if (matchesKey(data, "escape") && !isKeyRepeat(data)) this.cancel();
+      return;
+    }
+    this.#list.handleInput(data);
+  }
+  invalidate(): void {
+    this.#list.invalidate();
+  }
+  render(width: number): string[] {
+    return [
+      this.options.theme.primary("Switch Session"),
+      `${this.options.transition.runningCount} running · ${this.options.transition.queuedCount} queued`,
+      ...(this.#pending === undefined
+        ? this.#list.render(width)
+        : [
+            this.#pending === "wait"
+              ? "Waiting for agent work before switching…"
+              : "Suspending queued and settling running agents…",
+          ]),
+      ...(this.#notice ? wrapTextWithAnsi(this.#notice, width) : []),
+      "Enter choose · Esc stay",
+    ].map((line) => truncateToWidth(line, width));
+  }
+}

--- a/apps/tui/src/agent-navigator.test.ts
+++ b/apps/tui/src/agent-navigator.test.ts
@@ -819,3 +819,38 @@ function managedAgentFixture(
     ...overrides,
   };
 }
+
+test.each(["running", "completed", "recovery_required", "waiting_for_parent"] as const)(
+  "historical read-only %s child exposes inspection without legacy control shortcuts",
+  (status) => {
+    const agent = managedAgentFixture({
+      readOnly: true,
+      status,
+      attention: {
+        attentionId: "historical-attention",
+        status: "waiting",
+        question: "Historical question",
+      },
+    });
+    const onAction = vi.fn();
+    const navigator = new AgentNavigator({
+      managedAgents: { counts: { active: 0, terminal: 1, attention: 0 }, agents: [agent] },
+      onCancel: onAction,
+      onReply: onAction,
+      onFollowUp: onAction,
+      onRecovery: onAction,
+      onMessage: onAction,
+      onChange: () => {},
+      onClose: () => {},
+      theme: createAdamTuiTheme(true),
+    });
+    navigator.handleInput("\r");
+    for (const width of [40, 80]) {
+      const text = navigator.render(width).join("\n");
+      expect(text).toContain("Read-only history");
+      expect(text).not.toMatch(/f follow-up|r recover|r reply|c cancel|c twice cancel|m message/u);
+    }
+    for (const key of ["f", "r", "m", "c", "c"]) navigator.handleInput(key);
+    expect(onAction).not.toHaveBeenCalled();
+  },
+);

--- a/apps/tui/src/agent-navigator.ts
+++ b/apps/tui/src/agent-navigator.ts
@@ -238,6 +238,7 @@ export class AgentNavigator implements Component {
         }
         return;
       }
+      if (this.#detail.readOnly) return;
       if (
         matchesKey(data, "m") &&
         isActiveManagedAgent(this.#detail) &&
@@ -370,34 +371,42 @@ export class AgentNavigator implements Component {
               `${report.kind} r${report.revision} · ${safeTerminalText(report.message)}${report.messageTruncated ? ` · ${report.messageByteCount} bytes total` : ""}`,
           ),
       ];
-      const fullActionLines = [
-        ...(isActiveManagedAgent(detail) && this.#onMessage !== undefined
-          ? [
-              this.#theme.muted(
-                "m message at next safe boundary; delivery does not imply compliance",
-              ),
-            ]
-          : []),
-        ...(this.#cancelConfirmation === `${detail.agentId}:${detail.revision}`
-          ? [this.#theme.statusWarning("Press c again to stop this exact child")]
-          : []),
-        ...(canFollowUp(detail) && this.#onFollowUp !== undefined
-          ? [this.#theme.muted("f follow-up from exact terminal evidence")]
-          : []),
-        ...(detail.status === "recovery_required" && this.#onRecovery !== undefined
-          ? [this.#theme.muted("r recover from exact durable evidence")]
-          : []),
-        ...(hasArtifact && this.#onReadArtifact !== undefined
-          ? [this.#theme.muted("a read artifact")]
-          : []),
-        this.#theme.muted(
-          isActiveManagedAgent(detail) && detail.status !== "waiting_for_parent"
-            ? "↑↓ scroll · PgUp older · c cancel exact revision · Esc back · Ctrl+Q exit"
-            : detail.status === "waiting_for_parent"
-              ? "↑↓ scroll · PgUp older · r reply exact attention · c cancel exact revision · Esc back · Ctrl+Q exit"
-              : "Terminal child · Esc back · Ctrl+Q exit",
-        ),
-      ];
+      const fullActionLines = detail.readOnly
+        ? [
+            this.#theme.muted("Read-only history · Esc back"),
+            ...(hasArtifact && this.#onReadArtifact !== undefined
+              ? [this.#theme.muted("a read artifact")]
+              : []),
+            this.#theme.muted("↑↓ scroll · PgUp older · Ctrl+Q exit"),
+          ]
+        : [
+            ...(isActiveManagedAgent(detail) && this.#onMessage !== undefined
+              ? [
+                  this.#theme.muted(
+                    "m message at next safe boundary; delivery does not imply compliance",
+                  ),
+                ]
+              : []),
+            ...(this.#cancelConfirmation === `${detail.agentId}:${detail.revision}`
+              ? [this.#theme.statusWarning("Press c again to stop this exact child")]
+              : []),
+            ...(canFollowUp(detail) && this.#onFollowUp !== undefined
+              ? [this.#theme.muted("f follow-up from exact terminal evidence")]
+              : []),
+            ...(detail.status === "recovery_required" && this.#onRecovery !== undefined
+              ? [this.#theme.muted("r recover from exact durable evidence")]
+              : []),
+            ...(hasArtifact && this.#onReadArtifact !== undefined
+              ? [this.#theme.muted("a read artifact")]
+              : []),
+            this.#theme.muted(
+              isActiveManagedAgent(detail) && detail.status !== "waiting_for_parent"
+                ? "↑↓ scroll · PgUp older · c cancel exact revision · Esc back · Ctrl+Q exit"
+                : detail.status === "waiting_for_parent"
+                  ? "↑↓ scroll · PgUp older · r reply exact attention · c cancel exact revision · Esc back · Ctrl+Q exit"
+                  : "Terminal child · Esc back · Ctrl+Q exit",
+            ),
+          ];
       const fullHeaderLines = [
         this.#theme.toolTitle("Agent detail"),
         `${detail.profile} · ${detail.mode} · ${detail.status} · revision ${detail.revision} · ${detail.phase}${detail.activeTool === undefined ? "" : ` · ${detail.activeTool.name} ${detail.activeTool.status}`}`,
@@ -784,6 +793,8 @@ function compactAgentActions(
     readonly recovery: boolean;
   },
 ): string {
+  if (agent.readOnly)
+    return `Read-only history${available.artifact ? " · a artifact" : ""} · Esc back`;
   if (confirmation === `${agent.agentId}:${agent.revision}`) {
     return "c again cancel · Esc back";
   }

--- a/apps/tui/src/agent-widget.ts
+++ b/apps/tui/src/agent-widget.ts
@@ -1,0 +1,215 @@
+/**
+ * Agent tree layout adapted from tintinweb/pi-subagents src/ui/agent-widget.ts
+ * at 4f572eaa04c09d3dbc16e4a5f13a16b295e84e14 (MIT). See THIRD_PARTY_NOTICES.md.
+ * Adam Presentation supplies all execution truth; this component only renders it.
+ */
+import type {
+  AgentUiSettings,
+  ManagedControlThread,
+  ManagedWorkspaceSnapshot,
+  PresentationDisplayState,
+} from "@adam-agent/presentation";
+import { type Component, truncateToWidth } from "@earendil-works/pi-tui";
+import {
+  type DeadlineHandle,
+  type DeadlineScheduler,
+  nodeDeadlineScheduler,
+} from "./exit-policy.js";
+import { safeTerminalText } from "./safe-terminal-text.js";
+import type { AdamTuiTheme } from "./theme.js";
+
+export function agentElapsedLabel(thread: ManagedControlThread): string {
+  const start = thread.turn.startedAtUnixMilliseconds;
+  if (start === undefined) return "";
+  const end =
+    thread.turn.outcome === undefined
+      ? thread.residency === "live"
+        ? Date.now()
+        : undefined
+      : thread.turn.outcome.atUnixMilliseconds;
+  return end === undefined
+    ? " · elapsed unknown"
+    : ` · elapsed ${Math.max(0, Math.floor((end - start) / 1000))}s`;
+}
+
+export class AgentWidget implements Component {
+  #snapshot: ManagedWorkspaceSnapshot | undefined;
+  #activity: NonNullable<PresentationDisplayState["managedAgentActivity"]> = [];
+  readonly #previous = new Map<string, string>();
+  readonly #linger = new Map<string, DeadlineHandle>();
+  readonly #expired = new Set<string>();
+  #animation: DeadlineHandle | undefined;
+  #frame = 0;
+  #disposed = false;
+  constructor(
+    private readonly theme: AdamTuiTheme,
+    private readonly maximumLines: () => number = () => 12,
+    private readonly options: {
+      readonly settings?: () => AgentUiSettings;
+      readonly scheduler?: DeadlineScheduler;
+      readonly onChange?: () => void;
+    } = {},
+  ) {}
+  setSnapshot(snapshot: ManagedWorkspaceSnapshot | undefined): void {
+    if (this.#snapshot?.parentSessionId !== snapshot?.parentSessionId) {
+      for (const timer of this.#linger.values()) timer.cancel();
+      this.#linger.clear();
+      this.#expired.clear();
+      this.#previous.clear();
+    }
+    this.#snapshot = snapshot;
+    if (this.#disposed) return;
+    for (const thread of snapshot?.threads ?? []) {
+      const key = thread.turn.turnId;
+      const before = this.#previous.get(key);
+      if (thread.turn.phase === "idle" && before !== "idle" && !this.#expired.has(key)) {
+        if (before === undefined) this.#expired.add(key);
+        else {
+          let timer: DeadlineHandle | undefined;
+          timer = (this.options.scheduler ?? nodeDeadlineScheduler).schedule(4000, () => {
+            timer?.cancel();
+            this.#linger.delete(key);
+            this.#expired.add(key);
+            if (!this.#disposed) this.options.onChange?.();
+          });
+          this.#linger.set(key, timer);
+        }
+      }
+      this.#previous.set(key, thread.turn.phase);
+    }
+    this.synchronizeAnimation();
+  }
+  visibleThreads(): NonNullable<ManagedWorkspaceSnapshot>["threads"] {
+    return (
+      this.#snapshot?.threads.filter(
+        (thread) => thread.lifecycle === "open" && !this.#expired.has(thread.turn.turnId),
+      ) ?? []
+    );
+  }
+  private synchronizeAnimation(): void {
+    const active = this.visibleThreads().some(
+      (thread) => thread.turn.phase === "executing" || thread.turn.phase === "starting",
+    );
+    if (!active || this.#disposed) {
+      this.#animation?.cancel();
+      this.#animation = undefined;
+      return;
+    }
+    if (this.#animation !== undefined) return;
+    this.#animation = (this.options.scheduler ?? nodeDeadlineScheduler).schedule(80, () => {
+      this.#animation?.cancel();
+      this.#animation = undefined;
+      if (this.#disposed) return;
+      this.#frame = (this.#frame + 1) % 10;
+      this.options.onChange?.();
+      this.synchronizeAnimation();
+    });
+  }
+  dispose(): void {
+    this.#disposed = true;
+    this.#animation?.cancel();
+    this.#animation = undefined;
+    for (const timer of this.#linger.values()) timer.cancel();
+    this.#linger.clear();
+  }
+  setActivity(activity: PresentationDisplayState["managedAgentActivity"]): void {
+    this.#activity = activity ?? [];
+  }
+  invalidate(): void {}
+  render(width: number): string[] {
+    const settings = this.options.settings?.();
+    if (settings?.widgetMode === "off") return [];
+    const threads = this.visibleThreads().filter(
+      (thread) => settings?.widgetMode === "all" || thread.turn.lane !== "reserved",
+    );
+    if (threads.length === 0) return [];
+    const finished = threads.filter((thread) => thread.turn.phase === "idle");
+    const isQueuedThread = (thread: (typeof threads)[number]) =>
+      thread.turn.phase === "queued" ||
+      (!thread.turn.hasStarted && thread.turn.phase === "waiting");
+    const running = threads.filter(
+      (thread) => thread.turn.phase !== "idle" && !isQueuedThread(thread),
+    );
+    const queued = threads.filter(isQueuedThread);
+    const renderThread = (thread: (typeof threads)[number]): string[] => {
+      const activity = this.#activity.find(
+        (item) => item.agentId === thread.threadId && item.attemptId === thread.turn.attemptId,
+      );
+      const config = thread.turn.configuration;
+      const budget = thread.budget;
+      const isQueued = isQueuedThread(thread);
+      const elapsed = agentElapsedLabel(thread);
+      const content =
+        activity?.tool?.name ??
+        activity?.assistant?.text.split("\n").find((line) => line.trim().length > 0) ??
+        (activity?.reasoning ? "Thinking…" : thread.turn.label);
+      return [
+        `├─ ${isQueued ? `${thread.turn.label.split(" · ")[0]} ${thread.handle} · ` : thread.turn.phase === "executing" ? `${["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"][this.#frame]} ` : ""}${this.theme.reference(safeTerminalText(thread.displayName))} · ${thread.turn.phase === "idle" ? `${thread.turn.label} · ` : ""}${safeTerminalText(thread.description)}${elapsed}${thread.turn.phase === "idle" ? `${budget === undefined ? "" : ` · ${budget.knownUsed} used${budget.unknownReserved > 0 ? ` · ${budget.unknownReserved} unknown reserved` : ""}`}` : ""}`,
+        ...(!isQueued && thread.turn.phase !== "idle"
+          ? [
+              `   ⎿ ${safeTerminalText(content)}${budget === undefined ? "" : ` · ${budget.knownUsed} used · ${budget.outstandingReserved} reserved${budget.unknownReserved ? ` · ${budget.unknownReserved} unknown` : ""}`}`,
+            ]
+          : []),
+        ...((isQueued || settings?.showModel) && config !== undefined
+          ? [
+              `   ${safeTerminalText(config.targetId)} · thinking ${safeTerminalText(config.thinking)}`,
+            ]
+          : []),
+        ...(isQueued && budget !== undefined
+          ? [
+              `   ${budget.knownUsed} used · ${budget.outstandingReserved} reserved · ${budget.unknownReserved} unknown · ${budget.available} available`,
+            ]
+          : []),
+      ];
+    };
+    const maximum = Math.max(2, this.maximumLines());
+    const normal = [...finished, ...running, ...queued].flatMap(renderThread);
+    const lines = [
+      this.theme.primary(
+        `● Agents${normal.length + 1 > maximum ? ` · ${running.length} running · ${queued.length} queued` : ""}`,
+      ),
+    ];
+    if (normal.length + 1 <= maximum) lines.push(...normal);
+    else {
+      const showQueueSummary = queued.length > 0 && maximum > 2;
+      let budget = maximum - 2 - Number(showQueueSummary);
+      let hiddenRunning = 0;
+      let hiddenFinished = 0;
+      let hiddenDetails = 0;
+      for (const thread of running) {
+        if (budget === 0) {
+          hiddenRunning += 1;
+          continue;
+        }
+        const full = renderThread(thread);
+        const rendered = full.slice(0, budget);
+        lines.push(...rendered);
+        budget -= rendered.length;
+        hiddenDetails += full.length - rendered.length;
+      }
+      if (showQueueSummary) lines.push(`├─ ${queued.length} queued · /agents`);
+      for (const thread of finished) {
+        if (budget === 0) {
+          hiddenFinished += 1;
+          continue;
+        }
+        const full = renderThread(thread);
+        const rendered = full.slice(0, budget);
+        lines.push(...rendered);
+        budget -= rendered.length;
+        hiddenDetails += full.length - rendered.length;
+      }
+      const compact = width < 60;
+      const hidden = [
+        ...(hiddenRunning ? [`${hiddenRunning} ${compact ? "run" : "running"}`] : []),
+        ...(queued.length ? [`${queued.length} queued`] : []),
+        ...(hiddenFinished ? [`${hiddenFinished} ${compact ? "done" : "finished"}`] : []),
+        ...(hiddenDetails ? [`${hiddenDetails} ${compact ? "line" : "detail lines"}`] : []),
+      ];
+      lines.push(compact ? `… hidden ${hidden.join("/")}` : `… ${hidden.join(" / ")} hidden`);
+    }
+    const lastBranch = lines.findLastIndex((line) => line.includes("├─"));
+    if (lastBranch >= 0) lines[lastBranch] = (lines[lastBranch] ?? "").replace("├─", "└─");
+    return lines.map((line) => truncateToWidth(line, width));
+  }
+}

--- a/apps/tui/src/attention-center.ts
+++ b/apps/tui/src/attention-center.ts
@@ -1,0 +1,334 @@
+import { randomUUID } from "node:crypto";
+import type { CommandReceipt, ManagedAttentionItem } from "@adam-agent/presentation";
+import {
+  type Component,
+  Input,
+  isKeyRelease,
+  isKeyRepeat,
+  matchesKey,
+  truncateToWidth,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import { safeTerminalText } from "./safe-terminal-text.js";
+import type { AdamTuiTheme } from "./theme.js";
+
+export function managedAttentionKey(item: ManagedAttentionItem): string {
+  return `${item.parentSessionId}:${item.threadId}:${item.turnId}:${item.kind}:${item.id}`;
+}
+
+/** Local selection/focus only. Every decision goes back to the exact runtime owner. */
+export class AttentionCenter implements Component {
+  #items: readonly ManagedAttentionItem[] = [];
+  #focusedKey: string | undefined;
+  readonly #selected = new Set<string>();
+  readonly #busy = new Set<string>();
+  #explicitSelection = false;
+  #notice = "";
+  #focused = false;
+  #visible = new Set<string>();
+  #detailOffset = 0;
+  #detailPageSize = 1;
+  readonly #replyInput = new Input();
+  readonly #replyDrafts = new Map<string, string>();
+  #replyTarget: Extract<ManagedAttentionItem, { kind: "parent_input" }> | undefined;
+  #replySending = false;
+  #replySubmission:
+    | { readonly key: string; readonly text: string; readonly inputId: string }
+    | undefined;
+
+  constructor(
+    private readonly options: {
+      readonly theme: AdamTuiTheme;
+      readonly maximumLines: () => number;
+      readonly onPermission: (
+        item: Extract<ManagedAttentionItem, { kind: "permission" }>,
+        decision: "allow" | "deny",
+      ) => Promise<CommandReceipt>;
+      readonly onReply: (
+        item: Extract<ManagedAttentionItem, { kind: "parent_input" }>,
+        text: string,
+        inputId: string,
+      ) => Promise<CommandReceipt>;
+      readonly onChange: () => void;
+      readonly onClose: () => void;
+    },
+  ) {
+    this.#replyInput.onSubmit = (text) => {
+      void this.reply(text);
+    };
+  }
+
+  get focused(): boolean {
+    return this.#focused;
+  }
+  set focused(value: boolean) {
+    this.#focused = value;
+    this.#replyInput.focused = value && this.#replyTarget !== undefined;
+  }
+  hasPendingInput(): boolean {
+    return (
+      this.#replySending ||
+      (this.#replyTarget !== undefined && this.#replyInput.getValue().length > 0)
+    );
+  }
+  setItems(items: readonly ManagedAttentionItem[]): void {
+    const previousIndex = this.#items.findIndex(
+      (item) => managedAttentionKey(item) === this.#focusedKey,
+    );
+    this.#items = [
+      ...items.filter((item) => item.kind === "permission"),
+      ...items.filter((item) => item.kind === "parent_input"),
+    ];
+    const keys = new Set(this.#items.map(managedAttentionKey));
+    if (this.#focusedKey === undefined || !keys.has(this.#focusedKey)) {
+      const next = this.#items[Math.max(0, Math.min(previousIndex, this.#items.length - 1))];
+      this.#focusedKey = next === undefined ? undefined : managedAttentionKey(next);
+      this.#detailOffset = 0;
+    }
+    for (const key of this.#selected) if (!keys.has(key)) this.#selected.delete(key);
+    const focused = this.current();
+    if (!this.#explicitSelection && this.#selected.size === 0 && focused?.kind === "permission")
+      this.#selected.add(managedAttentionKey(focused));
+  }
+  private current(): ManagedAttentionItem | undefined {
+    return this.#items.find((item) => managedAttentionKey(item) === this.#focusedKey);
+  }
+  focusItem(key: string): void {
+    const item = this.#items.find((candidate) => managedAttentionKey(candidate) === key);
+    if (item === undefined) return;
+    if (this.#replyTarget !== undefined)
+      this.#replyDrafts.set(managedAttentionKey(this.#replyTarget), this.#replyInput.getValue());
+    this.#replyTarget = undefined;
+    this.#replyInput.focused = false;
+    this.#focusedKey = key;
+    this.#detailOffset = 0;
+    this.#explicitSelection = false;
+    this.#selected.clear();
+    if (item.kind === "permission") this.#selected.add(key);
+  }
+  back(): void {
+    if (this.#replyTarget !== undefined) {
+      this.#replyDrafts.set(managedAttentionKey(this.#replyTarget), this.#replyInput.getValue());
+      this.#replyTarget = undefined;
+      this.#replyInput.focused = false;
+      this.#detailOffset = 0;
+    } else this.options.onClose();
+    this.options.onChange();
+  }
+  private async decide(decision: "allow" | "deny"): Promise<void> {
+    const selected = this.#items.filter(
+      (item): item is Extract<ManagedAttentionItem, { kind: "permission" }> =>
+        item.kind === "permission" &&
+        this.#selected.has(managedAttentionKey(item)) &&
+        !this.#busy.has(managedAttentionKey(item)),
+    );
+    if (
+      selected.length === 0 ||
+      selected.some(
+        (item) => !item.available || (decision === "allow" && !item.interaction?.canAllow),
+      )
+    ) {
+      this.#notice = "Select exact available requests before deciding.";
+      this.options.onChange();
+      return;
+    }
+    for (const item of selected) this.#busy.add(managedAttentionKey(item));
+    this.#notice = "Submitting exact permission decisions…";
+    this.options.onChange();
+    try {
+      const receipts = await Promise.all(
+        selected.map((item) => this.options.onPermission(item, decision)),
+      );
+      const rejected = receipts.find((receipt) => receipt.status === "rejected");
+      this.#notice =
+        rejected?.status === "rejected"
+          ? rejected.message
+          : "Decision submitted; waiting for the recorded state.";
+    } catch {
+      this.#notice = "Some decisions could not be confirmed. Inspect the remaining requests.";
+    } finally {
+      for (const item of selected) this.#busy.delete(managedAttentionKey(item));
+      this.options.onChange();
+    }
+  }
+  private async reply(text: string): Promise<void> {
+    const target = this.#replyTarget;
+    if (target === undefined || this.#replySending || !text.trim()) return;
+    if (
+      !this.#items.some(
+        (item) => managedAttentionKey(item) === managedAttentionKey(target) && item.available,
+      )
+    ) {
+      this.#notice = "This exact request is no longer pending. Your text is retained.";
+      this.options.onChange();
+      return;
+    }
+    this.#replySending = true;
+    this.#notice = "Accepting the exact parent reply…";
+    this.options.onChange();
+    const key = managedAttentionKey(target);
+    if (this.#replySubmission?.key !== key || this.#replySubmission.text !== text)
+      this.#replySubmission = { key, text, inputId: randomUUID() };
+    try {
+      const receipt = await this.options.onReply(target, text, this.#replySubmission.inputId);
+      if (receipt.status === "rejected") this.#notice = receipt.message;
+      else if (receipt.control?.status === "input_accepted") {
+        if (
+          this.#replyTarget !== undefined &&
+          managedAttentionKey(this.#replyTarget) === managedAttentionKey(target) &&
+          this.#replyInput.getValue() === text
+        ) {
+          this.#replyInput.setValue("");
+          this.#replyTarget = undefined;
+          this.#replyInput.focused = false;
+        }
+        this.#replyDrafts.delete(managedAttentionKey(target));
+        this.#replySubmission = undefined;
+        this.#notice = "Reply accepted.";
+      }
+    } catch {
+      this.#notice = "Reply acceptance could not be confirmed. Your text is retained.";
+    } finally {
+      this.#replySending = false;
+      this.options.onChange();
+    }
+  }
+  handleInput(data: string): void {
+    if (isKeyRelease(data)) return;
+    if (matchesKey(data, "escape")) {
+      if (!isKeyRepeat(data)) this.back();
+      return;
+    }
+    if (matchesKey(data, "pageUp") || matchesKey(data, "pageDown")) {
+      this.#detailOffset = Math.max(
+        0,
+        this.#detailOffset +
+          (matchesKey(data, "pageUp") ? -this.#detailPageSize : this.#detailPageSize),
+      );
+      this.options.onChange();
+      return;
+    }
+    if (this.#replyTarget !== undefined) {
+      if (!this.#replySending && !(matchesKey(data, "enter") && isKeyRepeat(data))) {
+        this.#replyInput.handleInput(data);
+        if (this.#replyTarget !== undefined)
+          this.#replyDrafts.set(
+            managedAttentionKey(this.#replyTarget),
+            this.#replyInput.getValue(),
+          );
+      }
+      this.options.onChange();
+      return;
+    }
+    const focused = this.current();
+    if (matchesKey(data, "home") || matchesKey(data, "end")) {
+      const item = matchesKey(data, "home") ? this.#items[0] : this.#items.at(-1);
+      this.#focusedKey = item === undefined ? undefined : managedAttentionKey(item);
+      this.#detailOffset = 0;
+    } else if (matchesKey(data, "up") || matchesKey(data, "down")) {
+      const index = this.#items.findIndex((item) => managedAttentionKey(item) === this.#focusedKey);
+      const next =
+        this.#items[
+          Math.max(0, Math.min(this.#items.length - 1, index + (matchesKey(data, "up") ? -1 : 1)))
+        ];
+      this.#focusedKey = next === undefined ? undefined : managedAttentionKey(next);
+      this.#detailOffset = 0;
+    } else if (
+      focused !== undefined &&
+      this.#visible.has(managedAttentionKey(focused)) &&
+      !isKeyRepeat(data)
+    ) {
+      if (focused.kind === "permission") {
+        if (matchesKey(data, "space")) {
+          const key = managedAttentionKey(focused);
+          if (!this.#explicitSelection) {
+            this.#explicitSelection = true;
+            this.#selected.clear();
+            this.#selected.add(key);
+          } else if (!this.#selected.delete(key)) this.#selected.add(key);
+        } else if (matchesKey(data, "a") || matchesKey(data, "enter")) void this.decide("allow");
+        else if (matchesKey(data, "d")) void this.decide("deny");
+      } else if (matchesKey(data, "enter") && focused.available && !this.#replySending) {
+        this.#replyTarget = focused;
+        this.#replyInput.setValue(this.#replyDrafts.get(managedAttentionKey(focused)) ?? "");
+        this.#replyInput.focused = this.#focused;
+        this.#notice = "";
+        this.#detailOffset = 0;
+      }
+    }
+    if (
+      !this.#explicitSelection &&
+      (matchesKey(data, "home") ||
+        matchesKey(data, "end") ||
+        matchesKey(data, "up") ||
+        matchesKey(data, "down"))
+    ) {
+      this.#selected.clear();
+      const next = this.current();
+      if (next?.kind === "permission") this.#selected.add(managedAttentionKey(next));
+    }
+    this.options.onChange();
+  }
+  invalidate(): void {}
+  render(width: number): string[] {
+    const maximum = Math.max(6, this.options.maximumLines());
+    if (this.#replyTarget !== undefined) {
+      const question = wrapTextWithAnsi(safeTerminalText(this.#replyTarget.question), width);
+      this.#detailPageSize = Math.max(1, maximum - 3 - Number(Boolean(this.#notice)));
+      this.#detailOffset = Math.min(
+        this.#detailOffset,
+        Math.max(0, question.length - this.#detailPageSize),
+      );
+      return [
+        this.options.theme.primary(`Parent input · ${this.#replyTarget.handle}`),
+        ...question.slice(this.#detailOffset, this.#detailOffset + this.#detailPageSize),
+        ...(this.#notice ? [safeTerminalText(this.#notice)] : []),
+        ...this.#replyInput.render(width),
+        "Enter reply · PgDn question · Esc list",
+      ].map((line) => truncateToWidth(line, width));
+    }
+    const selectedIndex = Math.max(
+      0,
+      this.#items.findIndex((item) => managedAttentionKey(item) === this.#focusedKey),
+    );
+    const rowCount = Math.max(1, maximum - 7);
+    const start = Math.max(0, selectedIndex - rowCount + 1);
+    const visible = this.#items.slice(start, start + rowCount);
+    this.#visible = new Set(visible.map(managedAttentionKey));
+    const lines = [this.options.theme.primary("Attention Center")];
+    for (const kind of ["permission", "parent_input"] as const) {
+      const all = this.#items.filter((item) => item.kind === kind);
+      const rows = visible.filter((item) => item.kind === kind);
+      lines.push(
+        `${kind === "permission" ? "Permissions" : "Parent input"} · ${all.length}${all.length > rows.length ? ` · ${all.length - rows.length} hidden` : ""}`,
+      );
+      lines.push(
+        ...rows.map(
+          (item) =>
+            `${managedAttentionKey(item) === this.#focusedKey ? "●" : "○"} ${item.kind === "permission" ? (this.#selected.has(managedAttentionKey(item)) ? "[x] " : "[ ] ") : ""}${item.handle} · ${safeTerminalText(item.displayName)} · ${safeTerminalText(item.description)}`,
+        ),
+      );
+    }
+    const focused = this.current();
+    const detail =
+      focused?.kind === "permission"
+        ? focused.interaction === null
+          ? (focused.diagnostic ?? "Permission details unavailable.")
+          : `${focused.interaction.effect} · ${focused.interaction.subject.value}`
+        : (focused?.question ?? "No pending attention.");
+    const details = wrapTextWithAnsi(safeTerminalText(detail), width);
+    this.#detailPageSize = Math.max(0, maximum - lines.length - 1 - Number(Boolean(this.#notice)));
+    this.#detailOffset = Math.min(
+      this.#detailOffset,
+      Math.max(0, details.length - this.#detailPageSize),
+    );
+    lines.push(...details.slice(this.#detailOffset, this.#detailOffset + this.#detailPageSize));
+    if (this.#notice) lines.push(safeTerminalText(this.#notice));
+    lines.push(
+      focused?.kind === "permission"
+        ? `a Allow · d Deny · Space ${this.#explicitSelection ? "toggle" : "pin"} · Esc close`
+        : "Enter reply · PgDn detail · Esc close",
+    );
+    return lines.map((line) => truncateToWidth(line, width));
+  }
+}

--- a/apps/tui/src/command-registry.test.ts
+++ b/apps/tui/src/command-registry.test.ts
@@ -51,7 +51,11 @@ test("the TUI Registry exposes the active-run managed-child navigator", () => {
   const parsed = adamCommandRegistry.parse("/agents");
   expect(parsed).toMatchObject({
     kind: "known",
-    command: { id: "agents", availability: "always", usage: "/agents" },
+    command: {
+      id: "agents",
+      availability: "always",
+      usage: "/agents [history|settings|attention]",
+    },
   });
 });
 

--- a/apps/tui/src/command-registry.ts
+++ b/apps/tui/src/command-registry.ts
@@ -243,7 +243,7 @@ const builtInCommands: readonly AdamCommandDefinition[] = [
     id: "agents",
     name: "agents",
     summary: "Inspect, reply to, or cancel managed children for the active session.",
-    usage: "/agents",
+    usage: "/agents [history|settings|attention]",
   },
   {
     aliases: [],

--- a/apps/tui/src/fixture-scenario.ts
+++ b/apps/tui/src/fixture-scenario.ts
@@ -1,4 +1,5 @@
 export const fixtureScenarios = [
+  "managed-control",
   "artifact-backed-assistant",
   "artifact-page-race",
   "artifact-history",

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -1841,3 +1841,101 @@ test("the real terminal redraws through 40, 80, 120, and minimum-size layouts", 
     await rm(testRoot, { recursive: true, force: true });
   }
 });
+
+test("candidate ProjectRuntime runs real JSONL child Enter, Main response, layered Kitty Esc and settled continuation in a PTY", async () => {
+  const testRoot = await mkdtemp(join(tmpdir(), "adam-managed-project-pty-"));
+  const workspaceRoot = join(testRoot, "workspace");
+  const stateRoot = join(testRoot, "state");
+  const controlRoot = join(testRoot, "control");
+  await mkdir(workspaceRoot);
+  await mkdir(controlRoot);
+  await writeFile(join(workspaceRoot, "evidence.txt"), "Actual filesystem evidence.\n");
+  const fixture = startFixture({
+    external: true,
+    scenario: "managed-control",
+    noColor: true,
+    workspaceRoot,
+    stateRoot,
+    controlRoot,
+  });
+  let completed = false;
+  let waiting = "New session";
+  try {
+    await fixture.waitFor("Adam · New session");
+    fixture.write("Start child\r");
+    waiting = "Delegation permission";
+    await fixture.waitFor("Permission required");
+    fixture.write("\r");
+    waiting = "MAIN_READY";
+    await fixture.waitFor("MAIN_READY");
+    expect(fixture.screen()?.join("\n")).toContain("PTY child");
+    waiting = "child-started";
+    await waitForFileContents(join(controlRoot, "child-started"), "started\n");
+    let offset = fixture.output().length;
+    waiting = "Fleet";
+    fixture.write("\u001b[B");
+    await fixture.waitForCompleteFrameAfter("Fleet", offset);
+    offset = fixture.output().length;
+    waiting = "@explore-1";
+    fixture.write("\u001b[B");
+    await fixture.waitForCompleteFrameAfter("@explore-1", offset);
+    offset = fixture.output().length;
+    waiting = "Conversation";
+    fixture.write("\r");
+    await fixture.waitForCompleteFrameAfter("Conversation", offset);
+    offset = fixture.output().length;
+    waiting = "Cooperative";
+    fixture.write("\r");
+    await fixture.waitForCompleteFrameAfter("Cooperative", offset);
+    offset = fixture.output().length;
+    waiting = "Accepted";
+    fixture.write("PTY child input\r");
+    await fixture.waitForCompleteFrameAfter("Accepted", offset);
+    for (const visible of ["Enter compose", "Esc Main", "↓ navigate"]) {
+      waiting = visible;
+      offset = fixture.output().length;
+      fixture.write("\u001b[27;1:1u\u001b[27;1:2u\u001b[27;1:3u");
+      await fixture.waitForCompleteFrameAfter(visible, offset);
+    }
+    offset = fixture.output().length;
+    waiting = "MAIN_RESPONDED";
+    fixture.write("Main while child runs\r");
+    await fixture.waitForCompleteFrameAfter("MAIN_RESPONDED", offset);
+    await writeFile(join(controlRoot, "release-child"), "release\n");
+    await waitForFileContents(
+      join(controlRoot, "child-request"),
+      JSON.stringify({ delivered: true, childCalls: 2 }),
+    );
+    await fixture.waitFor("Completed");
+    offset = fixture.output().length;
+    waiting = "Agents workspace";
+    fixture.write("/agents\r");
+    await fixture.waitForCompleteFrameAfter("Agents workspace", offset);
+    offset = fixture.output().length;
+    waiting = "CHILD_DELIVERED";
+    fixture.write("\r");
+    await fixture.waitForCompleteFrameAfter("CHILD_DELIVERED", offset);
+    offset = fixture.output().length;
+    waiting = "New turn";
+    fixture.write("\r");
+    await fixture.waitForCompleteFrameAfter("New turn", offset);
+    offset = fixture.output().length;
+    waiting = "FOLLOWUP_RESPONDED";
+    fixture.write("Follow up\r");
+    await fixture.waitForCompleteFrameAfter("FOLLOWUP_RESPONDED", offset);
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    expectEveryTerminalInputModeRestored(result);
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: Inspect actual terminal SGR color sequences.
+    expect(result.stdout).not.toMatch(/\u001b\[[0-9;]*(?:3[0-7]|9[0-7]|38;|48;)[0-9;]*m/u);
+    completed = true;
+  } finally {
+    if (!completed)
+      console.error(
+        `Candidate PTY waiting for ${waiting}:\n${fixture.screen()?.join("\n")}\n${fixture.output().slice(-2000)}`,
+      );
+    await fixture.cleanup();
+    await rm(testRoot, { recursive: true, force: true });
+  }
+});

--- a/apps/tui/src/project-runtime.ts
+++ b/apps/tui/src/project-runtime.ts
@@ -25,10 +25,17 @@ import {
   type SessionSnapshot,
   type WorkspaceTrustController,
 } from "@adam-agent/agent";
+import { sessionManagedControl } from "@adam-agent/agent/internal-testing";
 import type { PresentationSession } from "@adam-agent/presentation";
 import { requireConfirmedLifecycleClose } from "./lifecycle-close.js";
 
+/** Internal candidate entry for conformance. The ordinary production caller never selects it. */
+export const projectRuntimeManagedControl = Symbol("project-runtime-managed-control-testing");
+
 export type ProductionProjectRuntimeOptions = {
+  readonly [projectRuntimeManagedControl]?: NonNullable<
+    Parameters<typeof createSessionLifecycle>[0][typeof sessionManagedControl]
+  >;
   readonly environment: NodeJS.ProcessEnv;
   readonly extensionPermissions: PermissionPolicy;
   readonly modelTargets: ModelTargets;
@@ -176,7 +183,9 @@ export async function createProductionProjectRuntime(
   });
   lifecycle = createSessionLifecycle({
     extensionHost: host,
-    managedAgentTools: "managed-agent-tools.a3-long-lived.v2",
+    ...(options[projectRuntimeManagedControl] === undefined
+      ? { managedAgentTools: "managed-agent-tools.a3-long-lived.v2" as const }
+      : { [sessionManagedControl]: options[projectRuntimeManagedControl] }),
     modelTargets: options.modelTargets,
     permissions: options.permissions,
     preferences: options.preferences,

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -10,6 +10,7 @@ import {
   createExtensionHost,
   createFileArtifactStore,
   createInMemoryOperationStore,
+  createJsonlSessionStoreDirectory,
   createPermissionPolicy,
   createPresentationPreferences,
   createPresentationSession,
@@ -24,6 +25,7 @@ import {
 } from "@adam-agent/agent";
 import {
   createInMemorySessionStoreDirectory,
+  createJsonlManagedAgentControlStore,
   createPlanToolProfileV1,
   createTrustedWorkspaceTrustForTesting,
   mcpCloseConfirmation,
@@ -44,6 +46,7 @@ import { ProcessTerminal, type Terminal } from "@earendil-works/pi-tui";
 import { createAdamCommandRegistry } from "./command-registry.js";
 import { type FixtureScenario, isFixtureScenario } from "./fixture-scenario.js";
 import { requireConfirmedLifecycleClose } from "./lifecycle-close.js";
+import { createProductionProjectRuntime, projectRuntimeManagedControl } from "./project-runtime.js";
 import { type ClipboardAdapter, type DeadlineScheduler, runTui } from "./tui-app.js";
 import { tuiProcessFailureMessage } from "./tui-process-failure.js";
 
@@ -255,6 +258,7 @@ export async function runTuiFixture(options: TuiFixtureOptions): Promise<void> {
   if (options.terminalProcessMarker !== undefined) {
     await writeFile(options.terminalProcessMarker, `${process.pid}\n`, "utf8");
   }
+  if (options.scenario === "managed-control") return runManagedControlProjectFixture(options);
   const modelTargets = createFixtureModelTargets(options);
   const preferences =
     options.launch === undefined
@@ -2641,4 +2645,135 @@ async function fileExists(path: string): Promise<boolean> {
     () => true,
     () => false,
   );
+}
+
+async function runManagedControlProjectFixture(options: TuiFixtureOptions): Promise<void> {
+  const controlRoot = options.controlRoot;
+  if (controlRoot === undefined)
+    throw new TypeError("Managed control fixture requires a causal control directory.");
+  const environment = { XDG_CONFIG_HOME: join(options.stateRoot, "fixture-config") };
+  const workspaceTrust = createWorkspaceTrust({
+    environment,
+    workspaceRoot: options.workspaceRoot,
+  });
+  const trust = await workspaceTrust.load();
+  if (trust.projectId === null) throw new Error("Fixture project identity unavailable.");
+  await workspaceTrust.setTrusted({ projectId: trust.projectId, trusted: true });
+  let mainCalls = 0;
+  let childCalls = 0;
+  const driver: ModelDriver = {
+    async *stream(request) {
+      if (request.purpose === "title") {
+        yield { type: "text_delta", text: "Control fixture" };
+        yield { type: "usage", inputTokens: 10, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+        return;
+      }
+      const main = request.tools.some(
+        (tool) => tool.name === "spawn_agents" || tool.name === "spawn_agent",
+      );
+      if (main) {
+        if (++mainCalls === 1) {
+          yield { type: "tool_call_start", id: "pty-spawn", name: "spawn_agents" };
+          yield {
+            type: "tool_call_delta",
+            id: "pty-spawn",
+            json: JSON.stringify({
+              entries: [
+                { role: "builtin:explore", task: "Inspect evidence.txt", description: "PTY child" },
+              ],
+            }),
+          };
+          yield { type: "tool_call_end", id: "pty-spawn" };
+          yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+          yield { type: "finish", reason: "tool_calls" };
+          return;
+        }
+        yield { type: "text_delta", text: mainCalls === 2 ? "MAIN_READY" : "MAIN_RESPONDED" };
+      } else {
+        childCalls += 1;
+        if (childCalls === 1) {
+          await writeFile(join(controlRoot, "child-started"), "started\n");
+          const released = await waitForFile(controlRoot, "release-child", request.signal);
+          if (!released) {
+            yield { type: "finish", reason: "stop" };
+            return;
+          }
+          yield { type: "tool_call_start", id: "pty-read", name: "read_file" };
+          yield { type: "tool_call_delta", id: "pty-read", json: '{"path":"evidence.txt"}' };
+          yield { type: "tool_call_end", id: "pty-read" };
+          yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+          yield { type: "finish", reason: "tool_calls" };
+          return;
+        }
+        const delivered = JSON.stringify(request.messages).includes("PTY child input");
+        await writeFile(
+          join(controlRoot, "child-request"),
+          JSON.stringify({ delivered, childCalls }),
+        );
+        yield {
+          type: "text_delta",
+          text:
+            childCalls === 2
+              ? delivered
+                ? "CHILD_DELIVERED"
+                : "CHILD_INPUT_MISSING"
+              : "FOLLOWUP_RESPONDED",
+        };
+      }
+      yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const modelTargets: ModelTargets = {
+    async resolve() {
+      return { identity: targetIdentity, contextProfile, driver };
+    },
+    async snapshot() {
+      return {
+        targets: [
+          {
+            identity: targetIdentity,
+            contextProfile,
+            readiness: { status: "available", credentialSource: "external fixture" },
+          },
+        ],
+      };
+    },
+  };
+  const runtime = await createProductionProjectRuntime({
+    [projectRuntimeManagedControl]: {
+      store: await createJsonlManagedAgentControlStore({
+        workspaceRoot: options.workspaceRoot,
+        stateRoot: options.stateRoot,
+      }),
+      childSessionStores: createJsonlSessionStoreDirectory<SessionRecord>({
+        workspaceRoot: options.workspaceRoot,
+        stateRoot: join(options.stateRoot, "managed-agent-sessions"),
+      }),
+    },
+    environment,
+    extensionPermissions: createPermissionPolicy({ allowedEffects: [] }),
+    modelTargets,
+    permissions: createPermissionPolicy({ allowedEffects: ["read", "delegate"] }),
+    preferences: createPresentationPreferences({ environment }),
+    projectLabel: "Control fixture",
+    reservedCommandNames: [],
+    stateRoot: options.stateRoot,
+    workspaceRoot: options.workspaceRoot,
+    workspaceTrust,
+  });
+  try {
+    const presentation = await runtime.createPresentation({ openProject: true });
+    options.onPresentationReady?.(presentation);
+    await runTui({
+      presentation,
+      startupTargetId: targetIdentity.targetId,
+      ...(options.terminal === undefined ? {} : { terminal: options.terminal }),
+      mouse: true,
+      closeRuntime: () => runtime.close(),
+    });
+  } finally {
+    await runtime.close();
+  }
 }

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -7,6 +7,7 @@ import type {
   ArtifactReference,
   BranchSourceBoundary,
   DraftPoint,
+  ManagedControlThread,
   OperationDisplay,
   PresentationCommand,
   PresentationSession,
@@ -18,6 +19,7 @@ import type {
   ThinkingPolicySelectionDisplay,
   TodoPageResource,
 } from "@adam-agent/presentation";
+import { defaultAgentUiSettings } from "@adam-agent/presentation";
 import {
   Box,
   type Component,
@@ -40,12 +42,16 @@ import {
   VStack,
 } from "@earendil-works/pi-tui";
 import PQueue from "p-queue";
+import { AgentConversationViewer } from "./agent-conversation-viewer.js";
+import { AgentFleet, AgentSessionTransition, AgentWorkspace } from "./agent-fleet.js";
 import { AgentNavigator, ManagedAgentRoster } from "./agent-navigator.js";
+import { AgentWidget } from "./agent-widget.js";
 import {
   ArtifactNavigator,
   activeChronologyArtifacts,
   activeChronologyDiffs,
 } from "./artifact-navigator.js";
+import { AttentionCenter, managedAttentionKey } from "./attention-center.js";
 import { ChronologyPicker, completeChronologyBoundaries } from "./chronology-picker.js";
 import { AdamAutocompleteProvider } from "./command-autocomplete.js";
 import {
@@ -344,6 +350,29 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     managedAgents: options.presentation.getState().authoritative.managedAgents,
     theme,
   });
+  const agentWidget = new AgentWidget(
+    theme,
+    () => Math.max(2, Math.min(12, Math.floor((physicalTerminal.rows - 8) / 2))),
+    {
+      scheduler: deadlineScheduler,
+      onChange: () => renderState(),
+      settings: () => options.presentation.getState().agentUiSettings ?? defaultAgentUiSettings,
+    },
+  );
+  const agentFleet = new AgentFleet({
+    theme,
+    onChange: () => tui.requestRender(),
+    onOpen: (thread) => showManagedConversation(thread),
+    hasDraft: (thread) =>
+      options.presentation
+        .getState()
+        .managedDrafts?.some(
+          (draft) =>
+            draft.threadId === thread.threadId && draft.parentSessionId === thread.parentSessionId,
+        ) ?? false,
+    maximumLines: () =>
+      Math.max(1, Math.min(7, physicalTerminal.rows - (physicalTerminal.columns < 80 ? 15 : 12))),
+  });
   const todoCompactViewModel = new TodoCompactViewModel();
   const todoCompactOverlay = new TodoCompactOverlay(todoCompactViewModel, theme);
   let todoCompactReadGeneration = 0;
@@ -464,6 +493,34 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         readonly navigator: AgentNavigator;
       }
     | undefined;
+  let agentConversation:
+    | {
+        readonly close: () => void;
+        readonly hide: () => void;
+        readonly viewer: AgentConversationViewer;
+        readonly pinnedTurnId?: string;
+        readonly threadId: string;
+      }
+    | undefined;
+  let agentConversationLoading:
+    | { readonly close: () => void; readonly hide: () => void }
+    | undefined;
+  let agentSessionTransition:
+    | {
+        readonly close: () => void;
+        readonly hide: () => void;
+        readonly id: string;
+        readonly view: AgentSessionTransition;
+      }
+    | undefined;
+  let agentWorkspace:
+    | {
+        readonly close: () => void;
+        readonly hide: () => void;
+        readonly focus: () => void;
+        readonly workspace: AgentWorkspace;
+      }
+    | undefined;
   let pendingManagedAgentInput:
     | {
         readonly action: "message" | "reply" | "follow_up" | "recovery";
@@ -473,6 +530,10 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         readonly attentionId?: string;
       }
     | undefined;
+  let attentionView: AttentionCenter | undefined;
+  let attentionOverlay: { readonly close: () => void; readonly hide: () => void } | undefined;
+  const dismissedAttention = new Set<string>();
+  let readyAgentConversation: (() => void) | undefined;
   let managedAgentFocusHandoffKey: "c" | "f" | "m" | "r" | null = null;
   let todoNavigatorGeneration = 0;
   let planActionOverlay:
@@ -490,8 +551,13 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     readonly hide: () => void;
   };
   const closeableOverlaysInPrecedence = (): readonly (CloseableOverlay | undefined)[] => [
+    attentionOverlay,
     planActionOverlay,
     helpNavigator,
+    agentSessionTransition,
+    agentConversation,
+    agentConversationLoading,
+    agentWorkspace,
     agentNavigator,
     todoNavigator,
     artifactNavigator,
@@ -509,6 +575,19 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   const focusedCloseableOverlay = (): CloseableOverlay | undefined =>
     closeableOverlaysInPrecedence().find((overlay) => overlay !== undefined);
   const hideSessionScopedOverlays = () => {
+    attentionOverlay?.hide();
+    attentionOverlay = undefined;
+    attentionView = undefined;
+    dismissedAttention.clear();
+    readyAgentConversation = undefined;
+    agentSessionTransition?.hide();
+    agentSessionTransition = undefined;
+    agentConversation?.hide();
+    agentConversation = undefined;
+    agentConversationLoading?.hide();
+    agentConversationLoading = undefined;
+    agentWorkspace?.hide();
+    agentWorkspace = undefined;
     planActionOverlay?.hide();
     planActionOverlay = undefined;
     dismissedPlanSubjectKey = undefined;
@@ -596,7 +675,16 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       component: managedAgentRoster,
       basis: "auto",
       minSize: 0,
-      visible: () => options.presentation.getState().authoritative.managedAgents.counts.active > 0,
+      visible: () =>
+        options.presentation.getState().authoritative.managedControl === undefined &&
+        options.presentation.getState().authoritative.managedAgents.counts.active > 0,
+    },
+    {
+      component: agentWidget,
+      basis: "auto",
+      minSize: 0,
+      shrink: 0,
+      visible: () => options.presentation.getState().authoritative.managedControl !== undefined,
     },
     {
       component: todoCompactOverlay,
@@ -625,6 +713,13 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         {
           component: statusLine,
           visible: () => statusNotice !== null,
+        },
+        {
+          component: agentFleet,
+          shrink: 0,
+          visible: () =>
+            options.presentation.getState().authoritative.managedControl !== undefined &&
+            options.presentation.getState().agentUiSettings?.fleetEnabled !== false,
         },
         footer,
       ]),
@@ -1343,6 +1438,55 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       ].join("\n"),
     );
     synchronizeTodoCompactOverlay(active);
+    agentWidget.setSnapshot(state.authoritative.managedControl);
+    agentWidget.setActivity(state.managedAgentActivity);
+    const visibleFleetThreads = [...agentWidget.visibleThreads()];
+    const viewingThread = state.authoritative.managedControl?.threads.find(
+      (thread) => thread.threadId === agentConversation?.threadId,
+    );
+    if (
+      viewingThread !== undefined &&
+      !visibleFleetThreads.some((thread) => thread.threadId === viewingThread.threadId)
+    )
+      visibleFleetThreads.push(viewingThread);
+    agentFleet.setSnapshot(state.authoritative.managedControl, visibleFleetThreads);
+    if (state.authoritative.managedControl !== undefined)
+      agentWorkspace?.workspace.setSnapshot(
+        state.authoritative.managedControl,
+        state.agentUiSettings ?? defaultAgentUiSettings,
+      );
+    if (agentConversation !== undefined) {
+      const selected = state.authoritative.managedControl?.threads.find(
+        (thread) => thread.threadId === agentConversation?.threadId,
+      );
+      if (selected !== undefined) {
+        const pinned = agentConversation.pinnedTurnId;
+        const turn =
+          pinned === undefined
+            ? undefined
+            : [...(selected.previousTurns ?? []), selected.turn].find(
+                (entry) => entry.turnId === pinned,
+              );
+        if (pinned === undefined) agentConversation.viewer.setThread(selected);
+        else if (turn !== undefined)
+          agentConversation.viewer.setThread({ ...selected, turn, actions: [] });
+      }
+      agentConversation.viewer.setCompletion(
+        state.authoritative.managedControl?.completions.find(
+          (entry) =>
+            entry.threadId === agentConversation?.threadId &&
+            entry.turnId === (agentConversation?.pinnedTurnId ?? selected?.turn.turnId),
+        ),
+      );
+      agentConversation.viewer.setExports(
+        state.authoritative.managedControl?.exports?.filter(
+          (entry) =>
+            entry.threadId === agentConversation?.threadId &&
+            entry.turnId === (agentConversation?.pinnedTurnId ?? selected?.turn.turnId),
+        ) ?? [],
+      );
+      agentConversation.viewer.setActivity(state.managedAgentActivity);
+    }
     managedAgentRoster.setManagedAgents(state.authoritative.managedAgents);
     agentNavigator?.navigator.setManagedAgents(
       state.authoritative.managedAgents,
@@ -1363,6 +1507,11 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     synchronizeDraftInputs(state.composer);
     const activeSessionChanged = active?.session.id !== previousActiveSessionId;
     if (activeSessionChanged) {
+      if (previousActiveSessionId !== undefined) {
+        sessionPicker?.hide();
+        sessionPicker = undefined;
+        sessionPickerRequested = false;
+      }
       transcriptViewport.followEnd();
       pendingOperationBaseline = null;
       expandedReasoningIds.clear();
@@ -1960,6 +2109,17 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           wide: `${theme.toolTitle(baseTitle)}${theme.text(` · ${action}`)}`,
         });
         tool.addChild(toolTitle);
+        for (const admission of item.managedAdmissions ?? []) {
+          tool.addChild(
+            new ResponsiveLine(
+              theme.toolOutput(
+                safeTerminalText(
+                  `${admission.status === "started" ? "Started" : "Queued"} ${admission.handle} · ${admission.displayName} · ${admission.description}`,
+                ),
+              ),
+            ),
+          );
+        }
         if (item.preview !== null) {
           tool.addChild(new ToolPreview(item.preview, expanded, theme));
         }
@@ -2230,6 +2390,79 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
             tui.requestRender();
           });
       }
+    }
+    const attention = state.managedAttention ?? [];
+    attentionView?.setItems(attention);
+    if (
+      attentionOverlay !== undefined &&
+      attention.length === 0 &&
+      !attentionView?.hasPendingInput()
+    ) {
+      attentionOverlay.hide();
+      attentionOverlay = undefined;
+    }
+    if (
+      permission === undefined &&
+      attentionOverlay === undefined &&
+      attention.some((item) => !dismissedAttention.has(managedAttentionKey(item)))
+    )
+      openAttentionCenter();
+    const managedTransition = state.authoritative.managedTransition;
+    if (
+      agentSessionTransition !== undefined &&
+      agentSessionTransition.id !== managedTransition?.id
+    ) {
+      agentSessionTransition.hide();
+      agentSessionTransition = undefined;
+    }
+    if (
+      managedTransition !== undefined &&
+      agentSessionTransition === undefined &&
+      permission === undefined &&
+      attentionOverlay === undefined
+    ) {
+      const view = new AgentSessionTransition({
+        transition: managedTransition,
+        theme,
+        onDecision(decision) {
+          view.setPending(decision);
+          tui.requestRender();
+          void options.presentation
+            .dispatch({
+              type: "resolve_managed_transition",
+              transitionId: managedTransition.id,
+              decision,
+            })
+            .then((receipt) => {
+              if (agentSessionTransition?.view !== view) return;
+              if (receipt.status === "rejected") view.setError(receipt.message);
+              renderState();
+            })
+            .catch(() => {
+              if (agentSessionTransition?.view === view) {
+                view.setError("The Session transition could not be confirmed.");
+                tui.requestRender();
+              }
+            });
+        },
+      });
+      const handle = showOverlay(view, { width: "80%", minWidth: 36, maxHeight: "85%", margin: 1 });
+      agentSessionTransition = {
+        id: managedTransition.id,
+        view,
+        close: () => view.cancel(),
+        hide: () => handle.hide(),
+      };
+    }
+    if (
+      permission === undefined &&
+      attentionOverlay === undefined &&
+      agentSessionTransition === undefined &&
+      readyAgentConversation !== undefined
+    ) {
+      const open = readyAgentConversation;
+      readyAgentConversation = undefined;
+      open();
     }
     if (
       active?.parentRun?.phase === "interrupted" ||
@@ -2933,7 +3166,362 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     clearNotice();
     tui.requestRender();
   };
-  const showAgentNavigator = (expectedSessionId: string): void => {
+  function openAttentionCenter(force = false): void {
+    const items = options.presentation.getState().managedAttention ?? [];
+    if (attentionOverlay !== undefined || (items.length === 0 && !attentionView?.hasPendingInput()))
+      return;
+    let handle: ReturnType<typeof showOverlay> | undefined;
+    const close = () => {
+      for (const item of options.presentation.getState().managedAttention ?? [])
+        dismissedAttention.add(managedAttentionKey(item));
+      handle?.hide();
+      attentionOverlay = undefined;
+      showNotice("info", "Attention pending · /agents", "until_next_action");
+      tui.requestRender();
+    };
+    if (attentionView === undefined)
+      attentionView = new AttentionCenter({
+        theme,
+        maximumLines: () => Math.max(6, Math.floor(physicalTerminal.rows * 0.85) - 4),
+        onPermission: (item, decision) =>
+          options.presentation.dispatch({
+            type: "managed_control",
+            commandId: randomUUID(),
+            command: {
+              type: "decide_permission",
+              parentSessionId: item.parentSessionId,
+              threadId: item.threadId,
+              expectedTurnId: item.turnId,
+              requestId: item.id,
+              decision,
+            },
+          }),
+        onReply: (item, text, inputId) =>
+          options.presentation.dispatch({
+            type: "managed_control",
+            commandId: randomUUID(),
+            command: {
+              type: "reply_agent",
+              parentSessionId: item.parentSessionId,
+              threadId: item.threadId,
+              expectedTurnId: item.turnId,
+              attentionId: item.id,
+              text,
+              inputId,
+            },
+          }),
+        onChange: () => renderState(),
+        onClose: () => attentionOverlay?.close(),
+      });
+    attentionView.setItems(items);
+    const fresh = items.find((item) => !dismissedAttention.has(managedAttentionKey(item)));
+    if (!force && fresh !== undefined) attentionView.focusItem(managedAttentionKey(fresh));
+    handle = showOverlay(attentionView, {
+      width: "90%",
+      minWidth: 36,
+      maxHeight: "85%",
+      margin: 1,
+    });
+    attentionOverlay = { close, hide: () => handle?.hide() };
+  }
+  function showManagedConversation(thread: ManagedControlThread, returnFocus?: () => void): void {
+    let cancelled = false;
+    const loading = showOverlay(
+      {
+        invalidate() {},
+        render: (width) => new Text("Loading agent conversation… · Esc cancel").render(width),
+        handleInput(data) {
+          if (matchesKey(data, "escape") && !isKeyRepeat(data) && !isKeyRelease(data)) close();
+        },
+      },
+      { width: "90%", minWidth: 36, maxHeight: "85%", margin: 1 },
+    );
+    const close = () => {
+      cancelled = true;
+      readyAgentConversation = undefined;
+      loading.hide();
+      agentConversationLoading = undefined;
+      if (
+        permission === undefined &&
+        attentionOverlay === undefined &&
+        agentSessionTransition === undefined
+      ) {
+        if (returnFocus === undefined && focusedCloseableOverlay() === undefined)
+          tui.setFocus(editor);
+        else returnFocus?.();
+      }
+      tui.requestRender();
+    };
+    agentConversationLoading = {
+      close,
+      hide: () => {
+        cancelled = true;
+        readyAgentConversation = undefined;
+        loading.hide();
+      },
+    };
+    void options.presentation
+      .dispatch({
+        type: "read_agent_draft",
+        sessionId: thread.parentSessionId,
+        threadId: thread.threadId,
+      })
+      .then((receipt) => {
+        if (
+          cancelled ||
+          options.presentation.getState().authoritative.active?.session.id !==
+            thread.parentSessionId
+        )
+          return;
+        const open = () => {
+          if (
+            cancelled ||
+            options.presentation.getState().authoritative.active?.session.id !==
+              thread.parentSessionId
+          )
+            return;
+          if (
+            permission !== undefined ||
+            attentionOverlay !== undefined ||
+            agentSessionTransition !== undefined
+          ) {
+            readyAgentConversation = open;
+            return;
+          }
+          loading.hide();
+          agentConversationLoading = undefined;
+          if (receipt.status === "rejected") {
+            showNotice("error", receipt.message, "until_next_action");
+            if (returnFocus === undefined && focusedCloseableOverlay() === undefined)
+              tui.setFocus(editor);
+            else returnFocus?.();
+            return;
+          }
+          if (receipt.managedDraft !== null && receipt.managedDraft !== undefined)
+            agentFleet.drafts.set(thread.threadId, receipt.managedDraft);
+          const current = options.presentation
+            .getState()
+            .authoritative.managedControl?.threads.find(
+              (entry) => entry.threadId === thread.threadId,
+            );
+          if (current !== undefined) showLoadedManagedConversation(current, returnFocus);
+        };
+        open();
+      })
+      .catch(() => {
+        if (!cancelled) {
+          close();
+          showNotice("error", "The private child draft is unavailable.", "until_next_action");
+        }
+      });
+  }
+  function showLoadedManagedConversation(
+    thread: ManagedControlThread,
+    returnFocus?: () => void,
+    readOnly = false,
+  ): void {
+    let handle: { hide(): void } | undefined;
+    const close = () => {
+      viewer.dispose();
+      handle?.hide();
+      agentConversation = undefined;
+      if (returnFocus === undefined) tui.setFocus(editor);
+      else returnFocus();
+      renderState();
+    };
+    const viewer = new AgentConversationViewer({
+      thread,
+      completion: options.presentation
+        .getState()
+        .authoritative.managedControl?.completions.find(
+          (entry) => entry.threadId === thread.threadId && entry.turnId === thread.turn.turnId,
+        ),
+      exports: options.presentation
+        .getState()
+        .authoritative.managedControl?.exports?.filter(
+          (entry) => entry.threadId === thread.threadId && entry.turnId === thread.turn.turnId,
+        ),
+      onExport: (selected, completion, fields) =>
+        options.presentation.dispatch({
+          type: "export_agent",
+          confirmed: true,
+          sessionId: selected.parentSessionId,
+          threadId: selected.threadId,
+          expectedTurnId: selected.turn.turnId,
+          completion: completion.receipt,
+          fields,
+        }),
+      onSeen: (completion) =>
+        options.presentation.dispatch({
+          type: "managed_control",
+          commandId: randomUUID(),
+          command: {
+            type: "mark_completion_seen",
+            parentSessionId: thread.parentSessionId,
+            threadId: completion.threadId,
+            expectedTurnId: completion.turnId,
+            completion: completion.receipt,
+          },
+        }),
+      onSuppress: (completion) =>
+        options.presentation.dispatch({
+          type: "managed_control",
+          commandId: randomUUID(),
+          command: {
+            type: "suppress_completion",
+            confirmed: true,
+            parentSessionId: thread.parentSessionId,
+            threadId: completion.threadId,
+            expectedTurnId: completion.turnId,
+            completion: completion.receipt,
+          },
+        }),
+      drafts: readOnly ? new Map() : agentFleet.drafts,
+      renderMode: options.presentation.getState().agentUiSettings?.viewerMode ?? "assistant",
+      onRenderMode: (viewerMode) =>
+        options.presentation.dispatch({
+          type: "set_agent_ui_settings",
+          settings: {
+            ...(options.presentation.getState().agentUiSettings ?? defaultAgentUiSettings),
+            viewerMode,
+          },
+        }),
+      theme,
+      activity: options.presentation
+        .getState()
+        .managedAgentActivity?.find(
+          (entry) => entry.agentId === thread.threadId && entry.attemptId === thread.turn.attemptId,
+        ),
+      maximumLines: () => Math.max(6, Math.floor(physicalTerminal.rows * 0.85) - 4),
+      onRead: async (selected, cursor) => {
+        const receipt = await options.presentation.dispatch({
+          type: "read_agent_conversation",
+          sessionId: selected.parentSessionId,
+          threadId: selected.threadId,
+          expectedTurnId: selected.turn.turnId,
+          cursor,
+        });
+        if (receipt.status === "rejected" || receipt.managedAgentTranscript === undefined)
+          throw new Error(
+            receipt.status === "rejected"
+              ? receipt.message
+              : "The bounded agent transcript is unavailable.",
+          );
+        return receipt.managedAgentTranscript;
+      },
+      onSend: (command) =>
+        options.presentation.dispatch({
+          type: "managed_control",
+          commandId: randomUUID(),
+          command,
+        }),
+      onSaveDraft: async (draft) => {
+        const receipt = await options.presentation.dispatch({ type: "save_agent_draft", draft });
+        if (receipt.status === "rejected") {
+          showNotice("error", receipt.message, "until_next_action");
+          throw new Error(receipt.message);
+        }
+      },
+      onClearDraft: async (draft) => {
+        const receipt = await options.presentation.dispatch({ type: "clear_agent_draft", draft });
+        if (receipt.status === "rejected") throw new Error(receipt.message);
+        return receipt.managedDraftCleared === true;
+      },
+      onReadResource: async (selected, resource, range) => {
+        const common = {
+          sessionId: selected.parentSessionId,
+          threadId: selected.threadId,
+          expectedTurnId: selected.turn.turnId,
+          range,
+        };
+        const receipt = await options.presentation.dispatch(
+          resource.kind === "artifact"
+            ? { ...common, type: "read_agent_artifact", artifact: resource.artifact }
+            : resource.kind === "input"
+              ? { ...common, type: "read_agent_input", inputId: resource.inputId }
+              : {
+                  ...common,
+                  type: "read_agent_content",
+                  kind: resource.kind,
+                  itemId: resource.itemId,
+                },
+        );
+        if (receipt.status === "rejected" || receipt.resource === null)
+          throw new Error(
+            receipt.status === "rejected"
+              ? receipt.message
+              : "The bounded agent resource is unavailable.",
+          );
+        return receipt.resource;
+      },
+      onChange: () => tui.requestRender(),
+      onClose: close,
+    });
+    handle = showOverlay(viewer, { width: "90%", minWidth: 36, maxHeight: "85%", margin: 1 });
+    agentConversation = {
+      close: () => viewer.back(),
+      hide: () => {
+        viewer.dispose();
+        handle?.hide();
+      },
+      viewer,
+      threadId: thread.threadId,
+      ...(readOnly ? { pinnedTurnId: thread.turn.turnId } : {}),
+    };
+  }
+
+  const showAgentNavigator = (
+    expectedSessionId: string,
+    initialView: "workspace" | "settings" | "history" = "workspace",
+  ): void => {
+    const snapshot = options.presentation.getState().authoritative.managedControl;
+    if (snapshot !== undefined && snapshot.parentSessionId === expectedSessionId) {
+      let handle: ReturnType<typeof showOverlay> | undefined;
+      const close = () => {
+        handle?.hide();
+        agentWorkspace = undefined;
+        tui.setFocus(editor);
+        tui.requestRender();
+      };
+      const workspace = new AgentWorkspace({
+        snapshot,
+        initialView,
+        settings: options.presentation.getState().agentUiSettings ?? defaultAgentUiSettings,
+        onSettings: (settings) =>
+          options.presentation.dispatch({ type: "set_agent_ui_settings", settings }),
+        onAttention: () => openAttentionCenter(true),
+        hasDraft: (thread) =>
+          options.presentation
+            .getState()
+            .managedDrafts?.some(
+              (draft) =>
+                draft.threadId === thread.threadId &&
+                draft.parentSessionId === thread.parentSessionId,
+            ) ?? false,
+        theme,
+        maximumLines: () => Math.max(4, Math.floor(physicalTerminal.rows * 0.85) - 4),
+        onChange: () => tui.requestRender(),
+        onClose: close,
+        onOpen: (thread, readOnly) =>
+          readOnly
+            ? showLoadedManagedConversation({ ...thread, actions: [] }, () => handle?.focus(), true)
+            : showManagedConversation(thread, () => handle?.focus()),
+        onDispatch: (command) =>
+          options.presentation.dispatch({
+            type: "managed_control",
+            commandId: randomUUID(),
+            command,
+          }),
+      });
+      handle = showOverlay(workspace, { width: "90%", minWidth: 36, maxHeight: "85%", margin: 1 });
+      agentWorkspace = {
+        close: () => workspace.back(),
+        hide: () => handle?.hide(),
+        focus: () => handle?.focus(),
+        workspace,
+      };
+      return;
+    }
     agentNavigator?.hide();
     agentNavigator = undefined;
     const actionId = showNotice(
@@ -2958,6 +3546,11 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
             expectedSessionId,
           );
           renderState();
+          return;
+        }
+        if (current.managedControl !== undefined) {
+          settleNotice(actionId, "info", "", "until_next_action", expectedSessionId);
+          showAgentNavigator(expectedSessionId, initialView);
           return;
         }
         let handle: { hide(): void } | undefined;
@@ -4652,11 +5245,22 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     if (
       parsedCommand.kind === "known" &&
       parsedCommand.command.id === "agents" &&
-      parsedCommand.argumentsText.length === 0
+      ["", "settings", "history", "attention"].includes(parsedCommand.argumentsText)
     ) {
       editor.setText("");
       editor.disableSubmit = false;
-      showAgentNavigator(active.session.id);
+      if (parsedCommand.argumentsText === "attention") {
+        openAttentionCenter(true);
+        return;
+      }
+      showAgentNavigator(
+        active.session.id,
+        parsedCommand.argumentsText === "settings"
+          ? "settings"
+          : parsedCommand.argumentsText === "history"
+            ? "history"
+            : "workspace",
+      );
       return;
     }
     if (
@@ -5487,6 +6091,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     }
     attempt(() => permission?.hide());
     attempt(() => working.stop());
+    attempt(() => agentWidget.dispose());
     attempt(() => thinking.stop());
     for (const loader of operationLoaders.values()) {
       attempt(() => loader.stop());
@@ -5583,6 +6188,21 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       return { consume: true };
     }
     if (
+      options.presentation.getState().authoritative.managedControl !== undefined &&
+      matchesKey(data, "escape") &&
+      (isKeyRepeat(data) || isKeyRelease(data))
+    )
+      return { consume: true };
+    if (
+      permission === undefined &&
+      focusedCloseableOverlay() === undefined &&
+      terminalSizeIsSupported(physicalTerminal.columns, physicalTerminal.rows) &&
+      options.presentation.getState().agentUiSettings?.fleetEnabled !== false &&
+      agentFleet.handleMainInput(data, editor.getText() === "")
+    ) {
+      return { consume: true };
+    }
+    if (
       !terminalSizeIsSupported(physicalTerminal.columns, physicalTerminal.rows) &&
       !commandRegistry.matchesInput(data, "interrupt")
     ) {
@@ -5594,6 +6214,20 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         }
       }
       return { consume: true };
+    }
+    if (
+      permission === undefined &&
+      (attentionOverlay !== undefined ||
+        agentConversation !== undefined ||
+        agentConversationLoading !== undefined ||
+        agentWorkspace !== undefined ||
+        agentSessionTransition !== undefined)
+    ) {
+      if (commandRegistry.matchesInput(data, "interrupt")) {
+        if (!isKeyRepeat(data) && !isKeyRelease(data)) focusedCloseableOverlay()?.close();
+        return { consume: true };
+      }
+      return undefined;
     }
     const recoveryActive = options.presentation.getState().authoritative.active;
     if (

--- a/packages/agent/src/artifact-store.ts
+++ b/packages/agent/src/artifact-store.ts
@@ -118,7 +118,19 @@ export type PlanArtifactSourceV1 = {
   readonly provenance: "model_submit_plan";
 };
 
+export type ManagedAgentExportArtifactSourceV1 = {
+  readonly type: "managed_agent_export";
+  readonly schemaVersion: 1;
+  readonly parentSessionId: string;
+  readonly threadId: string;
+  readonly turnId: string;
+  readonly completion: { readonly sequence: number; readonly digest: string };
+  readonly fields: readonly string[];
+  readonly provenance: "confirmed_agent_export";
+};
+
 export type ArtifactSource =
+  | ManagedAgentExportArtifactSourceV1
   | ChangePreviewArtifactSource
   | ExtensionArtifactSource
   | InputResourceArtifactSourceV1

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -93,6 +93,7 @@ export {
   presentationHistoryPageSize,
   presentationHydrationBarrier,
   presentationManagedAgentTranscriptPageSize,
+  presentationManagedControlReceiptBarrier,
   presentationRuntimeRefreshBarrier,
   presentationSessionRecordReader,
   resolvePresentationTerminalContext,

--- a/packages/agent/src/managed-agent-control.ts
+++ b/packages/agent/src/managed-agent-control.ts
@@ -1,4 +1,10 @@
-import type { ManagedControlCommand, ManagedControlReceipt } from "@adam-agent/presentation";
+import type {
+  ManagedAgentExport,
+  ManagedControlAction,
+  ManagedControlCommand,
+  ManagedControlReceipt,
+} from "@adam-agent/presentation";
+import { agentExportFields, presentationAgentExportMaximumBytes } from "@adam-agent/presentation";
 import type { ArtifactStore } from "./artifact-store.js";
 import type { PlanCycleSnapshot } from "./plan-mode.js";
 
@@ -18,7 +24,7 @@ import {
   managedAgentStorageQuota,
   sessionRecordCommittedBarrier,
 } from "./agent-session.js";
-import type { ModelDriver } from "./agent-session-contracts.js";
+import type { ModelDriver, RuntimeEvent } from "./agent-session-contracts.js";
 import type { ContextProfile } from "./context-profile.js";
 import {
   assertFleetReservation,
@@ -100,6 +106,15 @@ export type ManagedWorkspaceFrame = {
 };
 
 export type ManagedAgentControl = {
+  publishExport(
+    input: Omit<ManagedAgentExport, "artifact"> & { readonly content: string },
+  ): Promise<ManagedAgentExport>;
+  readInput(input: {
+    readonly parentSessionId: string;
+    readonly threadId: string;
+    readonly turnId: string;
+    readonly inputId: string;
+  }): Promise<string | undefined>;
   prepareDelegation(
     command: Extract<ManagedControlCommand, { type: "spawn_agents" }>,
   ): Promise<DelegationEnvelope>;
@@ -142,6 +157,27 @@ const validSpawnMode = (input: {
   entries: readonly unknown[];
 }) => input.mode !== "foreground" || input.entries.length === 1;
 const commandSchema = z.discriminatedUnion("type", [
+  z.strictObject({
+    type: z.literal("suppress_completion"),
+    confirmed: z.literal(true),
+    parentSessionId: z.uuid(),
+    threadId: z.uuid(),
+    expectedTurnId: z.uuid(),
+    completion: z.strictObject({
+      sequence: z.number().int().positive(),
+      digest: z.string().regex(/^sha256:[a-f0-9]{64}$/u),
+    }),
+  }),
+  z.strictObject({
+    type: z.literal("mark_completion_seen"),
+    parentSessionId: z.uuid(),
+    threadId: z.uuid(),
+    expectedTurnId: z.uuid(),
+    completion: z.strictObject({
+      sequence: z.number().int().positive(),
+      digest: z.string().regex(/^sha256:[a-f0-9]{64}$/u),
+    }),
+  }),
   z.strictObject({
     type: z.enum(["suspend_agents", "resume_agents"]),
     parentSessionId: z.uuid(),
@@ -286,7 +322,11 @@ export function createManagedAgentControl(options: {
   readonly executionDomain: ProjectExecutionDomain;
   readonly store: ManagedControlStore;
   readonly childSessionStores: SessionStoreDirectory<SessionRecord>;
-  readonly admissionGuard?: <T>(operation: () => Promise<T>) => Promise<T>;
+  readonly onChildRuntimeEvent?: (identity: ManagedControlIdentity, event: RuntimeEvent) => void;
+  readonly admissionGuard?: <T>(
+    operation: () => Promise<T>,
+    constraints?: { readonly requireIdleMain: true },
+  ) => Promise<T>;
   readonly artifactStore?: ArtifactStore;
   readonly policy?: FleetPolicy;
   readonly readPlan?: () => Promise<PlanCycleSnapshot | undefined>;
@@ -401,7 +441,7 @@ export function createManagedAgentControl(options: {
           childSessionId,
           schemaVersion: 3,
           sequence: Number.MAX_SAFE_INTEGER,
-          event: { type: "started" },
+          event: { type: "started", atUnixMilliseconds: Number.MAX_SAFE_INTEGER },
         },
       ])
     );
@@ -462,8 +502,9 @@ export function createManagedAgentControl(options: {
     admittingTurnId?: string,
   ): Promise<ManagedWorkspaceSnapshot> => {
     const snapshot = foldManagedControl(records, parentSessionId);
+    const policyAllowsInput = await currentCeilingAllows();
     const threads = await Promise.all(
-      snapshot.threads.map((thread) => {
+      snapshot.threads.map(async (thread) => {
         const local = active.get(thread.threadId)?.attemptId === thread.turn.attemptId;
         const warm =
           local || ready.has(thread.turn.turnId) || admittingTurnId === thread.turn.turnId;
@@ -473,12 +514,23 @@ export function createManagedAgentControl(options: {
           thread.turn.waitReason !== "plan" &&
           thread.turn.phase !== "idle" &&
           thread.turn.outcome === undefined;
-        return inspectManagedChildReceipt(
+        const inspected = await inspectManagedChildReceipt(
           {
             ...thread,
+            budget: fleetBudget(
+              records,
+              thread.turn.envelope?.threadTokens ?? policy.threadTokens,
+              (record) => record.threadId === thread.threadId,
+              new Set([...active.values()].map((entry) => entry.turnId)),
+            ),
             residency: live ? "live" : "unloaded",
             turn: {
               ...thread.turn,
+              ...(local &&
+              !thread.turn.hasStarted &&
+              (thread.turn.phase === "queued" || thread.turn.waitReason === "suspended")
+                ? { phase: "starting" as const, label: "Starting" }
+                : {}),
               recovery:
                 !warm &&
                 (thread.turn.phase !== "idle" ||
@@ -506,6 +558,118 @@ export function createManagedAgentControl(options: {
             (record) => record.turnId === thread.turn.turnId && record.event.type === "admitted",
           ),
         );
+        const actions: ManagedControlAction[] = [];
+        let recoveryDiagnostic = inspected.turn.diagnostic;
+        if (!closing && inspected.lifecycle === "open") {
+          if (local && inspected.turn.attention?.kind === "permission") actions.push("permission");
+          if (inspected.turn.phase !== "idle" && inspected.turn.outcome === undefined)
+            actions.push("cancel");
+          if (inspected.turn.phase === "idle") actions.push("close");
+          if (policyAllowsInput && inspected.turn.recovery === "none") {
+            if (
+              local &&
+              inspected.turn.hasStarted &&
+              inspected.turn.phase !== "idle" &&
+              inspected.turn.phase !== "settling" &&
+              inspected.turn.outcome === undefined
+            ) {
+              actions.push("cooperative", "interrupt");
+              if (inspected.turn.attention?.kind === "parent_input") actions.push("reply");
+            }
+            const origin = records.find(
+              (entry) => entry.threadId === thread.threadId && entry.event.type === "admitted",
+            );
+            const attempts = records.filter(
+              (entry) => entry.threadId === thread.threadId && entry.event.type === "admitted",
+            ).length;
+            if (
+              inspected.turn.phase === "idle" &&
+              inspected.turn.hasStarted &&
+              inspected.turn.outcome !== undefined &&
+              origin?.event.type === "admitted" &&
+              origin.event.frozen !== undefined &&
+              origin.event.envelope !== undefined &&
+              attempts <
+                Math.min(policy.maximumAttempts, origin.event.envelope.policy.maximumAttempts) &&
+              (inspected.budget?.available ?? 0) > 0
+            )
+              actions.push("new_turn");
+          }
+        }
+        if (
+          !closing &&
+          !local &&
+          !warm &&
+          inspected.lifecycle === "open" &&
+          inspected.turn.diagnostic === undefined &&
+          inspected.turn.recovery === "required"
+        ) {
+          const admission = records.find(
+            (entry) => entry.turnId === thread.turn.turnId && entry.event.type === "admitted",
+          );
+          if (inspected.turn.outcome !== undefined) actions.push("recover");
+          else if (
+            admission?.event.type === "admitted" &&
+            admission.event.envelope !== undefined &&
+            policyAllowsInput &&
+            inspected.turn.health !== "stalled" &&
+            admission.event.frozen !== undefined &&
+            isDeepStrictEqual(admission.event.frozen.targetIdentity, options.targetIdentity) &&
+            isDeepStrictEqual(admission.event.frozen.contextProfile, options.contextProfile)
+          ) {
+            try {
+              const childRecords = await (
+                await options.childSessionStores.open(admission.childSessionId)
+              )?.read();
+              if (childRecords === undefined && !thread.turn.hasStarted) actions.push("resume");
+              else if (childRecords !== undefined && childRecords[0] !== undefined) {
+                validateManagedChildGenesis(admission, childRecords[0]);
+                const terminal = await managedChildTerminalResult(
+                  childRecords,
+                  options.workspaceRoot,
+                  options.artifactStore,
+                );
+                if (terminal !== undefined) actions.push("recover");
+                else if (
+                  !records.some(
+                    (entry) =>
+                      entry.turnId === admission.turnId &&
+                      (entry.event.type === "cancel_requested" || entry.event.type === "stalled"),
+                  ) &&
+                  (childRecords.length === 1 ||
+                    prepareManagedChildResume(
+                      childRecords,
+                      childTools(admission),
+                      options.workspaceRoot,
+                    ) !== undefined)
+                )
+                  actions.push("resume");
+                else recoveryDiagnostic = "This interrupted effect cannot be replayed safely.";
+              }
+            } catch (error) {
+              if (!(error instanceof SessionStoreError || error instanceof SessionLifecycleError))
+                throw error;
+              recoveryDiagnostic = "Child history is unavailable. Inspect durable state.";
+            }
+          }
+        }
+        if (!closing && policyAllowsInput && ceilingWaits.has(thread.turn.turnId))
+          actions.push("resume");
+        return {
+          ...inspected,
+          actions,
+          ...(recoveryDiagnostic === undefined
+            ? {}
+            : {
+                turn: {
+                  ...inspected.turn,
+                  diagnostic: recoveryDiagnostic,
+                  ...(!actions.includes("resume") && inspected.turn.waitReason === "suspended"
+                    ? { label: "Suspended · Inspect or cancel" }
+                    : {}),
+                },
+              }),
+        };
       }),
     );
     return {
@@ -521,6 +685,11 @@ export function createManagedAgentControl(options: {
     };
   };
   const append = async (identity: ManagedControlIdentity, event: ManagedControlEvent) => {
+    if (
+      (event.type === "started" || event.type === "outcome") &&
+      event.atUnixMilliseconds === undefined
+    )
+      event = { ...event, atUnixMilliseconds: (options.now ?? Date.now)() };
     const history = await controlStore.read();
     const terminal =
       event.type === "outcome" ||
@@ -1192,6 +1361,11 @@ export function createManagedAgentControl(options: {
         let lastAssistantDelta: string | undefined;
         const lastReasoning = new Map<string, string>();
         const unsubscribe = child.subscribe((event) => {
+          try {
+            options.onChildRuntimeEvent?.(identity, event);
+          } catch {
+            /* Presentation cannot change execution. */
+          }
           if (
             event.type === "model_message_delta" &&
             event.text.length > 0 &&
@@ -1359,6 +1533,7 @@ export function createManagedAgentControl(options: {
   };
   const startReady = async () => {
     if (closing) return;
+    let launched = false;
     const records = await controlStore.read();
     const selected = selectManagedStarts(
       foldManagedControl(records, options.parentSessionId),
@@ -1413,6 +1588,11 @@ export function createManagedAgentControl(options: {
         recovery?.store,
         recovery?.resume,
       );
+      launched = true;
+    }
+    if (launched) {
+      const snapshot = await project(await controlStore.read(), options.parentSessionId);
+      for (const subscriber of subscribers) subscriber({ type: "reset", snapshot });
     }
   };
   const rejected = (
@@ -1420,6 +1600,90 @@ export function createManagedAgentControl(options: {
     message: string,
   ): ManagedControlReceipt => ({ status: "rejected", code, message });
   const control: ManagedAgentControl = {
+    async publishExport(input) {
+      return authorized(async () => {
+        const bytes = Buffer.from(input.content, "utf8");
+        if (
+          input.parentSessionId !== options.parentSessionId ||
+          options.artifactStore === undefined ||
+          bytes.byteLength > presentationAgentExportMaximumBytes ||
+          input.fields.length === 0 ||
+          input.fields.some((field) => !agentExportFields.includes(field)) ||
+          new Set(input.fields).size !== input.fields.length
+        )
+          throw new TypeError("The bounded export request is invalid.");
+        const records = await controlStore.read();
+        const completion = records.find(
+          (entry) =>
+            entry.threadId === input.threadId &&
+            entry.turnId === input.turnId &&
+            entry.event.type === "completion",
+        );
+        if (
+          completion === undefined ||
+          !isDeepStrictEqual(managedControlLink(completion), input.completion)
+        )
+          throw new TypeError("The exact export completion is unavailable.");
+        const saved = await options.artifactStore.write({
+          bytes,
+          mediaType: "application/json",
+          source: {
+            type: "managed_agent_export",
+            schemaVersion: 1,
+            parentSessionId: input.parentSessionId,
+            threadId: input.threadId,
+            turnId: input.turnId,
+            completion: input.completion,
+            fields: input.fields,
+            provenance: "confirmed_agent_export",
+          },
+        });
+        if (
+          saved.byteCount !== bytes.byteLength ||
+          saved.mediaType !== "application/json" ||
+          !/^sha256:[a-f0-9]{64}$/u.test(saved.id)
+        )
+          throw new TypeError("The export artifact receipt is invalid.");
+        const artifact: ManagedAgentExport["artifact"] = {
+          id: saved.id,
+          byteCount: saved.byteCount,
+          mediaType: "application/json",
+          source: "agent_export",
+        };
+        if (
+          !records.some(
+            (entry) => entry.event.type === "exported" && entry.event.artifact.id === artifact.id,
+          )
+        )
+          await append(completion, {
+            type: "exported",
+            completion: input.completion,
+            fields: input.fields,
+            artifact,
+          });
+        return {
+          parentSessionId: input.parentSessionId,
+          threadId: input.threadId,
+          turnId: input.turnId,
+          completion: input.completion,
+          fields: input.fields,
+          artifact,
+        };
+      });
+    },
+    async readInput(input) {
+      if (input.parentSessionId !== options.parentSessionId)
+        throw new TypeError("The input belongs to another parent Session.");
+      await serial;
+      const record = (await controlStore.read()).find(
+        (entry) =>
+          entry.parentSessionId === input.parentSessionId &&
+          entry.threadId === input.threadId &&
+          entry.turnId === input.turnId &&
+          managedAcceptedInput(entry)?.inputId === input.inputId,
+      );
+      return record === undefined ? undefined : managedAcceptedInput(record)?.text;
+    },
     async prepareDelegation(command) {
       const records = await controlStore.read();
       const sessionTokens = fleetSessionCeiling(records, policy);
@@ -1510,15 +1774,38 @@ export function createManagedAgentControl(options: {
       try {
         const snapshot = await control.inspect({ parentSessionId });
         let revision = snapshot.revision;
+        let highestReadyRevision = snapshot.status === "ready" ? snapshot.revision : 0;
+        let deliveredSnapshot = snapshot;
         yield { type: "snapshot", snapshot };
         while (!signal.aborted) {
-          const frame = pending.shift();
+          let frame = pending.shift();
           if (frame === undefined) {
             await wake.promise;
             wake = Promise.withResolvers<void>();
             continue;
           }
+          // A delayed initial read can already include queued liveness resets. Failure resets
+          // remain visible without allowing older healthy snapshots to restore stale authority.
+          if (frame.snapshot.status === "ready" && frame.snapshot.revision < highestReadyRevision)
+            continue;
           if (frame.type !== "reset" && frame.snapshot.revision <= revision) continue;
+          if (
+            frame.type === "reset" &&
+            frame.snapshot.status === "ready" &&
+            frame.snapshot.revision === highestReadyRevision
+          ) {
+            // Liveness can change without a journal append. Reproject at this head so an
+            // older queued reset cannot undo the initial snapshot's current owner state.
+            const current = await control.inspect({ parentSessionId });
+            if (signal.aborted) break;
+            if (
+              current.status === "ready" &&
+              (current.revision > frame.snapshot.revision ||
+                isDeepStrictEqual(current, deliveredSnapshot))
+            )
+              continue;
+            frame = { type: "reset", snapshot: current };
+          }
           yield {
             ...frame,
             type:
@@ -1527,6 +1814,9 @@ export function createManagedAgentControl(options: {
                 : "change",
           };
           revision = frame.snapshot.revision;
+          deliveredSnapshot = frame.snapshot;
+          if (frame.snapshot.status === "ready")
+            highestReadyRevision = Math.max(highestReadyRevision, revision);
         }
       } finally {
         subscribers.delete(subscriber);
@@ -1539,11 +1829,24 @@ export function createManagedAgentControl(options: {
         const receipt = await (options.admissionGuard !== undefined &&
         (command.type === "spawn_agents" ||
           command.type === "next_turn" ||
-          command.type === "recover_turn")
-          ? options.admissionGuard(execute)
+          command.type === "recover_turn" ||
+          command.type === "suppress_completion")
+          ? options.admissionGuard(
+              execute,
+              command.type === "suppress_completion" ? { requireIdleMain: true } : undefined,
+            )
           : execute());
         return await joinForeground(command, receipt, dispatchOptions);
       } catch (error) {
+        if (
+          error instanceof ProjectExecutionDomainError &&
+          error.code === "root_conflict" &&
+          command.type === "suppress_completion"
+        )
+          return rejected(
+            "authority_busy",
+            "Main is active. Suppress after the current run settles.",
+          );
         if (error instanceof ProjectExecutionDomainError)
           return rejected(
             error.code === "root_conflict" || error.code === "project_in_use"
@@ -1698,6 +2001,58 @@ export function createManagedAgentControl(options: {
             "Suspension is durable but running cleanup requires recovery.",
           )
         : { status: "suspended" };
+    }
+    if (command.type === "suppress_completion") {
+      if (options.admissionGuard === undefined)
+        return rejected("action_unavailable", "The Main admission owner is unavailable.");
+      // The family guard encloses reconciliation and the following serialized mutation.
+      const reconciled = await control.dispatch({
+        type: "prepare_main_delivery",
+        parentSessionId: command.parentSessionId,
+      });
+      if (reconciled.status === "rejected") return reconciled;
+      return authorized(async () => {
+        const records = await controlStore.read();
+        const snapshot = foldManagedControl(records, command.parentSessionId);
+        const completion = snapshot.completions.find(
+          (entry) => entry.threadId === command.threadId && entry.turnId === command.expectedTurnId,
+        );
+        if (completion === undefined || !isDeepStrictEqual(completion.receipt, command.completion))
+          return rejected("stale_revision", "The exact completion receipt changed.");
+        if (completion.consumption === "consumed")
+          return rejected("action_unavailable", "Main has already consumed this completion.");
+        if (completion.consumption === "pending") {
+          const record = records.find((entry) => entry.sequence === completion.receipt.sequence);
+          if (record === undefined)
+            return rejected("recovery_required", "The completion receipt is unavailable.");
+          await append(record, { type: "suppressed", completion: command.completion });
+        }
+        return { status: "acknowledged" as const };
+      });
+    }
+    if (command.type === "mark_completion_seen") {
+      return authorized(async () => {
+        const records = await controlStore.read();
+        const completion = records.find(
+          (entry) =>
+            entry.parentSessionId === command.parentSessionId &&
+            entry.threadId === command.threadId &&
+            entry.turnId === command.expectedTurnId &&
+            entry.event.type === "completion",
+        );
+        if (
+          completion === undefined ||
+          !isDeepStrictEqual(managedControlLink(completion), command.completion)
+        )
+          return rejected("stale_revision", "The exact completion receipt changed.");
+        if (
+          !records.some(
+            (entry) => entry.turnId === command.expectedTurnId && entry.event.type === "seen",
+          )
+        )
+          await append(completion, { type: "seen", completion: command.completion });
+        return { status: "acknowledged" as const };
+      });
     }
     if (command.type === "close_thread") {
       return serialized(async () => {
@@ -2360,8 +2715,32 @@ export function createManagedAgentControl(options: {
           const snapshot = await project(await controlStore.read(), options.parentSessionId);
           for (const subscriber of subscribers) subscriber({ type: "reset", snapshot });
           await startReady();
+          const admittedThreads = foldManagedControl(
+            await controlStore.read(),
+            options.parentSessionId,
+          ).threads;
           return {
             status: "admitted" as const,
+            admissions: records.map((record) => {
+              const thread = admittedThreads.find(
+                (candidate) =>
+                  candidate.threadId === record.threadId && candidate.turn.turnId === record.turnId,
+              );
+              if (thread === undefined)
+                throw new Error("The admitted thread is missing from its canonical batch.");
+              return {
+                threadId: thread.threadId,
+                turnId: thread.turn.turnId,
+                handle: thread.handle,
+                displayName: thread.displayName,
+                description: thread.description,
+                lane,
+                status:
+                  active.has(thread.threadId) || thread.turn.hasStarted
+                    ? ("started" as const)
+                    : ("queued" as const),
+              };
+            }),
             turns: records.map(
               ({ parentSessionId, threadId, turnId, attemptId, childSessionId }) => ({
                 parentSessionId,
@@ -3103,9 +3482,23 @@ function managedToolContainsCompletion(
     !Array.isArray(output.results)
   )
     return false;
-  return output.results.some((result) =>
-    isDeepStrictEqual(result, { ...completion, consumption: "pending" }),
-  );
+  const { userSeen: _seen, consumption: _consumption, ...immutable } = completion;
+  return output.results.some((result) => {
+    if (
+      typeof result !== "object" ||
+      result === null ||
+      !("consumption" in result) ||
+      (result.consumption !== "pending" && result.consumption !== "suppressed")
+    )
+      return false;
+    const { consumption: _resultConsumption, ...remaining } = result;
+    if ("userSeen" in remaining) {
+      if (remaining.userSeen !== true) return false;
+      const { userSeen: _resultSeen, ...payload } = remaining;
+      return isDeepStrictEqual(payload, immutable);
+    }
+    return isDeepStrictEqual(remaining, immutable);
+  });
 }
 
 function managedControlMessageDigest(

--- a/packages/agent/src/managed-agent-folds.ts
+++ b/packages/agent/src/managed-agent-folds.ts
@@ -1,10 +1,12 @@
 import type {
+  ManagedAgentExport,
   ManagedControlIdentity,
   ManagedControlLink,
   ManagedControlOutcome,
   ManagedControlThread,
   ManagedWorkspaceSnapshot,
 } from "@adam-agent/presentation";
+import { agentExportFields, presentationAgentExportMaximumBytes } from "@adam-agent/presentation";
 
 export type {
   ManagedControlIdentity,
@@ -49,6 +51,13 @@ export const managedControlFrozenSchema = z.strictObject({
 export type ManagedControlFrozen = z.infer<typeof managedControlFrozenSchema>;
 
 export type ManagedControlEvent =
+  | {
+      readonly type: "exported";
+      readonly completion: ManagedControlLink;
+      readonly fields: ManagedAgentExport["fields"];
+      readonly artifact: ManagedAgentExport["artifact"];
+    }
+  | { readonly type: "seen" | "suppressed"; readonly completion: ManagedControlLink }
   | { readonly type: "admission_paused"; readonly reason: "plan" }
   | { readonly type: "suspend_requested" | "thread_closed" }
   | {
@@ -102,7 +111,7 @@ export type ManagedControlEvent =
       readonly frozen?: ManagedControlFrozen;
       readonly envelope?: DelegationEnvelope;
     }
-  | { readonly type: "started" }
+  | { readonly type: "started"; readonly atUnixMilliseconds?: number }
   | { readonly type: "cancel_requested" }
   | {
       readonly type: "execution_progress";
@@ -209,7 +218,26 @@ const eventSchema = z.discriminatedUnion("type", [
     frozen: managedControlFrozenSchema.optional(),
     envelope: delegationEnvelopeSchema.optional(),
   }),
-  z.strictObject({ type: z.literal("started") }),
+  z.strictObject({
+    type: z.literal("exported"),
+    completion: linkSchema,
+    fields: z
+      .array(z.enum(agentExportFields))
+      .min(1)
+      .max(agentExportFields.length)
+      .refine((fields) => new Set(fields).size === fields.length),
+    artifact: z.strictObject({
+      id: z.string().regex(/^sha256:[a-f0-9]{64}$/u),
+      mediaType: z.literal("application/json"),
+      byteCount: z.number().int().positive().max(presentationAgentExportMaximumBytes),
+      source: z.literal("agent_export"),
+    }),
+  }),
+  z.strictObject({ type: z.enum(["seen", "suppressed"]), completion: linkSchema }),
+  z.strictObject({
+    type: z.literal("started"),
+    atUnixMilliseconds: z.number().int().nonnegative().optional(),
+  }),
   z.strictObject({ type: z.literal("cancel_requested") }),
   z.strictObject({
     type: z.literal("execution_progress"),
@@ -230,6 +258,7 @@ const eventSchema = z.discriminatedUnion("type", [
   }),
   z.strictObject({
     type: z.literal("outcome"),
+    atUnixMilliseconds: z.number().int().nonnegative().optional(),
     artifact: z
       .strictObject({
         id: z.string().regex(/^sha256:[a-f0-9]{64}$/u),
@@ -311,7 +340,10 @@ export function validateManagedControlRecord(
       (entry) =>
         entry.event.type !== "provider_reserved" &&
         entry.event.type !== "provider_usage" &&
-        entry.event.type !== "provider_unknown",
+        entry.event.type !== "provider_unknown" &&
+        entry.event.type !== "seen" &&
+        entry.event.type !== "suppressed" &&
+        entry.event.type !== "exported",
     );
     if (last !== undefined && last.event.type !== "completion" && last.event.type !== "consumed")
       return invalid();
@@ -333,6 +365,34 @@ export function validateManagedControlRecord(
       admission.childSessionId !== record.childSessionId
     )
       return invalid();
+    if (record.event.type === "exported") {
+      const event = record.event;
+      const completion = turnRecords.find((entry) => entry.event.type === "completion");
+      if (
+        completion === undefined ||
+        event.completion.sequence !== completion.sequence ||
+        event.completion.digest !== managedControlDigest(completion) ||
+        turnRecords.some(
+          (entry) =>
+            entry.event.type === "exported" && entry.event.artifact.id === event.artifact.id,
+        )
+      )
+        return invalid();
+      return record;
+    }
+    if (record.event.type === "seen" || record.event.type === "suppressed") {
+      const completion = turnRecords.find((entry) => entry.event.type === "completion");
+      if (
+        completion === undefined ||
+        record.event.completion.sequence !== completion.sequence ||
+        record.event.completion.digest !== managedControlDigest(completion) ||
+        turnRecords.some((entry) => entry.event.type === record.event.type) ||
+        (record.event.type === "suppressed" &&
+          turnRecords.some((entry) => entry.event.type === "consumed"))
+      )
+        return invalid();
+      return record;
+    }
     if (
       record.event.type === "admission_paused" ||
       record.event.type === "suspend_requested" ||
@@ -455,7 +515,10 @@ export function validateManagedControlRecord(
         entry.event.type !== "provider_reserved" &&
         entry.event.type !== "provider_usage" &&
         entry.event.type !== "provider_unknown" &&
-        entry.event.type !== "budget_blocked",
+        entry.event.type !== "budget_blocked" &&
+        entry.event.type !== "seen" &&
+        entry.event.type !== "suppressed" &&
+        entry.event.type !== "exported",
     );
     const event = record.event;
     if (
@@ -535,6 +598,9 @@ export function foldManagedControl(
       event.type === "input_undelivered" ||
       event.type === "budget_blocked" ||
       event.type === "consumed" ||
+      event.type === "seen" ||
+      event.type === "suppressed" ||
+      event.type === "exported" ||
       event.type === "provider_reserved" ||
       event.type === "provider_usage" ||
       event.type === "provider_unknown"
@@ -544,6 +610,9 @@ export function foldManagedControl(
       const existing = threads.get(record.threadId);
       threads.set(record.threadId, {
         parentSessionId,
+        ...(existing === undefined
+          ? {}
+          : { previousTurns: [...(existing.previousTurns ?? []), existing.turn] }),
         lifecycle: "open",
         displayName: "Explore",
         handle: existing?.handle ?? `@explore-${threads.size + 1}`,
@@ -568,6 +637,7 @@ export function foldManagedControl(
                   parentBranchId: event.frozen.parentBranchId,
                   targetId: event.frozen.targetIdentity.targetId,
                   thinking: event.frozen.thinkingPolicy?.effectiveLevelId ?? "default",
+                  contextWindowTokens: event.frozen.contextProfile.contextWindowTokens,
                 },
               }),
           health: "healthy",
@@ -615,6 +685,15 @@ export function foldManagedControl(
     }
     if (event.type === "capacity_wait" || event.type === "capacity_acquired") {
       const turn = { ...thread.turn };
+      const question =
+        event.type === "capacity_wait" && event.reason === "parent_input"
+          ? records.find(
+              (entry) =>
+                entry.turnId === record.turnId &&
+                entry.event.type === "parent_input_requested" &&
+                entry.event.id === event.requestId,
+            )
+          : undefined;
       delete turn.attention;
       threads.set(record.threadId, {
         ...thread,
@@ -635,7 +714,15 @@ export function foldManagedControl(
           ...(event.type === "capacity_wait" &&
           event.requestId !== undefined &&
           (event.reason === "permission" || event.reason === "parent_input")
-            ? { attention: { id: event.requestId, kind: event.reason } }
+            ? {
+                attention: {
+                  id: event.requestId,
+                  kind: event.reason,
+                  ...(question?.event.type === "parent_input_requested"
+                    ? { question: question.event.text }
+                    : {}),
+                },
+              }
             : {}),
           ...(turn.watchdog === undefined
             ? {}
@@ -703,7 +790,14 @@ export function foldManagedControl(
       residency: phase === "idle" ? "unloaded" : "live",
       turn: {
         ...previousTurn,
-        ...(event.type === "started" ? { hasStarted: true as const } : {}),
+        ...(event.type === "started"
+          ? {
+              hasStarted: true as const,
+              ...(event.atUnixMilliseconds === undefined
+                ? {}
+                : { startedAtUnixMilliseconds: event.atUnixMilliseconds }),
+            }
+          : {}),
         phase,
         ownerPhase:
           phase === "settling" ? "releasing" : phase === "executing" ? "claimed" : "released",
@@ -734,6 +828,20 @@ export function foldManagedControl(
     });
   }
   return {
+    exports: records.flatMap((record) =>
+      record.parentSessionId === parentSessionId && record.event.type === "exported"
+        ? [
+            {
+              parentSessionId,
+              threadId: record.threadId,
+              turnId: record.turnId,
+              completion: record.event.completion,
+              fields: record.event.fields,
+              artifact: record.event.artifact,
+            },
+          ]
+        : [],
+    ),
     completions: records.flatMap((record) => {
       if (record.parentSessionId !== parentSessionId || record.event.type !== "completion")
         return [];
@@ -749,11 +857,18 @@ export function foldManagedControl(
           turnId: record.turnId,
           receipt: managedControlLink(record),
           outcome: outcome.event,
+          ...(records.some((entry) => entry.turnId === record.turnId && entry.event.type === "seen")
+            ? { userSeen: true as const }
+            : {}),
           consumption: records.some(
             (entry) => entry.turnId === record.turnId && entry.event.type === "consumed",
           )
             ? ("consumed" as const)
-            : ("pending" as const),
+            : records.some(
+                  (entry) => entry.turnId === record.turnId && entry.event.type === "suppressed",
+                )
+              ? ("suppressed" as const)
+              : ("pending" as const),
         },
       ];
     }),

--- a/packages/agent/src/managed-agent-recovery.ts
+++ b/packages/agent/src/managed-agent-recovery.ts
@@ -159,9 +159,12 @@ export function managedOutcomeFromChild(
     blocked?.event.type === "budget_blocked"
       ? { code: blocked.event.code, message: blocked.event.message }
       : undefined;
+  const suspension = turnRecords.findLast((record) => record.event.type === "suspend_requested");
+  const execution = turnRecords.findLast(
+    (record) => record.event.type === "started" || record.event.type === "capacity_acquired",
+  );
   const suspended =
-    turnRecords.some((record) => record.event.type === "suspend_requested") &&
-    turnRecords.some((record) => record.event.type === "started");
+    suspension !== undefined && execution !== undefined && suspension.sequence > execution.sequence;
   const stalled = turnRecords.some((record) => record.event.type === "stalled");
   const provider = records.findLast(
     (record) => record.schemaVersion === 3 && record.record.type === "provider_attempt_started",

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { join } from "node:path";
+import { isDeepStrictEqual } from "node:util";
 
 import type {
   ArtifactChunk,
@@ -7,6 +8,9 @@ import type {
   ArtifactReference,
   AuthoritativePresentationSnapshot,
   CommandReceipt,
+  ManagedAttentionItem,
+  ManagedControlCommand,
+  ManagedControlReceipt,
   McpDisplay,
   PendingInteraction,
   PresentationCommand,
@@ -21,6 +25,10 @@ import type {
   TranscriptItem,
 } from "@adam-agent/presentation";
 import {
+  agentExportFields,
+  defaultAgentUiSettings,
+  isAgentUiSettings,
+  presentationAgentExportMaximumBytes,
   presentationArtifactPageMaximumBytes,
   reconcilePresentationUpdate,
   resolveSkillMentions,
@@ -59,6 +67,7 @@ import {
 import { listProjectPaths } from "./project-path-catalog.js";
 import {
   createRecoverableTurnDraftRepository,
+  parseManagedComposerDraft,
   type RecoverableTurnDraftRepository,
   type TurnDraftScopeV1,
 } from "./recoverable-turn-draft.js";
@@ -116,6 +125,10 @@ export const presentationArtifactReadBarrier = Symbol(
 export const presentationSessionRecordReader = Symbol(
   "adam-agent.presentation-session-record-reader",
 );
+/** Tests only: delay a returned receipt after the real Control command has completed. */
+export const presentationManagedControlReceiptBarrier = Symbol(
+  "adam-agent.presentation-managed-control-receipt-barrier",
+);
 
 export type PresentationHydrationBarrier = {
   afterAdmissionSnapshot?(): Promise<void>;
@@ -154,6 +167,10 @@ type PresentationSessionBaseOptions = {
   readonly [presentationRuntimeRefreshBarrier]?: PresentationRuntimeRefreshBarrier;
   readonly [presentationArtifactReadBarrier]?: PresentationArtifactReadBarrier;
   readonly [presentationSessionRecordReader]?: PresentationSessionRecordReader;
+  readonly [presentationManagedControlReceiptBarrier]?: (
+    command: ManagedControlCommand,
+    receipt: ManagedControlReceipt,
+  ) => Promise<void>;
   readonly [presentationHistoryPageSize]?: number;
   readonly [presentationCatalogPageSize]?: number;
   readonly [presentationManagedAgentTranscriptPageSize]?: number;
@@ -431,6 +448,9 @@ export async function createPresentationSession(
       );
     };
     let configuredPreferences = await options.preferences?.load();
+    let agentUiSettings =
+      (await options.preferences?.loadAgentUi?.().catch(() => defaultAgentUiSettings)) ??
+      defaultAgentUiSettings;
     let configuredWebSearch = await webSearchConfiguration?.load();
     let configuredTargetContexts = await projectConfiguredTargetContexts(configuredPreferences);
     let preferenceDiagnostic = resolvePreferenceDiagnostic(configuredPreferences);
@@ -621,6 +641,7 @@ export async function createPresentationSession(
       : "New session required for attachments";
     let planRevisionIntent: PresentationDisplayState["composer"]["revisionIntent"] = null;
     let state: PresentationDisplayState = {
+      agentUiSettings,
       revision: 1,
       authoritative,
       draft:
@@ -646,6 +667,9 @@ export async function createPresentationSession(
       transient: null,
     };
     let managedAgentActivity: NonNullable<PresentationDisplayState["managedAgentActivity"]> = [];
+    let hydrateManagedDrafts = async (
+      _snapshot: NonNullable<PresentationDisplayState["authoritative"]["managedControl"]>,
+    ) => {};
     let draftTargetIdentity: ModelTargetIdentity | null = initialDraft?.targetIdentity ?? null;
     const metadataThrough = new Map<string, number>();
     if (created !== undefined) {
@@ -666,6 +690,128 @@ export async function createPresentationSession(
         }
       }
     };
+    const attentionMetadata = new Map<
+      string,
+      {
+        readonly interaction: Extract<PendingInteraction, { readonly type: "permission" }> | null;
+        readonly diagnostic?: string;
+      }
+    >();
+    const attentionReads = new Map<string, Promise<void>>();
+    const attentionKey = (parent: string, thread: string, turn: string, id: string) =>
+      `${parent}:${thread}:${turn}:${id}`;
+    const managedAttention = (): readonly ManagedAttentionItem[] => {
+      const snapshot = state.authoritative.managedControl;
+      if (
+        snapshot === undefined ||
+        snapshot.parentSessionId !== state.authoritative.active?.session.id
+      )
+        return [];
+      return snapshot.threads.flatMap((thread): ManagedAttentionItem[] => {
+        const attention = thread.turn.attention;
+        if (attention === undefined) return [];
+        const common = {
+          id: attention.id,
+          parentSessionId: thread.parentSessionId,
+          threadId: thread.threadId,
+          turnId: thread.turn.turnId,
+          handle: thread.handle,
+          displayName: thread.displayName,
+          description: thread.description,
+        };
+        if (attention.kind === "parent_input")
+          return [
+            {
+              ...common,
+              kind: "parent_input",
+              available:
+                attention.question !== undefined && (thread.actions?.includes("reply") ?? false),
+              question: attention.question ?? "The exact parent question is unavailable.",
+            },
+          ];
+        const metadata = attentionMetadata.get(
+          attentionKey(thread.parentSessionId, thread.threadId, thread.turn.turnId, attention.id),
+        );
+        return [
+          {
+            ...common,
+            kind: "permission",
+            available: metadata !== undefined && (thread.actions?.includes("permission") ?? false),
+            interaction: metadata?.interaction ?? null,
+            ...(metadata?.diagnostic === undefined
+              ? metadata === undefined
+                ? { diagnostic: "Loading exact permission…" }
+                : {}
+              : { diagnostic: metadata.diagnostic }),
+          },
+        ];
+      });
+    };
+    const refreshManagedAttention = (
+      snapshot: NonNullable<AuthoritativePresentationSnapshot["managedControl"]>,
+    ) => {
+      const keys = new Set(
+        snapshot.threads.flatMap((thread) =>
+          thread.turn.attention?.kind === "permission"
+            ? [
+                attentionKey(
+                  thread.parentSessionId,
+                  thread.threadId,
+                  thread.turn.turnId,
+                  thread.turn.attention.id,
+                ),
+              ]
+            : [],
+        ),
+      );
+      for (const key of attentionMetadata.keys()) if (!keys.has(key)) attentionMetadata.delete(key);
+      for (const thread of snapshot.threads) {
+        const attention = thread.turn.attention;
+        if (attention?.kind !== "permission") continue;
+        const key = attentionKey(
+          thread.parentSessionId,
+          thread.threadId,
+          thread.turn.turnId,
+          attention.id,
+        );
+        if (attentionMetadata.has(key) || attentionReads.has(key)) continue;
+        const current = () =>
+          !closed &&
+          state.authoritative.active?.session.id === thread.parentSessionId &&
+          state.authoritative.managedControl?.threads.some(
+            (entry) =>
+              entry.threadId === thread.threadId &&
+              entry.turn.turnId === thread.turn.turnId &&
+              entry.turn.attention?.id === attention.id,
+          );
+        const read = (async () => {
+          try {
+            const child = await options.lifecycle[sessionManagedAgentTranscriptReader]({
+              sessionId: thread.parentSessionId,
+              threadId: thread.threadId,
+              turnId: thread.turn.turnId,
+            });
+            const interaction = projectPendingPermissionCandidates(
+              child.records.map((entry) => ({ sessionId: child.childSessionId, entry })),
+            ).find((entry) => entry.requestId === attention.id);
+            if (interaction === undefined)
+              throw new TypeError("The exact permission is unavailable.");
+            if (current()) attentionMetadata.set(key, { interaction });
+          } catch {
+            if (current())
+              attentionMetadata.set(key, {
+                interaction: null,
+                diagnostic: "Permission details unavailable. Inspect the thread.",
+              });
+          }
+          if (current()) {
+            state = { ...state, revision: state.revision + 1 };
+            publishStateChange();
+          }
+        })().finally(() => attentionReads.delete(key));
+        attentionReads.set(key, read);
+      }
+    };
     const observeManagedControl = async (parentSessionId: string) => {
       if (controlObserverParent === parentSessionId) return;
       controlObserver?.abort();
@@ -674,23 +820,39 @@ export async function createPresentationSession(
       controlObserverParent = parentSessionId;
       const control = await options.lifecycle[sessionManagedControl](parentSessionId);
       if (control === undefined || observer.signal.aborted) return;
+      const firstFrame = Promise.withResolvers<void>();
       controlObservation = (async () => {
         for await (const frame of control.observe({ parentSessionId, signal: observer.signal })) {
           if (
             closed ||
             observer.signal.aborted ||
             state.authoritative.active?.session.id !== parentSessionId
-          )
+          ) {
+            firstFrame.resolve();
             return;
+          }
           state = {
             ...state,
             revision: state.revision + 1,
             authoritative: { ...state.authoritative, managedControl: frame.snapshot },
           };
+          managedAgentActivity = managedAgentActivity.filter((activity) =>
+            frame.snapshot.threads.some(
+              (thread) =>
+                thread.threadId === activity.agentId &&
+                thread.turn.attemptId === activity.attemptId &&
+                thread.turn.phase !== "idle",
+            ),
+          );
+          void hydrateManagedDrafts(frame.snapshot);
+          refreshManagedAttention(frame.snapshot);
           publishStateChange();
+          firstFrame.resolve();
         }
+        firstFrame.resolve();
       })();
-      void controlObservation.catch(() => undefined);
+      void controlObservation.catch((error: unknown) => firstFrame.reject(error));
+      await firstFrame.promise;
     };
     if (created !== undefined) {
       const selected = await options.lifecycle[sessionManagedTransition]({
@@ -809,6 +971,43 @@ export async function createPresentationSession(
             projectId: state.authoritative.project.id,
             stateRoot: effectiveSessionStateRoot(options.stateRoot),
           });
+    const managedDrafts = new Map<
+      string,
+      import("@adam-agent/presentation").ManagedComposerDraft
+    >();
+    const loadedManagedDrafts = new Set<string>();
+    const managedDraftWrites = new Set<Promise<unknown>>();
+    const managedDraftKey = (parentSessionId: string, threadId: string) =>
+      `${parentSessionId}:${threadId}`;
+    hydrateManagedDrafts = async (snapshot) => {
+      const fresh = snapshot.threads.filter(
+        (thread) =>
+          !loadedManagedDrafts.has(managedDraftKey(thread.parentSessionId, thread.threadId)),
+      );
+      for (const thread of fresh)
+        loadedManagedDrafts.add(managedDraftKey(thread.parentSessionId, thread.threadId));
+      await Promise.all(
+        fresh.map(async (thread) => {
+          try {
+            const draft = await recoverableDrafts?.loadManaged(thread);
+            if (draft !== undefined && draft !== null && draft.text.length > 0)
+              managedDrafts.set(managedDraftKey(draft.parentSessionId, draft.threadId), draft);
+          } catch {
+            /* Explicit draft reads retain the diagnostic and refuse overwriting invalid data. */
+          }
+        }),
+      );
+      if (
+        fresh.length > 0 &&
+        !closed &&
+        state.authoritative.active?.session.id === snapshot.parentSessionId
+      ) {
+        state = { ...state, revision: state.revision + 1 };
+        publishStateChange();
+      }
+    };
+    if (state.authoritative.managedControl !== undefined)
+      await hydrateManagedDrafts(state.authoritative.managedControl);
     const currentDraftScope = (): TurnDraftScopeV1 | null => {
       const active = state.authoritative.active;
       if (active !== null) {
@@ -1665,12 +1864,23 @@ export async function createPresentationSession(
       if (closed || active === null || active.session.id !== parentSessionId) {
         return;
       }
-      refreshManagedAgents(parentSessionId);
+      if (state.authoritative.managedControl === undefined) refreshManagedAgents(parentSessionId);
       if (notification.type === "state_changed") {
         return;
       }
       if (notification.type === "child_runtime_event") {
         const { agentId, attemptId, childSessionId, event } = notification;
+        if (
+          state.authoritative.managedControl !== undefined &&
+          !state.authoritative.managedControl.threads.some(
+            (thread) =>
+              thread.threadId === agentId &&
+              thread.turn.attemptId === attemptId &&
+              thread.turn.childSessionId === childSessionId &&
+              thread.turn.phase !== "idle",
+          )
+        )
+          return;
         const current = managedAgentActivity.find(
           (activity) => activity.agentId === agentId && activity.attemptId === attemptId,
         );
@@ -1684,6 +1894,14 @@ export async function createPresentationSession(
             assistant: { itemId: `${attemptId}:assistant`, text: "" },
           };
         } else if (event.type === "model_message_delta") {
+          const text = boundedManagedAgentActivityText(
+            `${current?.assistant?.text ?? ""}${event.text}`,
+            16 * 1024,
+          );
+          const totalByteCount =
+            (current?.assistant?.totalByteCount ??
+              Buffer.byteLength(current?.assistant?.text ?? "", "utf8")) +
+            Buffer.byteLength(event.text, "utf8");
           projected = {
             agentId,
             attemptId,
@@ -1691,10 +1909,13 @@ export async function createPresentationSession(
             activity: "replying",
             assistant: {
               itemId: current?.assistant?.itemId ?? `${attemptId}:assistant`,
-              text: boundedManagedAgentActivityText(
-                `${current?.assistant?.text ?? ""}${event.text}`,
-                16 * 1024,
-              ),
+              text,
+              ...(state.authoritative.managedControl === undefined
+                ? {}
+                : {
+                    totalByteCount,
+                    omittedBytes: totalByteCount - Buffer.byteLength(text, "utf8"),
+                  }),
             },
           };
         } else if (event.type === "model_reasoning_started") {
@@ -2432,6 +2653,28 @@ export async function createPresentationSession(
           if (transition !== undefined) return transition;
         }
       }
+      if (command.type === "set_agent_ui_settings") {
+        if (command.settings !== null && !isAgentUiSettings(command.settings))
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message: "Agent UI settings are invalid.",
+          };
+        try {
+          await options.preferences?.setAgentUi?.(command.settings);
+          agentUiSettings = command.settings ?? defaultAgentUiSettings;
+          state = { ...state, revision: state.revision + 1, agentUiSettings };
+          publishStateChange();
+          return { status: "admitted", commandId: randomUUID(), resource: null };
+        } catch (error) {
+          return {
+            status: "rejected",
+            code: "action_unavailable",
+            message:
+              error instanceof Error ? error.message : "Agent UI settings could not be saved.",
+          };
+        }
+      }
       if (command.type === "managed_control") {
         const parentSessionId = command.command.parentSessionId;
         if (state.authoritative.active?.session.id !== parentSessionId)
@@ -2450,12 +2693,504 @@ export async function createPresentationSession(
         await observeManagedControl(parentSessionId);
         const receipt = await control.dispatch(command.command);
         if (receipt.status === "rejected") return receipt;
+        await options[presentationManagedControlReceiptBarrier]?.(command.command, receipt);
         return {
           status: "admitted",
           commandId: command.commandId,
           resource: null,
           control: receipt,
         };
+      }
+      if (
+        command.type === "read_agent_draft" ||
+        command.type === "save_agent_draft" ||
+        command.type === "clear_agent_draft"
+      ) {
+        const parentSessionId =
+          command.type === "read_agent_draft" ? command.sessionId : command.draft.parentSessionId;
+        const threadId =
+          command.type === "read_agent_draft" ? command.threadId : command.draft.threadId;
+        if (
+          state.authoritative.active?.session.id !== parentSessionId ||
+          !state.authoritative.managedControl?.threads.some(
+            (thread) => thread.threadId === threadId,
+          )
+        )
+          return {
+            status: "rejected",
+            code: "stale_revision",
+            message: "The selected child draft does not belong to the active Session.",
+          };
+        const key = managedDraftKey(parentSessionId, threadId);
+        try {
+          if (command.type === "read_agent_draft") {
+            await Promise.all(managedDraftWrites);
+            const draft =
+              recoverableDrafts === null
+                ? (managedDrafts.get(key) ?? null)
+                : await recoverableDrafts.loadManaged({ parentSessionId, threadId });
+            return {
+              status: "admitted",
+              commandId: randomUUID(),
+              resource: null,
+              managedDraft: draft,
+            };
+          }
+          const draft = parseManagedComposerDraft(command.draft);
+          const mutation = (async () => {
+            let cleared = false;
+            if (command.type === "clear_agent_draft") {
+              cleared =
+                recoverableDrafts === null
+                  ? !managedDrafts.has(key) || isDeepStrictEqual(managedDrafts.get(key), draft)
+                  : await recoverableDrafts.clearManaged(draft);
+              if (cleared) managedDrafts.delete(key);
+            } else {
+              await recoverableDrafts?.saveManaged(draft);
+              if (draft.text.length === 0) managedDrafts.delete(key);
+              else managedDrafts.set(key, draft);
+            }
+            state = { ...state, revision: state.revision + 1 };
+            publishStateChange();
+            return cleared;
+          })();
+          managedDraftWrites.add(mutation);
+          try {
+            return {
+              status: "admitted",
+              commandId: randomUUID(),
+              resource: null,
+              managedDraftCleared: await mutation,
+            };
+          } finally {
+            managedDraftWrites.delete(mutation);
+          }
+        } catch {
+          return {
+            status: "rejected",
+            code: "persistence_failed",
+            message:
+              "The private child draft could not be read or saved. Your current text is retained.",
+          };
+        }
+      }
+      if (command.type === "read_agent_conversation") {
+        const thread = state.authoritative.managedControl?.threads.find(
+          (entry) => entry.threadId === command.threadId,
+        );
+        if (state.authoritative.active?.session.id !== command.sessionId || thread === undefined)
+          return {
+            status: "rejected",
+            code: "stale_revision",
+            message: "The selected agent conversation is no longer current.",
+          };
+        const prefix = `agent-conversation:${command.sessionId}:${command.threadId}:${command.expectedTurnId}:`;
+        const cursor = command.cursor?.startsWith(prefix)
+          ? command.cursor.slice(prefix.length).match(/^(\d+):(\d+)$/u)
+          : null;
+        if (command.cursor !== null && cursor === null)
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message: "The agent conversation cursor is invalid.",
+          };
+        try {
+          const child = await options.lifecycle[sessionManagedAgentTranscriptReader]({
+            sessionId: command.sessionId,
+            threadId: command.threadId,
+            turnId: command.expectedTurnId,
+            ...(cursor === null ? {} : { throughSequence: Number(cursor[1]) }),
+          });
+          if (child.identity === undefined)
+            throw new TypeError("The exact child identity is unavailable.");
+          const items = projectManagedAgentTranscript(child);
+          const end = cursor === null ? items.length : Number(cursor[2]);
+          if (!Number.isSafeInteger(end) || end < 0 || end > items.length)
+            return {
+              status: "rejected",
+              code: "invalid_command",
+              message: "The agent conversation cursor is invalid.",
+            };
+          const throughSequence = child.records.at(-1)?.sequence ?? 0;
+          const start = Math.max(0, end - managedAgentTranscriptPageSize);
+          return {
+            status: "admitted",
+            commandId: randomUUID(),
+            resource: null,
+            managedAgentTranscript: {
+              type: "managed_agent_transcript_page",
+              agentId: thread.threadId,
+              turnId: command.expectedTurnId,
+              attemptId: child.identity.attemptId,
+              childSessionId: child.childSessionId,
+              throughSequence,
+              cursor: `${prefix}${throughSequence}:${end}`,
+              items: items.slice(start, end),
+              olderCursor: start === 0 ? null : `${prefix}${throughSequence}:${start}`,
+            },
+          };
+        } catch {
+          return {
+            status: "rejected",
+            code: "recovery_required",
+            message: "The agent transcript is unavailable. Inspect durable state.",
+          };
+        }
+      }
+      if (command.type === "export_agent") {
+        if (
+          command.confirmed !== true ||
+          !Array.isArray(command.fields) ||
+          command.fields.length === 0 ||
+          command.fields.length > agentExportFields.length ||
+          command.fields.some((field) => !agentExportFields.includes(field)) ||
+          new Set(command.fields).size !== command.fields.length
+        )
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message: "Confirm a finite export field selection.",
+          };
+        if (
+          state.authoritative.active?.session.id !== command.sessionId ||
+          options.stateRoot === undefined
+        )
+          return {
+            status: "rejected",
+            code: "stale_revision",
+            message: "The export Session is no longer active.",
+          };
+        try {
+          const control = await options.lifecycle[sessionManagedControl](command.sessionId);
+          const snapshot = await control?.inspect({ parentSessionId: command.sessionId });
+          const completion = snapshot?.completions.find(
+            (entry) =>
+              entry.threadId === command.threadId && entry.turnId === command.expectedTurnId,
+          );
+          const thread = snapshot?.threads.find((entry) => entry.threadId === command.threadId);
+          const turn =
+            thread === undefined
+              ? undefined
+              : [...(thread.previousTurns ?? []), thread.turn].find(
+                  (entry) => entry.turnId === command.expectedTurnId,
+                );
+          if (
+            control === undefined ||
+            completion === undefined ||
+            thread === undefined ||
+            turn === undefined ||
+            !isDeepStrictEqual(completion.receipt, command.completion)
+          )
+            return {
+              status: "rejected",
+              code: "stale_revision",
+              message: "The exact export completion changed.",
+            };
+          const emptyCancellation =
+            !turn.hasStarted &&
+            turn.recovery === "none" &&
+            completion.outcome.status === "cancelled" &&
+            completion.outcome.transcript.sequence === 0;
+          const child = emptyCancellation
+            ? undefined
+            : await options.lifecycle[sessionManagedAgentTranscriptReader]({
+                sessionId: command.sessionId,
+                threadId: command.threadId,
+                turnId: command.expectedTurnId,
+              });
+          const items = child === undefined ? [] : projectManagedAgentTranscript(child);
+          const common = {
+            sessionId: command.sessionId,
+            threadId: command.threadId,
+            expectedTurnId: command.expectedTurnId,
+          };
+          const fields = agentExportFields.filter((field) => command.fields.includes(field));
+          const output: Partial<Record<(typeof agentExportFields)[number], unknown>> = {};
+          const preview = (page: ArtifactChunk) => ({
+            text: page.text,
+            totalByteCount: page.totalByteCount,
+            omittedBytes: page.totalByteCount - page.byteCount,
+          });
+          const read = async (request: PresentationCommand) => {
+            const receipt = await dispatch(request);
+            if (receipt.status === "rejected" || receipt.resource === null)
+              throw new Error(
+                receipt.status === "rejected"
+                  ? receipt.message
+                  : "The selected export resource is unavailable.",
+              );
+            return receipt.resource;
+          };
+          for (const field of fields) {
+            if (field === "summary") {
+              output.summary = {
+                role: thread.role,
+                handle: thread.handle,
+                description: thread.description,
+                status: completion.outcome.status,
+                usage: completion.outcome.usage,
+                configuration: turn.configuration ?? null,
+              };
+            } else if (field === "result") {
+              const artifact = completion.outcome.artifact;
+              const page =
+                artifact === undefined
+                  ? readManagedInlinePage(
+                      completion.outcome.summary,
+                      { offset: 0, maximumBytes: presentationArtifactPageMaximumBytes },
+                      "text/plain; charset=utf-8",
+                    )
+                  : await read({
+                      ...common,
+                      type: "read_agent_artifact",
+                      artifact: { ...artifact, source: "model_response" },
+                      range: { offset: 0, maximumBytes: presentationArtifactPageMaximumBytes },
+                    });
+              output.result = preview(page);
+            } else {
+              const candidates = items.filter((item) =>
+                field === "conversation"
+                  ? item.type === "assistant_message"
+                  : field === "tools"
+                    ? item.type === "tool_call"
+                    : item.type === "reasoning_block",
+              );
+              const exported: {
+                readonly id: string;
+                readonly text: string;
+                readonly totalByteCount: number;
+                readonly omittedBytes: number;
+              }[] = [];
+              let remaining = presentationArtifactPageMaximumBytes;
+              for (const item of candidates.slice(0, 32)) {
+                if (remaining < 4) break;
+                const range = { offset: 0, maximumBytes: remaining };
+                const page =
+                  field === "conversation" && item.type === "assistant_message"
+                    ? item.text !== null
+                      ? readManagedInlinePage(item.text, range, "text/plain; charset=utf-8")
+                      : item.artifact !== null
+                        ? await read({
+                            ...common,
+                            type: "read_agent_artifact",
+                            artifact: item.artifact,
+                            range,
+                          })
+                        : undefined
+                    : await read({
+                        ...common,
+                        type: "read_agent_content",
+                        kind: field === "tools" ? "tool" : "reasoning",
+                        itemId: item.id,
+                        range,
+                      });
+                if (page === undefined)
+                  throw new Error("The selected export resource is unavailable.");
+                exported.push({ id: item.id, ...preview(page) });
+                remaining -= page.byteCount;
+              }
+              output[field] = {
+                items: exported,
+                omittedItems: candidates.length - exported.length,
+              };
+            }
+          }
+          const content = `${JSON.stringify({ format: "adam.agent-export.v1", identity: { parentSessionId: command.sessionId, threadId: command.threadId, turnId: command.expectedTurnId, completion: command.completion }, limits: { fieldBytes: presentationArtifactPageMaximumBytes, fieldItems: 32 }, fields: output }, null, 2)}\n`;
+          if (Buffer.byteLength(content, "utf8") > presentationAgentExportMaximumBytes)
+            return {
+              status: "rejected",
+              code: "not_available",
+              message: "The selected export exceeds its bounded document size.",
+            };
+          const agentExport = await control.publishExport({
+            parentSessionId: command.sessionId,
+            threadId: command.threadId,
+            turnId: command.expectedTurnId,
+            completion: command.completion,
+            fields,
+            content,
+          });
+          return { status: "admitted", commandId: randomUUID(), resource: null, agentExport };
+        } catch (error) {
+          return {
+            status: "rejected",
+            code: "not_available",
+            message:
+              error instanceof Error
+                ? error.message
+                : "The selected export resources are unavailable.",
+          };
+        }
+      }
+      if (
+        command.type === "read_agent_content" ||
+        command.type === "read_agent_artifact" ||
+        command.type === "read_agent_input"
+      ) {
+        if (
+          state.authoritative.active?.session.id !== command.sessionId ||
+          !state.authoritative.managedControl?.threads.some(
+            (thread) => thread.threadId === command.threadId,
+          )
+        )
+          return {
+            status: "rejected",
+            code: "stale_revision",
+            message: "The selected agent resource does not belong to the active Session.",
+          };
+        if (!isBoundedPresentationArtifactRange(command.range))
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message: "The agent resource range is invalid.",
+          };
+        try {
+          if (
+            command.type === "read_agent_artifact" &&
+            command.artifact.source === "agent_export"
+          ) {
+            const permitted = state.authoritative.managedControl?.exports?.some(
+              (entry) =>
+                entry.threadId === command.threadId &&
+                entry.turnId === command.expectedTurnId &&
+                sameArtifactReference(entry.artifact, command.artifact),
+            );
+            if (!permitted || options.stateRoot === undefined)
+              return {
+                status: "rejected",
+                code: "not_available",
+                message: "The export artifact does not belong to this exact agent turn.",
+              };
+            return {
+              status: "admitted",
+              commandId: randomUUID(),
+              resource: await readPresentationArtifact({
+                artifact: command.artifact,
+                range: command.range,
+                stateRoot: options.stateRoot,
+                barrier: options[presentationArtifactReadBarrier],
+              }),
+            };
+          }
+          if (command.type === "read_agent_input") {
+            const control = await options.lifecycle[sessionManagedControl](command.sessionId);
+            const text = await control?.readInput({
+              parentSessionId: command.sessionId,
+              threadId: command.threadId,
+              turnId: command.expectedTurnId,
+              inputId: command.inputId,
+            });
+            if (text === undefined)
+              return {
+                status: "rejected",
+                code: "not_available",
+                message: "The exact input receipt is unavailable.",
+              };
+            return {
+              status: "admitted",
+              commandId: randomUUID(),
+              resource: readManagedInlinePage(text, command.range, "text/plain; charset=utf-8"),
+            };
+          }
+          const child = await options.lifecycle[sessionManagedAgentTranscriptReader]({
+            sessionId: command.sessionId,
+            threadId: command.threadId,
+            turnId: command.expectedTurnId,
+          });
+          const projected = projectManagedAgentTranscript(child, "detail");
+          let text: string | undefined;
+          let artifact: ArtifactReference | undefined;
+          let mediaType = "text/plain; charset=utf-8";
+          if (command.type === "read_agent_artifact") {
+            const ordinary = projectManagedAgentTranscript(child);
+            const lastAnswer = projected.findLast((item) => item.type === "assistant_message");
+            const derived =
+              lastAnswer?.type === "assistant_message" && lastAnswer.text !== null
+                ? {
+                    id: `sha256:${createHash("sha256").update(lastAnswer.text, "utf8").digest("hex")}`,
+                    byteCount: Buffer.byteLength(lastAnswer.text, "utf8"),
+                    mediaType: "text/plain; charset=utf-8",
+                    source: "model_response" as const,
+                  }
+                : undefined;
+            if (
+              !managedTranscriptContainsArtifact(ordinary, command.artifact) &&
+              (derived === undefined || !sameArtifactReference(derived, command.artifact))
+            )
+              return {
+                status: "rejected",
+                code: "not_available",
+                message: "The artifact does not belong to this exact agent transcript.",
+              };
+            artifact = command.artifact;
+          } else {
+            const item = projected.find((entry) => entry.id === command.itemId);
+            if (command.kind === "reasoning" && item?.type === "reasoning_block") {
+              text = item.text ?? undefined;
+              artifact = item.artifact ?? undefined;
+            } else if (command.kind === "tool" && item?.type === "tool_call") {
+              const response = child.records.findLast(
+                (record) =>
+                  record.schemaVersion === 3 &&
+                  record.record.type === "model_response_completed" &&
+                  record.record.response.toolCalls.some((call) => call.id === item.callId),
+              );
+              const call =
+                response?.schemaVersion === 3 && response.record.type === "model_response_completed"
+                  ? response.record.response.toolCalls.find((entry) => entry.id === item.callId)
+                  : undefined;
+              const result = child.records.findLast(
+                (record) =>
+                  record.schemaVersion === 3 &&
+                  record.record.type === "runtime_event" &&
+                  (record.record.event.type === "tool_completed" ||
+                    record.record.event.type === "tool_failed") &&
+                  record.record.event.callId === item.callId,
+              );
+              text = JSON.stringify(
+                {
+                  name: item.qualifiedName,
+                  status: item.status,
+                  argumentsJson: call?.argumentsJson ?? null,
+                  result:
+                    result?.schemaVersion === 3 &&
+                    result.record.type === "runtime_event" &&
+                    (result.record.event.type === "tool_completed" ||
+                      result.record.event.type === "tool_failed")
+                      ? result.record.event
+                      : null,
+                },
+                null,
+                2,
+              );
+              mediaType = "application/json";
+            }
+          }
+          const resource =
+            artifact !== undefined && options.stateRoot !== undefined
+              ? await readPresentationArtifact({
+                  artifact,
+                  range: command.range,
+                  stateRoot: options.stateRoot,
+                  barrier: options[presentationArtifactReadBarrier],
+                })
+              : text !== undefined
+                ? readManagedInlinePage(text, command.range, mediaType)
+                : undefined;
+          if (resource === undefined)
+            return {
+              status: "rejected",
+              code: "not_available",
+              message: "The bounded agent resource is unavailable.",
+            };
+          return { status: "admitted", commandId: randomUUID(), resource };
+        } catch {
+          return {
+            status: "rejected",
+            code: "not_available",
+            message: "The exact agent resource could not be read safely.",
+          };
+        }
       }
       if (
         command.type === "refresh_managed_agents" ||
@@ -4965,7 +5700,18 @@ export async function createPresentationSession(
               : ("ready" as const);
         return {
           ...state,
+          agentUiSettings,
           ...(managedAgentActivity.length === 0 ? {} : { managedAgentActivity }),
+          managedAttention: managedAttention(),
+          managedDrafts: [...managedDrafts.values()]
+            .filter(
+              (draft) => draft.parentSessionId === active?.session.id && draft.text.length > 0,
+            )
+            .map(({ parentSessionId, threadId, expectedTurnId }) => ({
+              parentSessionId,
+              threadId,
+              expectedTurnId,
+            })),
           authoritative: {
             ...state.authoritative,
             active:
@@ -5027,6 +5773,8 @@ export async function createPresentationSession(
         unsubscribeMetadata();
         unsubscribeManagedAgentEvents();
         await activeRun?.settlement;
+        await Promise.all(managedDraftWrites);
+        await Promise.all(attentionReads.values());
         await Promise.all(connectionSettlements);
         await webSearchSettlement;
         await runtimeRefresh;
@@ -5241,7 +5989,10 @@ async function readPresentationArtifact(input: {
   };
 }
 
-function projectManagedAgentTranscript(child: ManagedAgentTranscriptRecords): TranscriptItem[] {
+function projectManagedAgentTranscript(
+  child: ManagedAgentTranscriptRecords,
+  disclosure: "summary" | "detail" = "summary",
+): TranscriptItem[] {
   const history = child.records.map((entry) => ({
     sessionId: child.childSessionId,
     entry,
@@ -5251,7 +6002,7 @@ function projectManagedAgentTranscript(child: ManagedAgentTranscriptRecords): Tr
     if (item.type === "user_message") {
       continue;
     }
-    if (item.type === "reasoning_block") {
+    if (item.type === "reasoning_block" && disclosure === "summary") {
       projected.push({ ...item, text: null, artifact: null });
       continue;
     }
@@ -5271,6 +6022,34 @@ function projectManagedAgentTranscript(child: ManagedAgentTranscriptRecords): Tr
     });
   }
   return projected;
+}
+
+function readManagedInlinePage(
+  text: string,
+  range: ArtifactRange,
+  mediaType: string,
+): ArtifactChunk {
+  const bytes = Buffer.from(text, "utf8");
+  if (range.offset > bytes.byteLength) throw new TypeError("The agent content offset is invalid.");
+  const end = Math.min(bytes.byteLength, range.offset + range.maximumBytes);
+  const decoded = decodeArtifactPage(bytes.subarray(range.offset, end), end === bytes.byteLength);
+  const eof = range.offset + decoded.byteCount === bytes.byteLength;
+  if (!eof && decoded.byteCount === 0)
+    throw new TypeError("The agent content page made no UTF-8 progress.");
+  return {
+    mediaType,
+    offset: range.offset,
+    byteCount: decoded.byteCount,
+    totalByteCount: bytes.byteLength,
+    eof,
+    nextRange: eof
+      ? null
+      : {
+          offset: range.offset + decoded.byteCount,
+          maximumBytes: presentationArtifactPageMaximumBytes,
+        },
+    text: decoded.text,
+  };
 }
 
 function managedTranscriptContainsArtifact(

--- a/packages/agent/src/presentation-tool-projection.ts
+++ b/packages/agent/src/presentation-tool-projection.ts
@@ -161,6 +161,9 @@ export function projectToolDisplays(
               tool.changePreviewRef,
               changePreviewCache,
             ),
+            ...(name === "spawn_agents"
+              ? { managedAdmissions: managedAdmissionDisplays(tool.output) }
+              : {}),
           },
         ] as const,
       ];
@@ -518,6 +521,38 @@ function toolResultSummary(name: string, output: JsonValue | undefined): string 
     return output === undefined ? null : `Completed${outputTruncated ? " · output truncated" : ""}`;
   }
   return output === undefined ? null : "Completed";
+}
+
+function managedAdmissionDisplays(
+  output: JsonValue | undefined,
+): NonNullable<ToolCallDisplay["managedAdmissions"]> {
+  const { admissions } = jsonRecord(output) ?? {};
+  if (!Array.isArray(admissions) || admissions.length > 32) return [];
+  return admissions.flatMap((value) => {
+    const { status, lane, threadId, turnId, handle, displayName, description } =
+      jsonRecord(value) ?? {};
+    if (
+      (status !== "started" && status !== "queued") ||
+      (lane !== "background" && lane !== "reserved") ||
+      typeof threadId !== "string" ||
+      typeof turnId !== "string" ||
+      typeof handle !== "string" ||
+      typeof displayName !== "string" ||
+      typeof description !== "string"
+    )
+      return [];
+    return [
+      {
+        threadId,
+        turnId,
+        handle: boundedDisplayText(handle),
+        displayName: boundedDisplayText(displayName),
+        description: boundedDisplayText(description),
+        lane,
+        status,
+      },
+    ];
+  });
 }
 
 const toolTextPreviewMaximumBytes = 16 * 1024;

--- a/packages/agent/src/recoverable-turn-draft.os.test.ts
+++ b/packages/agent/src/recoverable-turn-draft.os.test.ts
@@ -8,6 +8,42 @@ import { createRecoverableTurnDraftRepository } from "./recoverable-turn-draft.j
 
 const projectId = `sha256:${"b".repeat(64)}` as const;
 
+test("late input acceptance clears only its exact owner-private child draft", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-child-draft-clear-"));
+  const repository = await createRecoverableTurnDraftRepository({ projectId, stateRoot: root });
+  const first = {
+    parentSessionId: "00000000-0000-4000-8000-000000000001",
+    threadId: "00000000-0000-4000-8000-000000000002",
+    expectedTurnId: "00000000-0000-4000-8000-000000000003",
+    inputId: "00000000-0000-4000-8000-000000000004",
+    mode: "cooperative" as const,
+    text: "The submitted input.",
+  };
+  const later = {
+    ...first,
+    inputId: "00000000-0000-4000-8000-000000000005",
+    text: "A newer unsent draft.",
+  };
+  try {
+    await repository.saveManaged(first);
+    await repository.saveManaged(later);
+    await expect(repository.clearManaged(first)).resolves.toBe(false);
+    const reopened = await createRecoverableTurnDraftRepository({ projectId, stateRoot: root });
+    await expect(reopened.loadManaged(first)).resolves.toEqual(later);
+    const path = join(
+      root,
+      "drafts",
+      "b".repeat(64),
+      `managed-${first.parentSessionId}-${first.threadId}.json`,
+    );
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    await expect(repository.clearManaged(later)).resolves.toBe(true);
+    await expect(reopened.loadManaged(first)).resolves.toBeNull();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("recoverable turn draft atomically replaces one owner-private project manifest", async () => {
   const testRoot = await mkdtemp(join(tmpdir(), "adam-agent-recoverable-turn-draft-"));
   const repository = await createRecoverableTurnDraftRepository({

--- a/packages/agent/src/recoverable-turn-draft.ts
+++ b/packages/agent/src/recoverable-turn-draft.ts
@@ -2,6 +2,8 @@ import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import { chmod, mkdir, open, rename, unlink } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import type { ManagedComposerDraft } from "@adam-agent/presentation";
 
 import { z } from "zod";
 import type { StagedPastedTextSelectionV1 } from "./pasted-text.js";
@@ -109,7 +111,38 @@ export type RecoverableTurnDraftRepository = {
   load(scope: TurnDraftScopeV1): Promise<RecoverableTurnDraft | null>;
   save(draft: RecoverableTurnDraftV3): Promise<void>;
   delete(scope: TurnDraftScopeV1): Promise<void>;
+  loadManaged(
+    scope: Pick<ManagedComposerDraft, "parentSessionId" | "threadId">,
+  ): Promise<ManagedComposerDraft | null>;
+  saveManaged(draft: ManagedComposerDraft): Promise<void>;
+  clearManaged(draft: ManagedComposerDraft): Promise<boolean>;
 };
+
+const managedComposerDraftSchema = z
+  .strictObject({
+    parentSessionId: z.uuid(),
+    threadId: z.uuid(),
+    expectedTurnId: z.uuid(),
+    mode: z.enum(["cooperative", "interrupt", "new_turn", "reply"]),
+    attentionId: z.string().min(1).max(128).optional(),
+    inputId: z.uuid().optional(),
+    text: z.string().max(512 * 1024),
+  })
+  .refine((draft) => (draft.mode === "reply") === (draft.attentionId !== undefined));
+const managedDraftManifestSchema = z.strictObject({
+  schemaVersion: z.literal(1),
+  type: z.literal("managed_thread_draft"),
+  draft: managedComposerDraftSchema,
+});
+
+export function parseManagedComposerDraft(input: unknown): ManagedComposerDraft {
+  const { attentionId, inputId, ...draft } = managedComposerDraftSchema.parse(input);
+  return {
+    ...draft,
+    ...(attentionId === undefined ? {} : { attentionId }),
+    ...(inputId === undefined ? {} : { inputId }),
+  };
+}
 
 const digestSchema = z.string().regex(/^sha256:[0-9a-f]{64}$/u) as z.ZodType<`sha256:${string}`>;
 const stagedSelectionSchema = z.strictObject({
@@ -428,6 +461,38 @@ export async function createRecoverableTurnDraftRepository(options: {
   };
 
   return {
+    async loadManaged(scope) {
+      await mutationQueue;
+      const value = await readOwnerPrivateManifest(join(root, managedManifestName(scope)));
+      if (value === undefined) return null;
+      const { draft } = managedDraftManifestSchema.parse(value);
+      if (draft.parentSessionId !== scope.parentSessionId || draft.threadId !== scope.threadId)
+        throw new TypeError("The managed draft identity is invalid.");
+      return parseManagedComposerDraft(draft);
+    },
+    saveManaged(draft) {
+      return enqueueMutation(async () => {
+        const validated = parseManagedComposerDraft(draft);
+        const serialized = `${JSON.stringify({ schemaVersion: 1, type: "managed_thread_draft", draft: validated })}\n`;
+        if (Buffer.byteLength(serialized, "utf8") > maximumManifestBytes)
+          throw new TypeError("The recoverable draft manifest is too large.");
+        await replaceOwnerPrivateFile(join(root, managedManifestName(validated)), serialized);
+        await syncDirectory(root);
+      });
+    },
+    clearManaged(draft) {
+      return enqueueMutation(async () => {
+        const validated = parseManagedComposerDraft(draft);
+        const path = join(root, managedManifestName(validated));
+        const value = await readOwnerPrivateManifest(path);
+        if (value === undefined) return true;
+        if (!isDeepStrictEqual(managedDraftManifestSchema.parse(value).draft, validated))
+          return false;
+        await unlink(path);
+        await syncDirectory(root);
+        return true;
+      });
+    },
     delete(scope) {
       return enqueueMutation(async () => {
         try {
@@ -444,33 +509,9 @@ export async function createRecoverableTurnDraftRepository(options: {
     async load(scope) {
       await mutationQueue;
       const path = join(root, manifestName(scope));
-      let bytes: Buffer;
-      try {
-        const file = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
-        try {
-          const stats = await file.stat();
-          if (
-            !stats.isFile() ||
-            stats.size <= 0 ||
-            stats.size > maximumManifestBytes ||
-            (stats.mode & 0o077) !== 0 ||
-            (process.geteuid?.() !== undefined && stats.uid !== process.geteuid())
-          ) {
-            throw new TypeError("The recoverable draft manifest is unsafe.");
-          }
-          bytes = await file.readFile();
-        } finally {
-          await file.close();
-        }
-      } catch (error) {
-        if (isNodeError(error) && error.code === "ENOENT") {
-          return null;
-        }
-        throw error;
-      }
-      const parsed = recoverableDraftSchema.safeParse(
-        JSON.parse(bytes.toString("utf8")) as unknown,
-      );
+      const value = await readOwnerPrivateManifest(path);
+      if (value === undefined) return null;
+      const parsed = recoverableDraftSchema.safeParse(value);
       if (!parsed.success || !matchesScope(parsed.data.scope, scope)) {
         throw new TypeError("The recoverable draft manifest is invalid.");
       }
@@ -488,6 +529,40 @@ export async function createRecoverableTurnDraftRepository(options: {
       });
     },
   };
+}
+
+function managedManifestName(
+  scope: Pick<ManagedComposerDraft, "parentSessionId" | "threadId">,
+): string {
+  const validated = z
+    .strictObject({ parentSessionId: z.uuid(), threadId: z.uuid() })
+    .parse({ parentSessionId: scope.parentSessionId, threadId: scope.threadId });
+  return `managed-${validated.parentSessionId}-${validated.threadId}.json`;
+}
+
+async function readOwnerPrivateManifest(path: string): Promise<unknown> {
+  let bytes: Buffer;
+  try {
+    const file = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    try {
+      const stats = await file.stat();
+      if (
+        !stats.isFile() ||
+        stats.size <= 0 ||
+        stats.size > maximumManifestBytes ||
+        (stats.mode & 0o077) !== 0 ||
+        (process.geteuid?.() !== undefined && stats.uid !== process.geteuid())
+      )
+        throw new TypeError("The recoverable draft manifest is unsafe.");
+      bytes = await file.readFile();
+    } finally {
+      await file.close();
+    }
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") return undefined;
+    throw error;
+  }
+  return JSON.parse(bytes.toString("utf8")) as unknown;
 }
 
 async function replaceOwnerPrivateFile(path: string, content: string): Promise<void> {

--- a/packages/agent/src/secure-user-configuration.ts
+++ b/packages/agent/src/secure-user-configuration.ts
@@ -5,6 +5,11 @@ import { type FileHandle, mkdir, open, realpath, rename, unlink } from "node:fs/
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import {
+  type AgentUiSettings,
+  defaultAgentUiSettings,
+  isAgentUiSettings,
+} from "@adam-agent/presentation";
+import {
   createUserModelPolicyResolver,
   type UserModelPolicyField,
   type UserModelPolicyResolver,
@@ -33,6 +38,8 @@ export type PresentationPreferencesSnapshot = {
 };
 
 export type PresentationPreferences = {
+  loadAgentUi?(): Promise<AgentUiSettings>;
+  setAgentUi?(settings: AgentUiSettings | null): Promise<void>;
   load(): Promise<PresentationPreferencesSnapshot>;
   setDefaultTarget(targetId: string | null): Promise<void>;
   setModelPolicy(input: {
@@ -113,6 +120,12 @@ export function createPresentationPreferences(options: {
       directoryPath,
       maximumBytes: maximumConfigurationBytes,
       temporaryPrefix: ".config",
+    }),
+    createOwnerConfigurationFileStorage({
+      configurationPath: join(directoryPath, "ui.json"),
+      directoryPath,
+      maximumBytes: maximumConfigurationBytes,
+      temporaryPrefix: ".ui",
     }),
   );
 }
@@ -325,6 +338,7 @@ function createWorkspaceTrustFromStorage(options: {
 
 function createPresentationPreferencesFromStorage(
   storage: UserConfigurationStorage,
+  uiStorage?: UserConfigurationStorage,
 ): PresentationPreferences {
   let lastValidSnapshot = emptySnapshot();
 
@@ -374,6 +388,33 @@ function createPresentationPreferencesFromStorage(
   });
 
   return {
+    ...(uiStorage === undefined
+      ? {}
+      : {
+          async loadAgentUi(): Promise<AgentUiSettings> {
+            const stored = await uiStorage.read();
+            if (stored.status === "missing") return defaultAgentUiSettings;
+            if (stored.status === "unsafe")
+              throw new TypeError("Agent UI settings are not owner-private.");
+            const parsed: unknown = JSON.parse(stored.text);
+            if (
+              !isAgentUiSettings(parsed) ||
+              !("schemaVersion" in parsed) ||
+              parsed.schemaVersion !== 1
+            )
+              throw new TypeError("Agent UI settings are invalid.");
+            const { widgetMode, fleetEnabled, showModel, viewerMode, mentions } = parsed;
+            return { widgetMode, fleetEnabled, showModel, viewerMode, mentions };
+          },
+          async setAgentUi(settings: AgentUiSettings | null): Promise<void> {
+            const value = settings ?? defaultAgentUiSettings;
+            if (!isAgentUiSettings(value)) throw new TypeError("Agent UI settings are invalid.");
+            const { widgetMode, fleetEnabled, showModel, viewerMode, mentions } = value;
+            await uiStorage.write(
+              `${JSON.stringify({ schemaVersion: 1, widgetMode, fleetEnabled, showModel, viewerMode, mentions })}\n`,
+            );
+          },
+        }),
     async load() {
       return loadConfiguration();
     },

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import type {
+  ManagedControlIdentity,
   ManagedSessionTransition,
   ManagedSessionTransitionResult,
 } from "@adam-agent/presentation";
@@ -11,6 +12,7 @@ import {
   AgentSession,
   managedAgentPromptSummary,
   managedAgentRequestBoundary,
+  sessionRecordCommittedBarrier,
 } from "./agent-session.js";
 import type {
   ModelDriver,
@@ -65,8 +67,12 @@ import {
   createManagedAgentControl,
   createManagedAgentControlToolRegistry,
   type ManagedAgentControl,
+  managedAgentRecordBarrier,
+  managedAgentSettlementBarrier,
   managedControlMainRequestBoundary,
 } from "./managed-agent-control.js";
+import { managedTranscriptLink } from "./managed-agent-folds.js";
+import { validateManagedChildGenesis } from "./managed-agent-recovery.js";
 import { createJsonlManagedAgentStore } from "./managed-agent-store.js";
 import {
   createMcpRuntimeHost,
@@ -397,6 +403,7 @@ export function validateCurrentSessionHistoryForTesting(
 }
 
 export type ManagedAgentTranscriptRecords = {
+  readonly identity?: ManagedControlIdentity;
   readonly childSessionId: string;
   readonly records: readonly SessionRecord[];
   readonly partialOutput?: {
@@ -453,6 +460,11 @@ export const sessionManagedControl = Symbol("adam-agent.session-managed-control"
 
 export type SessionLifecycleOptions = {
   readonly [sessionManagedControl]?: {
+    readonly [managedAgentSettlementBarrier]?: () => Promise<void>;
+    readonly [managedAgentRecordBarrier]?: NonNullable<
+      Parameters<typeof createManagedAgentControl>[0][typeof managedAgentRecordBarrier]
+    >;
+    readonly [sessionRecordCommittedBarrier]?: (record: SessionRecord) => Promise<void>;
     readonly planPolicyVersion?: PlanPolicyVersion;
     readonly policy?: import("./fleet-ledger.js").FleetPolicy;
     readonly store: import("./managed-agent-folds.js").ManagedControlStore;
@@ -759,13 +771,22 @@ export interface SessionLifecycle {
   readonly [sessionManagedControl]: (
     sessionId: string,
   ) => Promise<import("./managed-agent-control.js").ManagedAgentControl | undefined>;
-  readonly [sessionManagedAgentTranscriptReader]: (input: {
-    readonly sessionId: string;
-    readonly agentId: string;
-    readonly attemptId: string;
-    readonly expectedRevision: number;
-    readonly expectedThroughSequence: number;
-  }) => Promise<ManagedAgentTranscriptRecords>;
+  readonly [sessionManagedAgentTranscriptReader]: (
+    input:
+      | {
+          readonly sessionId: string;
+          readonly agentId: string;
+          readonly attemptId: string;
+          readonly expectedRevision: number;
+          readonly expectedThroughSequence: number;
+        }
+      | {
+          readonly sessionId: string;
+          readonly threadId: string;
+          readonly turnId: string;
+          readonly throughSequence?: number;
+        },
+  ) => Promise<ManagedAgentTranscriptRecords>;
   admit(input: {
     readonly targetIdentity: ModelTargetIdentity;
     readonly input: UserInput;
@@ -1417,8 +1438,15 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           targetIdentity: snapshot.targetIdentity,
           contextProfile,
           ...(composition.policy === undefined ? {} : { policy: composition.policy }),
-          admissionGuard: (operation) =>
+          admissionGuard: (operation, constraints) =>
             serializeFamily(async () => {
+              if (
+                constraints?.requireIdleMain &&
+                [...trackedOwnerOperations].some(
+                  (entry) => entry.kind === "ordinary" && entry.sessionId === sessionId,
+                )
+              )
+                throw new ProjectExecutionDomainError("root_conflict");
               if (activeManagedFamily === undefined) activeManagedFamily = sessionId;
               if (
                 lifecycleClosing ||
@@ -1460,10 +1488,29 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             };
           },
           model: resolved.driver,
+          onChildRuntimeEvent(identity, event) {
+            publishManagedAgentNotification({
+              type: "child_runtime_event",
+              parentSessionId: sessionId,
+              agentId: identity.threadId,
+              attemptId: identity.attemptId,
+              childSessionId: identity.childSessionId,
+              event,
+            });
+          },
           permissions: options.permissions ?? createPermissionPolicy({ allowedEffects: [] }),
           executionDomain,
           store: composition.store,
           childSessionStores: composition.childSessionStores,
+          ...(composition[managedAgentRecordBarrier] === undefined
+            ? {}
+            : { [managedAgentRecordBarrier]: composition[managedAgentRecordBarrier] }),
+          ...(composition[managedAgentSettlementBarrier] === undefined
+            ? {}
+            : { [managedAgentSettlementBarrier]: composition[managedAgentSettlementBarrier] }),
+          ...(composition[sessionRecordCommittedBarrier] === undefined
+            ? {}
+            : { [sessionRecordCommittedBarrier]: composition[sessionRecordCommittedBarrier] }),
           parentSessionStore: await openSessionStore(options, sessionId),
         });
       })();
@@ -5775,6 +5822,58 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       return continueManagedAgent(input, "recovery");
     },
     async [sessionManagedAgentTranscriptReader](input) {
+      if ("threadId" in input) {
+        const composition = options[sessionManagedControl];
+        if (composition === undefined)
+          throw new SessionLifecycleError("session_managed_control_read_only");
+        const controlRecords = await composition.store.forParent(input.sessionId).read();
+        const admission = controlRecords.find(
+          (record) =>
+            record.event.type === "admitted" &&
+            record.parentSessionId === input.sessionId &&
+            record.threadId === input.threadId &&
+            record.turnId === input.turnId,
+        );
+        if (admission === undefined) throw new SessionLifecycleError("session_invalid");
+        const childRecords = await (
+          await composition.childSessionStores.open(admission.childSessionId)
+        )?.read();
+        const genesis = childRecords?.[0];
+        if (childRecords === undefined || genesis === undefined || !isGenesisRecord(genesis))
+          throw new SessionLifecycleError("session_invalid");
+        validateManagedChildGenesis(admission, genesis);
+        validateCurrentSessionHistory(genesis, childRecords, options.workspaceRoot);
+        const outcome = controlRecords.find(
+          (record) => record.turnId === input.turnId && record.event.type === "outcome",
+        );
+        if (
+          outcome?.event.type === "outcome" &&
+          (outcome.event.transcript.sequence !== childRecords.at(-1)?.sequence ||
+            outcome.event.transcript.digest !== managedTranscriptLink(childRecords).digest)
+        )
+          throw new SessionLifecycleError("session_invalid");
+        if (
+          input.throughSequence !== undefined &&
+          (!Number.isSafeInteger(input.throughSequence) ||
+            input.throughSequence < 1 ||
+            input.throughSequence > (childRecords.at(-1)?.sequence ?? 0))
+        )
+          throw new SessionLifecycleError("session_invalid");
+        return {
+          identity: {
+            parentSessionId: admission.parentSessionId,
+            threadId: admission.threadId,
+            turnId: admission.turnId,
+            attemptId: admission.attemptId,
+            childSessionId: admission.childSessionId,
+          },
+          childSessionId: admission.childSessionId,
+          records:
+            input.throughSequence === undefined
+              ? childRecords
+              : childRecords.filter((record) => record.sequence <= (input.throughSequence ?? 0)),
+        };
+      }
       const records = await managedAgentStore.read();
       const agentRecords = records.filter((record) => record.agentId === input.agentId);
       const admission = records.find(

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -243,7 +243,13 @@ export type ArtifactReference = {
   readonly id: string;
   readonly mediaType: string;
   readonly byteCount: number;
-  readonly source: "model_response" | "tool_output" | "change_preview" | "operation" | "plan";
+  readonly source:
+    | "model_response"
+    | "tool_output"
+    | "change_preview"
+    | "operation"
+    | "plan"
+    | "agent_export";
 };
 
 export type ArtifactChunk = {
@@ -345,6 +351,7 @@ export type ToolPreviewDisplay =
     };
 
 export type ToolCallDisplay = {
+  readonly managedAdmissions?: readonly ManagedAdmissionDisplay[];
   readonly type: "tool_call";
   readonly id: string;
   readonly sequence: number;
@@ -1113,7 +1120,51 @@ export type PresentationTransientState = {
   } | null;
 };
 
+export type AgentUiSettings = {
+  readonly widgetMode: "background" | "all" | "off";
+  readonly fleetEnabled: boolean;
+  readonly showModel: boolean;
+  readonly viewerMode: "raw" | "assistant" | "full";
+  readonly mentions: "direct" | "off";
+};
+export const defaultAgentUiSettings: AgentUiSettings = Object.freeze({
+  widgetMode: "background",
+  fleetEnabled: true,
+  showModel: false,
+  viewerMode: "assistant",
+  mentions: "direct",
+});
+export function nextAgentViewerMode(
+  mode: AgentUiSettings["viewerMode"],
+): AgentUiSettings["viewerMode"] {
+  return mode === "raw" ? "assistant" : mode === "assistant" ? "full" : "raw";
+}
+export function isAgentUiSettings(value: unknown): value is AgentUiSettings {
+  if (typeof value !== "object" || value === null) return false;
+  return (
+    "widgetMode" in value &&
+    typeof value.widgetMode === "string" &&
+    ["background", "all", "off"].includes(value.widgetMode) &&
+    "fleetEnabled" in value &&
+    typeof value.fleetEnabled === "boolean" &&
+    "showModel" in value &&
+    typeof value.showModel === "boolean" &&
+    "viewerMode" in value &&
+    typeof value.viewerMode === "string" &&
+    ["raw", "assistant", "full"].includes(value.viewerMode) &&
+    "mentions" in value &&
+    typeof value.mentions === "string" &&
+    ["direct", "off"].includes(value.mentions)
+  );
+}
+
 export type PresentationDisplayState = {
+  readonly agentUiSettings?: AgentUiSettings;
+  readonly managedAttention?: readonly ManagedAttentionItem[];
+  readonly managedDrafts?: readonly Pick<
+    ManagedComposerDraft,
+    "parentSessionId" | "threadId" | "expectedTurnId"
+  >[];
   readonly revision: number;
   readonly authoritative: AuthoritativePresentationSnapshot;
   readonly draft: NewSessionDraftDisplay | null;
@@ -1127,6 +1178,8 @@ export type PresentationDisplayState = {
     readonly assistant?: {
       readonly itemId: string;
       readonly text: string;
+      readonly totalByteCount?: number;
+      readonly omittedBytes?: number;
     };
     readonly reasoning?: {
       readonly itemId: string;
@@ -1166,6 +1219,9 @@ export type CommandReceipt =
       readonly draftText?: string;
       readonly todo?: TodoPageResource | TodoEntityResource;
       readonly managedAgentTranscript?: ManagedAgentTranscriptPageResource;
+      readonly managedDraft?: ManagedComposerDraft | null;
+      readonly managedDraftCleared?: boolean;
+      readonly agentExport?: ManagedAgentExport;
       readonly control?: ManagedControlReceipt;
       readonly managedAgentControl?: {
         readonly action: "message" | "reply" | "cancel" | "follow_up" | "recovery";
@@ -1243,6 +1299,8 @@ export type TodoEntityResource = {
 };
 
 export type ManagedAgentTranscriptPageResource = {
+  readonly turnId?: string;
+  readonly cursor?: string;
   readonly type: "managed_agent_transcript_page";
   readonly agentId: string;
   readonly attemptId: string;
@@ -1253,6 +1311,53 @@ export type ManagedAgentTranscriptPageResource = {
 };
 
 export type PresentationCommand =
+  | {
+      readonly type: "export_agent";
+      readonly confirmed: true;
+      readonly sessionId: string;
+      readonly threadId: string;
+      readonly expectedTurnId: string;
+      readonly completion: ManagedControlLink;
+      readonly fields: readonly AgentExportField[];
+    }
+  | {
+      readonly type: "read_agent_input";
+      readonly sessionId: string;
+      readonly threadId: string;
+      readonly expectedTurnId: string;
+      readonly inputId: string;
+      readonly range: ArtifactRange;
+    }
+  | {
+      readonly type: "read_agent_content";
+      readonly kind: "reasoning" | "tool";
+      readonly sessionId: string;
+      readonly threadId: string;
+      readonly expectedTurnId: string;
+      readonly itemId: string;
+      readonly range: ArtifactRange;
+    }
+  | {
+      readonly type: "read_agent_artifact";
+      readonly sessionId: string;
+      readonly threadId: string;
+      readonly expectedTurnId: string;
+      readonly artifact: ArtifactReference;
+      readonly range: ArtifactRange;
+    }
+  | { readonly type: "set_agent_ui_settings"; readonly settings: AgentUiSettings | null }
+  | { readonly type: "read_agent_draft"; readonly sessionId: string; readonly threadId: string }
+  | {
+      readonly type: "save_agent_draft" | "clear_agent_draft";
+      readonly draft: ManagedComposerDraft;
+    }
+  | {
+      readonly type: "read_agent_conversation";
+      readonly sessionId: string;
+      readonly threadId: string;
+      readonly expectedTurnId: string;
+      readonly cursor: string | null;
+    }
   | {
       readonly type: "resolve_managed_transition";
       readonly transitionId: string;
@@ -1653,12 +1758,59 @@ export type ManagedControlIdentity = {
   readonly childSessionId: string;
 };
 
+export type ManagedComposerDraft = {
+  readonly parentSessionId: string;
+  readonly threadId: string;
+  readonly expectedTurnId: string;
+  readonly mode: "cooperative" | "interrupt" | "new_turn" | "reply";
+  readonly attentionId?: string;
+  readonly inputId?: string;
+  readonly text: string;
+};
+
+export type ManagedAttentionItem = {
+  readonly id: string;
+  readonly parentSessionId: string;
+  readonly threadId: string;
+  readonly turnId: string;
+  readonly handle: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly available: boolean;
+  readonly diagnostic?: string;
+} & (
+  | {
+      readonly kind: "permission";
+      readonly interaction: Extract<PendingInteraction, { readonly type: "permission" }> | null;
+    }
+  | { readonly kind: "parent_input"; readonly question: string }
+);
+
+export type ManagedControlAction =
+  | ManagedComposerDraft["mode"]
+  | "cancel"
+  | "resume"
+  | "recover"
+  | "permission"
+  | "close";
+
+export type ManagedAdmissionDisplay = {
+  readonly threadId: string;
+  readonly turnId: string;
+  readonly handle: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly lane: "background" | "reserved";
+  readonly status: "started" | "queued";
+};
+
 export type ManagedControlLink = {
   readonly sequence: number;
   readonly digest: `sha256:${string}`;
 };
 
 export type ManagedControlOutcome = {
+  readonly atUnixMilliseconds?: number;
   readonly artifact?: {
     readonly id: `sha256:${string}`;
     readonly byteCount: number;
@@ -1679,6 +1831,9 @@ export type ManagedControlOutcome = {
 };
 
 export type ManagedControlThread = {
+  readonly previousTurns?: readonly ManagedControlThread["turn"][];
+  readonly actions?: readonly ManagedControlAction[];
+  readonly budget?: NonNullable<ManagedWorkspaceSnapshot["budget"]>;
   readonly inputs?: readonly {
     readonly id: string;
     readonly turnId: string;
@@ -1694,6 +1849,7 @@ export type ManagedControlThread = {
   readonly role: "builtin:explore";
   readonly description: string;
   readonly turn: {
+    readonly startedAtUnixMilliseconds?: number;
     readonly turnId: string;
     readonly attemptId: string;
     readonly childSessionId: string;
@@ -1707,9 +1863,14 @@ export type ManagedControlThread = {
       readonly parentBranchId: string;
       readonly targetId: string;
       readonly thinking: string;
+      readonly contextWindowTokens?: number;
     };
     readonly waitReason: "none" | "suspended" | "capacity" | "permission" | "parent_input" | "plan";
-    readonly attention?: { readonly id: string; readonly kind: "permission" | "parent_input" };
+    readonly attention?: {
+      readonly id: string;
+      readonly kind: "permission" | "parent_input";
+      readonly question?: string;
+    };
     readonly ownerPhase: "waiting" | "claimed" | "releasing" | "released";
     readonly lastOutcome: "none" | "completed" | "failed" | "cancelled" | "interrupted";
     readonly label: string;
@@ -1727,7 +1888,29 @@ export type ManagedControlThread = {
   };
 };
 
+export const agentExportFields = [
+  "summary",
+  "conversation",
+  "tools",
+  "result",
+  "reasoning",
+] as const;
+export type AgentExportField = (typeof agentExportFields)[number];
+export const presentationAgentExportMaximumBytes = 512 * 1024;
+export type ManagedAgentExport = {
+  readonly parentSessionId: string;
+  readonly threadId: string;
+  readonly turnId: string;
+  readonly completion: ManagedControlLink;
+  readonly fields: readonly AgentExportField[];
+  readonly artifact: ArtifactReference & {
+    readonly source: "agent_export";
+    readonly mediaType: "application/json";
+  };
+};
+
 export type ManagedWorkspaceSnapshot = {
+  readonly exports?: readonly ManagedAgentExport[];
   readonly storage?: {
     readonly status?: "known" | "unavailable";
     readonly ceiling: number;
@@ -1750,7 +1933,8 @@ export type ManagedWorkspaceSnapshot = {
     readonly turnId: string;
     readonly receipt: ManagedControlLink;
     readonly outcome: ManagedControlOutcome;
-    readonly consumption: "pending" | "consumed";
+    readonly consumption: "pending" | "consumed" | "suppressed";
+    readonly userSeen?: true;
   }[];
   readonly status: "ready" | "recovery_required" | "runtime_unavailable";
   readonly diagnostic?: string;
@@ -1793,6 +1977,21 @@ export type ManagedDelegationEnvelope = {
 };
 
 export type ManagedControlCommand =
+  | {
+      readonly type: "suppress_completion";
+      readonly confirmed: true;
+      readonly parentSessionId: string;
+      readonly threadId: string;
+      readonly expectedTurnId: string;
+      readonly completion: ManagedControlLink;
+    }
+  | {
+      readonly type: "mark_completion_seen";
+      readonly parentSessionId: string;
+      readonly threadId: string;
+      readonly expectedTurnId: string;
+      readonly completion: ManagedControlLink;
+    }
   | {
       readonly type: "suspend_agents";
       readonly parentSessionId: string;
@@ -1921,7 +2120,11 @@ export type ManagedControlReceipt =
       readonly revision: number;
     }
   | { readonly status: "completed"; readonly results: ManagedWorkspaceSnapshot["completions"] }
-  | { readonly status: "admitted"; readonly turns: readonly ManagedControlIdentity[] }
+  | {
+      readonly status: "admitted";
+      readonly turns: readonly ManagedControlIdentity[];
+      readonly admissions?: readonly ManagedAdmissionDisplay[];
+    }
   | {
       readonly status: "delivery";
       readonly messages: readonly { readonly id: `sha256:${string}`; readonly text: string }[];

--- a/packages/testkit/src/managed-agent-control.test.ts
+++ b/packages/testkit/src/managed-agent-control.test.ts
@@ -596,17 +596,32 @@ test("ManagedAgentControl observers register before their initial read and remai
     firstAbort.abort();
     expect(await first.next()).toMatchObject({ done: true });
     const revisions = [initial.value?.snapshot.revision ?? -1];
+    let startupResets = 0;
     await withManagedFailureGuard(
       (async () => {
         while (true) {
           const frame = await second.next();
           if (frame.done) throw new Error("Second subscription ended unexpectedly.");
-          revisions.push(frame.value.snapshot.revision);
+          if (frame.value.snapshot.revision === revisions.at(-1)) {
+            expect(frame.value.type).toBe("reset");
+            expect(frame.value.snapshot.threads[0]).toMatchObject({
+              residency: "live",
+              turn: { phase: "starting", label: "Starting" },
+            });
+            startupResets += 1;
+          } else {
+            if (frame.value.type === "reset")
+              expect(frame.value.snapshot.threads[0]?.turn.phase).toBe("queued");
+            else expect(frame.value.type).toBe("change");
+            revisions.push(frame.value.snapshot.revision);
+          }
           if (frame.value.snapshot.threads[0]?.turn.phase === "idle") break;
         }
       })(),
       "independent second subscriber settlement",
     );
+    expect(startupResets).toBe(1);
+    expect(revisions.at(-1)).toBeGreaterThan(revisions[0] ?? -1);
     expect(
       revisions.every(
         (revision, index) => index === 0 || revision === (revisions[index - 1] ?? -1) + 1,
@@ -1254,3 +1269,105 @@ test("ManagedAgentControl keeps outcome Settling until cleanup and admits immedi
     await domain.close();
   }
 });
+
+test.each(["starting", "executing"] as const)(
+  "ManagedAgentControl discards a queued reset already covered by its initial %s snapshot",
+  async (phase) => {
+    const providerStarted = Promise.withResolvers<void>();
+    const finish = Promise.withResolvers<void>();
+    const harness = await controlHarness({
+      async *stream() {
+        providerStarted.resolve();
+        await finish.promise;
+        yield { type: "text_delta", text: "Current observer evidence." };
+        yield { type: "finish", reason: "stop" };
+      },
+    });
+    const createReached = Promise.withResolvers<void>();
+    const releaseCreate = Promise.withResolvers<void>();
+    const children = harness.options.childSessionStores;
+    const childSessionStores: typeof children = {
+      ...children,
+      async create(id) {
+        createReached.resolve();
+        if (phase === "starting") await releaseCreate.promise;
+        return children.create(id);
+      },
+    };
+    const firstRead = Promise.withResolvers<void>();
+    const releaseRead = Promise.withResolvers<void>();
+    let gate = true;
+    const backing = harness.options.store;
+    const store: typeof backing = {
+      ...backing,
+      forParent() {
+        return store;
+      },
+      async read() {
+        if (gate) {
+          gate = false;
+          firstRead.resolve();
+          await releaseRead.promise;
+        }
+        return backing.read();
+      },
+    };
+    const control = createManagedAgentControl({ ...harness.options, store, childSessionStores });
+    const abort = new AbortController();
+    const iterator = control
+      .observe({ parentSessionId, signal: abort.signal })
+      [Symbol.asyncIterator]();
+    try {
+      const initialPending = iterator.next();
+      await firstRead.promise;
+      expect(
+        await control.dispatch({
+          type: "start_thread",
+          parentSessionId,
+          role: "builtin:explore",
+          task: "Inspect",
+          description: "Snapshot boundary",
+        }),
+      ).toMatchObject({ status: "accepted" });
+      await createReached.promise;
+      if (phase === "executing") await providerStarted.promise;
+      releaseRead.resolve();
+      const initial = await initialPending;
+      if (initial.done) throw new Error("Missing initial snapshot");
+      expect(initial.value.type).toBe("snapshot");
+      expect(initial.value.snapshot.revision).toBe((await backing.read()).length);
+      expect(initial.value.snapshot.threads[0]?.turn.phase).toBe(phase);
+      const next = iterator.next();
+      releaseCreate.resolve();
+      finish.resolve();
+      await withManagedFailureGuard(
+        (async () => {
+          let current = await next;
+          while (
+            !current.done &&
+            current.value.snapshot.revision === initial.value.snapshot.revision
+          ) {
+            expect(current.value.type).toBe("reset");
+            expect(current.value.snapshot.threads[0]).toMatchObject({
+              residency: "live",
+              turn: { phase, label: phase === "starting" ? "Starting" : "Running" },
+            });
+            current = await iterator.next();
+          }
+          if (current.done) throw new Error("Missing current change");
+          expect(current.value.snapshot.revision).toBe(initial.value.snapshot.revision + 1);
+          expect(current.value.type).toBe("change");
+        })(),
+        "post-snapshot durable change",
+      );
+    } finally {
+      releaseRead.resolve();
+      releaseCreate.resolve();
+      finish.resolve();
+      abort.abort();
+      await iterator.return?.();
+      await control.dispatch({ type: "close", parentSessionId });
+      await harness.close();
+    }
+  },
+);

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -1482,6 +1482,15 @@ test("PresentationSession opens an empty project catalog without creating a sess
 
     const state = presentation.getState();
     expect(state).toEqual({
+      agentUiSettings: {
+        widgetMode: "background",
+        fleetEnabled: true,
+        showModel: false,
+        viewerMode: "assistant",
+        mentions: "direct",
+      },
+      managedAttention: [],
+      managedDrafts: [],
       revision: 1,
       authoritative: {
         schemaVersion: 1,
@@ -5962,6 +5971,15 @@ test("PresentationSession opens an exact target as a recoverable draft", async (
 
     const state = presentation.getState();
     expect(state).toEqual({
+      agentUiSettings: {
+        widgetMode: "background",
+        fleetEnabled: true,
+        showModel: false,
+        viewerMode: "assistant",
+        mentions: "direct",
+      },
+      managedAttention: [],
+      managedDrafts: [],
       revision: 1,
       authoritative: {
         schemaVersion: 1,


### PR DESCRIPTION
Managed sessions in the internal Control composition can now be inspected and controlled from the TUI while Main remains usable. A compact agent tree and Fleet open live conversations with independent, durable child drafts and exact input receipts.

- Add live conversation scrolling, bounded history/resource pages, rendering modes, same-thread continuation, and explicit handling of stale or undelivered drafts.
- Add exact permission and parent-input attention controls, cancellation, session transitions, history, persistent display settings, and responsive keyboard navigation.
- Keep completion visibility separate from Main consumption. Add confirmed suppression and bounded immutable exports with reasoning selected separately.
- Preserve Control and SessionLifecycle ownership, including ordered observer snapshots and cold recovery. Keep the existing production entry until the later composition cutover.

Validation: `pnpm quality:check` passed: 92 test files, 2,021 tests passed, and 18 existing opt-in tests skipped. Independent standards, specification, and primary-reference parity reviews are closed. Real JSONL/PTY tests cover input delivery, concurrent Main activity, focus handoff, cold drafts, process closure, and terminal restoration. A native WSL2/Windows Terminal reproduction also verified child input and same-thread continuation with a deterministic provider. No dependencies, public package versions, or CI workflows change.
