### PR TITLE
feat: add managed roles and direct delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Extension JavaScript runs with the Adam process's authority: this is not a packa
 
 ## Development
 
+The [managed-control candidate](docs/managed-control-candidate.md) documents the internal role, direct-input, grant and recovery composition, including its test coverage and current publication boundary.
+
 ```bash
 corepack enable
 pnpm install --frozen-lockfile

--- a/apps/tui/src/agent-delegation.test.ts
+++ b/apps/tui/src/agent-delegation.test.ts
@@ -1,0 +1,285 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ModelRequest } from "@adam-agent/agent";
+import { expect, test, vi } from "vitest";
+import { startManagedTui } from "./agent-fleet.test-support.js";
+
+test("custom aggregate limits validate the visible range and persist the exact non-preset value", async () => {
+  const requests: ModelRequest[] = [];
+  const h = await startManagedTui({
+    async *stream(request) {
+      requests.push(request);
+      yield { type: "text_delta", text: "Custom bounded evidence." };
+      yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    await h.press("@Explore", "A · Explore");
+    await h.press("\t", "@Explore");
+    await h.press(" Inspect a custom grant.\r", "Delegation");
+    await h.press("\x1b[B\x1b[B\x1b[B\r", "Execution and limits");
+    await h.press("\x1b[A\r", "Custom limits");
+    await h.press("\r", "Custom aggregate tokens");
+    await h.press("\x01\x0b0\r", "Enter an integer from 1 to 512000.");
+    expect(requests).toHaveLength(0);
+    expect(await h.store.read()).toHaveLength(0);
+    await h.press("\x01\x0b123457\r", "Limits updated.");
+    await h.press("\r", "Completed");
+    const admission = (await h.store.read()).find((record) => record.event.type === "admitted");
+    expect(admission?.event).toMatchObject({ envelope: { aggregateTokens: 123457 } });
+    expect(requests).toHaveLength(1);
+  } finally {
+    await h.close();
+  }
+});
+
+test("direct delegation reviews finite execution and token bounds before one exact grant", async () => {
+  const requests: ModelRequest[] = [];
+  const h = await startManagedTui({
+    async *stream(request) {
+      requests.push(request);
+      yield { type: "text_delta", text: "Bounded foreground evidence." };
+      yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    await h.press("@Explore", "A · Explore");
+    await h.press("\t", "@Explore");
+    await h.press(" Inspect bounded evidence", "Inspect bounded evidence");
+    await h.press("\r", "Execution and limits");
+    await h.press("\x1b[B\x1b[B\x1b[B\r", "Foreground");
+    await h.press("\x1b[B\r", "Limits updated.");
+    await h.press("\x1b[B\x1b[B\x1b[B\r", "Aggregate 1x");
+    await h.press("\x1b[B\x1b[B\r", "128000 tokens · Current request");
+    await h.press("\x1b[B\x1b[B\x1b[B\x1b[B\x1b[B\r", "Enter apply");
+    await h.press("\x01\x0bNamed evidence work\r", "Description updated.");
+    expect(requests).toHaveLength(0);
+    await h.press("\r", "@explore-1 · Explore · Completed");
+    expect(requests).toHaveLength(1);
+    const admission = (await h.store.read()).find((record) => record.event.type === "admitted");
+    expect(admission?.event).toMatchObject({
+      lane: "reserved",
+      description: "Named evidence work",
+      envelope: {
+        mode: "foreground",
+        threads: 1,
+        running: 1,
+        queued: 0,
+        aggregateTokens: 128000,
+        sessionTokens: 2048000,
+        origin: { kind: "direct_request" },
+      },
+    });
+  } finally {
+    await h.close();
+  }
+});
+
+test("a Main model delegation uses the exact editable grant in its pending permission", async () => {
+  const h = await startManagedTui({
+    async *stream(request) {
+      if (JSON.stringify(request.messages).includes("MODEL CHILD TASK")) {
+        yield { type: "text_delta", text: "Model child evidence." };
+        yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+        yield { type: "finish", reason: "stop" };
+      } else {
+        yield { type: "tool_call_start", id: "model-spawn", name: "spawn_agents" };
+        yield {
+          type: "tool_call_delta",
+          id: "model-spawn",
+          json: JSON.stringify({
+            entries: [
+              {
+                role: "builtin:explore",
+                task: "MODEL CHILD TASK",
+                description: "Model requested evidence",
+              },
+            ],
+          }),
+        };
+        yield { type: "tool_call_end", id: "model-spawn" };
+        yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+        yield { type: "finish", reason: "tool_calls" };
+      }
+    },
+  });
+  try {
+    await h.press("Delegate evidence", "Delegate evidence");
+    await h.press("\r", "Execution and limits");
+    await h.press("\x1b[B\x1b[B\r", "Task only");
+    await h.press("\x1b[B\r", "Context updated.");
+    await h.press("\x1b[B\x1b[B\x1b[B\r", "Aggregate 1x");
+    await h.press("\x1b[B\x1b[B\r", "128000 tokens · Task only");
+    const pending = h.presentation.getState().authoritative.active?.pendingInteractions[0];
+    if (pending?.delegation === undefined) throw new Error("No pending exact delegation.");
+    expect(
+      await h.presentation.dispatch({
+        type: "decide_permission",
+        requestId: pending.requestId,
+        decision: "allow",
+        delegation: { ...pending.delegation, aggregateTokens: Number.MAX_SAFE_INTEGER },
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(
+      (await h.store.read()).filter((record) => record.event.type === "admitted"),
+    ).toHaveLength(0);
+    await h.press("\r", "@explore-1 · Explore · Completed");
+    const admission = (await h.store.read()).find((record) => record.event.type === "admitted");
+    expect(admission?.event).toMatchObject({
+      context: { mode: "task" },
+      envelope: {
+        context: "task",
+        aggregateTokens: 128000,
+        origin: { kind: "main_run", callId: "model-spawn" },
+      },
+    });
+    const records = await (await h.sessions.open(h.parent.sessionId))?.read();
+    const decided = records?.findLast(
+      (record) =>
+        record.schemaVersion === 3 &&
+        record.record.type === "runtime_event" &&
+        record.record.event.type === "tool_permission_decided" &&
+        record.record.event.name === "spawn_agents",
+    );
+    expect(decided?.schemaVersion === 3 ? decided.record : undefined).toMatchObject({
+      type: "runtime_event",
+      event: {
+        decision: "allow",
+        subject: {
+          envelope: admission?.event.type === "admitted" ? admission.event.envelope : undefined,
+        },
+      },
+    });
+  } finally {
+    await h.close();
+  }
+});
+
+test.each([40, 80, 120])(
+  "delegation exposes its complete grant at %i columns with NO_COLOR",
+  async (columns) => {
+    vi.stubEnv("NO_COLOR", "1");
+    const h = await startManagedTui(
+      {
+        stream() {
+          throw new Error("A preview or denial must not start a provider.");
+        },
+      },
+      { columns },
+    );
+    try {
+      await h.press("@Explore", columns === 40 ? "A @Explore" : "A · Explore");
+      await h.press("\t", "@Explore");
+      await h.press(" Inspect bounds", "Inspect bounds");
+      await h.press("\r", "Delegation");
+      await h.press("\x1b[B\x1b[B\x1b[B\x1b[B\r", "ID:");
+      const compact = h.terminal.lines().join("").replace(/[\s│]/gu, "");
+      expect(compact).toMatch(
+        /ID:[a-f0-9-]{36}Digest:sha256:[a-f0-9]{64}Policy:sha256:[a-f0-9]{64}/u,
+      );
+      await h.press("\x1b", "Delegation");
+      await h.press("\x1b", "@Explore");
+      expect(
+        (await h.store.read()).filter((record) => record.event.type === "admitted"),
+      ).toHaveLength(0);
+      expect(
+        h.presentation
+          .getState()
+          .composer?.elements.some(
+            (element) => element.type === "mention" && element.kind === "role",
+          ),
+      ).toBe(true);
+    } finally {
+      await h.close();
+      vi.unstubAllEnvs();
+    }
+  },
+);
+
+test.each([
+  ["direct", "keep"],
+  ["direct", "remove"],
+  ["model", "keep"],
+  ["model", "remove"],
+] as const)(
+  "the %s delegation overlay can %s a requested Skill preactivation",
+  async (source, choice) => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-delegation-skill-"));
+    const directory = join(workspaceRoot, ".agents", "skills", "requested");
+    await mkdir(directory, { recursive: true });
+    await writeFile(
+      join(directory, "SKILL.md"),
+      "---\nname: requested\ndescription: Inspect requested evidence.\n---\nREQUESTED CHILD SKILL BODY\n",
+    );
+    const requests: ModelRequest[] = [];
+    const h = await startManagedTui(
+      {
+        async *stream(request) {
+          if (source === "model" && request.tools.some((tool) => tool.name === "spawn_agents")) {
+            if (!request.messages.some((message) => message.role === "tool")) {
+              yield { type: "tool_call_start", id: "skill-spawn", name: "spawn_agents" };
+              yield {
+                type: "tool_call_delta",
+                id: "skill-spawn",
+                json: JSON.stringify({
+                  entries: [
+                    {
+                      role: "builtin:explore",
+                      task: "Inspect evidence",
+                      description: "Requested Skill evidence",
+                      skills: ["skill:v1:project:.:requested"],
+                    },
+                  ],
+                }),
+              };
+              yield { type: "tool_call_end", id: "skill-spawn" };
+              yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+              yield { type: "finish", reason: "tool_calls" };
+              return;
+            }
+            yield { type: "text_delta", text: "Main delegation recorded." };
+            yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+            yield { type: "finish", reason: "stop" };
+            return;
+          }
+          requests.push(request);
+          yield { type: "text_delta", text: "Selected Skill choice inspected." };
+          yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+          yield { type: "finish", reason: "stop" };
+        },
+      },
+      { workspaceRoot },
+    );
+    try {
+      if (source === "direct") {
+        await h.press("@Explore", "A · Explore");
+        await h.press("\t", "@Explore");
+        await h.press(" Inspect evidence with $requested", "Inspect requested evidence.");
+        await h.press("\t", "$requested");
+      } else await h.press("Delegate Skill evidence", "Delegate Skill evidence");
+      await h.press("\r", "Skill: skill:v1:project:.:requested");
+      if (choice === "remove") {
+        await h.press("\x1b[B\x1b[B\r", "Use selected Skills");
+        await h.press("\x1b[B\r", "0 pre-activations");
+        await h.press("\x1b[A\r", "Context updated.");
+      }
+      expect(requests).toHaveLength(0);
+      await h.press("\r", "@explore-1 · Explore · Completed");
+      expect(requests).toHaveLength(1);
+      const text = JSON.stringify(requests[0]?.messages);
+      if (choice === "keep") expect(text).toContain("REQUESTED CHILD SKILL BODY");
+      else expect(text).not.toContain("REQUESTED CHILD SKILL BODY");
+      const admission = (await h.store.read()).find((record) => record.event.type === "admitted");
+      expect(admission?.event).toMatchObject({
+        skills: choice === "keep" ? ["skill:v1:project:.:requested"] : [],
+        envelope: { skills: choice === "keep" ? ["skill:v1:project:.:requested"] : [] },
+      });
+    } finally {
+      await h.close();
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  },
+);

--- a/apps/tui/src/agent-fleet.test-support.ts
+++ b/apps/tui/src/agent-fleet.test-support.ts
@@ -9,6 +9,7 @@ import {
   type ModelTargets,
 } from "@adam-agent/agent";
 import {
+  createDirectDeepSeekThinkingCapability,
   createInMemoryManagedAgentControlStore,
   createInMemorySessionStoreDirectory,
   createTrustedWorkspaceTrustForTesting,
@@ -81,6 +82,7 @@ export type ManagedTuiFixture = {
 export async function startManagedTui(
   driver: ModelDriver,
   viewport: {
+    readonly clipboard?: Parameters<typeof runTui>[0]["clipboard"];
     readonly preferences?: Parameters<typeof createPresentationSession>[0]["preferences"];
     readonly rows?: number;
     readonly columns?: number;
@@ -88,6 +90,8 @@ export async function startManagedTui(
     readonly draftPersistencePolicy?: "process_only" | "recoverable";
     readonly restore?: ManagedTuiStorage;
     readonly withDestination?: boolean;
+    readonly blankDraft?: boolean;
+    readonly thinking?: boolean;
     readonly controlReceiptBarrier?: (
       command: ManagedControlCommand,
       receipt: ManagedControlReceipt,
@@ -98,7 +102,13 @@ export async function startManagedTui(
     ) => Promise<void>;
     readonly childRecordBarrier?: (record: SessionRecord) => Promise<void>;
     readonly workspaceRoot?: string;
+    readonly modelTargets?: ModelTargets;
     readonly permissions?: NonNullable<Parameters<typeof createSessionLifecycle>[0]["permissions"]>;
+    readonly webHttp?: Parameters<typeof createSessionLifecycle>[0]["webHttp"];
+    readonly webSearchConfiguration?: Parameters<
+      typeof createSessionLifecycle
+    >[0]["webSearchConfiguration"];
+    readonly planPolicyVersion?: "plan-policy.hybrid-delegation-v1";
   } = {},
 ): Promise<ManagedTuiFixture> {
   const stateRoot =
@@ -109,9 +119,12 @@ export async function startManagedTui(
   const children =
     viewport.restore?.children ?? createInMemorySessionStoreDirectory<SessionRecord>();
   const store = viewport.restore?.store ?? createInMemoryManagedAgentControlStore();
-  const modelTargets: ModelTargets = {
+  const thinking = viewport.thinking
+    ? { thinkingCapability: createDirectDeepSeekThinkingCapability(identity) }
+    : {};
+  const modelTargets: ModelTargets = viewport.modelTargets ?? {
     async resolve() {
-      return { identity, contextProfile, driver };
+      return { identity, contextProfile, driver, ...thinking };
     },
     async snapshot() {
       return {
@@ -119,6 +132,7 @@ export async function startManagedTui(
           {
             identity,
             contextProfile,
+            ...thinking,
             readiness: { status: "available", credentialSource: "test" },
           },
         ],
@@ -138,6 +152,11 @@ export async function startManagedTui(
   const lifecycle = createSessionLifecycle({
     workspaceRoot,
     stateRoot,
+    ...(viewport.preferences === undefined ? {} : { preferences: viewport.preferences }),
+    ...(viewport.webHttp === undefined ? {} : { webHttp: viewport.webHttp }),
+    ...(viewport.webSearchConfiguration === undefined
+      ? {}
+      : { webSearchConfiguration: viewport.webSearchConfiguration }),
     modelTargets,
     permissions:
       viewport.permissions ?? createPermissionPolicy({ allowedEffects: ["read", "delegate"] }),
@@ -156,6 +175,10 @@ export async function startManagedTui(
       },
     },
     [sessionManagedControl]: {
+      userRoleDirectory: join(stateRoot, "roles"),
+      ...(viewport.planPolicyVersion === undefined
+        ? {}
+        : { planPolicyVersion: viewport.planPolicyVersion }),
       store,
       childSessionStores: children,
       ...(viewport.controlRecordBarrier === undefined
@@ -171,7 +194,7 @@ export async function startManagedTui(
   });
   const parent =
     viewport.restore === undefined
-      ? await lifecycle.create({ targetIdentity: identity })
+      ? await lifecycle.create({ targetIdentity: identity, mode: "default" })
       : { sessionId: viewport.restore.sessionId };
   if (viewport.restore === undefined)
     await lifecycle.setSessionManualName({ sessionId: parent.sessionId, name: "Fleet fixture" });
@@ -199,7 +222,7 @@ export async function startManagedTui(
     workspaceRoot,
     stateRoot,
     ...(viewport.preferences === undefined ? {} : { preferences: viewport.preferences }),
-    sessionId: parent.sessionId,
+    ...(viewport.blankDraft ? { targetIdentity: identity } : { sessionId: parent.sessionId }),
     projectLabel: "Fleet fixture",
     draftPersistencePolicy: viewport.draftPersistencePolicy ?? "process_only",
     ...(viewport.controlReceiptBarrier === undefined
@@ -212,12 +235,13 @@ export async function startManagedTui(
   let waitingForFrame = "initial frame";
   onTestFailed(() =>
     console.error(
-      `Fleet screen at failure (${waitingForFrame}):\n${terminal.lines().join("\n")}\nPending transition: ${JSON.stringify(presentation.getState().authoritative.managedTransition)}\nAttention: ${JSON.stringify(presentation.getState().managedAttention)}\nControl: ${JSON.stringify(presentation.getState().authoritative.managedControl?.threads.map((thread) => ({ handle: thread.handle, phase: thread.turn.phase, label: thread.turn.label, diagnostic: thread.turn.diagnostic, attention: thread.turn.attention, actions: thread.actions })))}`,
+      `Fleet screen at failure (${waitingForFrame}):\n${terminal.lines().join("\n")}\nPending transition: ${JSON.stringify(presentation.getState().authoritative.managedTransition)}\nAttention: ${JSON.stringify(presentation.getState().managedAttention)}\nControl: ${JSON.stringify(presentation.getState().authoritative.managedControl?.threads.map((thread) => ({ handle: thread.handle, phase: thread.turn.phase, label: thread.turn.label, diagnostic: thread.turn.diagnostic, outcome: thread.turn.outcome, attention: thread.turn.attention, actions: thread.actions })))}`,
     ),
   );
   const running = runTui({
     terminal,
     presentation,
+    ...(viewport.clipboard === undefined ? {} : { clipboard: viewport.clipboard }),
     ...(viewport.deadlineScheduler === undefined
       ? {}
       : { deadlineScheduler: viewport.deadlineScheduler }),

--- a/apps/tui/src/agent-fleet.test.ts
+++ b/apps/tui/src/agent-fleet.test.ts
@@ -1811,8 +1811,8 @@ test("viewer Help disarms an earlier x-x cancellation before returning to the sa
     await h.press("\r", "Conversation");
     await h.press("x", "x again to cancel");
     await h.press("?", "Conversation details");
-    await h.press("\u001b", "Conversation");
-    await h.press("x", "Conversation");
+    await h.press("\u001b", "Following tail");
+    await h.press("x", "x again to cancel");
     expect(h.conversationText()).toContain("x again to cancel");
     expect(aborts).toBe(0);
     await h.press("x", "Cancelled");

--- a/apps/tui/src/agent-fleet.test.ts
+++ b/apps/tui/src/agent-fleet.test.ts
@@ -148,7 +148,7 @@ test("background spawn cards settle to Started and Queued with frozen identities
     },
   );
   try {
-    await h.press("Inspect these five items.\r", "Allow");
+    await h.press("Inspect these five items.\r", "Confirm delegation");
     await h.press("\r", "Batch admitted; Main ready.");
     await prepared.promise;
     await h.terminal.waitForScreen("Starting · 0 used");

--- a/apps/tui/src/agent-fleet.ts
+++ b/apps/tui/src/agent-fleet.ts
@@ -164,6 +164,7 @@ export class AgentWorkspace implements Component {
       readonly initialView?: "workspace" | "settings" | "history";
       readonly onSettings: (settings: AgentUiSettings | null) => Promise<CommandReceipt>;
       readonly onAttention: () => void;
+      readonly onTypes?: () => void;
       readonly theme: AdamTuiTheme;
       readonly maximumLines: () => number;
       readonly onChange: () => void;
@@ -281,6 +282,10 @@ export class AgentWorkspace implements Component {
           });
       }
       this.options.onChange();
+      return;
+    }
+    if (matchesKey(data, "t") && !isKeyRepeat(data)) {
+      this.options.onTypes?.();
       return;
     }
     if (matchesKey(data, "s") && !isKeyRepeat(data)) {
@@ -587,8 +592,8 @@ export class AgentWorkspace implements Component {
       ].join(" · ");
       const hints = [
         width < 72
-          ? "Enter inspect · h/s/a · Esc"
-          : "Enter inspect · h history · s settings · a attention · Esc back",
+          ? "Enter inspect · t types · h/s/a · Esc"
+          : "Enter inspect · t types · h history · s settings · a attention · Esc back",
         ...(controls ? [controls] : []),
       ];
       const maximum = Math.max(

--- a/apps/tui/src/agent-role-catalog.test.ts
+++ b/apps/tui/src/agent-role-catalog.test.ts
@@ -1,0 +1,287 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ModelRequest } from "@adam-agent/agent";
+import {
+  createPresentationPreferencesWithStorageForTesting,
+  sessionManagedControl,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+import { startManagedTui } from "./agent-fleet.test-support.js";
+
+test("an inherited role retains the parent's tightened context and output policy", async () => {
+  const preferences = createPresentationPreferencesWithStorageForTesting({
+    async read() {
+      return {
+        status: "available",
+        text: JSON.stringify({
+          schemaVersion: 2,
+          defaultTargetId: null,
+          modelPolicy: {
+            contextWindowTokens: 64000,
+            maximumOutputTokens: 1024,
+            automaticCompactionWindowTokens: null,
+          },
+        }),
+      };
+    },
+    async write() {},
+  });
+  const requests: ModelRequest[] = [];
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        requests.push(request);
+        yield { type: "text_delta", text: "Inherited policy evidence." };
+        yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    { preferences },
+  );
+  try {
+    await h.press("@Explore", "A · Explore");
+    await h.press("\t", "@Explore");
+    await h.press(" Inspect within the parent policy.\r", "Delegation");
+    await h.press("\r", "Completed");
+    const admission = (await h.store.read()).find((record) => record.event.type === "admitted");
+    expect(admission?.event).toMatchObject({
+      frozen: { contextProfile: { contextWindowTokens: 64000, maximumOutputTokens: 1024 } },
+    });
+    expect(requests[0]?.maximumOutputTokens).toBe(1024);
+  } finally {
+    await h.close();
+  }
+});
+
+test("a trusted custom role admits only its narrowed tools and appends its instructions", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-role-catalog-"));
+  const directory = join(workspaceRoot, ".agents", "agents");
+  await mkdir(directory, { recursive: true });
+  await writeFile(
+    join(directory, "auditor.md"),
+    "---\nname: Auditor\ndescription: Inspect one exact evidence file.\nbase: explore\ntools: [read_file]\nskills: false\ncontext_mode: task\n---\nAUDITOR INSTRUCTIONS: cite exact file evidence.\n",
+  );
+  const requests: ModelRequest[] = [];
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        requests.push(request);
+        yield {
+          type: "text_delta",
+          text: requests.length === 1 ? "Custom audit complete." : "Original audit continued.",
+        };
+        yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    { workspaceRoot },
+  );
+  try {
+    const catalogControl = await h.lifecycle[sessionManagedControl](h.parent.sessionId);
+    const discovered = await catalogControl?.dispatch({
+      type: "list_agents",
+      parentSessionId: h.parent.sessionId,
+      view: "roles",
+      limit: 2,
+    });
+    expect(discovered?.status).toBe("roles_listed");
+    if (discovered?.status !== "roles_listed") throw new Error("Missing role catalog.");
+    const customPage = await catalogControl?.dispatch({
+      type: "list_agents",
+      parentSessionId: h.parent.sessionId,
+      view: "roles",
+      ...(discovered.cursor === undefined ? {} : { cursor: discovered.cursor }),
+    });
+    expect(customPage).toMatchObject({
+      status: "roles_listed",
+      roles: [{ qualifiedId: "project:Auditor", tools: ["read_file"] }],
+    });
+    await h.press("@Auditor", "A · Inspect one exact evidence file.");
+    await h.press("\t", "@Auditor");
+    await h.press(" Inspect the evidence.", "Inspect the evidence.");
+    await h.press("\r", "Delegation");
+    await h.press("\r", "Completed");
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.tools.map((tool) => tool.name)).toEqual(["read_file"]);
+    expect(JSON.stringify(requests[0]?.messages)).toContain("AUDITOR INSTRUCTIONS");
+    const first = h.presentation.getState().authoritative.managedControl?.threads[0];
+    expect(first?.role).toBe("project:Auditor");
+    await writeFile(
+      join(directory, "auditor.md"),
+      "---\nname: Auditor\ndescription: Reloaded audit role.\nbase: explore\ntools: [search_repository]\n---\nRELOADED INSTRUCTIONS\n",
+    );
+    const control = await h.lifecycle[sessionManagedControl](h.parent.sessionId);
+    const reloaded = await control?.inspectRoles({ reload: true });
+    expect(reloaded?.roles.find((role) => role.qualifiedId === "project:Auditor")?.tools).toEqual([
+      "search_repository",
+    ]);
+    await h.openFirstAgent("@auditor-1");
+    await h.press("\r", "New turn");
+    await h.press("Continue the original audit.", "Continue the original audit.");
+    await h.press("\r", "Original audit continued.");
+    expect(requests[1]?.tools.map((tool) => tool.name)).toEqual(["read_file"]);
+    expect(JSON.stringify(requests[1]?.messages)).toContain("AUDITOR INSTRUCTIONS");
+    expect(JSON.stringify(requests[1]?.messages)).not.toContain("RELOADED INSTRUCTIONS");
+  } finally {
+    await h.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("a role uses its configured certified target and keeps it after definition reload", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-role-target-"));
+  const directory = join(workspaceRoot, ".agents", "agents");
+  await mkdir(directory, { recursive: true });
+  await writeFile(
+    join(directory, "specialist.md"),
+    "---\nname: Specialist\ndescription: Inspect using the selected specialist target.\nbase: explore\nmodel: specialist.direct\n---\nSpecialist instructions.\n",
+  );
+  let mainCalls = 0;
+  let childCalls = 0;
+  const parentDriver = {
+    async *stream() {
+      mainCalls += 1;
+      yield { type: "text_delta" as const, text: "Wrong target." };
+      yield { type: "usage" as const, inputTokens: 100, outputTokens: 20 };
+      yield { type: "finish" as const, reason: "stop" as const };
+    },
+  };
+  const childDriver = {
+    async *stream() {
+      childCalls += 1;
+      yield {
+        type: "text_delta" as const,
+        text: childCalls === 1 ? "Specialist completed." : "Specialist continued.",
+      };
+      yield { type: "usage" as const, inputTokens: 100, outputTokens: 20 };
+      yield { type: "finish" as const, reason: "stop" as const };
+    },
+  };
+  const profile = {
+    version: 1 as const,
+    contextWindowTokens: 128000,
+    maximumOutputTokens: 4096,
+    compactAtTokens: 96000,
+    postCompactTargetTokens: 32000,
+    retainedTargetTokens: 8000,
+    estimatorVersion: 1 as const,
+  };
+  const parentTarget = {
+    targetId: "deepseek-v4-flash.direct",
+    vendor: "deepseek",
+    modelId: "deepseek-v4-flash",
+    route: "direct" as const,
+    profileVersion: 1,
+    certification: "certified" as const,
+  };
+  const specialistTarget = {
+    ...parentTarget,
+    targetId: "specialist.direct",
+    modelId: "specialist",
+  };
+  const h = await startManagedTui(parentDriver, {
+    workspaceRoot,
+    modelTargets: {
+      async resolve(input) {
+        return {
+          identity: input.targetId === specialistTarget.targetId ? specialistTarget : parentTarget,
+          contextProfile: profile,
+          driver: input.targetId === specialistTarget.targetId ? childDriver : parentDriver,
+        };
+      },
+      async snapshot() {
+        return {
+          targets: [parentTarget, specialistTarget].map((identity) => ({
+            identity,
+            contextProfile: profile,
+            readiness: { status: "available" as const, credentialSource: "test" },
+          })),
+        };
+      },
+    },
+  });
+  try {
+    await h.press("@Specialist", "A · Inspect using");
+    await h.press("\t", "@Specialist");
+    await h.press(" Inspect specialist evidence.", "Inspect specialist evidence.");
+    await h.press("\r", "Delegation");
+    await h.press("\r", "Completed");
+    expect(childCalls).toBe(1);
+    expect(mainCalls).toBe(0);
+    await writeFile(
+      join(directory, "specialist.md"),
+      "---\nname: Specialist\ndescription: Changed target.\nbase: explore\n---\nUpdated instructions.\n",
+    );
+    const control = await h.lifecycle[sessionManagedControl](h.parent.sessionId);
+    await control?.inspectRoles({ reload: true });
+    await h.openFirstAgent("@specialist-1");
+    await h.press("\r", "New turn");
+    await h.press("Continue specialist evidence.", "Continue specialist evidence.");
+    await h.press("\r", "Specialist continued.");
+    expect(childCalls).toBe(2);
+    expect(mainCalls).toBe(0);
+  } finally {
+    await h.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test.each(
+  (["inherit", "update", "cancel"] as const).flatMap((choice) =>
+    [false, true].map((blankDraft) => ({ choice, blankDraft })),
+  ),
+)(
+  "an unavailable role target offers $choice before admission (blank draft: $blankDraft)",
+  async ({ choice, blankDraft }) => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-role-unavailable-"));
+    const directory = join(workspaceRoot, ".agents", "agents");
+    await mkdir(directory, { recursive: true });
+    const path = join(directory, "specialist.md");
+    const original =
+      "---\nname: Specialist\ndescription: Inspect with a configured target.\nbase: explore\nmodel: missing.direct\n---\nKeep these instructions.\n";
+    await writeFile(path, original);
+    let calls = 0;
+    const h = await startManagedTui(
+      {
+        async *stream() {
+          calls += 1;
+          yield { type: "text_delta", text: "Explicit target choice completed." };
+          yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+          yield { type: "finish", reason: "stop" };
+        },
+      },
+      { workspaceRoot, blankDraft },
+    );
+    try {
+      await h.press("@Specialist", "A · Inspect with");
+      await h.press("\t", "@Specialist");
+      await h.press(" Inspect evidence.", "Inspect evidence.");
+      await h.press("\r", "Role target unavailable");
+      expect(calls).toBe(0);
+      expect(h.presentation.getState().authoritative.managedControl?.threads ?? []).toEqual([]);
+      if (choice === "cancel") {
+        await h.press("\x1b", "@Specialist");
+        expect(await readFile(path, "utf8")).toBe(original);
+        expect(calls).toBe(0);
+      } else {
+        if (choice === "update") {
+          await h.press("\x1b[B", "Update");
+          await h.press("\r", "Save this certified target");
+        }
+        await h.press("\r", "Delegation");
+        expect(calls).toBe(0);
+        const updated = await readFile(path, "utf8");
+        expect(updated).toContain("Keep these instructions.");
+        expect(updated).not.toContain("missing.direct");
+        if (choice === "update") expect(updated).toContain("model: deepseek-v4-flash.direct");
+        else expect(updated).not.toContain("model:");
+        await h.press("\r", "Completed");
+        expect(calls).toBe(1);
+      }
+    } finally {
+      await h.close();
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  },
+);

--- a/apps/tui/src/agent-role-input.test.ts
+++ b/apps/tui/src/agent-role-input.test.ts
@@ -1,0 +1,1235 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ModelDriver, ModelRequest } from "@adam-agent/agent";
+import { sessionManagedControl } from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+import { startManagedTui } from "./agent-fleet.test-support.js";
+
+test("direct delegation reads only its explicitly attached immutable resource", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-role-attachment-"));
+  const path = join(workspaceRoot, "evidence.txt");
+  await writeFile(path, "IMMUTABLE SELECTED EVIDENCE\n");
+  const requests: ModelRequest[] = [];
+  const driver: ModelDriver = {
+    async *stream(request) {
+      requests.push(request);
+      if (requests.length % 2 === 1) {
+        const text = JSON.stringify(request.messages);
+        const ids = [
+          ...new Set([...text.matchAll(/[a-f0-9-]{36}:input:\d+/gu)].map((match) => match[0])),
+        ];
+        const currentRun = ids.at(-1)?.split(":input:")[0];
+        if (currentRun === undefined)
+          throw new Error("Selected immutable resource descriptor missing.");
+        for (const occurrenceId of ids.filter((id) => id.startsWith(currentRun))) {
+          const id = `read-${occurrenceId}`;
+          yield { type: "tool_call_start", id, name: "read_input_resource" };
+          yield { type: "tool_call_delta", id, json: JSON.stringify({ occurrenceId }) };
+          yield { type: "tool_call_end", id };
+        }
+        yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+        yield { type: "finish", reason: "tool_calls" };
+      } else {
+        yield {
+          type: "text_delta",
+          text:
+            requests.length < 4
+              ? "Attached evidence inspected."
+              : requests.length < 6
+                ? "Added attachment inspected."
+                : "Both attachments retained.",
+        };
+        yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+        yield { type: "finish", reason: "stop" };
+      }
+    },
+  };
+  const h = await startManagedTui(driver, { workspaceRoot, blankDraft: true });
+  let cold: Awaited<ReturnType<typeof startManagedTui>> | undefined;
+  try {
+    await h.press("@Explore", "A · Explore");
+    await h.press("\t", "@Explore");
+    await h.press(" Inspect this attachment. ", "Inspect this attachment.");
+    expect(await h.presentation.dispatch({ type: "stage_input_resource", path })).toMatchObject({
+      status: "admitted",
+    });
+    await writeFile(path, "LATER LIVE FILE CONTENT\n");
+    await h.press("\r", "Delegation");
+    expect(requests).toHaveLength(0);
+    await h.press("\r", "Completed");
+    expect(JSON.stringify(requests[1]?.messages)).toContain("IMMUTABLE SELECTED EVIDENCE");
+    expect(JSON.stringify(requests)).not.toContain("LATER LIVE FILE CONTENT");
+    const admission = (await h.store.read()).find((record) => record.event.type === "admitted");
+    expect(admission?.event).toMatchObject({
+      frozen: { inputResources: [{ artifact: { id: expect.stringMatching(/^sha256:/u) } }] },
+    });
+    expect(h.presentation.getState().composer.renderedText).toBe("");
+    const addedPath = join(workspaceRoot, "added.txt");
+    await writeFile(addedPath, "EXPLICIT LATER ATTACHMENT\n");
+    await h.press("@explore-1", "A · Inspect this attachment.");
+    await h.press("\t", "@explore-1");
+    await h.press(
+      " Read the explicitly added attachment. ",
+      "Read the explicitly added attachment.",
+    );
+    expect(
+      await h.presentation.dispatch({ type: "stage_input_resource", path: addedPath }),
+    ).toMatchObject({ status: "admitted" });
+    await h.press("\r", "Delegation");
+    await h.press("\r", "Input accepted for @explore-1");
+    await h.terminal.waitForScreen("○ @explore-1 · Explore · Completed");
+    expect(requests).toHaveLength(4);
+    expect(JSON.stringify(requests[3]?.messages)).toContain("EXPLICIT LATER ATTACHMENT");
+    const sessionId = h.presentation.getState().authoritative.active?.session.id;
+    if (sessionId === undefined) throw new Error("Direct parent Session missing.");
+    await h.stop();
+    cold = await startManagedTui(driver, { workspaceRoot, restore: { ...h.storage, sessionId } });
+    await cold.press("/agents\r", "Agents workspace");
+    await cold.press("\r", "Added attachment inspected.");
+    await cold.press("\r", "New turn");
+    await cold.press("Read both immutable attachments again.\r", "Both attachments retained.");
+    expect(requests).toHaveLength(6);
+    expect(JSON.stringify(requests[5]?.messages)).toContain("IMMUTABLE SELECTED EVIDENCE");
+    expect(JSON.stringify(requests[5]?.messages)).toContain("EXPLICIT LATER ATTACHMENT");
+    expect(JSON.stringify(requests[5]?.messages)).not.toContain("LATER LIVE FILE CONTENT");
+    const latest = (await cold.store.read()).findLast((record) => record.event.type === "admitted");
+    const records =
+      latest === undefined ? [] : await (await cold.children.open(latest.childSessionId))?.read();
+    expect(
+      records?.filter(
+        (record) =>
+          record.schemaVersion === 3 && record.record.type === "input_resource_read_committed",
+      ),
+    ).toHaveLength(2);
+  } finally {
+    await (cold ?? h).close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("model delegation links only an exact explicitly selected parent attachment", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-selected-attachment-"));
+  const selectedPath = join(workspaceRoot, "selected.txt");
+  const privatePath = join(workspaceRoot, "unselected.txt");
+  await writeFile(selectedPath, "SELECTED IMMUTABLE BODY\n");
+  await writeFile(privatePath, "UNSELECTED PRIVATE BODY\n");
+  let mainCalls = 0;
+  const children: ModelRequest[] = [];
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        const main = request.tools.some((tool) => tool.name === "spawn_agents");
+        if (main) mainCalls += 1;
+        else children.push(request);
+        const text = JSON.stringify(request.messages);
+        const occurrenceId = text.match(/[a-f0-9-]{36}:input:1/u)?.[0];
+        if (main && mainCalls === 1) {
+          if (occurrenceId === undefined) throw new Error("Missing parent attachment descriptor.");
+          yield { type: "tool_call_start", id: "select-artifact", name: "spawn_agents" };
+          yield {
+            type: "tool_call_delta",
+            id: "select-artifact",
+            json: JSON.stringify({
+              entries: [
+                {
+                  role: "builtin:explore",
+                  description: "Selected artifact",
+                  task: "Inspect only the selected artifact.",
+                  context: { mode: "task" },
+                  artifacts: [occurrenceId],
+                },
+              ],
+            }),
+          };
+          yield { type: "tool_call_end", id: "select-artifact" };
+        } else if (!main && children.length === 1) {
+          if (occurrenceId === undefined) throw new Error("Missing child attachment descriptor.");
+          yield { type: "tool_call_start", id: "read-selected", name: "read_input_resource" };
+          yield {
+            type: "tool_call_delta",
+            id: "read-selected",
+            json: JSON.stringify({ occurrenceId }),
+          };
+          yield { type: "tool_call_end", id: "read-selected" };
+        } else
+          yield {
+            type: "text_delta",
+            text: main ? "Parent delegated one artifact." : "Selected artifact inspected.",
+          };
+        yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+        yield {
+          type: "finish",
+          reason:
+            (main && mainCalls === 1) || (!main && children.length === 1) ? "tool_calls" : "stop",
+        };
+      },
+    },
+    { workspaceRoot },
+  );
+  try {
+    for (const path of [selectedPath, privatePath])
+      expect(await h.presentation.dispatch({ type: "stage_input_resource", path })).toMatchObject({
+        status: "admitted",
+      });
+    await h.press(" Delegate one selected artifact.\r", "Delegation");
+    await h.press("\r", "Parent delegated one artifact.");
+    await h.terminal.waitForScreen("○ @explore-1 · Explore · Completed");
+    expect(children).toHaveLength(2);
+    expect(JSON.stringify(children)).toContain("SELECTED IMMUTABLE BODY");
+    expect(JSON.stringify(children)).not.toContain("unselected.txt");
+    expect(JSON.stringify(children)).not.toContain("UNSELECTED PRIVATE BODY");
+    const admission = (await h.store.read()).find((record) => record.event.type === "admitted");
+    expect(admission?.event).toMatchObject({
+      frozen: {
+        inputResources: [{ displayName: "selected.txt" }],
+        artifactSources: [
+          {
+            parentSessionId: h.parent.sessionId,
+            sequence: expect.any(Number),
+            digest: expect.stringMatching(/^sha256:/u),
+          },
+        ],
+      },
+    });
+  } finally {
+    await h.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("direct role and exact-thread messages preserve folded pasted evidence", async () => {
+  const requests: ModelRequest[] = [];
+  const h = await startManagedTui({
+    async *stream(request) {
+      requests.push(request);
+      yield { type: "text_delta", text: "Pasted evidence inspected." };
+      yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    for (const [mention, marker] of [
+      ["@Explore", "INITIAL PASTED EVIDENCE"],
+      ["@explore-1", "FOLLOWUP PASTED EVIDENCE"],
+    ] as const) {
+      await h.press(mention, mention === "@Explore" ? "A · Explore" : "A · Inspect these logs.");
+      await h.press("\t", mention);
+      await h.press(" Inspect these logs.\n", "Inspect these logs.");
+      expect(
+        await h.presentation.dispatch({
+          type: "stage_pasted_text",
+          text: `${marker}\n`.repeat(50),
+        }),
+      ).toMatchObject({ status: "admitted" });
+      expect(
+        h.presentation
+          .getState()
+          .composer.elements.some((element) => element.type === "pasted_text"),
+      ).toBe(true);
+      await h.press("\r", "Delegation");
+      await h.press("\r", mention === "@Explore" ? "Completed" : "Input accepted for @explore-1");
+      await h.terminal.waitForScreen("○ @explore-1 · Explore · Completed");
+      expect(JSON.stringify(requests.at(-1)?.messages)).toContain(marker);
+      expect(h.presentation.getState().composer.renderedText).toBe("");
+    }
+    expect(requests).toHaveLength(2);
+  } finally {
+    await h.close();
+  }
+});
+
+test("requested Skill preactivation is atomic and preserves the rest of the child catalog", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-preactivate-"));
+  for (const name of ["requested", "independent"]) {
+    const directory = join(workspaceRoot, ".agents", "skills", name);
+    await mkdir(directory, { recursive: true });
+    await writeFile(
+      join(directory, "SKILL.md"),
+      `---\nname: ${name}\ndescription: Inspect ${name} evidence.\n---\n${name.toUpperCase()} SKILL BODY\n`,
+    );
+  }
+  const requests: ModelRequest[] = [];
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        requests.push(request);
+        if (requests.length === 1) {
+          yield { type: "tool_call_start", id: "independent", name: "activate_skill" };
+          yield {
+            type: "tool_call_delta",
+            id: "independent",
+            json: '{"qualifiedId":"skill:v1:project:.:independent"}',
+          };
+          yield { type: "tool_call_end", id: "independent" };
+          yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+          yield { type: "finish", reason: "tool_calls" };
+        } else {
+          yield { type: "text_delta", text: "Both Skills independently available." };
+          yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+          yield { type: "finish", reason: "stop" };
+        }
+      },
+    },
+    { workspaceRoot },
+  );
+  try {
+    const control = await h.lifecycle[sessionManagedControl](h.parent.sessionId);
+    const entry = {
+      role: "builtin:explore",
+      task: "Inspect both Skills.",
+      description: "Skill preactivation",
+      skills: ["skill:v1:project:.:requested"],
+    };
+    expect(
+      await control?.dispatch({
+        type: "spawn_agents",
+        parentSessionId: h.parent.sessionId,
+        entries: [entry, { ...entry, skills: ["skill:v1:project:.:missing"] }],
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect(await h.store.read()).toHaveLength(0);
+    expect(requests).toHaveLength(0);
+    expect(
+      await control?.dispatch({
+        type: "spawn_agents",
+        parentSessionId: h.parent.sessionId,
+        entries: [entry],
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await h.terminal.waitForScreen("@explore-1 · Explore · Completed");
+    expect(requests).toHaveLength(2);
+    expect(JSON.stringify(requests[0]?.messages)).toContain("REQUESTED SKILL BODY");
+    expect(JSON.stringify(requests[0]?.messages)).toContain("skill:v1:project:.:independent");
+    expect(JSON.stringify(requests[0]?.messages)).not.toContain("INDEPENDENT SKILL BODY");
+    expect(JSON.stringify(requests[1]?.messages)).toContain("INDEPENDENT SKILL BODY");
+    const parent = await h.lifecycle.inspect({ sessionId: h.parent.sessionId });
+    expect(parent.schemaVersion === 3 ? parent.skillContext?.active : undefined).toEqual([]);
+  } finally {
+    await h.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("the direct delegation overlay shares an explicitly selected older message", async () => {
+  const requests: ModelRequest[] = [];
+  const h = await startManagedTui({
+    async *stream(request) {
+      requests.push(request);
+      yield { type: "text_delta", text: "Parent or child evidence recorded." };
+      yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    await h.press("EXPLICIT OLDER CONTEXT\r", "Parent or child evidence recorded.");
+    await h.terminal.waitForScreen("provider reported · idle");
+    await h.press("UNSELECTED NEWER CONTEXT\r", "Parent or child evidence recorded.");
+    await h.terminal.waitForScreen("provider reported · idle");
+    await h.press("@Explore", "A · Explore");
+    await h.press("\t", "@Explore");
+    await h.press(" Inspect this direct task.", "Inspect this direct task.");
+    await h.press("\r", "Delegation");
+    await h.press("\x1b[B\x1b[B\r", "Context sharing");
+    await h.press("\x1b[B\x1b[B\r", "Select parent messages");
+    await h.press("\x1b[B\x1b[B\x1b[B\x1b[B\r", "[x] user");
+    await h.press("\x1b[A\x1b[A\x1b[A\x1b[A\r", "Context updated.");
+    expect(requests).toHaveLength(2);
+    await h.press("\r", "@explore-1 · Explore · Completed");
+    expect(requests).toHaveLength(3);
+    expect(JSON.stringify(requests[2]?.messages)).toContain("EXPLICIT OLDER CONTEXT");
+    expect(JSON.stringify(requests[2]?.messages)).toContain("Inspect this direct task.");
+    expect(JSON.stringify(requests[2]?.messages)).not.toContain("UNSELECTED NEWER CONTEXT");
+    expect(
+      (await h.store.read()).find((record) => record.event.type === "admitted")?.event,
+    ).toMatchObject({
+      context: {
+        mode: "selected_messages",
+        messages: [{ sequence: expect.any(Number), digest: expect.stringMatching(/^sha256:/u) }],
+      },
+      envelope: { context: "selected_messages" },
+    });
+  } finally {
+    await h.close();
+  }
+});
+
+test("delegation shares only the selected initial context and does not absorb later Main messages", async () => {
+  const requests: ModelRequest[] = [];
+  const started = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const h = await startManagedTui({
+    async *stream(request) {
+      const child = JSON.stringify(request.messages).includes("on the exact delegated task");
+      if (child) {
+        requests.push(request);
+        if (requests.length === 3) started.resolve();
+        await release.promise;
+      }
+      yield {
+        type: "text_delta",
+        text: child ? "Context evidence inspected." : "Main context recorded.",
+      };
+      yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    await h.press("OLDER SELECTED USER MESSAGE\r", "Main context recorded.");
+    await h.terminal.waitForScreen("provider reported · idle");
+    const parent = await h.sessions.open(h.parent.sessionId);
+    const source = (await parent?.read())?.find(
+      (record) => record.schemaVersion === 3 && record.record.type === "logical_run_started",
+    );
+    if (source === undefined) throw new Error("Missing durable source message.");
+    const link = {
+      sequence: source.sequence,
+      digest:
+        `sha256:${createHash("sha256").update(JSON.stringify(source)).digest("hex")}` as const,
+    };
+    await h.press("CURRENT PARENT REQUEST\r", "Main context recorded.");
+    await h.terminal.waitForScreen("provider reported · idle");
+    const control = await h.lifecycle[sessionManagedControl](h.parent.sessionId);
+    const entries = [
+      {
+        role: "builtin:explore",
+        task: "Inspect TASK ONLY.",
+        description: "Task only",
+        context: { mode: "task" },
+      },
+      {
+        role: "builtin:explore",
+        task: "Inspect CURRENT.",
+        description: "Current",
+        context: { mode: "current_request" },
+      },
+      {
+        role: "builtin:explore",
+        task: "Inspect SELECTED.",
+        description: "Selected",
+        context: { mode: "selected_messages", messages: [link] },
+      },
+    ] as const;
+    expect(
+      await control?.dispatch({
+        type: "spawn_agents",
+        parentSessionId: h.parent.sessionId,
+        entries,
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await started.promise;
+    const texts = requests.map((request) => JSON.stringify(request.messages));
+    expect(texts.find((text) => text.includes("Inspect TASK ONLY."))).not.toMatch(
+      /OLDER SELECTED|CURRENT PARENT/,
+    );
+    expect(texts.find((text) => text.includes("Inspect CURRENT."))).toContain(
+      "CURRENT PARENT REQUEST",
+    );
+    expect(texts.find((text) => text.includes("Inspect CURRENT."))).not.toContain("OLDER SELECTED");
+    expect(texts.find((text) => text.includes("Inspect SELECTED."))).toContain(
+      "OLDER SELECTED USER MESSAGE",
+    );
+    expect(texts.find((text) => text.includes("Inspect SELECTED."))).not.toContain(
+      "CURRENT PARENT REQUEST",
+    );
+    await h.press("LATER MAIN MESSAGE MUST STAY IN MAIN\r", "Main context recorded.");
+    await h.terminal.waitForScreen("provider reported · idle");
+    release.resolve();
+    await h.terminal.waitForScreen("@explore-3 · Explore · Completed");
+    expect(requests.map((request) => JSON.stringify(request.messages))).toEqual(texts);
+    expect(texts.join("\n")).not.toContain("LATER MAIN MESSAGE");
+    const admissions = (await h.store.read()).filter((record) => record.event.type === "admitted");
+    expect(admissions).toHaveLength(3);
+    expect(admissions[2]?.event).toMatchObject({
+      context: { mode: "selected_messages", messages: [link] },
+    });
+    const before = (await h.store.read()).length;
+    const forged = {
+      ...entries[2],
+      role: "builtin:explore",
+      task: "Forged context",
+      description: "Forged",
+      context: {
+        mode: "selected_messages" as const,
+        messages: [{ ...link, digest: `sha256:${"0".repeat(64)}` as const }],
+      },
+    };
+    expect(
+      await control?.dispatch({
+        type: "spawn_agents",
+        parentSessionId: h.parent.sessionId,
+        entries: [forged],
+      }),
+    ).toMatchObject({ status: "rejected" });
+    expect((await h.store.read()).length).toBe(before);
+  } finally {
+    release.resolve();
+    await h.close();
+  }
+});
+
+test("a lifetime alias restores the exact thread and cannot be rebound after closure", async () => {
+  let calls = 0;
+  const driver = {
+    async *stream() {
+      calls += 1;
+      yield { type: "text_delta" as const, text: "Alias evidence inspected." };
+      yield { type: "usage" as const, inputTokens: 100, outputTokens: 20 };
+      yield { type: "finish" as const, reason: "stop" as const };
+    },
+  };
+  const h = await startManagedTui(driver, { draftPersistencePolicy: "recoverable" });
+  let cold: Awaited<ReturnType<typeof startManagedTui>> | undefined;
+  try {
+    const control = await h.lifecycle[sessionManagedControl](h.parent.sessionId);
+    if (control === undefined) throw new Error("Missing control.");
+    const entry = {
+      role: "builtin:explore",
+      task: "Inspect aliases.",
+      description: "Alias evidence",
+      alias: "证据",
+    };
+    expect(
+      await control.dispatch({
+        type: "spawn_agents",
+        parentSessionId: h.parent.sessionId,
+        entries: [entry],
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await h.terminal.waitForScreen("@explore-1 · Explore · Completed");
+    const thread = h.presentation.getState().authoritative.managedControl?.threads[0];
+    if (thread === undefined) throw new Error("Missing thread.");
+    await h.press("@证据", "A · Alias evidence");
+    await h.press("\t", "@证");
+    await h.press(" Continue explicitly.", "Continue explicitly.");
+    await h.stop();
+    cold = await startManagedTui(driver, {
+      restore: h.storage,
+      draftPersistencePolicy: "recoverable",
+    });
+    await cold.terminal.waitForScreen("Continue explicitly.");
+    expect(cold.presentation.getState().composer.elements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "agent",
+          literal: "@证据",
+          threadId: thread.threadId,
+          handle: "@explore-1",
+        }),
+      ]),
+    );
+    await cold.press("\r", "Delegation");
+    await cold.press("\r", "Input accepted for @explore-1");
+    await cold.terminal.waitForScreen("@explore-1 · Explore · Completed");
+    const resumedControl = await cold.lifecycle[sessionManagedControl](h.parent.sessionId);
+    if (resumedControl === undefined) throw new Error("Missing restored control.");
+    const current = (await resumedControl.inspect({ parentSessionId: h.parent.sessionId }))
+      .threads[0];
+    if (current === undefined) throw new Error("Missing restored thread.");
+    expect(current).toMatchObject({
+      threadId: thread.threadId,
+      alias: "证据",
+      handle: "@explore-1",
+    });
+    expect(
+      await resumedControl.dispatch({
+        type: "close_thread",
+        parentSessionId: h.parent.sessionId,
+        threadId: current.threadId,
+        expectedTurnId: current.turn.turnId,
+      }),
+    ).toMatchObject({ status: "closed" });
+    const before = (await cold.store.read()).length;
+    for (const alias of ["证据", "explore-1", "main"]) {
+      expect(
+        await resumedControl.dispatch({
+          type: "spawn_agents",
+          parentSessionId: h.parent.sessionId,
+          entries: [
+            { ...entry, alias },
+            { ...entry, alias: "fresh" },
+          ],
+        }),
+      ).toMatchObject({ status: "rejected" });
+    }
+    expect((await cold.store.read()).length).toBe(before);
+    expect(calls).toBe(2);
+  } finally {
+    if (cold !== undefined) await cold.close();
+    await h.close();
+  }
+});
+
+test.each(["cooperative", "interrupt"] as const)(
+  "a selected running handle explicitly delivers %s input at a safe boundary",
+  async (mode) => {
+    const release = Promise.withResolvers<void>();
+    const requests: ModelRequest[] = [];
+    const h = await startManagedTui({
+      async *stream(request) {
+        requests.push(request);
+        if (requests.length === 1) {
+          yield { type: "text_delta", text: "Inspecting before the boundary." };
+          await release.promise;
+          yield { type: "tool_call_start", id: "direct-read", name: "read_file" };
+          yield { type: "tool_call_delta", id: "direct-read", json: '{"path":"package.json"}' };
+          yield { type: "tool_call_end", id: "direct-read" };
+          yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+          yield { type: "finish", reason: "tool_calls" };
+        } else {
+          yield { type: "text_delta", text: "Direct input delivered at the boundary." };
+          yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+          yield { type: "finish", reason: "stop" };
+        }
+      },
+    });
+    try {
+      await h.press("@Explore", "A · Explore");
+      await h.press("\t", "@Explore");
+      await h.press(" Inspect evidence.", "Inspect evidence.");
+      await h.press("\r", "Delegation");
+      await h.press("\r", "@explore-1 · Explore · Running");
+      await h.press("@explore-1", "A · Inspect evidence.");
+      await h.press("\t", "@explore-1");
+      await h.press(" Use this explicit later context.", "Use this explicit later context.");
+      await h.press("\r", "Send to @explore-1");
+      if (mode === "interrupt") await h.press("\x1b[B", "Interrupt after current effect");
+      await h.press("\r", "Input accepted for @explore-1");
+      expect(requests).toHaveLength(1);
+      expect(JSON.stringify(requests[0]?.messages)).not.toContain(
+        "Use this explicit later context.",
+      );
+      const accepted = (await h.store.read()).find(
+        (record) => record.event.type === "input_accepted",
+      );
+      expect(accepted?.event).toMatchObject({ mode, text: "Use this explicit later context." });
+      expect(h.presentation.getState().composer.renderedText).toBe("");
+      await h.openFirstAgent();
+      release.resolve();
+      await h.terminal.waitForScreen("Direct input delivered at the boundary.");
+      expect(JSON.stringify(requests[1]?.messages)).toContain("Use this explicit later context.");
+      expect(
+        h.presentation.getState().authoritative.managedControl?.threads[0]?.inputs,
+      ).toMatchObject([{ status: "delivered" }]);
+      expect(requests).toHaveLength(2);
+    } finally {
+      release.resolve();
+      await h.close();
+    }
+  },
+);
+
+test("a direct handle confirmation rejects a changed turn and retains the draft", async () => {
+  let calls = 0;
+  const release = Promise.withResolvers<void>();
+  const started = Promise.withResolvers<void>();
+  const h = await startManagedTui({
+    async *stream() {
+      calls += 1;
+      if (calls > 1) {
+        started.resolve();
+        await release.promise;
+      }
+      yield { type: "text_delta", text: "Turn evidence inspected." };
+      yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    await h.press("@Explore", "A · Explore");
+    await h.press("\t", "@Explore");
+    await h.press(" Inspect evidence.", "Inspect evidence.");
+    await h.press("\r", "Delegation");
+    await h.press("\r", "Completed");
+    const thread = h.presentation.getState().authoritative.managedControl?.threads[0];
+    if (thread === undefined) throw new Error("Missing first turn.");
+    await h.press("@explore-1", "A · Inspect evidence.");
+    await h.press("\t", "@explore-1");
+    await h.press(" Send only to the reviewed turn.", "Send only to the reviewed turn.");
+    await h.press("\r", "Delegation");
+    const control = await h.lifecycle[sessionManagedControl](h.parent.sessionId);
+    expect(
+      await control?.dispatch({
+        type: "next_turn",
+        parentSessionId: h.parent.sessionId,
+        threadId: thread.threadId,
+        expectedTurnId: thread.turn.turnId,
+        task: "Another explicit continuation.",
+      }),
+    ).toMatchObject({ status: "accepted" });
+    await started.promise;
+    await h.press("\r", "The exact turn or input action changed.");
+    expect(h.presentation.getState().composer.renderedText).toBe(
+      "@explore-1 Send only to the reviewed turn.",
+    );
+    const admissions = (await h.store.read()).filter((record) => record.event.type === "admitted");
+    expect(admissions).toHaveLength(2);
+    expect(admissions.at(-1)?.event).toMatchObject({ task: "Another explicit continuation." });
+    expect((await h.store.read()).some((record) => record.event.type === "input_accepted")).toBe(
+      false,
+    );
+  } finally {
+    release.resolve();
+    await h.close();
+  }
+});
+
+test("a selected main atom routes the following task to the existing Main Session", async () => {
+  const requests: ModelRequest[] = [];
+  const h = await startManagedTui({
+    async *stream(request) {
+      requests.push(request);
+      yield { type: "text_delta", text: "Main received the selected task." };
+      yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    await h.press("@main", "A · Main conversation");
+    await h.press("\t", "@main");
+    await h.press(" Inspect the parent request.", "Inspect the parent request.");
+    await h.press("\r", "Main received the selected task.");
+    expect(requests).toHaveLength(1);
+    expect(JSON.stringify(requests[0]?.messages)).toContain("Inspect the parent request.");
+    expect(h.presentation.getState().authoritative.active?.session.id).toBe(h.parent.sessionId);
+    expect(h.presentation.getState().authoritative.managedControl?.threads).toHaveLength(0);
+  } finally {
+    await h.close();
+  }
+});
+
+test("a selected exact handle starts a confirmed new turn in that thread", async () => {
+  const requests: ModelRequest[] = [];
+  const h = await startManagedTui({
+    async *stream(request) {
+      requests.push(request);
+      yield {
+        type: "text_delta",
+        text: requests.length === 1 ? "Initial evidence inspected." : "Exact handle continued.",
+      };
+      yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    await h.press("@Explore", "A · Explore");
+    await h.press("\t", "@Explore");
+    await h.press(" Inspect evidence.", "Inspect evidence.");
+    await h.press("\r", "Delegation");
+    await h.press("\r", "Completed");
+    const first = h.presentation.getState().authoritative.managedControl?.threads[0];
+    if (first === undefined) throw new Error("Missing original thread.");
+    await h.press("@explore-1", "A · Inspect evidence.");
+    await h.press("\t", "@explore-1");
+    await h.press(" Continue only this thread.", "Continue only this thread.");
+    await h.press("\r", "Delegation");
+    expect(requests).toHaveLength(1);
+    await h.press("\r", "Input accepted for @explore-1");
+    await h.terminal.waitForScreen("○ @explore-1 · Explore · Completed");
+    await h.openFirstAgent();
+    await h.terminal.waitForScreen("Exact handle continued.");
+    const threads = h.presentation.getState().authoritative.managedControl?.threads;
+    expect(threads).toHaveLength(1);
+    expect(threads?.[0]?.threadId).toBe(first.threadId);
+    expect(threads?.[0]?.turn.turnId).not.toBe(first.turn.turnId);
+    const records = await h.store.read();
+    expect(records.filter((record) => record.event.type === "admitted")).toHaveLength(2);
+    expect(records.findLast((record) => record.event.type === "admitted")?.event).toMatchObject({
+      task: "Continue only this thread.",
+      envelope: { origin: { kind: "direct_request" } },
+    });
+    expect(requests).toHaveLength(2);
+    expect(h.presentation.getState().composer.renderedText).toBe("");
+  } finally {
+    await h.close();
+  }
+});
+
+test.each(["default", "plan"] as const)(
+  "a blank %s draft confirms an independent control request without a Main provider turn",
+  async (mode) => {
+    const requests: ModelRequest[] = [];
+    const h = await startManagedTui(
+      {
+        async *stream(request) {
+          requests.push(request);
+          yield { type: "text_delta", text: "Blank draft evidence inspected." };
+          yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+          yield { type: "finish", reason: "stop" };
+        },
+      },
+      { blankDraft: true, thinking: true, draftPersistencePolicy: "recoverable" },
+    );
+    let cold: Awaited<ReturnType<typeof startManagedTui>> | undefined;
+    try {
+      const before = await h.sessions.listSessionIds();
+      await h.presentation.dispatch({ type: "set_draft_mode", mode });
+      expect(h.presentation.getState().authoritative.active).toBeNull();
+      await h.press("/thinking off\r", "Thinking Off selected for the next prompt.");
+      await h.press("@Explore", "A · Explore");
+      await h.press("\t", "@Explore");
+      await h.press(" Inspect this direct request.", "Inspect this direct request.");
+      await h.press("\r", "Delegation");
+      expect(await h.sessions.listSessionIds()).toEqual(before);
+      expect(requests).toHaveLength(0);
+      const revision = h.presentation.getState().composer.draftRevision;
+      const preview = await h.presentation.dispatch({
+        type: "direct_delegation",
+        draftRevision: revision,
+      });
+      if (preview.status !== "admitted" || preview.delegation === undefined)
+        throw new Error("Missing delegation preview.");
+      const forged = await h.presentation.dispatch({
+        type: "direct_delegation",
+        draftRevision: revision,
+        confirmedEnvelope: { ...preview.delegation.envelope, digest: `sha256:${"0".repeat(64)}` },
+      });
+      expect(forged.status).toBe("rejected");
+      expect(await h.sessions.listSessionIds()).toEqual(before);
+      expect(
+        await h.presentation.dispatch({
+          type: "direct_delegation",
+          draftRevision: revision,
+          confirmedEnvelope: preview.delegation.envelope,
+          thinkingSelection: {
+            requestedLevelId: "off",
+            capability: { id: "stale-capability", version: 1, digest: `sha256:${"0".repeat(64)}` },
+          },
+        }),
+      ).toMatchObject({ status: "rejected" });
+      expect(await h.sessions.listSessionIds()).toEqual(before);
+      expect(h.presentation.getState().authoritative.active).toBeNull();
+      expect(requests).toHaveLength(0);
+      await h.press("\x1b", "Inspect this direct request.");
+      expect(await h.sessions.listSessionIds()).toEqual(before);
+      await h.press("\r", "Delegation");
+      await h.press("\r", "Completed");
+      const active = h.presentation.getState().authoritative.active;
+      expect(active?.session.id).toBeDefined();
+      expect(active?.session.id).not.toBe(h.parent.sessionId);
+      expect(active?.plan?.state).toBe(mode === "plan" ? "exploring" : undefined);
+      expect(await h.sessions.listSessionIds()).toHaveLength(before.length + 1);
+      const records = await (await h.sessions.open(active?.session.id ?? ""))?.read();
+      expect(
+        records?.some(
+          (record) => record.schemaVersion === 3 && record.record.type === "logical_run_started",
+        ),
+      ).toBe(false);
+      const admission = (await h.store.read()).find((record) => record.event.type === "admitted");
+      expect(admission?.parentSessionId).toBe(active?.session.id);
+      expect(admission?.event).toMatchObject({
+        type: "admitted",
+        envelope: { origin: { kind: "direct_request", id: expect.any(String) } },
+        frozen: {
+          parentRequest: "Inspect this direct request.",
+          thinkingPolicy: { effectiveLevelId: "off" },
+        },
+      });
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.thinkingPolicy?.effectiveLevelId).toBe("off");
+      expect(h.presentation.getState().composer.renderedText).toBe("");
+      await h.stop();
+      cold = await startManagedTui(
+        {
+          stream() {
+            throw new Error("No provider expected while reopening the draft.");
+          },
+        },
+        { restore: h.storage, blankDraft: true, draftPersistencePolicy: "recoverable" },
+      );
+      expect(cold.presentation.getState().composer.renderedText).toBe("");
+    } finally {
+      if (cold !== undefined) await cold.close();
+      await h.close();
+    }
+  },
+);
+
+test("manual and pasted Unicode mentions are atomic literals without role authority", async () => {
+  const h = await startManagedTui({
+    stream() {
+      throw new Error("No provider expected.");
+    },
+  });
+  try {
+    await h.press("mail@example.com @探索🧭 ", "mail@example.com");
+    expect(h.presentation.getState().composer.elements).toEqual([
+      expect.objectContaining({ type: "text", text: "mail@example.com " }),
+      expect.objectContaining({ type: "mention", kind: "literal", literal: "@探索🧭" }),
+      expect.objectContaining({ type: "text", text: " " }),
+    ]);
+    await h.press("\x7f", "mail@example.com");
+    await h.press("\x7f", "mail@example.com");
+    expect(
+      h.presentation.getState().composer.elements.some((element) => element.type === "mention"),
+    ).toBe(false);
+    await h.press(String.fromCharCode(31), "Draft edit undone.");
+    expect(h.presentation.getState().composer.elements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "mention", kind: "literal", literal: "@探索🧭" }),
+      ]),
+    );
+    await h.press("\x7f", "Draft element removed.");
+    await h.press("\x1b[200~@Explore @main \x1b[201~", "@main");
+    expect(
+      h.presentation.getState().composer.elements.filter((element) => element.type === "mention"),
+    ).toEqual([
+      expect.objectContaining({ kind: "literal", literal: "@Explore" }),
+      expect.objectContaining({ kind: "literal", literal: "@main" }),
+    ]);
+    expect(h.presentation.getState().authoritative.managedControl?.threads).toHaveLength(0);
+  } finally {
+    await h.close();
+  }
+});
+
+test("an unselected trailing Unicode mention deletes as one unit before any whitespace", async () => {
+  const h = await startManagedTui({
+    stream() {
+      throw new Error("No provider expected.");
+    },
+  });
+  try {
+    await h.press("Inspect @探索🧭", "Inspect");
+    await h.press("\x7f", "Draft element removed.");
+    expect(h.presentation.getState().composer.renderedText).toBe("Inspect ");
+    await h.press(String.fromCharCode(31), "Draft edit undone.");
+    expect(h.presentation.getState().composer.elements).toEqual(
+      expect.arrayContaining([expect.objectContaining({ kind: "literal", literal: "@探索🧭" })]),
+    );
+  } finally {
+    await h.close();
+  }
+});
+
+test("multiple selected recipients require one explicit choice before delegation", async () => {
+  const h = await startManagedTui({
+    stream() {
+      throw new Error("No provider expected before confirmation.");
+    },
+  });
+  try {
+    await h.press("@Explore", "A · Explore");
+    await h.press("\t", "@Explore");
+    await h.press(" @Research", "A · Research");
+    await h.press("\t", "@Research");
+    await h.press(" Inspect the evidence.", "Inspect the evidence.");
+    await h.press("\r", "Choose recipient");
+    expect(h.presentation.getState().authoritative.managedControl?.threads).toHaveLength(0);
+    await h.press("\x1b[B", "@Research");
+    await h.press("\r", "Recipient selected.");
+    expect(
+      h.presentation.getState().composer.elements.filter((element) => element.type === "mention"),
+    ).toEqual([expect.objectContaining({ kind: "role", qualifiedRoleId: "builtin:research" })]);
+    await h.press("\r", "Delegation");
+    expect(h.presentation.getState().authoritative.managedControl?.threads).toHaveLength(0);
+    await h.press("\x1b", "Inspect the evidence.");
+  } finally {
+    await h.close();
+  }
+});
+
+test("a selected role survives cold restart and copied bytes return as literal mentions", async () => {
+  const driver = {
+    stream() {
+      throw new Error("No provider expected.");
+    },
+  };
+  let copied = "";
+  const h = await startManagedTui(driver, {
+    draftPersistencePolicy: "recoverable",
+    clipboard: {
+      async writeText(text) {
+        copied = text;
+        return "copied";
+      },
+    },
+  });
+  let cold: Awaited<ReturnType<typeof startManagedTui>> | undefined;
+  try {
+    await h.press("@Explore", "A · Explore");
+    await h.press("\t", "@Explore");
+    await h.press(" Inspect evidence.", "Inspect evidence.");
+    await h.stop();
+    const selected = h.presentation.getState().composer.elements;
+    expect(copied).toBe("@Explore Inspect evidence.");
+    expect(selected).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "role", qualifiedRoleId: "builtin:explore" }),
+      ]),
+    );
+    cold = await startManagedTui(driver, {
+      restore: h.storage,
+      draftPersistencePolicy: "recoverable",
+    });
+    await cold.terminal.waitForScreen("Inspect evidence.");
+    expect(cold.presentation.getState().composer.elements).toEqual(selected);
+    await cold.presentation.dispatch({
+      type: "clear_draft",
+      baseRevision: cold.presentation.getState().composer.draftRevision,
+    });
+    await cold.press(`\x1b[200~${copied}\x1b[201~`, "Inspect evidence.");
+    await cold.stop();
+    expect(cold.presentation.getState().composer.elements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "mention", kind: "literal", literal: "@Explore" }),
+      ]),
+    );
+    expect(cold.presentation.getState().authoritative.managedControl?.threads).toHaveLength(0);
+  } finally {
+    if (cold !== undefined) await cold.close();
+    await h.close();
+  }
+});
+
+test.each(["remove", "literal", "retarget"] as const)(
+  "an unavailable exact thread offers %s without rebinding its handle",
+  async (action) => {
+    let calls = 0;
+    const h = await startManagedTui({
+      async *stream() {
+        calls += 1;
+        yield { type: "text_delta", text: "Evidence inspected." };
+        yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+        yield { type: "finish", reason: "stop" };
+      },
+    });
+    try {
+      await h.press("@Explore", "A · Explore");
+      await h.press("\t", "@Explore");
+      await h.press(" Inspect evidence.", "Inspect evidence.");
+      await h.press("\r", "Delegation");
+      await h.press("\r", "Completed");
+      const thread = h.presentation.getState().authoritative.managedControl?.threads[0];
+      if (thread === undefined) throw new Error("Missing completed thread.");
+      await h.press("@explore-1", "A · Inspect evidence.");
+      await h.press("\t", "@explore-1");
+      await h.press(" Continue inspecting.", "Continue inspecting.");
+      const control = await h.lifecycle[sessionManagedControl](h.parent.sessionId);
+      await control?.dispatch({
+        type: "close_thread",
+        parentSessionId: h.parent.sessionId,
+        threadId: thread.threadId,
+        expectedTurnId: thread.turn.turnId,
+      });
+      await h.terminal.waitForScreen("@explore-1 unavailable");
+      expect(h.presentation.getState().composer.elements).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: "agent",
+            threadId: thread.threadId,
+            parentSessionId: h.parent.sessionId,
+          }),
+        ]),
+      );
+      await h.press("\r", "Recipient unavailable");
+      if (action !== "remove") await h.press("\x1b[B", "Convert to literal");
+      if (action === "retarget") await h.press("\x1b[B", "Retarget");
+      await h.press("\r", action === "retarget" ? "Retarget recipient" : "Recipient updated.");
+      if (action === "retarget") await h.press("\r", "Recipient updated.");
+      expect(calls).toBe(1);
+      expect(
+        h.presentation.getState().composer.elements.filter((element) => element.type === "mention"),
+      ).toEqual(
+        action === "remove"
+          ? []
+          : [
+              expect.objectContaining(
+                action === "literal"
+                  ? { kind: "literal", literal: "@explore-1" }
+                  : { kind: "role", qualifiedRoleId: "builtin:explore" },
+              ),
+            ],
+      );
+    } finally {
+      await h.close();
+    }
+  },
+);
+
+test.each([
+  { name: "Explore", role: "builtin:explore" },
+  { name: "Research", role: "builtin:research" },
+])(
+  "selected $name directly starts a described child with independent frozen Skill activation",
+  async ({ name, role }) => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-role-input-"));
+    const skillRoot = join(workspaceRoot, ".agents", "skills", "inspect-evidence");
+    await mkdir(skillRoot, { recursive: true });
+    await writeFile(
+      join(skillRoot, "SKILL.md"),
+      "---\nname: inspect-evidence\ndescription: Inspect exact repository evidence.\n---\nReport the independently activated evidence procedure.\n",
+    );
+    const requests: ModelRequest[] = [];
+    let mainCalls = 0;
+    const h = await startManagedTui(
+      {
+        async *stream(request) {
+          if (request.tools.some((tool) => tool.name === "spawn_agents")) mainCalls += 1;
+          requests.push(request);
+          if (requests.length === 1) {
+            yield { type: "tool_call_start", id: "activate-evidence", name: "activate_skill" };
+            yield {
+              type: "tool_call_delta",
+              id: "activate-evidence",
+              json: '{"qualifiedId":"skill:v1:project:.:inspect-evidence"}',
+            };
+            yield { type: "tool_call_end", id: "activate-evidence" };
+            yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+            yield { type: "finish", reason: "tool_calls" };
+          } else {
+            yield { type: "text_delta", text: "Independent Skill evidence complete." };
+            yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+            yield { type: "finish", reason: "stop" };
+          }
+        },
+      },
+      { workspaceRoot },
+    );
+    try {
+      await h.press(`@${name}`, name);
+      await h.press("\t", `@${name}`);
+      expect(h.presentation.getState().composer.elements).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "mention",
+            kind: "role",
+            qualifiedRoleId: role,
+          }),
+        ]),
+      );
+      await h.press(" Inspect exact repository evidence.", "Inspect exact repository evidence.");
+      await h.press("\r", "Delegation");
+      expect(requests).toHaveLength(0);
+      await h.press("\r", "Completed");
+      const thread = h.presentation.getState().authoritative.managedControl?.threads[0];
+      expect(thread).toMatchObject({
+        role,
+        description: "Inspect exact repository evidence.",
+        turn: { outcome: { status: "completed", summary: "Independent Skill evidence complete." } },
+      });
+      expect(mainCalls).toBe(0);
+      expect(requests).toHaveLength(2);
+      expect(JSON.stringify(requests[0]?.messages)).toContain(
+        "skill:v1:project:.:inspect-evidence",
+      );
+      expect(JSON.stringify(requests[0]?.messages)).not.toContain(
+        "Report the independently activated",
+      );
+      expect(JSON.stringify(requests[1]?.messages)).toContain("Report the independently activated");
+      for (const request of requests) {
+        const names = request.tools.map((tool) => tool.name);
+        expect(names).toEqual(
+          expect.arrayContaining(["read_file", "activate_skill", "read_skill_resource"]),
+        );
+        expect(names).not.toEqual(expect.arrayContaining(["write_file"]));
+        expect(names.some((name) => /web|mcp|shell|spawn/u.test(name))).toBe(false);
+      }
+      const parent = await h.lifecycle.inspect({ sessionId: h.parent.sessionId });
+      expect(parent.schemaVersion === 3 ? parent.skillContext?.active : undefined).toEqual([]);
+    } finally {
+      await h.close();
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test("an Explore continuation retains its activated Skill and resources across a parent catalog reload", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-role-continuation-"));
+  const skillRoot = join(workspaceRoot, ".agents", "skills", "origin-procedure");
+  await mkdir(skillRoot, { recursive: true });
+  await writeFile(
+    join(skillRoot, "SKILL.md"),
+    "---\nname: origin-procedure\ndescription: Inspect origin evidence.\n---\nORIGIN PROCEDURE BODY\n",
+  );
+  await writeFile(join(skillRoot, "evidence.md"), "Exact origin resource evidence.\n");
+  const requests: ModelRequest[] = [];
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        requests.push(request);
+        if (requests.length === 3) {
+          yield { type: "tool_call_start", id: "read-nested", name: "read_file" };
+          yield {
+            type: "tool_call_delta",
+            id: "read-nested",
+            json: '{"path":"nested/evidence.md"}',
+          };
+          yield { type: "tool_call_end", id: "read-nested" };
+          yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+          yield { type: "finish", reason: "tool_calls" };
+        } else if (requests.length === 1 || requests.length === 4) {
+          const activate = requests.length === 1;
+          yield {
+            type: "tool_call_start",
+            id: activate ? "activate-origin" : "read-origin",
+            name: activate ? "activate_skill" : "read_skill_resource",
+          };
+          yield {
+            type: "tool_call_delta",
+            id: activate ? "activate-origin" : "read-origin",
+            json: activate
+              ? '{"qualifiedId":"skill:v1:project:.:origin-procedure"}'
+              : '{"qualifiedId":"skill:v1:project:.:origin-procedure","path":"evidence.md"}',
+          };
+          yield { type: "tool_call_end", id: activate ? "activate-origin" : "read-origin" };
+          yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+          yield { type: "finish", reason: "tool_calls" };
+        } else {
+          yield {
+            type: "text_delta",
+            text:
+              requests.length === 2
+                ? "Origin evidence complete."
+                : "Continuation resource complete.",
+          };
+          yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+          yield { type: "finish", reason: "stop" };
+        }
+      },
+    },
+    { workspaceRoot },
+  );
+  try {
+    await h.press("@Explore", "A · Explore repository");
+    await h.press("\t", "@Explore");
+    await h.press(" Inspect origin evidence.", "Inspect origin evidence.");
+    await h.press("\r", "Delegation");
+    await h.press("\r", "Completed");
+    const first = h.presentation.getState().authoritative.managedControl?.threads[0];
+    expect(first?.turn.outcome?.status).toBe("completed");
+    const laterRoot = join(workspaceRoot, ".agents", "skills", "later-procedure");
+    await mkdir(laterRoot, { recursive: true });
+    await writeFile(
+      join(laterRoot, "SKILL.md"),
+      "---\nname: later-procedure\ndescription: Later parent procedure.\n---\nLATER PARENT BODY\n",
+    );
+    const nestedSkill = join(workspaceRoot, "nested", ".agents", "skills", "nested-late-procedure");
+    await mkdir(nestedSkill, { recursive: true });
+    await writeFile(
+      join(nestedSkill, "SKILL.md"),
+      "---\nname: nested-late-procedure\ndescription: Later scoped metadata.\n---\nLATE NESTED PROCEDURE\n",
+    );
+    await writeFile(join(workspaceRoot, "nested", "AGENTS.md"), "LATER NESTED INSTRUCTIONS\n");
+    await writeFile(join(workspaceRoot, "nested", "evidence.md"), "Nested file evidence.\n");
+    await h.lifecycle.reloadSkills({ sessionId: h.parent.sessionId });
+    await h.openFirstAgent();
+    await h.press("\r", "New turn");
+    await h.press("Read the active procedure resource.", "Read the active procedure resource.");
+    await h.press("\r", "Continuation resource complete.");
+    expect(requests).toHaveLength(5);
+    expect(JSON.stringify(requests[2]?.messages)).toContain("ORIGIN PROCEDURE BODY");
+    expect(JSON.stringify(requests[2]?.messages)).not.toContain("later-procedure");
+    expect(JSON.stringify(requests[3]?.messages)).not.toContain("nested-late-procedure");
+    expect(JSON.stringify(requests[3]?.messages)).not.toContain("LATER NESTED INSTRUCTIONS");
+    expect(JSON.stringify(requests[3]?.messages)).toContain("Nested file evidence.");
+    expect(JSON.stringify(requests[4]?.messages)).toContain("Exact origin resource evidence.");
+    expect(h.presentation.getState().authoritative.managedControl?.threads[0]?.threadId).toBe(
+      first?.threadId,
+    );
+  } finally {
+    await h.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});

--- a/apps/tui/src/agent-role-recovery.test.ts
+++ b/apps/tui/src/agent-role-recovery.test.ts
@@ -1,0 +1,154 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createPermissionPolicy, type ModelDriver, type ModelRequest } from "@adam-agent/agent";
+import {
+  createInMemoryManagedAgentControlStore,
+  createInMemorySessionStoreDirectory,
+  createWebSearchConfigurationWithStorageForTesting,
+  type SessionRecord,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+import { startManagedTui } from "./agent-fleet.test-support.js";
+
+test("cold Research resumes a committed Skill resource boundary with frozen Skills and Web authority", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-role-recovery-"));
+  const skillRoot = join(workspaceRoot, ".agents", "skills", "procedure");
+  await mkdir(skillRoot, { recursive: true });
+  await writeFile(
+    join(skillRoot, "SKILL.md"),
+    "---\nname: procedure\ndescription: Inspect evidence.\n---\nFROZEN PROCEDURE BODY\n",
+  );
+  await writeFile(join(skillRoot, "evidence.md"), "COMMITTED RESOURCE EVIDENCE\n");
+  const boundary = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const requests: ModelRequest[] = [];
+  let restoring = false;
+  const driver: ModelDriver = {
+    async *stream(request) {
+      requests.push(request);
+      const call =
+        !restoring && requests.length === 1
+          ? {
+              name: "read_skill_resource",
+              json: '{"qualifiedId":"skill:v1:project:.:procedure","path":"evidence.md"}',
+            }
+          : restoring && !JSON.stringify(request.messages).includes("COLD WEB EVIDENCE")
+            ? { name: "web_fetch", json: '{"url":"https://example.com/cold.txt"}' }
+            : undefined;
+      if (call !== undefined) {
+        yield { type: "tool_call_start", id: `call-${requests.length}`, name: call.name };
+        yield { type: "tool_call_delta", id: `call-${requests.length}`, json: call.json };
+        yield { type: "tool_call_end", id: `call-${requests.length}` };
+      } else yield { type: "text_delta", text: "Cold role evidence complete." };
+      yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+      yield { type: "finish", reason: call === undefined ? "stop" : "tool_calls" };
+    },
+  };
+  const configuration = createWebSearchConfigurationWithStorageForTesting({
+    async read() {
+      return { status: "missing" };
+    },
+    async write() {},
+  });
+  const fetched: string[] = [];
+  const options = {
+    workspaceRoot,
+    permissions: createPermissionPolicy({ allowedEffects: ["read", "delegate", "network"] }),
+    webSearchConfiguration: configuration,
+    webHttp: {
+      async fetch(input: { url: string }) {
+        fetched.push(input.url);
+        return {
+          status: 200,
+          url: input.url,
+          mediaType: "text/plain",
+          body: Buffer.from("COLD WEB EVIDENCE"),
+        };
+      },
+    },
+  };
+  const h = await startManagedTui(driver, {
+    ...options,
+    async childRecordBarrier(record) {
+      if (
+        record.schemaVersion === 3 &&
+        record.record.type === "runtime_event" &&
+        record.record.event.type === "tool_completed" &&
+        record.record.event.name === "read_skill_resource"
+      ) {
+        boundary.resolve();
+        await release.promise;
+      }
+    },
+  });
+  let cold: Awaited<ReturnType<typeof startManagedTui>> | undefined;
+  try {
+    await h.presentation.dispatch({
+      type: "managed_control",
+      commandId: "cold-skill",
+      command: {
+        type: "spawn_agents",
+        parentSessionId: h.parent.sessionId,
+        entries: [
+          {
+            role: "builtin:research",
+            task: "Inspect exact evidence.",
+            description: "Cold evidence",
+            skills: ["skill:v1:project:.:procedure"],
+          },
+        ],
+      },
+    });
+    await boundary.promise;
+    const sessions = createInMemorySessionStoreDirectory<SessionRecord>();
+    const children = createInMemorySessionStoreDirectory<SessionRecord>();
+    for (const [source, destination] of [
+      [h.sessions, sessions],
+      [h.children, children],
+    ] as const) {
+      for (const id of await source.listSessionIds()) {
+        const records = await (await source.open(id))?.read();
+        await (await destination.create(id)).appendBatch(records ?? []);
+      }
+    }
+    const store = createInMemoryManagedAgentControlStore();
+    for (const record of await h.store.read()) await store.append(record);
+    release.resolve();
+    await h.stop();
+    await writeFile(
+      join(skillRoot, "SKILL.md"),
+      "---\nname: procedure\ndescription: Changed procedure.\n---\nLATER PROCEDURE BODY\n",
+    );
+    const before = requests.length;
+    restoring = true;
+    cold = await startManagedTui(driver, {
+      ...options,
+      restore: { ...h.storage, sessions, children, store },
+    });
+    expect(requests).toHaveLength(before);
+    await cold.press("/agents\r", "Agents workspace");
+    await cold.press("u", "u again to resume 1");
+    await cold.press("u", "Completed");
+    expect(fetched).toEqual(["https://example.com/cold.txt"]);
+    expect(JSON.stringify(requests[before]?.messages)).toContain("FROZEN PROCEDURE BODY");
+    expect(JSON.stringify(requests[before]?.messages)).toContain("COMMITTED RESOURCE EVIDENCE");
+    expect(JSON.stringify(requests[before]?.messages)).not.toContain("LATER PROCEDURE BODY");
+    expect(JSON.stringify(requests.at(-1)?.messages)).toContain("COLD WEB EVIDENCE");
+    expect(requests[before]?.tools.map((tool) => tool.name)).toEqual(
+      expect.arrayContaining(["activate_skill", "read_skill_resource", "web_fetch"]),
+    );
+    const childId = (await children.listSessionIds())[0];
+    const records = childId === undefined ? [] : await (await children.open(childId))?.read();
+    expect(
+      records?.filter(
+        (record) =>
+          record.schemaVersion === 3 && record.record.type === "skill_resource_read_committed",
+      ),
+    ).toHaveLength(1);
+  } finally {
+    release.resolve();
+    await (cold ?? h).close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});

--- a/apps/tui/src/agent-role-web.test.ts
+++ b/apps/tui/src/agent-role-web.test.ts
@@ -1,0 +1,375 @@
+import { createHash } from "node:crypto";
+import { createPermissionPolicy, type ModelRequest } from "@adam-agent/agent";
+import { createWebSearchConfigurationWithStorageForTesting } from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+import { startManagedTui } from "./agent-fleet.test-support.js";
+
+test.each([
+  { role: "Main", allowed: true },
+  { role: "Research", allowed: true },
+  { role: "Main", allowed: false },
+  { role: "Research", allowed: false },
+])(
+  "$role obeys Web permission allow=$allowed under the delegation Plan policy",
+  async ({ role, allowed }) => {
+    const requests: ModelRequest[] = [];
+    const fetched: string[] = [];
+    const configuration = createWebSearchConfigurationWithStorageForTesting({
+      async read() {
+        return { status: "missing" };
+      },
+      async write() {},
+    });
+    const h = await startManagedTui(
+      {
+        async *stream(request) {
+          requests.push(request);
+          if (requests.length === 1) {
+            yield { type: "tool_call_start", id: "fetch-source", name: "web_fetch" };
+            yield {
+              type: "tool_call_delta",
+              id: "fetch-source",
+              json: '{"url":"https://example.com/evidence.txt"}',
+            };
+            yield { type: "tool_call_end", id: "fetch-source" };
+            yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+            yield { type: "finish", reason: "tool_calls" };
+          } else {
+            yield { type: "text_delta", text: "Web evidence complete." };
+            yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+            yield { type: "finish", reason: "stop" };
+          }
+        },
+      },
+      {
+        planPolicyVersion: "plan-policy.hybrid-delegation-v1",
+        permissions: createPermissionPolicy({
+          allowedEffects: allowed ? ["read", "delegate", "network"] : ["read", "delegate"],
+        }),
+        webSearchConfiguration: configuration,
+        webHttp: {
+          async fetch(input) {
+            fetched.push(input.url);
+            return {
+              status: 200,
+              url: input.url,
+              mediaType: "text/plain",
+              body: Buffer.from("Exact Web evidence body."),
+            };
+          },
+        },
+      },
+    );
+    try {
+      await h.presentation.dispatch({ type: "enter_plan", sessionId: h.parent.sessionId });
+      if (role === "Main") {
+        await h.press("Fetch the exact Web evidence.", "Fetch the exact Web evidence.");
+        await h.press("\r", "Web evidence complete.");
+      } else {
+        await h.press("@Research", "A · Research evidence");
+        await h.press("\t", "@Research");
+        await h.press(" Fetch the exact Web evidence.", "Fetch the exact Web evidence.");
+        await h.press("\r", "Delegation");
+        await h.press("\r", "Completed");
+      }
+      expect(requests[0]?.tools.map((tool) => tool.name)).toEqual(
+        expect.arrayContaining(["web_fetch", "web_open", "web_find"]),
+      );
+      expect(requests[0]?.tools.some((tool) => tool.name === "web_search")).toBe(false);
+      expect(fetched).toEqual(allowed ? ["https://example.com/evidence.txt"] : []);
+      expect(JSON.stringify(requests[1]?.messages)).toContain(
+        allowed ? "Exact Web evidence body." : "permission_denied",
+      );
+    } finally {
+      await h.close();
+    }
+  },
+);
+
+test("cancelling Research aborts its in-flight Web request before settling", async () => {
+  const fetching = Promise.withResolvers<AbortSignal>();
+  let aborted = false;
+  const configuration = createWebSearchConfigurationWithStorageForTesting({
+    async read() {
+      return { status: "missing" };
+    },
+    async write() {},
+  });
+  const h = await startManagedTui(
+    {
+      async *stream() {
+        yield { type: "tool_call_start", id: "cancel-web", name: "web_fetch" };
+        yield {
+          type: "tool_call_delta",
+          id: "cancel-web",
+          json: '{"url":"https://example.com/held.txt"}',
+        };
+        yield { type: "tool_call_end", id: "cancel-web" };
+        yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+        yield { type: "finish", reason: "tool_calls" };
+      },
+    },
+    {
+      permissions: createPermissionPolicy({ allowedEffects: ["read", "delegate", "network"] }),
+      webSearchConfiguration: configuration,
+      webHttp: {
+        async fetch(input) {
+          const closed = Promise.withResolvers<void>();
+          const close = () => {
+            aborted = true;
+            closed.resolve();
+          };
+          input.signal.addEventListener("abort", close, { once: true });
+          if (input.signal.aborted) close();
+          fetching.resolve(input.signal);
+          try {
+            await closed.promise;
+            throw new DOMException("Aborted", "AbortError");
+          } finally {
+            input.signal.removeEventListener("abort", close);
+          }
+        },
+      },
+    },
+  );
+  try {
+    const receipt = await h.presentation.dispatch({
+      type: "managed_control",
+      commandId: "cancel-research-web",
+      command: {
+        type: "spawn_agents",
+        parentSessionId: h.parent.sessionId,
+        entries: [
+          {
+            role: "builtin:research",
+            task: "Fetch the held source.",
+            description: "Held Web source",
+          },
+        ],
+      },
+    });
+    expect(receipt.status).toBe("admitted");
+    const signal = await fetching.promise;
+    const thread = h.presentation.getState().authoritative.managedControl?.threads[0];
+    if (thread === undefined) throw new Error("Missing admitted Research thread.");
+    const offset = h.terminal.output().length;
+    await h.presentation.dispatch({
+      type: "managed_control",
+      commandId: "cancel-held-web",
+      command: {
+        type: "cancel_agents",
+        parentSessionId: h.parent.sessionId,
+        targets: [{ threadId: thread.threadId, expectedTurnId: thread.turn.turnId }],
+      },
+    });
+    await h.terminal.waitForFrameAfter("Cancelled", offset);
+    expect(signal.aborted).toBe(true);
+    expect(aborted).toBe(true);
+    expect(h.presentation.getState().authoritative.managedControl?.threads[0]?.turn).toMatchObject({
+      phase: "idle",
+      outcome: { status: "cancelled" },
+    });
+  } finally {
+    await h.close();
+  }
+});
+
+test("Research uses the configured search provider and immutable open/find without another network request", async () => {
+  let text: string | undefined;
+  const configuration = createWebSearchConfigurationWithStorageForTesting({
+    async read() {
+      return text === undefined ? { status: "missing" } : { status: "available", text };
+    },
+    async write(next) {
+      text = next;
+    },
+  });
+  await configuration.activateSearxng("https://search.example.test/search");
+  const body = "Frozen source evidence.\nSecond evidence line.\n";
+  const artifactId = `sha256:${createHash("sha256").update(body).digest("hex")}`;
+  const calls = [
+    { name: "web_search", json: '{"query":"exact source","limit":1}' },
+    { name: "web_fetch", json: '{"url":"https://example.com/source.txt"}' },
+    { name: "web_open", json: JSON.stringify({ artifactId }) },
+    { name: "web_find", json: JSON.stringify({ artifactId, text: "Second evidence" }) },
+  ];
+  const requests: ModelRequest[] = [];
+  const fetched: string[] = [];
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        requests.push(request);
+        const call =
+          requests.length === 6
+            ? { name: "web_search", json: '{"query":"search after configuration revocation"}' }
+            : calls[requests.length - 1];
+        if (requests.length === 3) await configuration.clear();
+        if (call !== undefined) {
+          yield { type: "tool_call_start", id: call.name, name: call.name };
+          yield { type: "tool_call_delta", id: call.name, json: call.json };
+          yield { type: "tool_call_end", id: call.name };
+          yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+          yield { type: "finish", reason: "tool_calls" };
+        } else {
+          yield {
+            type: "text_delta",
+            text:
+              requests.length === 5
+                ? "Immutable search evidence complete."
+                : "Revoked search settled.",
+          };
+          yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+          yield { type: "finish", reason: "stop" };
+        }
+      },
+    },
+    {
+      planPolicyVersion: "plan-policy.hybrid-delegation-v1",
+      permissions: createPermissionPolicy({ allowedEffects: ["read", "delegate", "network"] }),
+      webSearchConfiguration: configuration,
+      webHttp: {
+        async fetch(input) {
+          fetched.push(input.url);
+          const search = new URL(input.url).origin === "https://search.example.test";
+          return {
+            status: 200,
+            url: input.url,
+            mediaType: search ? "application/json" : "text/plain",
+            body: Buffer.from(
+              search
+                ? JSON.stringify({
+                    results: [
+                      {
+                        url: "https://example.com/source.txt",
+                        title: "Exact source",
+                        content: "Search evidence",
+                      },
+                    ],
+                  })
+                : body,
+            ),
+          };
+        },
+      },
+    },
+  );
+  try {
+    await h.presentation.dispatch({ type: "enter_plan", sessionId: h.parent.sessionId });
+    await h.press("@Research", "A · Research evidence");
+    await h.press("\t", "@Research");
+    await h.press(
+      " Search and inspect immutable evidence.",
+      "Search and inspect immutable evidence.",
+    );
+    await h.press("\r", "Delegation");
+    await h.press("\r", "Completed");
+    expect(requests).toHaveLength(5);
+    expect(new URL(fetched[0] ?? "").searchParams.get("q")).toBe("exact source");
+    expect(fetched).toHaveLength(2);
+    expect(fetched[1]).toBe("https://example.com/source.txt");
+    for (const [index, name] of ["web_search", "web_fetch", "web_open", "web_find"].entries())
+      expect(
+        requests[index + 1]?.messages.findLast(
+          (message) => message.role === "tool" && message.name === name,
+        ),
+      ).toMatchObject({ result: { status: "completed" } });
+    expect(JSON.stringify(requests[4]?.messages)).toContain("Second evidence line.");
+    expect(
+      requests[0]?.tools.some((tool) =>
+        /shell|mcp|write_file|edit_file|spawn_agents/u.test(tool.name),
+      ),
+    ).toBe(false);
+    await h.openFirstAgent("@research-1");
+    await h.press("\r", "New turn");
+    await h.press("Search with the original provider.", "Search with the original provider.");
+    await h.press("\r", "Revoked search settled.");
+    expect(fetched).toHaveLength(2);
+    expect(JSON.stringify(requests[6]?.messages)).toContain("web_provider_unavailable");
+  } finally {
+    await h.close();
+  }
+});
+
+test.each(["allow", "deny"] as const)(
+  "Research asks for one exact Web request and respects %s",
+  async (decision) => {
+    let networkCalls = 0;
+    const requests: ModelRequest[] = [];
+    const configuration = createWebSearchConfigurationWithStorageForTesting({
+      async read() {
+        return { status: "missing" };
+      },
+      async write() {},
+    });
+    const h = await startManagedTui(
+      {
+        async *stream(request) {
+          requests.push(request);
+          if (requests.length === 1) {
+            yield { type: "tool_call_start", id: "exact-web-call", name: "web_fetch" };
+            yield {
+              type: "tool_call_delta",
+              id: "exact-web-call",
+              json: '{"url":"https://example.com/exact-request.txt"}',
+            };
+            yield { type: "tool_call_end", id: "exact-web-call" };
+            yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+            yield { type: "finish", reason: "tool_calls" };
+          } else {
+            yield { type: "text_delta", text: "Permission outcome complete." };
+            yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+            yield { type: "finish", reason: "stop" };
+          }
+        },
+      },
+      {
+        permissions: createPermissionPolicy({
+          allowedEffects: ["read", "delegate"],
+          askedEffects: ["network"],
+        }),
+        planPolicyVersion: "plan-policy.hybrid-delegation-v1",
+        webSearchConfiguration: configuration,
+        webHttp: {
+          async fetch(input) {
+            networkCalls += 1;
+            return {
+              status: 200,
+              url: input.url,
+              mediaType: "text/plain",
+              body: Buffer.from("Confirmed exact Web body."),
+            };
+          },
+        },
+      },
+    );
+    try {
+      await h.presentation.dispatch({ type: "enter_plan", sessionId: h.parent.sessionId });
+      await h.press("@Research", "A · Research evidence");
+      await h.press("\t", "@Research");
+      await h.press(" Fetch the exact request.", "Fetch the exact request.");
+      await h.press("\r", "Delegation");
+      await h.press("\r", "Attention Center");
+      const pending = await h.waitForAttention(
+        (items) =>
+          items.length === 1 &&
+          items[0]?.kind === "permission" &&
+          items[0].interaction !== null &&
+          items[0].available,
+      );
+      expect(pending[0]).toMatchObject({
+        handle: "@research-1",
+        displayName: "Research",
+        interaction: { callId: "exact-web-call", effect: "network" },
+      });
+      expect(JSON.stringify(pending)).toContain("https://example.com/exact-request.txt");
+      expect(networkCalls).toBe(0);
+      await h.press(decision === "allow" ? "a" : "d", "Completed");
+      expect(networkCalls).toBe(decision === "allow" ? 1 : 0);
+      expect(JSON.stringify(requests[1]?.messages)).toContain(
+        decision === "allow" ? "Confirmed exact Web body." : "permission_denied",
+      );
+    } finally {
+      await h.close();
+    }
+  },
+);

--- a/apps/tui/src/agent-types.test.ts
+++ b/apps/tui/src/agent-types.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { startManagedTui } from "./agent-fleet.test-support.js";
+
+test("Agent types creates a previewed project role and explicitly disables and reloads it", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-types-"));
+  let calls = 0;
+  const h = await startManagedTui(
+    {
+      async *stream() {
+        calls += 1;
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    { workspaceRoot, rows: 40 },
+  );
+  try {
+    await h.press("/agents", "/agents");
+    await h.press("\r", "Agents workspace");
+    await h.press("t", "Agent types");
+    await h.press("n", "Name");
+    await h.press("Auditor", "Auditor");
+    await h.press("\r", "Description");
+    await h.press("Inspect exact evidence.", "Inspect exact evidence.");
+    await h.press("\r", "Base");
+    for (const next of [
+      "Tools",
+      "Skills",
+      "Web",
+      "Context",
+      "Target",
+      "Thinking",
+      "Limits",
+      "Source",
+      "Preview",
+    ]) {
+      await h.press("\r", next);
+    }
+    expect(calls).toBe(0);
+    await expect(
+      readFile(join(workspaceRoot, ".agents", "agents", "Auditor.md")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await h.press("\r", "Saved Auditor");
+    const definition = await readFile(
+      join(workspaceRoot, ".agents", "agents", "Auditor.md"),
+      "utf8",
+    );
+    expect(definition).toContain("base: explore");
+    expect(definition).toContain("Inspect exact evidence.");
+    await h.press(" ", "Confirm disable Auditor");
+    await h.press("\r", "Disabled Auditor");
+    expect(h.presentation.getState().agentRoles?.some((role) => role.name === "Auditor")).toBe(
+      false,
+    );
+    await h.press("r", "Reloaded");
+    await h.press(" ", "Confirm enable Auditor");
+    await h.press("\r", "Enabled Auditor");
+    expect(h.presentation.getState().agentRoles?.some((role) => role.name === "Auditor")).toBe(
+      true,
+    );
+    expect(calls).toBe(0);
+  } finally {
+    await h.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("Agent types ejects an exact built-in override only after preview confirmation", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-agent-eject-"));
+  const h = await startManagedTui(
+    {
+      async *stream() {
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    { workspaceRoot, rows: 40 },
+  );
+  try {
+    await h.press("/agents", "/agents");
+    await h.press("\r", "Agents workspace");
+    await h.press("t", "Agent types");
+    await h.press("e", "Source");
+    await h.press("\r", "Exact override: builtin:explore");
+    await h.press("\x1b", "Agent types");
+    await expect(
+      readFile(join(workspaceRoot, ".agents", "agents", "Explore.md")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await h.press("e", "Source");
+    await h.press("\r", "Exact override: builtin:explore");
+    await h.press("\r", "Saved Explore");
+    expect(
+      await readFile(join(workspaceRoot, ".agents", "agents", "Explore.md"), "utf8"),
+    ).toContain("overrides: builtin:explore");
+    expect(h.presentation.getState().agentRoles?.map((role) => role.qualifiedId)).toEqual([
+      "builtin:research",
+      "project:Explore",
+    ]);
+    await h.press(" ", "Confirm disable Explore");
+    await h.press("\r", "Disabled Explore");
+    expect(h.presentation.getState().agentRoles?.map((role) => role.qualifiedId)).toEqual([
+      "builtin:explore",
+      "builtin:research",
+    ]);
+  } finally {
+    await h.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});

--- a/apps/tui/src/agent-types.ts
+++ b/apps/tui/src/agent-types.ts
@@ -1,0 +1,552 @@
+import type {
+  AgentRoleDefinitionInput,
+  AgentRoleMutation,
+  AgentRoleTypeDisplay,
+  AgentTypesDisplay,
+  CommandReceipt,
+} from "@adam-agent/presentation";
+import {
+  type Component,
+  Input,
+  isKeyRelease,
+  isKeyRepeat,
+  matchesKey,
+  SelectList,
+  truncateToWidth,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import { safeTerminalText } from "./safe-terminal-text.js";
+import type { AdamTuiTheme } from "./theme.js";
+
+const steps = [
+  "Name",
+  "Description",
+  "Base",
+  "Tools",
+  "Skills",
+  "Web",
+  "Context",
+  "Target",
+  "Thinking",
+  "Limits",
+  "Source",
+  "Preview",
+] as const;
+const readTools = [
+  "read_file",
+  "search_repository",
+  "activate_skill",
+  "read_skill_resource",
+  "report_to_parent",
+  "request_parent_input",
+];
+const webTools = ["web_fetch", "web_search", "web_open", "web_find"];
+
+/** A finite Owner editor; all writes and catalog truth remain in the lifecycle. */
+export class AgentTypes implements Component {
+  #catalog: AgentTypesDisplay;
+  #selected = 0;
+  #notice = "";
+  #pending = false;
+  #scroll = 0;
+  #maximumScroll = 0;
+  #diagnostics = false;
+  #step: number | undefined;
+  #input = new Input();
+  #list: SelectList | undefined;
+  #fields: AgentRoleDefinitionInput = { name: "", description: "", base: "explore" };
+  #source: "project" | "user" = "project";
+  #original: AgentRoleTypeDisplay | undefined;
+  #toggle: AgentRoleMutation | undefined;
+  constructor(
+    private readonly options: {
+      readonly catalog: AgentTypesDisplay;
+      readonly theme: AdamTuiTheme;
+      readonly maximumLines: () => number;
+      readonly onChange: () => void;
+      readonly onClose: () => void;
+      readonly onReload: () => Promise<AgentTypesDisplay>;
+      readonly onWrite: (mutation: AgentRoleMutation) => Promise<CommandReceipt>;
+    },
+  ) {
+    this.#catalog = options.catalog;
+  }
+
+  #change(): void {
+    this.options.onChange();
+  }
+  #begin(original?: AgentRoleTypeDisplay, eject = false): void {
+    this.#original = original;
+    this.#fields =
+      original === undefined
+        ? {
+            name: "",
+            description: "",
+            base: "explore",
+            skills: true,
+            web: false,
+            context_mode: "current_request",
+          }
+        : {
+            name: eject ? original.name : `${original.name} copy`,
+            description: original.description,
+            base: original.base,
+            tools: [...original.tools],
+            skills: original.skills ?? true,
+            web: original.web,
+            context_mode: original.contextMode ?? "current_request",
+            ...(original.model === undefined ? {} : { model: original.model }),
+            ...(original.thinking === undefined ? {} : { thinking: original.thinking }),
+            ...(original.limits === undefined ? {} : { limits: { ...original.limits } }),
+            ...(eject ? { overrides: original.qualifiedId } : {}),
+          };
+    this.#source = this.#catalog.sources.some(
+      (source) => source.kind === "project" && source.writable,
+    )
+      ? "project"
+      : "user";
+    this.#notice = "";
+    this.#showStep(eject ? 10 : 0);
+  }
+  #showStep(step: number): void {
+    this.#step = step;
+    this.#scroll = 0;
+    this.#maximumScroll = 0;
+    this.#list = undefined;
+    if (step < 2) {
+      this.#input.setValue(step === 0 ? this.#fields.name : this.#fields.description);
+      this.#input.onSubmit = (value) => {
+        const text = value.trim();
+        if (!text) {
+          this.#notice = "Enter a nonempty value.";
+          this.#change();
+          return;
+        }
+        if (step === 0) this.#fields.name = text;
+        else this.#fields.description = text;
+        this.#showStep(step + 1);
+      };
+    } else if (step < 11) {
+      const choices: { value: string; label: string; description: string }[] =
+        step === 2
+          ? [
+              {
+                value: "explore",
+                label: "Explore",
+                description: "Repository reads and Skills; no Web.",
+              },
+              {
+                value: "research",
+                label: "Research",
+                description: "Repository reads, Skills and Main's permitted Web.",
+              },
+            ]
+          : step === 3
+            ? [
+                {
+                  value: "base",
+                  label: "Base tools",
+                  description: "All tools allowed by the selected base.",
+                },
+                {
+                  value: "files",
+                  label: "Read files only",
+                  description: "Only read_file; no Skills or Web tools.",
+                },
+                {
+                  value: "repository",
+                  label: "Repository tools",
+                  description: "read_file and search_repository.",
+                },
+              ]
+            : step === 4
+              ? [
+                  {
+                    value: "full",
+                    label: "Full frozen Skill catalog",
+                    description: "Independent activation; no additional effects.",
+                  },
+                  {
+                    value: "none",
+                    label: "No Skills",
+                    description: "Remove Skill activation and resource tools.",
+                  },
+                ]
+              : step === 5
+                ? [
+                    {
+                      value: "base",
+                      label: this.#fields.base === "research" ? "Effective Main Web" : "No Web",
+                      description: "Always subject to Main's current permission ceiling.",
+                    },
+                    ...(this.#fields.base === "research"
+                      ? [{ value: "none", label: "No Web", description: "Remove all Web tools." }]
+                      : []),
+                  ]
+                : step === 6
+                  ? [
+                      {
+                        value: "current_request",
+                        label: "Current request",
+                        description:
+                          "Current request and explicit task; no automatic earlier history.",
+                      },
+                      {
+                        value: "task",
+                        label: "Task only",
+                        description: "Only the explicit delegated task.",
+                      },
+                    ]
+                  : step === 7
+                    ? [
+                        {
+                          value: "inherit",
+                          label: "Inherit Main target and thinking",
+                          description:
+                            "Freeze Main's exact target and effective thinking at admission.",
+                        },
+                        ...this.#catalog.targets.map((target) => ({
+                          value: target.targetId,
+                          label: target.label,
+                          description: "Certified target; use its supported default thinking.",
+                        })),
+                      ]
+                    : step === 8
+                      ? [
+                          {
+                            value: "inherit",
+                            label:
+                              this.#fields.model === undefined
+                                ? "Inherit effective thinking"
+                                : "Target default thinking",
+                            description: "Resolve against the exact target at admission.",
+                          },
+                          ...(
+                            this.#catalog.targets.find(
+                              (target) => target.targetId === this.#fields.model,
+                            )?.thinkingLevels ?? []
+                          ).map((level) => ({
+                            value: level.id,
+                            label: level.label,
+                            description: "Supported by the selected certified target.",
+                          })),
+                        ]
+                      : step === 9
+                        ? [
+                            {
+                              value: "base",
+                              label: "Base and envelope limits",
+                              description: "No additional limit; never increases Main's ceiling.",
+                            },
+                            {
+                              value: "4",
+                              label: "At most 4 turns",
+                              description: "Further limit each child attempt.",
+                            },
+                            {
+                              value: "1",
+                              label: "At most 1 turn",
+                              description: "A single model step.",
+                            },
+                          ]
+                        : [
+                            {
+                              value: "project",
+                              label: "Trusted project",
+                              description: ".agents/agents; shareable project definition.",
+                            },
+                            {
+                              value: "user",
+                              label: "User",
+                              description: "Adam XDG agents directory; local Owner configuration.",
+                            },
+                          ];
+      const list = new SelectList(
+        choices.map((choice) => ({
+          ...choice,
+          label: safeTerminalText(choice.label),
+          description: safeTerminalText(choice.description),
+        })),
+        6,
+        this.options.theme.editor.selectList,
+      );
+      list.onSelect = (item) => {
+        const value = item.value;
+        if (step === 2) this.#fields.base = value === "research" ? "research" : "explore";
+        if (step === 3)
+          this.#fields.tools =
+            value === "files"
+              ? ["read_file"]
+              : value === "repository"
+                ? ["read_file", "search_repository"]
+                : [...readTools, ...(this.#fields.base === "research" ? webTools : [])];
+        if (step === 4) {
+          this.#fields.skills = value === "full";
+          if (value === "none")
+            this.#fields.tools = (this.#fields.tools ?? []).filter(
+              (tool) => tool !== "activate_skill" && tool !== "read_skill_resource",
+            );
+        }
+        if (step === 5) {
+          this.#fields.web = value === "base" && this.#fields.base === "research";
+          if (!this.#fields.web)
+            this.#fields.tools = (this.#fields.tools ?? []).filter(
+              (tool) => !webTools.includes(tool),
+            );
+        }
+        if (step === 6) this.#fields.context_mode = value === "task" ? "task" : "current_request";
+        if (step === 7) {
+          delete this.#fields.thinking;
+          if (value === "inherit") delete this.#fields.model;
+          else this.#fields.model = value;
+        }
+        if (step === 8) {
+          if (value === "inherit") delete this.#fields.thinking;
+          else this.#fields.thinking = value;
+        }
+        if (step === 9) {
+          if (value === "base") delete this.#fields.limits;
+          else this.#fields.limits = { maxTurns: Number(value) };
+        }
+        if (step === 10) this.#source = value === "user" ? "user" : "project";
+        this.#showStep(step + 1);
+      };
+      list.onCancel = () => {
+        this.#step = undefined;
+        this.#change();
+      };
+      this.#list = list;
+    }
+    this.#change();
+  }
+  async #write(mutation: AgentRoleMutation): Promise<void> {
+    this.#pending = true;
+    this.#change();
+    try {
+      const receipt = await this.options.onWrite(mutation);
+      if (receipt.status === "rejected") {
+        this.#notice = receipt.message;
+        return;
+      }
+      this.#catalog = await this.options.onReload();
+      const id =
+        mutation.action === "create"
+          ? `${mutation.source}:${encodeURIComponent(mutation.fields.name)}`
+          : mutation.qualifiedId;
+      this.#selected = Math.max(
+        0,
+        this.#catalog.definitions.findIndex((role) => role.qualifiedId === id),
+      );
+      const role = this.#catalog.definitions[this.#selected];
+      this.#notice = `${mutation.action === "create" ? "Saved" : mutation.enabled ? "Enabled" : "Disabled"} ${role?.name ?? "role"}`;
+      this.#step = undefined;
+      this.#toggle = undefined;
+    } catch (error) {
+      this.#notice = error instanceof Error ? error.message : "Role change failed.";
+    } finally {
+      this.#pending = false;
+      this.#change();
+    }
+  }
+  handleInput(data: string): void {
+    if (isKeyRelease(data) || this.#pending) return;
+    if (matchesKey(data, "escape") && !isKeyRepeat(data)) {
+      if (this.#diagnostics) {
+        this.#diagnostics = false;
+        this.#scroll = 0;
+        this.#change();
+        return;
+      }
+      if (this.#step !== undefined || this.#toggle !== undefined) {
+        this.#step = undefined;
+        this.#toggle = undefined;
+        this.#change();
+      } else this.options.onClose();
+      return;
+    }
+    if (
+      (this.#step === 11 || this.#diagnostics) &&
+      (matchesKey(data, "down") || matchesKey(data, "up"))
+    ) {
+      this.#scroll = Math.max(
+        0,
+        Math.min(this.#maximumScroll, this.#scroll + (matchesKey(data, "down") ? 1 : -1)),
+      );
+      this.#change();
+      return;
+    }
+    if (this.#diagnostics) return;
+    if (this.#toggle !== undefined) {
+      if (matchesKey(data, "enter") && !isKeyRepeat(data)) void this.#write(this.#toggle);
+      return;
+    }
+    if (this.#step !== undefined) {
+      if (this.#step < 2) this.#input.handleInput(data);
+      else if (this.#step < 11) this.#list?.handleInput(data);
+      else if (
+        matchesKey(data, "enter") &&
+        !isKeyRepeat(data) &&
+        this.#scroll === this.#maximumScroll
+      )
+        void this.#write({
+          action: "create",
+          source: this.#source,
+          fields: this.#fields,
+          instructions: this.#original?.instructions ?? "",
+          ...(this.#original === undefined
+            ? {}
+            : {
+                original: {
+                  qualifiedId: this.#original.qualifiedId,
+                  definitionDigest: this.#original.definitionDigest,
+                },
+              }),
+        });
+      this.#change();
+      return;
+    }
+    const role = this.#catalog.definitions[this.#selected];
+    if (matchesKey(data, "down"))
+      this.#selected = Math.min(this.#catalog.definitions.length - 1, this.#selected + 1);
+    else if (matchesKey(data, "up")) this.#selected = Math.max(0, this.#selected - 1);
+    else if (!isKeyRepeat(data)) {
+      if (data === "!") {
+        this.#diagnostics = true;
+        this.#scroll = 0;
+      } else if (matchesKey(data, "n")) this.#begin();
+      else if (matchesKey(data, "d") && role !== undefined) this.#begin(role);
+      else if (matchesKey(data, "e") && role?.source?.kind === "builtin") this.#begin(role, true);
+      else if (data === " " && role !== undefined)
+        this.#toggle = {
+          action: "toggle",
+          qualifiedId: role.qualifiedId,
+          definitionDigest: role.definitionDigest,
+          enabled: !role.enabled,
+        };
+      else if (matchesKey(data, "r")) {
+        this.#pending = true;
+        void this.options
+          .onReload()
+          .then(
+            (catalog) => {
+              this.#catalog = catalog;
+              this.#selected = Math.min(
+                this.#selected,
+                Math.max(0, catalog.definitions.length - 1),
+              );
+              this.#notice = "Reloaded; existing threads keep their frozen definitions.";
+            },
+            (error) => {
+              this.#notice = String(error);
+            },
+          )
+          .finally(() => {
+            this.#pending = false;
+            this.#change();
+          });
+      }
+    }
+    this.#change();
+  }
+  invalidate(): void {
+    this.#input.invalidate();
+    this.#list?.invalidate();
+  }
+  render(width: number): string[] {
+    const role = this.#catalog.definitions[this.#selected];
+    const heading = this.#diagnostics
+      ? "Agent types · Diagnostics"
+      : this.#toggle !== undefined
+        ? `Confirm ${this.#toggle.action === "toggle" && this.#toggle.enabled ? "enable" : "disable"} ${role?.name}`
+        : this.#step === undefined
+          ? "Agent types"
+          : `Agent types · ${steps[this.#step]}`;
+    let content: string[];
+    if (this.#diagnostics)
+      content =
+        this.#catalog.diagnostics.length === 0
+          ? ["No diagnostics."]
+          : this.#catalog.diagnostics.map(
+              (diagnostic) => `${diagnostic.source}: ${diagnostic.message}`,
+            );
+    else if (this.#toggle !== undefined)
+      content = [
+        "Applies to future admissions. Existing threads retain their definitions.",
+        "Enter confirm · Esc cancel",
+      ];
+    else if (this.#step !== undefined)
+      content =
+        this.#step < 2
+          ? this.#input.render(width)
+          : this.#step < 11
+            ? (this.#list?.render(width) ?? [])
+            : [
+                `${this.#fields.name} · ${this.#fields.description}`,
+                `Source: ${this.#catalog.sources.find((source) => source.kind === this.#source)?.path ?? this.#source}/${encodeURIComponent(this.#fields.name)}.md`,
+                `Base: ${this.#fields.base} · Web: ${this.#fields.web ? "effective Main" : "none"}`,
+                `Tools: ${this.#fields.tools?.join(", ") ?? "base tools"}`,
+                `Skills: ${this.#fields.skills ? "frozen catalog" : "none"} · Context: ${this.#fields.context_mode ?? "current_request"}`,
+                `Target: ${this.#fields.model ?? "inherit Main"} · Thinking: ${this.#fields.thinking ?? "inherited or target default"}`,
+                `Limits: ${this.#fields.limits?.maxTurns ?? "base"} turns · ${this.#fields.limits?.maxTokens ?? "envelope"} tokens`,
+                ...(this.#fields.overrides === undefined
+                  ? []
+                  : [`Exact override: ${this.#fields.overrides}`]),
+                ...(this.#original?.instructions
+                  ? [`Instructions: ${this.#original.instructions}`]
+                  : []),
+                "Enter save atomically · Esc cancel",
+              ];
+    else {
+      const capacity = Math.max(1, this.options.maximumLines() - 10);
+      const start = Math.max(0, this.#selected - capacity + 1);
+      content = [
+        "n create · d duplicate · e eject built-in · Space enable/disable · r Reload · ! diagnostics · Esc",
+        ...this.#catalog.definitions
+          .slice(start, start + capacity)
+          .map(
+            (entry, index) =>
+              `${index + start === this.#selected ? "●" : "○"} ${entry.name} · ${entry.enabled ? (entry.available ? "enabled" : "shadowed") : "disabled"} · ${entry.source?.kind ?? "builtin"}`,
+          ),
+        ...(role === undefined
+          ? []
+          : [
+              role.description,
+              `Source: ${role.source?.path ?? role.qualifiedId}`,
+              `Tools: ${role.tools.join(", ")}`,
+              `Skills: ${role.skills ? "frozen catalog" : "none"} · Web: ${role.web ? "effective Main" : "none"}`,
+              `Target: ${role.model ?? "inherit Main"} · ${role.thinking ?? "effective thinking"}`,
+            ]),
+        ...this.#catalog.diagnostics
+          .slice(0, 2)
+          .map((diagnostic) => `! ${diagnostic.source}: ${diagnostic.message}`),
+      ];
+    }
+    if (this.#step === 11 || this.#diagnostics) {
+      const lines = content.flatMap((line) =>
+        wrapTextWithAnsi(safeTerminalText(line), Math.max(1, width)),
+      );
+      const maximum = Math.max(1, this.options.maximumLines() - 3);
+      this.#maximumScroll = Math.max(0, lines.length - maximum);
+      this.#scroll = Math.min(this.#scroll, this.#maximumScroll);
+      return [
+        this.options.theme.toolTitle(safeTerminalText(heading)),
+        ...lines.slice(this.#scroll, this.#scroll + maximum),
+        this.options.theme.muted(
+          this.#scroll < this.#maximumScroll
+            ? "↓ review remaining details · Esc cancel"
+            : this.#diagnostics
+              ? "↑ scroll · Esc back"
+              : "Enter save atomically · ↑ scroll · Esc cancel",
+        ),
+        this.options.theme.muted(safeTerminalText(this.#notice)),
+      ].map((line) => truncateToWidth(line, width));
+    }
+    return [
+      this.options.theme.toolTitle(safeTerminalText(heading)),
+      ...(this.#step === undefined || this.#step === 11
+        ? content.map((line) => safeTerminalText(line).replace(/[\r\n]/gu, " "))
+        : content),
+      this.options.theme.muted(safeTerminalText(this.#pending ? "Saving…" : this.#notice)),
+    ].map((line) => truncateToWidth(line, width));
+  }
+}

--- a/apps/tui/src/command-autocomplete.test.ts
+++ b/apps/tui/src/command-autocomplete.test.ts
@@ -1,6 +1,47 @@
+import { SelectList } from "@earendil-works/pi-tui";
 import { expect, test } from "vitest";
 import { AdamAutocompleteProvider } from "./command-autocomplete.js";
 import { adamCommandRegistry } from "./command-registry.js";
+
+test("role completion renders untrusted descriptions as inert terminal text", async () => {
+  const provider = new AdamAutocompleteProvider({
+    getProjectPaths: () => [],
+    getRunActive: () => false,
+    getSkills: () => [],
+    getRoles: () => [
+      {
+        qualifiedId: "user:Audit",
+        name: "Audit",
+        description: "\x1b[2JFORGED",
+        base: "explore",
+        tools: [],
+        web: false,
+        definitionDigest: `sha256:${"0".repeat(64)}`,
+      },
+    ],
+  });
+  const suggestions = await provider.getSuggestions(["@"], 0, 1, {
+    signal: new AbortController().signal,
+  });
+  const list = new SelectList(
+    [
+      { value: "@Explore", label: "@Explore", description: "Safe built-in" },
+      ...(suggestions?.items ?? []),
+    ],
+    8,
+    {
+      selectedPrefix: (s) => s,
+      selectedText: (s) => s,
+      description: (s) => s,
+      scrollInfo: (s) => s,
+      noMatch: (s) => s,
+    },
+    { overrideSelectedStyles: true },
+  );
+  const rendered = list.render(120).join("\n");
+  expect(rendered).toContain("FORGED");
+  expect(rendered).not.toContain("\x1b[2J");
+});
 
 test("active-run slash completion keeps the complete Registry with availability annotations", async () => {
   const provider = new AdamAutocompleteProvider({
@@ -122,13 +163,13 @@ test("path mention rows separate file names from parent paths without changing i
         adamPath: { path: "README.md" },
         value: "@README.md",
         label: "<text>@README.md</text>",
-        description: "./",
+        description: "F · ./",
       },
       {
         adamPath: { path: "packages/extension-api/README.md" },
         value: "@packages/extension-api/README.md",
         label: "<text>@README.md</text>",
-        description: "packages/extension-api/",
+        description: "F · packages/extension-api/",
       },
     ],
     prefix: "@",
@@ -157,13 +198,13 @@ test("path mentions recall root and nested files with the same matching name", a
         adamPath: { path: "AGENTS.md" },
         value: "@AGENTS.md",
         label: "@AGENTS.md",
-        description: "./",
+        description: "F · ./",
       },
       {
         adamPath: { path: "examples/portfolio-walkthrough/AGENTS.md" },
         value: "@examples/portfolio-walkthrough/AGENTS.md",
         label: "@AGENTS.md",
-        description: "examples/portfolio-walkthrough/",
+        description: "F · examples/portfolio-walkthrough/",
       },
     ],
     prefix: "@agents",

--- a/apps/tui/src/command-autocomplete.ts
+++ b/apps/tui/src/command-autocomplete.ts
@@ -1,11 +1,19 @@
 import type {
+  AtMentionAtom,
+  ManagedControlThread,
+  PresentationDisplayState,
+} from "@adam-agent/presentation";
+import type {
   AutocompleteItem,
   AutocompleteProvider,
   AutocompleteSuggestions,
 } from "@earendil-works/pi-tui";
-
 import { type AdamCommandRegistry, adamCommandRegistry } from "./command-registry.js";
 import { safeTerminalText } from "./safe-terminal-text.js";
+
+export function mentionAutocompleteIdentity(item: AutocompleteItem): AtMentionAtom | null {
+  return (item as AutocompleteItem & { readonly adamMention?: AtMentionAtom }).adamMention ?? null;
+}
 
 type SkillCompletion = {
   readonly description: string;
@@ -49,6 +57,11 @@ export function skillAutocompleteIdentity(
 }
 
 export class AdamAutocompleteProvider implements AutocompleteProvider {
+  readonly #getThreads: () => readonly ManagedControlThread[];
+  readonly #getMain: () => boolean;
+  readonly #mention: (text: string) => string;
+  readonly #structuralBadges: () => boolean;
+  readonly #getRoles: () => NonNullable<PresentationDisplayState["agentRoles"]>;
   readonly triggerCharacters = ["$", "@"];
   readonly #getAttachmentsAvailable: () => boolean;
   readonly #getProjectPaths: () => readonly string[];
@@ -61,6 +74,11 @@ export class AdamAutocompleteProvider implements AutocompleteProvider {
   readonly #registry: AdamCommandRegistry;
 
   constructor(options: {
+    readonly getThreads?: () => readonly ManagedControlThread[];
+    readonly getMain?: () => boolean;
+    readonly mention?: (text: string) => string;
+    readonly structuralBadges?: () => boolean;
+    readonly getRoles?: () => NonNullable<PresentationDisplayState["agentRoles"]>;
     readonly getAttachmentsAvailable?: () => boolean;
     readonly getProjectPaths: () => readonly string[];
     readonly getRunActive: () => boolean;
@@ -72,6 +90,11 @@ export class AdamAutocompleteProvider implements AutocompleteProvider {
     readonly registry?: AdamCommandRegistry;
   }) {
     this.#getAttachmentsAvailable = options.getAttachmentsAvailable ?? (() => true);
+    this.#getRoles = options.getRoles ?? (() => []);
+    this.#getThreads = options.getThreads ?? (() => []);
+    this.#getMain = options.getMain ?? (() => false);
+    this.#mention = options.mention ?? ((text) => text);
+    this.#structuralBadges = options.structuralBadges ?? (() => false);
     this.#getProjectPaths = options.getProjectPaths;
     this.#getRunActive = options.getRunActive;
     this.#getSkills = options.getSkills;
@@ -221,13 +244,80 @@ export class AdamAutocompleteProvider implements AutocompleteProvider {
         return {
           adamPath: { path: safePath },
           value: `@${safePath}`,
-          label: this.#path(`@${columns.fileName}`),
-          description: columns.parentPath,
+          label: this.#path(`${this.#structuralBadges() ? "F " : ""}@${columns.fileName}`),
+          description: `F · ${columns.parentPath}`,
         };
       });
-      return Promise.resolve(
-        pathItems.length === 0 ? null : { items: pathItems, prefix: pathPrefix },
-      );
+      const catalog = this.#getRoles();
+      const roles = catalog
+        .map((role) => ({
+          role,
+          alias:
+            catalog.filter(
+              (other) => other.name.toLocaleLowerCase() === role.name.toLocaleLowerCase(),
+            ).length === 1 && !/\s/u.test(role.name)
+              ? role.name
+              : role.qualifiedId,
+        }))
+        .filter(({ role, alias }) =>
+          [role.name, alias].some((name) =>
+            name.toLocaleLowerCase().startsWith(pathPrefix.slice(1).toLocaleLowerCase()),
+          ),
+        )
+        .map(({ role, alias }) => ({
+          adamMention: {
+            type: "mention",
+            kind: "role",
+            literal: `@${alias}`,
+            qualifiedRoleId: role.qualifiedId,
+            definitionDigest: role.definitionDigest,
+          } satisfies AtMentionAtom,
+          value: `@${alias}`,
+          label: this.#mention(
+            `${this.#structuralBadges() ? "A " : ""}${safeTerminalText(`@${alias}`)}`,
+          ),
+          description: `A · ${safeTerminalText(role.description)}`,
+        }));
+      const threads = this.#getThreads()
+        .filter((thread) => thread.lifecycle === "open")
+        .flatMap((thread) =>
+          [thread.handle, ...(thread.alias === undefined ? [] : [`@${thread.alias}`])]
+            .filter((literal) =>
+              literal.replace(/^@/u, "").toLocaleLowerCase().startsWith(normalizedPrefix),
+            )
+            .map((literal) => ({
+              adamMention: {
+                type: "mention",
+                kind: "agent",
+                literal,
+                parentSessionId: thread.parentSessionId,
+                threadId: thread.threadId,
+                handle: thread.handle,
+              } satisfies AtMentionAtom,
+              value: literal,
+              label: this.#mention(
+                `${this.#structuralBadges() ? "A " : ""}${safeTerminalText(literal)}`,
+              ),
+              description: `A · ${safeTerminalText(thread.description)} · ${safeTerminalText(thread.turn.label)}`,
+            })),
+        );
+      const main =
+        this.#getMain() && "main".startsWith(normalizedPrefix)
+          ? [
+              {
+                adamMention: {
+                  type: "mention",
+                  kind: "main",
+                  literal: "@main",
+                } satisfies AtMentionAtom,
+                value: "@main",
+                label: this.#mention(`${this.#structuralBadges() ? "A " : ""}@main`),
+                description: "A · Main conversation",
+              },
+            ]
+          : [];
+      const items = [...roles, ...threads, ...main, ...pathItems];
+      return Promise.resolve(items.length === 0 ? null : { items, prefix: pathPrefix });
     }
     if (options.force !== true) {
       return Promise.resolve(null);

--- a/apps/tui/src/delegation-selector.ts
+++ b/apps/tui/src/delegation-selector.ts
@@ -1,0 +1,536 @@
+import type {
+  ManagedDelegationContext,
+  ManagedDelegationEnvelope,
+  ManagedDelegationLimits,
+  ManagedDelegationMessage,
+} from "@adam-agent/presentation";
+import {
+  type Component,
+  Input,
+  matchesKey,
+  SelectList,
+  truncateToWidth,
+} from "@earendil-works/pi-tui";
+import { safeTerminalText } from "./safe-terminal-text.js";
+import type { AdamTuiTheme } from "./theme.js";
+
+type NumericLimit = "aggregateTokens" | "threadTokens" | "running" | "queued" | "sessionTokens";
+
+export class DelegationSelector implements Component {
+  #list: SelectList;
+  #envelope: ManagedDelegationEnvelope;
+  #context: ManagedDelegationContext;
+  #selected = new Set<number>();
+  #page: "review" | "context" | "messages" | "skills" | "limits" | "identity" | "custom" = "review";
+  #pending = false;
+  #notice = "";
+  #description: string;
+  #descriptionInput: Input | undefined;
+  #numericInput: Input | undefined;
+  #numericField: NumericLimit = "aggregateTokens";
+  #skills: readonly string[];
+  readonly #requestedSkills: readonly string[];
+  constructor(
+    private readonly options: {
+      readonly description: string;
+      readonly envelope: ManagedDelegationEnvelope;
+      readonly messages?: readonly ManagedDelegationMessage[];
+      readonly canChangeMode?: boolean;
+      readonly theme: AdamTuiTheme;
+      readonly onConfirm: (
+        envelope: ManagedDelegationEnvelope,
+        context: ManagedDelegationContext,
+        skills: readonly string[],
+      ) => void;
+      readonly onCancel: () => void;
+      readonly onContext?: (
+        context: ManagedDelegationContext,
+        skills: readonly string[],
+        source: "context" | "skills",
+      ) => Promise<ManagedDelegationEnvelope>;
+      readonly onChange?: () => void;
+      readonly onDescription?: (
+        description: string,
+        context: ManagedDelegationContext,
+        skills: readonly string[],
+      ) => Promise<ManagedDelegationEnvelope>;
+      readonly onLimits?: (
+        limits: ManagedDelegationLimits,
+        context: ManagedDelegationContext,
+        skills: readonly string[],
+      ) => Promise<ManagedDelegationEnvelope>;
+    },
+  ) {
+    this.#envelope = options.envelope;
+    this.#description = options.description;
+    this.#skills = options.envelope.skills;
+    this.#requestedSkills = options.envelope.skills;
+    this.#context =
+      options.envelope.context === "task" ? { mode: "task" } : { mode: "current_request" };
+    this.#list = this.#createList();
+  }
+  #createList(): SelectList {
+    const envelope = this.#envelope;
+    const lane = envelope.policy[envelope.mode === "background" ? "background" : "reserved"];
+    const items =
+      this.#page === "review"
+        ? [
+            {
+              value: "confirm",
+              label: "Confirm delegation",
+              description: "Start this described child.",
+            },
+            { value: "cancel", label: "Cancel", description: "Keep the draft." },
+            ...(this.options.onContext !== undefined && this.#requestedSkills.length > 0
+              ? [
+                  {
+                    value: "skills",
+                    label: "Requested Skills",
+                    description: "Remove optional pre-activations.",
+                  },
+                ]
+              : []),
+            ...(this.options.onContext === undefined
+              ? []
+              : [
+                  {
+                    value: "context",
+                    label: "Context sharing",
+                    description: "Choose the exact parent context.",
+                  },
+                ]),
+            ...(this.options.onLimits === undefined
+              ? []
+              : [
+                  {
+                    value: "limits",
+                    label: "Execution and limits",
+                    description: "Choose within current authority.",
+                  },
+                ]),
+            {
+              value: "identity",
+              label: "Exact grant",
+              description: "Inspect the complete ID and digest.",
+            },
+            ...(this.options.onDescription === undefined
+              ? []
+              : [
+                  {
+                    value: "description",
+                    label: "Edit description",
+                    description: "Name the work in up to 256 UTF-8 bytes.",
+                  },
+                ]),
+          ]
+        : this.#page === "identity"
+          ? [
+              {
+                value: "back",
+                label: "Back to delegation",
+                description: "Review this exact grant.",
+              },
+            ]
+          : this.#page === "custom"
+            ? (
+                ["aggregateTokens", "threadTokens", "running", "queued", "sessionTokens"] as const
+              ).map((field) => {
+                const bound = this.#numericBound(field);
+                return {
+                  value: field,
+                  label: bound.label,
+                  description: `Current ${envelope[field]}; range ${bound.min}–${bound.max}`,
+                };
+              })
+            : this.#page === "limits"
+              ? [
+                  ...(this.options.canChangeMode === false
+                    ? []
+                    : [
+                        {
+                          value: "background",
+                          label: "Background",
+                          description: "Continue working in Main.",
+                        },
+                      ]),
+                  ...(envelope.threads === 1 && this.options.canChangeMode !== false
+                    ? [
+                        {
+                          value: "foreground",
+                          label: "Foreground",
+                          description: "Join one child execution.",
+                        },
+                      ]
+                    : []),
+                  ...[1, 2, 4]
+                    .filter(
+                      (n) =>
+                        n * envelope.policy.threadTokens <=
+                        Math.min(envelope.policy.batchTokens, envelope.sessionTokens),
+                    )
+                    .map((n) => ({
+                      value: `tokens:${n * envelope.policy.threadTokens}`,
+                      label: `Aggregate ${n}x`,
+                      description: `${n * envelope.policy.threadTokens} tokens`,
+                    })),
+                  ...Array.from({ length: lane.running }, (_, i) => i + 1)
+                    .filter((running) => envelope.threads - running <= lane.queued)
+                    .map((running) => ({
+                      value: `running:${running}`,
+                      label: `Running ${running}`,
+                      description: `Range 1–${lane.running}; queued ${Math.max(0, envelope.threads - running)} (0–${lane.queued})`,
+                    })),
+                  ...[0.25, 0.5, 1].map((n) => ({
+                    value: `thread:${Math.max(1, Math.floor(n * envelope.policy.threadTokens))}`,
+                    label: `Thread ${n}x`,
+                    description: `${Math.max(1, Math.floor(n * envelope.policy.threadTokens))} tokens`,
+                  })),
+                  {
+                    value: "custom",
+                    label: "Custom limits",
+                    description: "Enter an integer within the displayed range.",
+                  },
+                ]
+              : this.#page === "context"
+                ? [
+                    {
+                      value: "current_request",
+                      label: "Current request",
+                      description: "Only the current submitted request.",
+                    },
+                    { value: "task", label: "Task only", description: "Only the delegated task." },
+                    {
+                      value: "selected_messages",
+                      label: "Selected messages",
+                      description: "Choose exact earlier parent messages.",
+                    },
+                  ]
+                : this.#page === "skills"
+                  ? [
+                      {
+                        value: "done",
+                        label: "Use selected Skills",
+                        description: `${this.#skills.length} pre-activations`,
+                      },
+                      ...this.#requestedSkills.map((id) => ({
+                        value: id,
+                        label: `${this.#skills.includes(id) ? "[x]" : "[ ]"} ${id}`,
+                        description: "Optional child pre-activation",
+                      })),
+                    ]
+                  : [
+                      {
+                        value: "done",
+                        label: "Use selected messages",
+                        description: `${this.#selected.size} selected`,
+                      },
+                      ...(this.options.messages ?? []).map((message) => ({
+                        value: String(message.sequence),
+                        label: `${this.#selected.has(message.sequence) ? "[x]" : "[ ]"} ${message.role} ${message.sequence}`,
+                        description: message.text.replace(/\s+/gu, " "),
+                      })),
+                    ];
+    const list = new SelectList(
+      items.map((item) => ({
+        ...item,
+        label: safeTerminalText(item.label),
+        description: safeTerminalText(item.description),
+      })),
+      8,
+      this.options.theme.editor.selectList,
+    );
+    list.onCancel = () => {
+      if (this.#page === "review") this.options.onCancel();
+      else {
+        this.#page = "review";
+        this.#list = this.#createList();
+      }
+    };
+    list.onSelect = (item) => {
+      if (this.#page === "review") {
+        if (item.value === "confirm")
+          this.options.onConfirm(this.#envelope, this.#context, this.#skills);
+        else if (item.value === "cancel") this.options.onCancel();
+        else if (item.value === "description") {
+          this.#descriptionInput = new Input();
+          this.#descriptionInput.setValue(this.#description);
+          this.#descriptionInput.onSubmit = (description) => {
+            if (this.options.onDescription === undefined) return;
+            this.#update(
+              this.options
+                .onDescription(description.trim(), this.#context, this.#skills)
+                .then((envelope) => {
+                  this.#description = description.trim();
+                  this.#descriptionInput = undefined;
+                  return envelope;
+                }),
+              "Description updated.",
+            );
+          };
+        } else {
+          this.#page =
+            item.value === "skills"
+              ? "skills"
+              : item.value === "limits"
+                ? "limits"
+                : item.value === "identity"
+                  ? "identity"
+                  : "context";
+          this.#list = this.#createList();
+        }
+      } else if (this.#page === "identity") {
+        this.#page = "review";
+        this.#list = this.#createList();
+      } else if (this.#page === "custom") {
+        const field = item.value as NumericLimit;
+        this.#numericField = field;
+        this.#numericInput = new Input();
+        this.#numericInput.setValue(String(envelope[field]));
+        this.#numericInput.onSubmit = (raw) => {
+          const value = Number(raw);
+          const bound = this.#numericBound(field);
+          if (
+            !/^\d+$/u.test(raw) ||
+            !Number.isSafeInteger(value) ||
+            value < bound.min ||
+            value > bound.max
+          ) {
+            this.#notice = `Enter an integer from ${bound.min} to ${bound.max}.`;
+            return;
+          }
+          if (this.options.onLimits === undefined) return;
+          this.#update(
+            this.options
+              .onLimits({ ...this.#limits(), [field]: value }, this.#context, this.#skills)
+              .then((updated) => {
+                this.#numericInput = undefined;
+                return updated;
+              }),
+            "Limits updated.",
+          );
+        };
+      } else if (this.#page === "limits") {
+        if (item.value === "custom") {
+          this.#page = "custom";
+          this.#list = this.#createList();
+          return;
+        }
+        const limits: ManagedDelegationLimits = {
+          mode: envelope.mode,
+          running: envelope.running,
+          queued: envelope.queued,
+          aggregateTokens: envelope.aggregateTokens,
+          threadTokens: envelope.threadTokens,
+          sessionTokens: envelope.sessionTokens,
+        };
+        const [field, raw] = item.value.split(":");
+        const update: ManagedDelegationLimits =
+          field === "tokens"
+            ? { aggregateTokens: Number(raw) }
+            : field === "thread"
+              ? { threadTokens: Number(raw) }
+              : field === "running"
+                ? { running: Number(raw), queued: Math.max(0, envelope.threads - Number(raw)) }
+                : {
+                    mode: item.value === "foreground" ? "foreground" : "background",
+                    running: Math.min(
+                      envelope.threads,
+                      envelope.policy[item.value === "foreground" ? "reserved" : "background"]
+                        .running,
+                    ),
+                    queued: Math.max(
+                      0,
+                      envelope.threads -
+                        envelope.policy[item.value === "foreground" ? "reserved" : "background"]
+                          .running,
+                    ),
+                  };
+        if (this.options.onLimits !== undefined)
+          this.#update(
+            this.options.onLimits({ ...limits, ...update }, this.#context, this.#skills),
+            "Limits updated.",
+          );
+      } else if (this.#page === "skills") {
+        if (item.value === "done") this.#updateContext(this.#context, "skills");
+        else {
+          this.#skills = this.#skills.includes(item.value)
+            ? this.#skills.filter((id) => id !== item.value)
+            : [...this.#skills, item.value];
+          this.#list = this.#createList();
+          this.#list.setSelectedIndex(items.findIndex((entry) => entry.value === item.value));
+        }
+      } else if (this.#page === "context") {
+        if (item.value === "selected_messages") {
+          this.#page = "messages";
+          this.#list = this.#createList();
+        } else this.#updateContext({ mode: item.value === "task" ? "task" : "current_request" });
+      } else if (item.value === "done") {
+        if (this.#selected.size === 0) {
+          this.#notice = "Select at least one message.";
+          return;
+        }
+        this.#updateContext({
+          mode: "selected_messages",
+          messages: (this.options.messages ?? [])
+            .filter((message) => this.#selected.has(message.sequence))
+            .map(({ sequence, digest }) => ({ sequence, digest })),
+        });
+      } else {
+        const sequence = Number(item.value);
+        if (this.#selected.has(sequence)) this.#selected.delete(sequence);
+        else this.#selected.add(sequence);
+        this.#list = this.#createList();
+        this.#list.setSelectedIndex(items.findIndex((entry) => entry.value === item.value));
+      }
+    };
+    return list;
+  }
+  #updateContext(
+    context: ManagedDelegationContext,
+    source: "context" | "skills" = "context",
+  ): void {
+    if (this.options.onContext === undefined) return;
+    this.#update(
+      this.options.onContext(context, this.#skills, source).then((envelope) => {
+        this.#context = context;
+        return envelope;
+      }),
+      "Context updated.",
+    );
+  }
+  #limits(): ManagedDelegationLimits {
+    const { mode, running, queued, aggregateTokens, threadTokens, sessionTokens } = this.#envelope;
+    return { mode, running, queued, aggregateTokens, threadTokens, sessionTokens };
+  }
+  #numericBound(field: NumericLimit): { label: string; min: number; max: number } {
+    const envelope = this.#envelope;
+    const lane = envelope.policy[envelope.mode === "background" ? "background" : "reserved"];
+    switch (field) {
+      case "aggregateTokens":
+        return {
+          label: "Aggregate tokens",
+          min: 1,
+          max: Math.min(envelope.policy.batchTokens, envelope.sessionTokens),
+        };
+      case "threadTokens":
+        return { label: "Thread tokens", min: 1, max: envelope.policy.threadTokens };
+      case "running":
+        return {
+          label: "Running slots",
+          min: Math.max(1, envelope.threads - envelope.queued),
+          max: lane.running,
+        };
+      case "queued":
+        return {
+          label: "Queued slots",
+          min: Math.max(0, envelope.threads - envelope.running),
+          max: lane.queued,
+        };
+      case "sessionTokens":
+        return {
+          label: "Session ceiling",
+          min: envelope.aggregateTokens,
+          max: this.options.envelope.sessionTokens,
+        };
+    }
+  }
+  #update(update: Promise<ManagedDelegationEnvelope>, notice: string): void {
+    this.#pending = true;
+    this.#notice = "Preparing exact grant…";
+    void update
+      .then((envelope) => {
+        this.#envelope = envelope;
+        this.#page = "review";
+        this.#list = this.#createList();
+        this.#notice = notice;
+      })
+      .catch((error: unknown) => {
+        this.#notice = error instanceof Error ? error.message : "Context is unavailable.";
+      })
+      .finally(() => {
+        this.#pending = false;
+        this.options.onChange?.();
+      });
+  }
+  handleInput(data: string): void {
+    if (this.#pending) return;
+    if (this.#numericInput !== undefined) {
+      if (matchesKey(data, "escape")) this.#numericInput = undefined;
+      else this.#numericInput.handleInput(data);
+    } else if (this.#descriptionInput !== undefined) {
+      if (matchesKey(data, "escape")) this.#descriptionInput = undefined;
+      else this.#descriptionInput.handleInput(data);
+    } else this.#list.handleInput(data);
+  }
+  invalidate(): void {
+    this.#list.invalidate();
+  }
+  render(width: number): string[] {
+    const { theme } = this.options;
+    if (this.#numericInput !== undefined) {
+      const bound = this.#numericBound(this.#numericField);
+      return [
+        theme.toolTitle(`Custom ${bound.label.toLowerCase()}`),
+        `Range ${bound.min}–${bound.max}`,
+        ...this.#numericInput.render(width),
+        truncateToWidth(safeTerminalText(this.#notice), width),
+        "Enter apply · Esc back",
+      ];
+    }
+    if (this.#descriptionInput !== undefined)
+      return [
+        theme.toolTitle("Edit description"),
+        ...this.#descriptionInput.render(width),
+        truncateToWidth(safeTerminalText(this.#notice), width),
+        "Enter apply · Esc back",
+      ];
+    const envelope = this.#envelope;
+    if (this.#page === "identity") {
+      const wrap = (value: string) =>
+        Array.from({ length: Math.ceil(value.length / width) }, (_, i) =>
+          value.slice(i * width, (i + 1) * width),
+        );
+      return [
+        theme.toolTitle("Exact grant"),
+        ...wrap(`ID: ${envelope.id}`),
+        ...wrap(`Digest: ${envelope.digest}`),
+        ...wrap(`Policy: ${envelope.policyDigest}`),
+        ...this.#list.render(width),
+      ];
+    }
+    const context =
+      envelope.context === "task"
+        ? "Task only"
+        : envelope.context === "current_request"
+          ? "Current request"
+          : `${this.#selected.size} selected messages`;
+    return [
+      theme.toolTitle(
+        this.#page === "review"
+          ? "Delegation"
+          : this.#page === "context"
+            ? "Context sharing"
+            : this.#page === "skills"
+              ? "Requested Skills"
+              : this.#page === "custom"
+                ? "Custom limits"
+                : this.#page === "limits"
+                  ? "Execution and limits"
+                  : "Select parent messages",
+      ),
+      truncateToWidth(safeTerminalText(this.#description), width),
+      truncateToWidth(
+        `${envelope.mode} · ${envelope.threads} thread · ${envelope.running} running`,
+        width,
+      ),
+      truncateToWidth(`${envelope.aggregateTokens} tokens · ${context}`, width),
+      truncateToWidth(`Queued ${envelope.queued} · Thread ${envelope.threadTokens}`, width),
+      truncateToWidth(`Session ceiling ${envelope.sessionTokens}`, width),
+      ...envelope.skills.map((id) => truncateToWidth(`Skill: ${safeTerminalText(id)}`, width)),
+      "",
+      ...this.#list.render(width),
+      ...(this.#notice ? [truncateToWidth(safeTerminalText(this.#notice), width)] : []),
+      truncateToWidth(theme.muted("Enter choose · Esc cancel"), width),
+    ];
+  }
+}

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -1876,7 +1876,7 @@ test("candidate ProjectRuntime runs real JSONL child Enter, Main response, layer
     await fixture.waitForScreen("Adam · New session");
     fixture.write("Start child\r");
     waiting = "Delegation permission";
-    await fixture.waitForRecordedOutput("Permission required");
+    await fixture.waitForRecordedOutput("Confirm delegation");
     fixture.write("\r");
     waiting = "MAIN_READY";
     await fixture.waitForRecordedOutput("MAIN_READY");

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -5310,7 +5310,7 @@ test("accepted Skill completion preserves its exact identity across a recoverabl
     await expect(first.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
 
     const recoveredManifest = await readFilesRecursively(join(stateRoot, "drafts"));
-    expect(recoveredManifest).toContain('"schemaVersion":3');
+    expect(recoveredManifest).toContain('"schemaVersion":4');
     expect(recoveredManifest).toContain('"type":"skill"');
     expect(recoveredManifest).toMatch(/"elementId":"adam-skill-[^"]+"/u);
     expect(recoveredManifest).toContain(
@@ -5373,7 +5373,7 @@ test("a Skill atom navigates as one token and Backspace removes its exact occurr
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
 
     const recoveredManifest = await readFilesRecursively(join(stateRoot, "drafts"));
-    expect(recoveredManifest).toContain('"schemaVersion":3');
+    expect(recoveredManifest).toContain('"schemaVersion":4');
     expect(recoveredManifest).toContain('"text":"xy"');
     expect(recoveredManifest).not.toContain('"type":"skill"');
     expect(recoveredManifest).not.toContain("skill:v1:project:.:first");
@@ -7802,13 +7802,13 @@ test("the real TUI opens inline project path completion from the at trigger", as
     await fixture.waitForCompleteFrameAfter("@README.md", beforeCompletion);
     const frame = fixture.output().slice(beforeCompletion);
     let screen = fixture.screen()?.join("\n") ?? "";
-    expect(screen).toMatch(/@README\.md\s+\.\//u);
-    expect(screen).toMatch(/@alpha\.ts\s+src\//u);
+    expect(screen).toMatch(/@README\.md\s+F · \.\//u);
+    expect(screen).toMatch(/@alpha\.ts\s+F · src\//u);
 
     await fixture.resize(120, 40);
     screen = fixture.screen()?.join("\n") ?? "";
-    expect(screen).toMatch(/@README\.md\s+\.\//u);
-    expect(screen).toMatch(/@alpha\.ts\s+src\//u);
+    expect(screen).toMatch(/@README\.md\s+F · \.\//u);
+    expect(screen).toMatch(/@alpha\.ts\s+F · src\//u);
 
     await fixture.resize(40, 12);
     screen = fixture.screen()?.join("\n") ?? "";
@@ -7846,7 +7846,8 @@ test("the real TUI fuzzy-selects one durable project path atom without reading i
     await fixture.closed;
 
     const durableState = await readFilesRecursively(stateRoot);
-    expect(durableState).toContain('"type":"path"');
+    expect(durableState).toContain('"type":"mention"');
+    expect(durableState).toContain('"kind":"path"');
     expect(durableState).toContain('"path":"src/alpha.ts"');
     expect(durableState).not.toContain("PRIVATE_ALPHA_BYTES");
     expect(fixture.output()).not.toContain("PRIVATE_ALPHA_BYTES");

--- a/apps/tui/src/mention-recipient-selector.ts
+++ b/apps/tui/src/mention-recipient-selector.ts
@@ -1,0 +1,37 @@
+import { type Component, SelectList, truncateToWidth } from "@earendil-works/pi-tui";
+import type { AdamTuiTheme } from "./theme.js";
+
+export class MentionRecipientSelector implements Component {
+  readonly #list: SelectList;
+  constructor(
+    private readonly options: {
+      readonly title: string;
+      readonly choices: readonly {
+        readonly value: string;
+        readonly label: string;
+        readonly description: string;
+      }[];
+      readonly theme: AdamTuiTheme;
+      readonly onChoose: (value: string) => void;
+      readonly onCancel: () => void;
+    },
+  ) {
+    this.#list = new SelectList([...options.choices], 8, options.theme.editor.selectList);
+    this.#list.onSelect = (item) => options.onChoose(item.value);
+    this.#list.onCancel = options.onCancel;
+  }
+  handleInput(data: string): void {
+    this.#list.handleInput(data);
+  }
+  invalidate(): void {
+    this.#list.invalidate();
+  }
+  render(width: number): string[] {
+    return [
+      truncateToWidth(this.options.theme.toolTitle(this.options.title), width),
+      "",
+      ...this.#list.render(width),
+      this.options.theme.muted("Enter choose · Esc retain draft"),
+    ];
+  }
+}

--- a/apps/tui/src/role-target-selector.ts
+++ b/apps/tui/src/role-target-selector.ts
@@ -1,0 +1,75 @@
+import type { CommandReceipt } from "@adam-agent/presentation";
+import { type Component, SelectList, truncateToWidth } from "@earendil-works/pi-tui";
+import { safeTerminalText } from "./safe-terminal-text.js";
+import type { AdamTuiTheme } from "./theme.js";
+
+type Recovery = NonNullable<Extract<CommandReceipt, { status: "admitted" }>["roleTarget"]>;
+export class RoleTargetSelector implements Component {
+  #list: SelectList;
+  #updating = false;
+  constructor(
+    private readonly options: {
+      readonly recovery: Recovery;
+      readonly theme: AdamTuiTheme;
+      readonly onChoose: (model: string | null) => void;
+      readonly onCancel: () => void;
+      readonly onChange: () => void;
+    },
+  ) {
+    this.#list = this.#choices();
+  }
+  #choices(): SelectList {
+    const list = new SelectList(
+      this.#updating
+        ? this.options.recovery.targets.map((target) => ({
+            value: target.targetId,
+            label: safeTerminalText(target.label),
+            description: "Save this certified target for future threads.",
+          }))
+        : [
+            {
+              value: "inherit",
+              label: "Use inherited",
+              description:
+                "Remove this role's target and thinking settings; future threads inherit Main.",
+            },
+            {
+              value: "update",
+              label: "Update",
+              description: "Choose and save an available certified target.",
+            },
+            { value: "cancel", label: "Cancel", description: "Keep the definition and draft." },
+          ],
+      8,
+      this.options.theme.editor.selectList,
+    );
+    list.onSelect = (item) => {
+      if (this.#updating) this.options.onChoose(item.value);
+      else if (item.value === "inherit") this.options.onChoose(null);
+      else if (item.value === "cancel") this.options.onCancel();
+      else {
+        this.#updating = true;
+        this.#list = this.#choices();
+        this.options.onChange();
+      }
+    };
+    list.onCancel = this.options.onCancel;
+    return list;
+  }
+  handleInput(data: string): void {
+    this.#list.handleInput(data);
+  }
+  invalidate(): void {
+    this.#list.invalidate();
+  }
+  render(width: number): string[] {
+    return [
+      this.options.theme.toolTitle("Role target unavailable"),
+      truncateToWidth(safeTerminalText(this.options.recovery.message), width),
+      truncateToWidth(`Save changes to ${safeTerminalText(this.options.recovery.source)}`, width),
+      "",
+      ...this.#list.render(width),
+      this.options.theme.muted("Enter choose and save · Esc cancel"),
+    ];
+  }
+}

--- a/apps/tui/src/structured-editor-completion.ts
+++ b/apps/tui/src/structured-editor-completion.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import type { DraftMentionElement } from "@adam-agent/presentation";
 import type {
   EditorDocumentPart,
   EditorDocumentPoint,
@@ -6,6 +7,7 @@ import type {
   EditorStructuredCompletionProjection,
 } from "@earendil-works/pi-tui";
 import {
+  mentionAutocompleteIdentity,
   type PathAutocompleteIdentity,
   pathAutocompleteIdentity,
   type SkillAutocompleteIdentity,
@@ -14,6 +16,8 @@ import {
 
 export function createAdamStructuredEditorCompletion(
   options: {
+    readonly onMentionAtom?: (element: DraftMentionElement) => void;
+    readonly mentionStyle?: (text: string) => string;
     readonly pathStyle?: (text: string) => string;
     readonly onPathAtom?: (
       identity: PathAutocompleteIdentity & { readonly elementId: string },
@@ -23,8 +27,31 @@ export function createAdamStructuredEditorCompletion(
     ) => void;
   } = {},
 ): EditorStructuredCompletion {
+  const selectedItem = (item: Parameters<EditorStructuredCompletion["accept"]>[2]) => {
+    const path = pathAutocompleteIdentity(item);
+    return options.onMentionAtom === undefined || path === null
+      ? item
+      : {
+          ...item,
+          adamMention: {
+            type: "mention" as const,
+            kind: "path" as const,
+            literal: `@${encodeURI(path.path)}`,
+            path: path.path,
+          },
+        };
+  };
   return {
     promote(text, cursorOffset, item, prefix) {
+      item = selectedItem(item);
+      if (mentionAutocompleteIdentity(item) !== null)
+        return acceptMentionAtom(
+          [{ type: "text", id: "adam-editor-text-1", text }],
+          { partId: "adam-editor-text-1", offset: cursorOffset },
+          item,
+          prefix,
+          options,
+        );
       if (skillAutocompleteIdentity(item) === null && pathAutocompleteIdentity(item) === null) {
         return null;
       }
@@ -65,6 +92,9 @@ export function createAdamStructuredEditorCompletion(
       );
     },
     accept(document, cursor, item, prefix) {
+      item = selectedItem(item);
+      if (mentionAutocompleteIdentity(item) !== null)
+        return acceptMentionAtom(document, cursor, item, prefix, options);
       const textCursor = textPartAtCursor(document, cursor);
       if (textCursor === null) {
         if (prefix.length === 0 && "edge" in cursor && item.value.length > 0) {
@@ -128,6 +158,78 @@ export function createAdamStructuredEditorCompletion(
 }
 
 export const adamStructuredEditorCompletion = createAdamStructuredEditorCompletion();
+
+export function completeLiteralMentionAtCursor(
+  document: readonly EditorDocumentPart[],
+  cursor: EditorDocumentPoint,
+  onMentionAtom: (element: DraftMentionElement) => void,
+): ReturnType<EditorStructuredCompletion["accept"]> {
+  const current = textPartAtCursor(document, cursor);
+  if (current === null || current.offset !== current.part.text.length) return null;
+  const match = /(^|\s)(@[^\s\p{Cc}]+)$/u.exec(current.part.text);
+  const literal = match?.[2];
+  if (literal === undefined || (match?.index === 0 && match[1] === "" && current.index > 0))
+    return null;
+  return acceptMentionAtom(
+    document,
+    cursor,
+    {
+      value: literal,
+      label: literal,
+      adamMention: { type: "mention", kind: "literal", literal },
+    } as Parameters<EditorStructuredCompletion["accept"]>[2],
+    literal,
+    { onMentionAtom },
+  );
+}
+
+function acceptMentionAtom(
+  document: readonly EditorDocumentPart[],
+  cursor: EditorDocumentPoint,
+  item: Parameters<EditorStructuredCompletion["accept"]>[2],
+  prefix: string,
+  options: {
+    readonly onMentionAtom?: (element: DraftMentionElement) => void;
+    readonly mentionStyle?: (text: string) => string;
+    readonly pathStyle?: (text: string) => string;
+  },
+): ReturnType<EditorStructuredCompletion["accept"]> {
+  const atom = mentionAutocompleteIdentity(item);
+  const textCursor = textPartAtCursor(document, cursor);
+  if (atom === null || textCursor === null) return null;
+  const start = textCursor.offset - prefix.length;
+  if (start < 0 || textCursor.part.text.slice(start, textCursor.offset) !== prefix) return null;
+  const elementId = `adam-mention-${randomUUID()}`;
+  const before = textCursor.part.text.slice(0, start);
+  const after = textCursor.part.text.slice(textCursor.offset);
+  options.onMentionAtom?.({ ...atom, elementId });
+  return {
+    cursor: { partId: elementId, edge: "after" },
+    document: [
+      ...document.slice(0, textCursor.index),
+      ...(before.length === 0 ? [] : [{ ...textCursor.part, text: before }]),
+      {
+        type: "atom",
+        id: elementId,
+        label: atom.literal,
+        ...(atom.kind === "path" && options.pathStyle !== undefined
+          ? { style: options.pathStyle }
+          : options.mentionStyle === undefined
+            ? {}
+            : { style: options.mentionStyle }),
+      },
+      ...(after.length === 0
+        ? []
+        : [{ type: "text" as const, id: nextTextPartId(document), text: after }]),
+      ...document.slice(textCursor.index + 1),
+    ],
+    range: {
+      anchor: { partId: textCursor.part.id, offset: start },
+      focus: { partId: textCursor.part.id, offset: textCursor.offset },
+    },
+    text: item.value,
+  };
+}
 
 function acceptPathAtom(
   document: readonly EditorDocumentPart[],

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -1,11 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { MessageChannel } from "node:worker_threads";
-
 import { isLargePastedTextV1 } from "@adam-agent/agent";
 import type {
   ActiveSessionDisplay,
   ArtifactReference,
+  AtMentionAtom,
   BranchSourceBoundary,
+  DraftMentionElement,
   DraftPoint,
   ManagedControlThread,
   OperationDisplay,
@@ -19,7 +20,7 @@ import type {
   ThinkingPolicySelectionDisplay,
   TodoPageResource,
 } from "@adam-agent/presentation";
-import { defaultAgentUiSettings } from "@adam-agent/presentation";
+import { defaultAgentUiSettings, leadingMentionRecipients } from "@adam-agent/presentation";
 import {
   Box,
   type Component,
@@ -45,6 +46,7 @@ import PQueue from "p-queue";
 import { AgentConversationViewer } from "./agent-conversation-viewer.js";
 import { AgentFleet, AgentSessionTransition, AgentWorkspace } from "./agent-fleet.js";
 import { AgentNavigator, ManagedAgentRoster } from "./agent-navigator.js";
+import { AgentTypes } from "./agent-types.js";
 import { AgentWidget } from "./agent-widget.js";
 import {
   ArtifactNavigator,
@@ -60,6 +62,7 @@ import {
   adamCommandRegistry,
 } from "./command-registry.js";
 import { type ConfigurationField, ConfigurationPage } from "./configuration-page.js";
+import { DelegationSelector } from "./delegation-selector.js";
 import {
   type ClipboardAdapter,
   copyDraftToClipboard,
@@ -79,6 +82,7 @@ import {
 } from "./large-reasoning-view.js";
 import { mcpAdvanceCommand } from "./mcp-advance.js";
 import { McpWizard } from "./mcp-wizard.js";
+import { MentionRecipientSelector } from "./mention-recipient-selector.js";
 import { OverlayFrame } from "./overlay-frame.js";
 import { PermissionOverlay } from "./permission-overlay.js";
 import {
@@ -96,12 +100,16 @@ import {
   terminalSizeIsSupported,
 } from "./responsive-root.js";
 import { RightEdgeGuardTerminal } from "./right-edge-guard-terminal.js";
+import { RoleTargetSelector } from "./role-target-selector.js";
 import { RoundedFrame } from "./rounded-frame.js";
 import { safeTerminalText } from "./safe-terminal-text.js";
 import { SessionInspector, type SessionRunStatus } from "./session-inspector.js";
 import { SessionPicker } from "./session-picker.js";
 import { SkillPalette } from "./skill-palette.js";
-import { createAdamStructuredEditorCompletion } from "./structured-editor-completion.js";
+import {
+  completeLiteralMentionAtCursor,
+  createAdamStructuredEditorCompletion,
+} from "./structured-editor-completion.js";
 import { TargetPicker } from "./target-picker.js";
 import { type AdamTuiTheme, createAdamTuiTheme } from "./theme.js";
 import { ThinkingPicker } from "./thinking-picker.js";
@@ -278,7 +286,12 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     { readonly name: string; readonly qualifiedId: string }
   >();
   const pathAtomValues = new Map<string, string>();
+  const mentionAtoms = new Map<string, DraftMentionElement>();
   const structuredEditorCompletion = createAdamStructuredEditorCompletion({
+    mentionStyle: theme.reference,
+    onMentionAtom(element) {
+      mentionAtoms.set(element.elementId, element);
+    },
     pathStyle: theme.pathReference,
     onPathAtom({ elementId, path }) {
       pathAtomValues.set(elementId, path);
@@ -291,6 +304,12 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     const created = new Editor(tui, theme.editor, { paddingX: 1 });
     created.setAutocompleteProvider(
       new AdamAutocompleteProvider({
+        getThreads: () =>
+          options.presentation.getState().authoritative.managedControl?.threads ?? [],
+        getMain: () => (options.presentation.getState().agentRoles?.length ?? 0) > 0,
+        mention: theme.reference,
+        structuralBadges: () => physicalTerminal.columns < 60 || theme.reference("a") === "a",
+        getRoles: () => options.presentation.getState().agentRoles ?? [],
         getAttachmentsAvailable: () => options.presentation.getState().composer.attachmentAvailable,
         getProjectPaths: () =>
           options.presentation.getState().authoritative.active?.projectPaths.items ??
@@ -394,7 +413,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   } | null = null;
   let permission:
     | {
-        readonly overlay: PermissionOverlay;
+        readonly overlay: PermissionOverlay | DelegationSelector;
         readonly requestId: string;
         readonly hide: () => void;
       }
@@ -840,8 +859,10 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     if (scopeChanged) {
       skillAtomIdentities.clear();
       pathAtomValues.clear();
+      mentionAtoms.clear();
     }
     for (const element of composer.elements) {
+      if (element.type === "mention") mentionAtoms.set(element.elementId, element);
       if (element.type === "skill") {
         skillAtomIdentities.set(element.elementId, {
           name: element.name,
@@ -870,6 +891,18 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       return;
     }
     const parts: readonly EditorDocumentPart[] = composer.elements.map((element) => {
+      if (element.type === "mention")
+        return {
+          type: "atom",
+          id: element.elementId,
+          label: element.literal,
+          style:
+            element.kind === "path"
+              ? theme.pathReference
+              : element.kind === "literal"
+                ? theme.text
+                : theme.reference,
+        };
       if (element.type === "text") {
         return { type: "text", id: element.elementId, text: element.text };
       }
@@ -895,6 +928,28 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     localStructuredDocument = parts;
   };
 
+  const mentionAvailable = (atom: AtMentionAtom): boolean => {
+    const state = options.presentation.getState();
+    if (atom.kind === "role")
+      return (
+        state.agentRoles?.some(
+          (role) =>
+            role.qualifiedId === atom.qualifiedRoleId &&
+            role.definitionDigest === atom.definitionDigest,
+        ) === true
+      );
+    if (atom.kind === "agent")
+      return (
+        atom.parentSessionId === state.authoritative.active?.session.id &&
+        state.authoritative.managedControl?.threads.some(
+          (thread) =>
+            thread.threadId === atom.threadId &&
+            thread.handle === atom.handle &&
+            thread.lifecycle === "open",
+        ) === true
+      );
+    return true;
+  };
   const synchronizeDraftInputs = (
     composer: ReturnType<PresentationSession["getState"]>["composer"],
   ): void => {
@@ -902,16 +957,31 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     const unavailableSkills = composer.elements.filter(
       (element) => element.type === "skill" && !element.available,
     );
+    const unavailableMentions = composer.elements.filter(
+      (element) => element.type === "mention" && !mentionAvailable(element),
+    );
     if (
       composer.resources.length === 0 &&
       composer.pastedTexts.length === 0 &&
-      unavailableSkills.length === 0
+      unavailableSkills.length === 0 &&
+      unavailableMentions.length === 0
     ) {
       return;
     }
     const resources = new Box(1, 1, theme.toolBackground);
     resources.addChild(new ResponsiveLine(theme.toolTitle("Draft inputs")));
     for (const element of composer.elements) {
+      if (element.type === "mention") {
+        if (!mentionAvailable(element))
+          resources.addChild(
+            new ResponsiveWrappedText(
+              theme.statusError(
+                `${element.literal} unavailable · Remove, convert to literal, or retarget before sending.`,
+              ),
+            ),
+          );
+        continue;
+      }
       if (element.type === "text") {
         continue;
       }
@@ -2355,17 +2425,91 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     } else if (pending !== undefined && permission?.requestId !== pending.requestId) {
       clearExitWindow();
       permission?.hide();
-      const overlay = new PermissionOverlay({
-        interaction: pending,
-        theme,
-        onDecision(decision) {
-          void options.presentation.dispatch({
-            type: "decide_permission",
-            requestId: pending.requestId,
-            decision,
-          });
-        },
-      });
+      let delegationSelection:
+        | import("@adam-agent/presentation").ManagedDelegationSelection
+        | undefined;
+      let delegationLimits: import("@adam-agent/presentation").ManagedDelegationLimits = {};
+      const overlay =
+        pending.delegation !== undefined
+          ? new DelegationSelector({
+              envelope: pending.delegation,
+              canChangeMode: pending.delegationCanChangeMode ?? false,
+              description: `${pending.delegation.threads} child delegation · ${pending.delegation.roles.join(", ")}`,
+              theme,
+              messages: pending.delegationMessages ?? [],
+              onChange: () => tui.requestRender(),
+              ...(pending.delegationCanChangeMode !== true
+                ? {}
+                : {
+                    async onContext(
+                      context: import("@adam-agent/presentation").ManagedDelegationContext,
+                      skills: readonly string[],
+                      source: "context" | "skills",
+                    ) {
+                      const selection = {
+                        ...delegationSelection,
+                        skills,
+                        ...(source === "context" ? { context } : {}),
+                      };
+                      const receipt = await options.presentation.dispatch({
+                        type: "preview_permission_delegation",
+                        requestId: pending.requestId,
+                        limits: delegationLimits,
+                        selection,
+                      });
+                      if (receipt.status === "rejected") throw new Error(receipt.message);
+                      if (receipt.delegation === undefined)
+                        throw new Error("Delegation preview is unavailable.");
+                      delegationSelection = selection;
+                      return receipt.delegation.envelope;
+                    },
+                  }),
+              async onLimits(limits) {
+                const receipt = await options.presentation.dispatch({
+                  type: "preview_permission_delegation",
+                  requestId: pending.requestId,
+                  limits,
+                  ...(delegationSelection === undefined ? {} : { selection: delegationSelection }),
+                });
+                if (receipt.status === "rejected") throw new Error(receipt.message);
+                if (receipt.delegation === undefined)
+                  throw new Error("Delegation preview is unavailable.");
+                delegationLimits = limits;
+                return receipt.delegation.envelope;
+              },
+              onConfirm(delegation) {
+                void options.presentation
+                  .dispatch({
+                    type: "decide_permission",
+                    requestId: pending.requestId,
+                    decision: "allow",
+                    delegation,
+                    ...(delegationSelection === undefined ? {} : { delegationSelection }),
+                  })
+                  .then((receipt) => {
+                    if (receipt.status === "rejected")
+                      showNotice("error", receipt.message, "until_edit");
+                  });
+              },
+              onCancel() {
+                void options.presentation.dispatch({
+                  type: "decide_permission",
+                  requestId: pending.requestId,
+                  decision: "deny",
+                });
+              },
+            })
+          : new PermissionOverlay({
+              interaction: pending,
+              theme,
+              onDecision(decision) {
+                void options.presentation.dispatch({
+                  type: "decide_permission",
+                  requestId: pending.requestId,
+                  decision,
+                });
+              },
+            });
       const handle = showOverlay(overlay, {
         width: "80%",
         minWidth: 36,
@@ -2373,7 +2517,9 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         margin: 1,
       });
       permission = { overlay, requestId: pending.requestId, hide: () => handle.hide() };
-      if (pending.changePreviewRef === null) {
+      if (overlay instanceof DelegationSelector) {
+        tui.requestRender();
+      } else if (pending.changePreviewRef === null) {
         overlay.setPreview({ readable: pending.canAllow, text: "No preview available." });
       } else {
         void options.presentation
@@ -2893,6 +3039,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         });
       return;
     }
+    structuredEditorActive = true;
     localStructuredDocument = intent.document;
     const localLiteralText = intent.document
       .flatMap((part) => (part.type === "text" ? [part.text] : []))
@@ -2910,27 +3057,29 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           document: intent.document.map((part) =>
             part.type === "text"
               ? { type: "text", text: part.text }
-              : skillAtomIdentities.has(part.id)
-                ? {
-                    type: "skill" as const,
-                    elementId: part.id,
-                    name: skillAtomIdentities.get(part.id)?.name ?? "",
-                    qualifiedId: skillAtomIdentities.get(part.id)?.qualifiedId ?? "",
-                  }
-                : pathAtomValues.has(part.id)
+              : mentionAtoms.has(part.id)
+                ? (mentionAtoms.get(part.id) as DraftMentionElement)
+                : skillAtomIdentities.has(part.id)
                   ? {
-                      type: "path" as const,
+                      type: "skill" as const,
                       elementId: part.id,
-                      path: pathAtomValues.get(part.id) ?? "",
+                      name: skillAtomIdentities.get(part.id)?.name ?? "",
+                      qualifiedId: skillAtomIdentities.get(part.id)?.qualifiedId ?? "",
                     }
-                  : {
-                      type:
-                        composer.elements.find((element) => element.elementId === part.id)?.type ===
-                        "pasted_text"
-                          ? ("pasted_text" as const)
-                          : ("resource" as const),
-                      elementId: part.id,
-                    },
+                  : pathAtomValues.has(part.id)
+                    ? {
+                        type: "path" as const,
+                        elementId: part.id,
+                        path: pathAtomValues.get(part.id) ?? "",
+                      }
+                    : {
+                        type:
+                          composer.elements.find((element) => element.elementId === part.id)
+                            ?.type === "pasted_text"
+                            ? ("pasted_text" as const)
+                            : ("resource" as const),
+                        elementId: part.id,
+                      },
           ),
         });
       })
@@ -3490,6 +3639,56 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         onSettings: (settings) =>
           options.presentation.dispatch({ type: "set_agent_ui_settings", settings }),
         onAttention: () => openAttentionCenter(true),
+        onTypes: () => {
+          const reload = async () => {
+            const receipt = await options.presentation.dispatch({
+              type: "refresh_agent_types",
+              sessionId: expectedSessionId,
+            });
+            if (receipt.status === "rejected") throw new Error(receipt.message);
+            const catalog = options.presentation.getState().agentTypes;
+            if (catalog === undefined) throw new Error("Agent types unavailable.");
+            return catalog;
+          };
+          void reload().then(
+            (catalog) => {
+              let typesHandle: ReturnType<typeof showOverlay> | undefined;
+              const types = new AgentTypes({
+                catalog,
+                theme,
+                maximumLines: () => Math.max(8, Math.floor(physicalTerminal.rows * 0.85) - 4),
+                onChange: () => tui.requestRender(),
+                onClose: () => {
+                  typesHandle?.hide();
+                  handle?.focus();
+                  tui.requestRender();
+                },
+                onReload: reload,
+                onWrite: (mutation) =>
+                  options.presentation.dispatch({
+                    type: "mutate_agent_types",
+                    sessionId: expectedSessionId,
+                    confirmed: true,
+                    mutation,
+                  }),
+              });
+              typesHandle = showOverlay(types, {
+                width: "90%",
+                minWidth: 36,
+                maxHeight: "85%",
+                margin: 1,
+              });
+            },
+            (error) => {
+              showNotice(
+                "error",
+                error instanceof Error ? error.message : "Agent types unavailable.",
+                "until_next_action",
+              );
+              renderState();
+            },
+          );
+        },
         hasDraft: (thread) =>
           options.presentation
             .getState()
@@ -4609,9 +4808,452 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         },
       );
   };
+  const showUnavailableRecipient = (
+    recipient: DraftMentionElement,
+    draftRevision: number,
+  ): void => {
+    let handle: { hide(): void } | undefined;
+    const close = () => {
+      handle?.hide();
+      editor.disableSubmit = false;
+      renderState();
+    };
+    const mutate = (command: PresentationCommand) => {
+      void draftMutationQueue
+        .add(() => options.presentation.dispatch(command))
+        .then((receipt) => {
+          close();
+          showNotice(
+            receipt?.status === "rejected" ? "error" : "success",
+            receipt?.status === "rejected"
+              ? receipt.message
+              : "Recipient updated. Review and send.",
+            "until_edit",
+          );
+          renderState();
+        });
+    };
+    const selector = new MentionRecipientSelector({
+      title: `Recipient unavailable · ${recipient.literal}`,
+      theme,
+      choices: [
+        {
+          value: "remove",
+          label: "Remove",
+          description: "Remove this exact atom and keep the task.",
+        },
+        {
+          value: "literal",
+          label: "Convert to literal",
+          description: "Keep visible text without routing authority.",
+        },
+        {
+          value: "retarget",
+          label: "Retarget",
+          description: "Explicitly choose an available exact recipient.",
+        },
+      ],
+      onCancel: close,
+      onChoose(value) {
+        if (value === "remove")
+          mutate({
+            type: "remove_draft_element",
+            baseRevision: draftRevision,
+            elementId: recipient.elementId,
+          });
+        else if (value === "literal")
+          mutate({
+            type: "resolve_draft_recipient",
+            baseRevision: draftRevision,
+            elementId: recipient.elementId,
+            action: "literal",
+          });
+        else {
+          handle?.hide();
+          const state = options.presentation.getState();
+          const candidates: AtMentionAtom[] = [
+            ...(state.agentRoles ?? []).map(
+              (role): AtMentionAtom => ({
+                type: "mention",
+                kind: "role",
+                literal: `@${role.qualifiedId}`,
+                qualifiedRoleId: role.qualifiedId,
+                definitionDigest: role.definitionDigest,
+              }),
+            ),
+            ...(state.authoritative.managedControl?.threads ?? [])
+              .filter((thread) => thread.lifecycle === "open")
+              .map(
+                (thread): AtMentionAtom => ({
+                  type: "mention",
+                  kind: "agent",
+                  literal: thread.handle,
+                  parentSessionId: thread.parentSessionId,
+                  threadId: thread.threadId,
+                  handle: thread.handle,
+                }),
+              ),
+            { type: "mention", kind: "main", literal: "@main" },
+          ];
+          handle = showOverlay(
+            new MentionRecipientSelector({
+              title: "Retarget recipient",
+              theme,
+              choices: candidates.map((atom, index) => ({
+                value: String(index),
+                label: atom.literal,
+                description: `A · ${atom.kind}`,
+              })),
+              onCancel: close,
+              onChoose(index) {
+                const replacement = candidates[Number(index)];
+                if (replacement !== undefined)
+                  mutate({
+                    type: "resolve_draft_recipient",
+                    baseRevision: draftRevision,
+                    elementId: recipient.elementId,
+                    action: "retarget",
+                    replacement,
+                  });
+              },
+            }),
+            { width: "90%", maxHeight: "80%", margin: 1 },
+          );
+        }
+      },
+    });
+    handle = showOverlay(selector, { width: "90%", maxHeight: "80%", margin: 1 });
+    tui.requestRender();
+  };
   const submitEditorValue = (text: string) => {
     const state = options.presentation.getState();
     const active = state.authoritative.active;
+    const recipients = leadingMentionRecipients(state.composer.elements);
+    if (recipients.length > 1) {
+      let handle: { hide(): void } | undefined;
+      const close = () => {
+        handle?.hide();
+        editor.disableSubmit = false;
+        renderState();
+      };
+      const selector = new MentionRecipientSelector({
+        title: "Choose recipient",
+        theme,
+        choices: [
+          ...recipients.map((recipient) => ({
+            value: recipient.elementId,
+            label: recipient.literal,
+            description: `A · ${recipient.kind} · Keep this recipient and remove the others`,
+          })),
+          {
+            value: "remove-extra",
+            label: "Remove extra recipients",
+            description: `Keep ${recipients[0]?.literal ?? ""}`,
+          },
+        ],
+        onCancel: close,
+        onChoose(value) {
+          const elementId = value === "remove-extra" ? recipients[0]?.elementId : value;
+          if (elementId === undefined) return;
+          void draftMutationQueue
+            .add(() =>
+              options.presentation.dispatch({
+                type: "resolve_draft_recipient",
+                baseRevision: state.composer.draftRevision,
+                elementId,
+                action: "keep",
+              }),
+            )
+            .then((receipt) => {
+              close();
+              if (receipt?.status === "rejected")
+                showNotice("error", receipt.message, "until_edit");
+              else showNotice("success", "Recipient selected. Review and send.", "until_edit");
+              renderState();
+            });
+        },
+      });
+      handle = showOverlay(selector, { width: "90%", maxHeight: "80%", margin: 1 });
+      tui.requestRender();
+      return;
+    }
+    const first = state.composer.elements.find(
+      (element) => element.type !== "text" || element.text.trim().length > 0,
+    );
+    if (recipients[0] !== undefined && !mentionAvailable(recipients[0])) {
+      showUnavailableRecipient(recipients[0], state.composer.draftRevision);
+      return;
+    }
+    if (first?.type === "mention" && first.kind === "agent") {
+      const draftRevision = state.composer.draftRevision;
+      void options.presentation
+        .dispatch({ type: "direct_agent_input", draftRevision })
+        .then((receipt) => {
+          if (receipt.status === "rejected") {
+            showNotice("error", receipt.message, "until_edit");
+            renderState();
+            return;
+          }
+          const prepared = receipt.agentInput;
+          if (prepared === undefined) return;
+          let handle: { hide(): void } | undefined;
+          const cancel = () => {
+            handle?.hide();
+            editor.disableSubmit = false;
+            renderState();
+          };
+          const send = (mode: "cooperative" | "interrupt" | "new_turn" | "reply") => {
+            handle?.hide();
+            void options.presentation
+              .dispatch({
+                type: "direct_agent_input",
+                draftRevision,
+                confirmedInput: { ...prepared.input, mode },
+                ...(prepared.envelope === undefined
+                  ? {}
+                  : { confirmedEnvelope: prepared.envelope }),
+              })
+              .then((result) => {
+                editor.disableSubmit = false;
+                if (result.status === "rejected") showNotice("error", result.message, "until_edit");
+                else {
+                  editor.setText("");
+                  showNotice("success", `Input accepted for ${first.handle}.`, "until_edit");
+                }
+                renderState();
+              })
+              .catch(() => {
+                editor.disableSubmit = false;
+                showNotice(
+                  "error",
+                  "The exact input could not be accepted. The draft is retained.",
+                  "until_edit",
+                );
+                renderState();
+              });
+          };
+          const selector =
+            prepared.actions.length === 1 &&
+            prepared.actions[0] === "new_turn" &&
+            prepared.envelope !== undefined
+              ? new DelegationSelector({
+                  envelope: prepared.envelope,
+                  description: `New turn · ${first.handle} · ${prepared.input.text}`,
+                  theme,
+                  onCancel: cancel,
+                  onConfirm: () => send("new_turn"),
+                })
+              : new MentionRecipientSelector({
+                  title: `Send to ${first.handle}`,
+                  choices: prepared.actions.map((mode) => ({
+                    value: mode,
+                    label:
+                      mode === "cooperative"
+                        ? "Cooperative post"
+                        : mode === "interrupt"
+                          ? "Interrupt after current effect"
+                          : mode === "reply"
+                            ? "Reply to exact parent question"
+                            : "New turn",
+                    description: prepared.input.text,
+                  })),
+                  theme,
+                  onCancel: cancel,
+                  onChoose: (mode) => {
+                    const action = prepared.actions.find((candidate) => candidate === mode);
+                    if (action !== undefined) send(action);
+                  },
+                });
+          handle = showOverlay(selector, { width: "90%", maxHeight: "80%", margin: 1 });
+          tui.requestRender();
+        })
+        .catch(() => {
+          editor.disableSubmit = false;
+          showNotice(
+            "error",
+            "The selected thread is unavailable. The draft is retained.",
+            "until_edit",
+          );
+          renderState();
+        });
+      return;
+    }
+    if (first?.type === "mention" && first.kind === "role") {
+      const draftRevision = state.composer.draftRevision;
+      const directTarget = targetForState(state);
+      const thinkingSelection = thinkingSelectionFor(
+        directTarget,
+        selectedThinkingLevel(directTarget),
+      );
+      void options.presentation
+        .dispatch({ type: "direct_delegation", draftRevision, thinkingSelection })
+        .then((receipt) => {
+          if (receipt.status === "rejected") {
+            if (receipt.code === "stale_interaction") {
+              showUnavailableRecipient(first, draftRevision);
+              return;
+            }
+            showNotice("error", receipt.message, "until_edit");
+            editor.disableSubmit = false;
+            renderState();
+            return;
+          }
+          if (receipt.roleTarget !== undefined) {
+            const recovery = receipt.roleTarget;
+            let targetHandle: { hide(): void } | undefined;
+            const cancelTarget = () => {
+              targetHandle?.hide();
+              editor.disableSubmit = false;
+              renderState();
+            };
+            const selector = new RoleTargetSelector({
+              recovery,
+              theme,
+              onCancel: cancelTarget,
+              onChange: () => tui.requestRender(),
+              onChoose(model) {
+                targetHandle?.hide();
+                void options.presentation
+                  .dispatch({
+                    type: "configure_role_target",
+                    qualifiedId: recovery.qualifiedId,
+                    definitionDigest: recovery.definitionDigest,
+                    model,
+                    draftRevision,
+                    confirmed: true,
+                  })
+                  .then((result) => {
+                    editor.disableSubmit = false;
+                    if (result.status === "rejected") {
+                      showNotice("error", result.message, "until_edit");
+                      renderState();
+                    } else submitEditorValue(text);
+                  })
+                  .catch(() => {
+                    showNotice("error", "Role target could not be saved.", "until_edit");
+                    editor.disableSubmit = false;
+                    renderState();
+                  });
+              },
+            });
+            targetHandle = showOverlay(selector, {
+              width: "90%",
+              minWidth: 36,
+              maxHeight: "80%",
+              margin: 1,
+            });
+            tui.requestRender();
+            return;
+          }
+          if (receipt.delegation === undefined) return;
+          const { envelope, description } = receipt.delegation;
+          let selectedDescription = description;
+          let limits: import("@adam-agent/presentation").ManagedDelegationLimits | undefined;
+          let handle: { hide(): void } | undefined;
+          const cancel = () => {
+            handle?.hide();
+            editor.disableSubmit = false;
+            renderState();
+          };
+          const selector = new DelegationSelector({
+            envelope,
+            description,
+            theme,
+            onCancel: cancel,
+            messages: receipt.delegation.messages,
+            onChange: () => tui.requestRender(),
+            async onDescription(description, context, skills) {
+              const updated = await options.presentation.dispatch({
+                type: "direct_delegation",
+                draftRevision,
+                thinkingSelection,
+                context,
+                skills,
+                description,
+                ...(limits === undefined ? {} : { limits }),
+              });
+              if (updated.status === "rejected") throw new Error(updated.message);
+              if (updated.delegation === undefined)
+                throw new Error("The role or target changed. Retry the draft.");
+              selectedDescription = description;
+              return updated.delegation.envelope;
+            },
+            async onLimits(selectedLimits, context, skills) {
+              const updated = await options.presentation.dispatch({
+                type: "direct_delegation",
+                draftRevision,
+                thinkingSelection,
+                context,
+                skills,
+                description: selectedDescription,
+                limits: selectedLimits,
+              });
+              if (updated.status === "rejected") throw new Error(updated.message);
+              if (updated.delegation === undefined)
+                throw new Error("The role or target changed. Retry the draft.");
+              limits = selectedLimits;
+              return updated.delegation.envelope;
+            },
+            async onContext(context, skills) {
+              const updated = await options.presentation.dispatch({
+                type: "direct_delegation",
+                draftRevision,
+                thinkingSelection,
+                context,
+                skills,
+                description: selectedDescription,
+                ...(limits === undefined ? {} : { limits }),
+              });
+              if (updated.status === "rejected") throw new Error(updated.message);
+              if (updated.delegation === undefined)
+                throw new Error("The role or target changed. Retry the draft.");
+              return updated.delegation.envelope;
+            },
+            onConfirm(selectedEnvelope, context, skills) {
+              handle?.hide();
+              void options.presentation
+                .dispatch({
+                  type: "direct_delegation",
+                  draftRevision,
+                  thinkingSelection,
+                  confirmedEnvelope: selectedEnvelope,
+                  description: selectedDescription,
+                  context,
+                  skills,
+                })
+                .then((result) => {
+                  if (result.status === "rejected")
+                    showNotice("error", result.message, "until_edit");
+                  else editor.setText("");
+                  editor.disableSubmit = false;
+                  renderState();
+                })
+                .catch(() => {
+                  showNotice(
+                    "error",
+                    "Delegation could not be admitted. The draft is retained.",
+                    "until_edit",
+                  );
+                  editor.disableSubmit = false;
+                  renderState();
+                });
+            },
+          });
+          handle = showOverlay(selector, {
+            width: "80%",
+            minWidth: 36,
+            maxHeight: "70%",
+            margin: 1,
+          });
+          tui.requestRender();
+        })
+        .catch(() => {
+          showNotice("error", "Delegation could not be prepared.", "until_edit");
+          editor.disableSubmit = false;
+          renderState();
+        });
+      return;
+    }
     if (
       text.trim().length === 0 &&
       state.composer.pastedTexts.length === 0 &&
@@ -6171,6 +6813,39 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     handleTerminationSignal("SIGTERM");
   }
   tui.addInputListener((data) => {
+    if (
+      permission === undefined &&
+      focusedCloseableOverlay() === undefined &&
+      (matchesKey(data, "backspace") || matchesKey(data, "left") || matchesKey(data, "home")) &&
+      !options.presentation.getState().composer.sealed
+    ) {
+      const visible = editor.getText();
+      const position = editor.getCursor();
+      const lines = editor.getLines();
+      if (position.line === lines.length - 1 && position.col === (lines.at(-1)?.length ?? 0)) {
+        const document: readonly EditorDocumentPart[] =
+          structuredEditorActive && localStructuredDocument !== null
+            ? localStructuredDocument
+            : [{ type: "text", id: "adam-literal-input", text: visible }];
+        const last = document.at(-1);
+        if (last?.type === "text") {
+          const edit = completeLiteralMentionAtCursor(
+            document,
+            { partId: last.id, offset: last.text.length },
+            (atom) => mentionAtoms.set(atom.elementId, atom),
+          );
+          if (edit !== null) {
+            editor.setDocument(edit.document, edit.cursor);
+            editor.onEditIntent?.({
+              type: "replace",
+              range: edit.range,
+              text: edit.text,
+              document: edit.document,
+            });
+          }
+        }
+      }
+    }
     if (managedAgentFocusHandoffKey !== null) {
       if (
         matchesKey(data, managedAgentFocusHandoffKey) &&
@@ -6955,7 +7630,7 @@ function planPolicyFooterSummary(
   }
   return density === "compact"
     ? "inspect:auto · ambig:ask · mutate:deny"
-    : "plan-policy.hybrid-v1 · inspect auto · ambiguous exec asks · mutation denies";
+    : `${policyVersion} · inspect auto · ambiguous exec asks · mutation denies`;
 }
 
 function footerContextText(active: ActiveSessionDisplay): string {

--- a/docs/managed-control-candidate.md
+++ b/docs/managed-control-candidate.md
@@ -1,0 +1,45 @@
+# Managed-control candidate
+
+The internal managed-control composition exercises ordinary child threads through `ManagedAgentControl`, the existing `AgentSession` loop, and shared Lifecycle/Presentation owners. It is selected by the internal test composition. The default product entry and the public managed-review extension capability retain their existing execution paths.
+
+## Roles and authority
+
+Explore receives repository reads, explicitly selected immutable input resources, its own frozen Skill catalog, and bounded parent coordination. Research adds the exact Web tools available to Main. An unconfigured search provider exposes no `web_search`; fetch uses normal network permission, while open/find read immutable evidence without another network request. Children cannot write, execute shell commands, access MCP or ambient extensions, or create other children. Skill content does not grant authority.
+
+Each new thread freezes its role definition, exact certified target, effective context and thinking policy, initial context, permissions and budget. Unconfigured roles inherit Main's effective target and limits. A configured but unavailable target requires an explicit Use inherited, Update, or Cancel choice. Reloading definitions or the parent Skill catalog affects future threads. Existing threads retain their frozen definitions and independently activated Skills.
+
+The candidate Plan policy, `plan-policy.hybrid-delegation-v1`, admits only the registered non-mutating role/control and Main/Research Web families under their ordinary permissions. Current Plan and permission ceilings remain enforceable at execution, queued work and recovery boundaries. Compatible work can continue while Plan is active. Plan approval is never delegated to a child.
+
+## Custom definitions
+
+Trusted project definitions live in `.agents/agents/*.md`; user definitions live in `$XDG_CONFIG_HOME/adam-agent/agents/*.md`, with `~/.config` as the fallback configuration root. The Agent types surface supports explicit preview, creation, duplication, built-in ejection, enable/disable and reload. Writes are atomic and revalidate their source authority. Invalid files appear as isolated diagnostics.
+
+```markdown
+---
+name: audit
+description: Inspect repository evidence.
+base: explore
+tools: [read_file, search_repository, read_input_resource]
+skills: false
+context_mode: task
+---
+Cite the exact evidence used for each conclusion.
+```
+
+Definitions may use `display_name`, `color`, `model`, `thinking`, `web`, `limits`, and an explicit qualified `overrides` identity. These settings can only narrow a built-in base. Unknown fields, ambiguous names and unqualified overrides do not silently replace another definition. Models cannot select targets through spawn arguments.
+
+## Direct input and grants
+
+Selecting a role from `@` completion creates a semantic role reference. Selecting a handle or lifetime alias creates an exact thread reference; selected `@main` routes to Main. Manually typed or pasted mentions remain literal. References survive atomic cursor movement, deletion, undo, history and recoverable draft storage. Copy exposes visible text only. Multiple recipients require an explicit choice; stale references require removal, literal conversion or a new selection.
+
+A leading selected role opens a delegation review before admission. The same surface supports model-requested delegation through the pending permission owner. It exposes context choice, removable Skill pre-activations, execution mode, numeric presets and Custom limits, plus the complete grant and policy identities. An empty new-session draft creates its parent Session only after confirmation and validation, without a Main provider turn. Folded pasted text is included in the delegated task and remains subject to the task size limit.
+
+Only explicitly selected input artifacts are linked into the child. Direct attachments use staged immutable bytes; model calls name exact parent occurrence IDs in `entries[].artifacts`. The runtime resolves those IDs through validated parent history, records their source boundary, and binds bounded `read_input_resource` access to the selected child occurrences. New turns preserve prior attachments and may explicitly add more. Attachments cannot be sent as cooperative input into a currently running turn; the draft remains available until a new turn can accept them. Unsupported media remain subject to the receiving target's normal resource capabilities.
+
+Task only, Current request and Selected messages govern initial text sharing. Complete parent history, later messages, configuration changes and other child completions are not automatically copied. Later input uses an exact post, parent-input reply or new-turn receipt. Accepted input, delivered input, settled completion, user-seen state and Main consumption are distinct durable facts.
+
+## Recovery and verification
+
+Recovery reconstructs frozen Prompt/Skill/resource context and resource usage from canonical records. It validates the child admission link and exact resource occurrences, preserves run and thread budgets, and never resends an acknowledged unfinished provider request. Historical control formats remain readable without becoming executable through the candidate.
+
+Focused tests cover role discovery and administration, target recovery, direct input, editable grants, Skills/Web, selected artifacts and cold recovery. The candidate ProjectRuntime PTY spine verifies real JSONL child input, layered Escape handling, Main responsiveness and settled continuation. Full Linux Quality and the historical compatibility suites remain required before publication; deterministic tests alone do not establish model quality or production readiness.

--- a/packages/agent/src/agent-session-contracts.ts
+++ b/packages/agent/src/agent-session-contracts.ts
@@ -1,3 +1,7 @@
+import type {
+  ManagedDelegationEnvelope,
+  ManagedDelegationSelection,
+} from "@adam-agent/presentation";
 import type { ArtifactReference, ChangePreviewArtifactSource } from "./artifact-store.js";
 import type { ContextCallUsage } from "./durable-context.js";
 import type { InputResourceOccurrenceV1 } from "./input-resources.js";
@@ -203,6 +207,8 @@ export type RunResult =
     };
 
 export type PermissionDecisionCommand = {
+  readonly delegation?: ManagedDelegationEnvelope;
+  readonly delegationSelection?: ManagedDelegationSelection;
   readonly requestId: string;
   readonly decision: "allow" | "deny";
 };

--- a/packages/agent/src/agent-session.ts
+++ b/packages/agent/src/agent-session.ts
@@ -85,6 +85,7 @@ import {
   digestApprovedPlanProjectionV1,
   isHybridPlanPolicy,
   isPlanDelegationTool,
+  isPlanWebTool,
   type PlanCycleSnapshot,
   submitPlanToolDefinitionV1,
 } from "./plan-mode.js";
@@ -284,6 +285,10 @@ export class AgentSession {
     | {
         readonly requestId: string;
         readonly resolve: (decision: "allow" | "deny") => void;
+        readonly refineDelegation?: (
+          envelope: NonNullable<PermissionDecisionCommand["delegation"]>,
+          selection?: PermissionDecisionCommand["delegationSelection"],
+        ) => void;
       }
     | undefined;
 
@@ -474,6 +479,21 @@ export class AgentSession {
           message: "The permission request is not pending.",
         },
       };
+    }
+    if (command.delegation !== undefined) {
+      try {
+        if (command.decision !== "allow" || pendingPermission.refineDelegation === undefined)
+          throw new TypeError("This pending request cannot refine delegation.");
+        pendingPermission.refineDelegation(command.delegation, command.delegationSelection);
+      } catch {
+        return {
+          status: "rejected",
+          error: {
+            code: "invalid_permission_decision",
+            message: "The exact delegation grant is invalid for this pending request.",
+          },
+        };
+      }
     }
     pendingPermission.resolve(command.decision);
     return { status: "accepted" };
@@ -2408,7 +2428,7 @@ export class AgentSession {
       preparedPermissionSubject,
       planCommandAssessment,
     );
-    const permissionInput: PermissionPolicyInput = {
+    let permissionInput: PermissionPolicyInput = {
       callId: call.id,
       name: call.name,
       effect: adapter.effect,
@@ -2557,7 +2577,19 @@ export class AgentSession {
         throw new Error("Cannot request permission without an active run ID.");
       }
       const requestId = `${runId}:${call.id}`;
-      const pendingDecision = this.#createPendingPermissionDecision(requestId, signal);
+      let delegationRefined = false;
+      const refineDelegation = preparedCall.refineDelegation?.bind(preparedCall);
+      const pendingDecision = this.#createPendingPermissionDecision(
+        requestId,
+        signal,
+        refineDelegation === undefined
+          ? undefined
+          : (envelope, selection) => {
+              const subject = refineDelegation(envelope, selection);
+              permissionInput = { ...permissionInput, subject };
+              delegationRefined = true;
+            },
+      );
       try {
         await this.#emit({
           type: "tool_permission_requested",
@@ -2570,6 +2602,8 @@ export class AgentSession {
           return this.#settleCancelled();
         }
         decision = userDecision;
+        if (delegationRefined)
+          await this.#emit({ type: "tool_permission_requested", requestId, ...permissionInput });
         await this.#emit({
           type: "tool_permission_decided",
           requestId,
@@ -3567,6 +3601,7 @@ export class AgentSession {
     call: ToolCall,
     subject: PermissionSubject,
   ): Promise<Extract<ToolResult, { readonly status: "failed" }> | undefined> {
+    if (this.#durableContext?.frozenProjectContext === true) return undefined;
     const context = this.#promptContext;
     const workspaceRoot = this.#repositoryWorkspaceRoot;
     if (
@@ -4104,6 +4139,10 @@ export class AgentSession {
   #createPendingPermissionDecision(
     requestId: string,
     signal: AbortSignal,
+    refineDelegation?: (
+      envelope: NonNullable<PermissionDecisionCommand["delegation"]>,
+      selection?: PermissionDecisionCommand["delegationSelection"],
+    ) => void,
   ): {
     readonly promise: Promise<"allow" | "deny" | undefined>;
     readonly cancel: () => void;
@@ -4126,6 +4165,7 @@ export class AgentSession {
       settle = finish;
       this.#pendingPermission = {
         requestId,
+        ...(refineDelegation === undefined ? {} : { refineDelegation }),
         resolve: (decision) => finish(decision),
       };
       if (signal.aborted) {
@@ -4809,6 +4849,10 @@ function planProfileAllowsDefinition(
   return (
     (plan.policyVersion === "plan-policy.hybrid-delegation-v1" &&
       definition.source === "builtin" &&
+      definition.effect === "network" &&
+      isPlanWebTool(definition.name)) ||
+    (plan.policyVersion === "plan-policy.hybrid-delegation-v1" &&
+      definition.source === "builtin" &&
       definition.effect === "delegate" &&
       isPlanDelegationTool(definition.name)) ||
     (definition.source === "builtin" &&
@@ -4840,6 +4884,14 @@ function planToolDisposition(
   if (definition.effect === "read") {
     return "allow";
   }
+  if (
+    plan.policyVersion === "plan-policy.hybrid-delegation-v1" &&
+    definition.source === "builtin" &&
+    definition.effect === "network" &&
+    isPlanWebTool(definition.name) &&
+    subject.type === "web_request"
+  )
+    return undefined;
   if (
     plan.policyVersion === "plan-policy.hybrid-delegation-v1" &&
     definition.source === "builtin" &&

--- a/packages/agent/src/at-mention.ts
+++ b/packages/agent/src/at-mention.ts
@@ -1,0 +1,66 @@
+import type { AtMentionAtom, DraftMentionElement } from "@adam-agent/presentation";
+import { z } from "zod";
+
+const fields = {
+  type: z.literal("mention"),
+  literal: z
+    .string()
+    .min(2)
+    .max(16_384)
+    .regex(/^@[^\s\p{Cc}]+$/u),
+};
+
+export const atMentionAtomSchema: z.ZodType<AtMentionAtom> = z.discriminatedUnion("kind", [
+  z.strictObject({ ...fields, kind: z.literal("literal") }),
+  z.strictObject({ ...fields, kind: z.literal("path"), path: z.string().min(1).max(4096) }),
+  z.strictObject({
+    ...fields,
+    kind: z.literal("role"),
+    qualifiedRoleId: z.string().min(1).max(1024),
+    definitionDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/u),
+  }),
+  z.strictObject({
+    ...fields,
+    kind: z.literal("agent"),
+    parentSessionId: z.uuid(),
+    threadId: z.uuid(),
+    handle: z.string().min(1).max(256),
+  }),
+  z.strictObject({ ...fields, kind: z.literal("main") }),
+]);
+
+export const draftMentionElementSchema = z.intersection(
+  z.object({ elementId: z.string().min(1).max(256) }),
+  z.unknown().transform((input, context) => {
+    if (typeof input !== "object" || input === null || !("elementId" in input)) {
+      context.addIssue({ code: "custom", message: "Missing mention identity." });
+      return z.NEVER;
+    }
+    const { elementId: _elementId, ...atom } = input;
+    const parsed = atMentionAtomSchema.safeParse(atom);
+    if (!parsed.success) {
+      context.addIssue({ code: "custom", message: "Invalid mention identity." });
+      return z.NEVER;
+    }
+    return parsed.data;
+  }),
+);
+
+// Only the durable wire spelling differs; Presentation keeps the one atom family.
+export function serializeMention(element: DraftMentionElement): object {
+  if (element.kind !== "role" && element.kind !== "agent") return element;
+  const { type: _type, kind, ...identity } = element;
+  return { type: kind === "role" ? "role_ref" : "agent_ref", ...identity };
+}
+
+export function deserializeMention(element: unknown): unknown {
+  if (
+    typeof element !== "object" ||
+    element === null ||
+    !("type" in element) ||
+    (element.type !== "role_ref" && element.type !== "agent_ref") ||
+    "kind" in element
+  )
+    return element;
+  return { ...element, type: "mention", kind: element.type === "role_ref" ? "role" : "agent" };
+}

--- a/packages/agent/src/delegation-context.ts
+++ b/packages/agent/src/delegation-context.ts
@@ -1,0 +1,43 @@
+import type { ManagedDelegationMessage } from "@adam-agent/presentation";
+import { type DelegationContext, managedControlDigest } from "./fleet-ledger.js";
+import type { SessionRecord } from "./session-store.js";
+
+export function delegationMessages(records: readonly SessionRecord[]): ManagedDelegationMessage[] {
+  return records.flatMap((record) => {
+    if (record.schemaVersion !== 3) return [];
+    const value = record.record;
+    const message =
+      value.type === "logical_run_started"
+        ? { role: "user" as const, text: value.userMessage }
+        : value.type === "runtime_event" && value.event.type === "model_message_completed"
+          ? { role: "assistant" as const, text: value.event.text }
+          : undefined;
+    return message === undefined || Buffer.byteLength(message.text, "utf8") > 16 * 1024
+      ? []
+      : [{ ...message, sequence: record.sequence, digest: managedControlDigest(record) }];
+  });
+}
+
+export function resolveDelegationContext(
+  context: DelegationContext,
+  currentRequest: string,
+  messages: readonly ManagedDelegationMessage[],
+): string {
+  if (context.mode === "task") return "";
+  if (context.mode === "current_request") return currentRequest;
+  const seen = new Set<number>();
+  const selected = context.messages
+    .map((reference) => {
+      const message = messages.find(
+        (message) => message.sequence === reference.sequence && message.digest === reference.digest,
+      );
+      if (message === undefined || seen.has(message.sequence))
+        throw new TypeError("Select available exact parent messages without duplicates.");
+      seen.add(message.sequence);
+      return `Selected parent ${message.role} message (${message.sequence}):\n${message.text}`;
+    })
+    .join("\n\n");
+  if (Buffer.byteLength(selected, "utf8") > 64 * 1024)
+    throw new TypeError("Selected context exceeds 64 KiB.");
+  return selected;
+}

--- a/packages/agent/src/fleet-ledger.ts
+++ b/packages/agent/src/fleet-ledger.ts
@@ -1,12 +1,41 @@
 import { createHash, randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
+import type { ManagedDelegationContext, ManagedDelegationLimits } from "@adam-agent/presentation";
 import { z } from "zod";
 import type { ContextProfile } from "./context-profile.js";
 import type { ManagedControlRecord } from "./managed-agent-folds.js";
+import { agentRoleIdSchema } from "./role-catalog.js";
 export function managedControlDigest(value: unknown): `sha256:${string}` {
   return `sha256:${createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;
 }
 
 const positive = z.number().int().positive().max(Number.MAX_SAFE_INTEGER);
+export const delegationContextSchema = z.discriminatedUnion("mode", [
+  z.strictObject({ mode: z.literal("task") }),
+  z.strictObject({ mode: z.literal("current_request") }),
+  z.strictObject({
+    mode: z.literal("selected_messages"),
+    messages: z
+      .array(
+        z.strictObject({
+          sequence: positive,
+          digest: z.string().regex(/^sha256:[a-f0-9]{64}$/u),
+        }),
+      )
+      .min(1)
+      .max(32),
+  }),
+]);
+export type DelegationContext = ManagedDelegationContext;
+export function requestedDelegationContext(
+  entries: readonly { readonly context?: DelegationContext | undefined }[],
+): DelegationEnvelope["context"] {
+  return entries.some((entry) => entry.context?.mode === "selected_messages")
+    ? "selected_messages"
+    : entries.every((entry) => entry.context?.mode === "task")
+      ? "task"
+      : "current_request";
+}
 export const fleetPolicySchema = z.strictObject({
   version: z.literal(1),
   background: z.strictObject({ running: positive.max(4), queued: z.number().int().min(0).max(32) }),
@@ -30,7 +59,7 @@ export const delegationEnvelopeSchema = z.strictObject({
     .templateLiteral(["sha256:", z.string()])
     .refine((value) => /^sha256:[a-f0-9]{64}$/u.test(value)),
   origin: delegationOriginSchema,
-  roles: z.tuple([z.literal("builtin:explore")]),
+  roles: z.array(agentRoleIdSchema).min(1).max(32),
   mode: z.enum(["background", "foreground"]),
   threads: positive.max(32),
   running: positive.max(4),
@@ -38,7 +67,7 @@ export const delegationEnvelopeSchema = z.strictObject({
   aggregateTokens: positive,
   threadTokens: positive,
   sessionTokens: positive,
-  context: z.literal("current_request"),
+  context: z.enum(["task", "current_request", "selected_messages"]),
   skills: z.array(z.string().max(512)).max(64),
   policy: fleetPolicySchema,
   policyDigest: z
@@ -46,6 +75,16 @@ export const delegationEnvelopeSchema = z.strictObject({
     .refine((value) => /^sha256:[a-f0-9]{64}$/u.test(value)),
 });
 export type DelegationEnvelope = z.infer<typeof delegationEnvelopeSchema>;
+const delegationLimitsSchema = delegationEnvelopeSchema
+  .pick({
+    mode: true,
+    running: true,
+    queued: true,
+    aggregateTokens: true,
+    threadTokens: true,
+    sessionTokens: true,
+  })
+  .partial();
 export const fleetProviderEventSchema = z.discriminatedUnion("type", [
   z.strictObject({
     type: z.literal("provider_reserved"),
@@ -100,6 +139,10 @@ export function createDelegationEnvelope(
     sessionTokens: number;
     availableTokens?: number;
     threadTokens?: number;
+    roles?: DelegationEnvelope["roles"];
+    context?: DelegationEnvelope["context"];
+    skills?: readonly string[];
+    limits?: ManagedDelegationLimits;
   },
 ): DelegationEnvelope {
   const lane = input.mode === "background" ? policy.background : policy.reserved;
@@ -107,7 +150,7 @@ export function createDelegationEnvelope(
     version: 1 as const,
     id: randomUUID(),
     origin: input.origin,
-    roles: ["builtin:explore"] as const,
+    roles: input.roles ?? ["builtin:explore"],
     mode: input.mode,
     threads: input.count,
     running: Math.min(lane.running, input.count),
@@ -119,12 +162,71 @@ export function createDelegationEnvelope(
     ),
     threadTokens: Math.min(policy.threadTokens, input.threadTokens ?? policy.threadTokens),
     sessionTokens: input.sessionTokens,
-    context: "current_request" as const,
-    skills: [],
+    context: input.context ?? "current_request",
+    skills: [...(input.skills ?? [])],
+    ...delegationLimitsSchema.parse(input.limits ?? {}),
     policy,
     policyDigest: managedControlDigest(policy),
   };
-  return delegationEnvelopeSchema.parse({ ...value, digest: managedControlDigest(value) });
+  const envelope = delegationEnvelopeSchema.parse({
+    ...value,
+    digest: managedControlDigest(value),
+  });
+  if (
+    !delegationEnvelopeMatches(envelope, {
+      policy,
+      roles: value.roles,
+      count: input.count,
+      mode: input.mode,
+      origin: input.origin,
+      sessionTokens: input.sessionTokens,
+      context: value.context,
+      skills: value.skills,
+    }) ||
+    envelope.aggregateTokens > (input.availableTokens ?? input.sessionTokens)
+  )
+    throw new TypeError("Delegation limits exceed the available policy or Session budget.");
+  return envelope;
+}
+
+export function delegationEnvelopeMatches(
+  candidate: unknown,
+  expected: {
+    readonly policy: FleetPolicy;
+    readonly roles: readonly string[];
+    readonly count: number;
+    readonly mode: "background" | "foreground";
+    readonly origin?: DelegationEnvelope["origin"];
+    readonly sessionTokens: number;
+    readonly context?: DelegationEnvelope["context"];
+    readonly skills?: readonly string[];
+  },
+): candidate is DelegationEnvelope {
+  const parsed = delegationEnvelopeSchema.safeParse(candidate);
+  if (!parsed.success) return false;
+  const envelope = parsed.data;
+  const { digest, ...fields } = envelope;
+  return (
+    managedControlDigest(fields) === digest &&
+    managedControlDigest(envelope.policy) === envelope.policyDigest &&
+    isDeepStrictEqual(envelope.policy, expected.policy) &&
+    isDeepStrictEqual(envelope.roles, [...new Set(expected.roles)]) &&
+    envelope.threads === expected.count &&
+    envelope.threads <= envelope.running + envelope.queued &&
+    isDeepStrictEqual(envelope.skills, [...new Set(expected.skills ?? [])]) &&
+    envelope.context === (expected.context ?? "current_request") &&
+    envelope.mode === expected.mode &&
+    (expected.origin === undefined || isDeepStrictEqual(envelope.origin, expected.origin)) &&
+    envelope.running <=
+      expected.policy[envelope.mode === "background" ? "background" : "reserved"].running &&
+    envelope.queued <=
+      expected.policy[envelope.mode === "background" ? "background" : "reserved"].queued &&
+    (envelope.mode !== "foreground" || envelope.threads === 1) &&
+    envelope.aggregateTokens <= expected.policy.batchTokens &&
+    envelope.aggregateTokens <= envelope.sessionTokens &&
+    envelope.threadTokens <= expected.policy.threadTokens &&
+    envelope.sessionTokens <= expected.sessionTokens
+  );
 }
 export function fleetBudget(
   records: readonly ManagedControlRecord[],

--- a/packages/agent/src/input-resources.ts
+++ b/packages/agent/src/input-resources.ts
@@ -197,6 +197,55 @@ export async function ingestLocalInputResourcesV1(input: {
   return occurrences;
 }
 
+/** Rebind explicitly selected immutable resources to the receiving logical run. */
+export async function linkInputResourcesV1(input: {
+  readonly artifactStore: ArtifactStore;
+  readonly runId: string;
+  readonly occurrences: readonly InputResourceOccurrenceV1[];
+}): Promise<readonly InputResourceOccurrenceV1[]> {
+  const sources = inputResourceOccurrenceV1Schema
+    .array()
+    .max(inputResourceLimitsV1.maximumOccurrencesPerRun)
+    .parse(input.occurrences);
+  if (
+    sources.reduce((sum, source) => sum + source.artifact.byteCount, 0) >
+    inputResourceLimitsV1.maximumAggregateBytesPerRun
+  )
+    throw new InputResourceError(
+      "input_resource_aggregate_too_large",
+      "The selected input resources exceed the v1 aggregate run limit.",
+    );
+  return Promise.all(
+    sources.map(async (source, index) => {
+      const bytes = await input.artifactStore.read(source.artifact.id, {
+        maximumBytes: source.artifact.byteCount,
+      });
+      if (
+        bytes === undefined ||
+        bytes.byteLength !== source.artifact.byteCount ||
+        `sha256:${createHash("sha256").update(bytes).digest("hex")}` !== source.digest
+      )
+        throw new InputResourceError(
+          "input_resource_io_failed",
+          "The selected immutable resource is unavailable.",
+        );
+      const occurrenceId = `${input.runId}:input:${index + 1}`;
+      await input.artifactStore.write({
+        bytes,
+        mediaType: source.artifact.mediaType,
+        source: {
+          type: "input_resource",
+          schemaVersion: 1,
+          occurrenceId,
+          runId: input.runId,
+          provenance: source.provenance,
+        },
+      });
+      return { ...source, occurrenceId };
+    }),
+  );
+}
+
 async function ingestSelectedLocalFile(input: {
   readonly artifactStore: ArtifactStore;
   readonly afterResolved?: () => Promise<void> | void;

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -185,6 +185,7 @@ export {
   type SessionToolIntent,
   type SessionV3Record,
 } from "./session-store.js";
+export { createDirectDeepSeekThinkingCapability } from "./thinking-policy.js";
 export { createCodingToolRegistryForTesting } from "./tool-runtime.js";
 export {
   type TurnComposerStageBarrier,

--- a/packages/agent/src/managed-agent-control.ts
+++ b/packages/agent/src/managed-agent-control.ts
@@ -3,10 +3,23 @@ import type {
   ManagedControlAction,
   ManagedControlCommand,
   ManagedControlReceipt,
+  ManagedDelegationLimits,
 } from "@adam-agent/presentation";
 import { agentExportFields, presentationAgentExportMaximumBytes } from "@adam-agent/presentation";
 import type { ArtifactStore } from "./artifact-store.js";
+import {
+  InputResourceError,
+  type InputResourceOccurrenceV1,
+  ingestLocalInputResourcesV1,
+  linkInputResourcesV1,
+  type StagedInputResourceSelectionV1,
+} from "./input-resources.js";
 import type { PlanCycleSnapshot } from "./plan-mode.js";
+import {
+  type AgentRoleAdministration,
+  createAgentRoleAdministration,
+} from "./role-administration.js";
+import { type AgentRoleDefinition, agentRoleIdSchema } from "./role-catalog.js";
 
 export type { ManagedControlCommand, ManagedControlReceipt } from "@adam-agent/presentation";
 
@@ -26,10 +39,14 @@ import {
 } from "./agent-session.js";
 import type { ModelDriver, RuntimeEvent } from "./agent-session-contracts.js";
 import type { ContextProfile } from "./context-profile.js";
+import { delegationMessages, resolveDelegationContext } from "./delegation-context.js";
 import {
   assertFleetReservation,
   createDelegationEnvelope,
+  type DelegationContext,
   type DelegationEnvelope,
+  delegationContextSchema,
+  delegationEnvelopeMatches,
   delegationEnvelopeSchema,
   delegationOriginSchema,
   FleetBudgetError,
@@ -40,6 +57,7 @@ import {
   fleetStorage,
   managedChildTerminalBytes,
   managedControlTerminalBytes,
+  requestedDelegationContext,
   resolveFleetPolicy,
   storedRecordBytes,
 } from "./fleet-ledger.js";
@@ -57,9 +75,11 @@ import {
   type ManagedControlStore,
   type ManagedWorkspaceSnapshot,
   managedAcceptedInput,
+  managedAliasSchema,
   managedControlDigest,
   managedControlFrozenSchema,
   managedControlLink,
+  managedNameKey,
   managedTranscriptLink,
 } from "./managed-agent-folds.js";
 import {
@@ -76,9 +96,25 @@ import type { ModelTargetIdentity } from "./model-targets.js";
 import {
   type ProjectExecutionDomain,
   ProjectExecutionDomainError,
+  projectRuntimeRootId,
 } from "./project-execution-domain.js";
-import { createPromptContextV1 } from "./prompt-assembly.js";
-import { sessionDurableContext } from "./session-durable-context.js";
+import {
+  createPromptContextV1,
+  createPromptContextV2,
+  hasSkillPromptContext,
+  replacePromptSkillsV2,
+} from "./prompt-assembly.js";
+import {
+  type AgentSessionDurableContext,
+  sessionDurableContext,
+} from "./session-durable-context.js";
+import {
+  inputResourceBytesFromRecords,
+  isGenesisRecord,
+  promptContextRecordFromRecords,
+  skillContextRecordFromRecords,
+  skillResourceBytesFromRecords,
+} from "./session-history-folds.js";
 import { modelMessagesFromCompleteRecords } from "./session-history-replay.js";
 import {
   cancelManagedChildSessionRecords,
@@ -87,12 +123,17 @@ import {
 import { SessionLifecycleError } from "./session-lifecycle-error.js";
 import type { SessionRecord, SessionStore, SessionStoreDirectory } from "./session-store.js";
 import { SessionLogicalQuotaError, SessionStoreError } from "./session-store.js";
+import { createIndependentSkillContextV1, readActiveSkillContentsV1 } from "./skills.js";
+import type { ThinkingPolicySelectionV1 } from "./thinking-policy.js";
 import {
+  bindInputResourceToolRegistry,
+  createCodingToolRegistry,
   createInternalToolAdapter,
   createInternalToolRegistry,
   createReadToolRegistry,
   type JsonValue,
   type PermissionPolicy,
+  type ToolAdapter,
   type ToolRegistry,
 } from "./tool-runtime.js";
 
@@ -105,7 +146,7 @@ export type ManagedWorkspaceFrame = {
   readonly snapshot: ManagedWorkspaceSnapshot;
 };
 
-export type ManagedAgentControl = {
+export type ManagedAgentControl = AgentRoleAdministration & {
   publishExport(
     input: Omit<ManagedAgentExport, "artifact"> & { readonly content: string },
   ): Promise<ManagedAgentExport>;
@@ -117,6 +158,7 @@ export type ManagedAgentControl = {
   }): Promise<string | undefined>;
   prepareDelegation(
     command: Extract<ManagedControlCommand, { type: "spawn_agents" }>,
+    limits?: ManagedDelegationLimits,
   ): Promise<DelegationEnvelope>;
   prepareContinuation(
     command: Extract<ManagedControlCommand, { type: "next_turn" }>,
@@ -129,19 +171,35 @@ export type ManagedAgentControl = {
   }): AsyncIterable<ManagedWorkspaceFrame>;
   dispatch(
     command: ManagedControlCommand,
-    options?: { readonly signal?: AbortSignal },
+    options?: {
+      readonly signal?: AbortSignal;
+      readonly directThinkingSelection?: ThinkingPolicySelectionV1 | null;
+      readonly directResources?: readonly StagedInputResourceSelectionV1[];
+    },
   ): Promise<ManagedControlReceipt>;
 };
 
 const taskSchema = z
   .string()
   .refine((text) => text.trim().length > 0 && Buffer.byteLength(text, "utf8") <= 16 * 1024);
-const spawnInputSchema = z.strictObject({
+export const managedSpawnInputSchema = z.strictObject({
   mode: z.enum(["background", "foreground"]).optional(),
   entries: z
     .array(
       z.strictObject({
-        role: z.literal("builtin:explore"),
+        role: agentRoleIdSchema,
+        alias: managedAliasSchema.optional(),
+        context: delegationContextSchema.optional(),
+        artifacts: z
+          .array(z.string().min(1).max(256))
+          .max(8)
+          .refine((ids) => new Set(ids).size === ids.length)
+          .optional(),
+        skills: z
+          .array(z.string().min(1).max(512))
+          .max(8)
+          .refine((skills) => new Set(skills).size === skills.length)
+          .optional(),
         task: taskSchema,
         description: z
           .string()
@@ -232,6 +290,7 @@ const commandSchema = z.discriminatedUnion("type", [
   }),
   z.strictObject({
     type: z.literal("list_agents"),
+    view: z.enum(["threads", "roles", "context"]).optional(),
     parentSessionId: z.uuid(),
     limit: z.number().int().min(1).max(41).optional(),
     cursor: z.string().max(128).optional(),
@@ -253,7 +312,7 @@ const commandSchema = z.discriminatedUnion("type", [
     requestId: z.string().min(1).max(512),
     decision: z.enum(["allow", "deny"]),
   }),
-  spawnInputSchema.extend({
+  managedSpawnInputSchema.extend({
     type: z.literal("spawn_agents"),
     parentSessionId: z.uuid(),
     envelope: delegationEnvelopeSchema.optional(),
@@ -281,7 +340,7 @@ const commandSchema = z.discriminatedUnion("type", [
   z.strictObject({
     type: z.literal("start_thread"),
     parentSessionId: z.uuid(),
-    role: z.literal("builtin:explore"),
+    role: agentRoleIdSchema,
     task: taskSchema,
     description: z
       .string()
@@ -328,9 +387,38 @@ export function createManagedAgentControl(options: {
     constraints?: { readonly requireIdleMain: true },
   ) => Promise<T>;
   readonly artifactStore?: ArtifactStore;
+  readonly artifactRoot?: string;
+  readonly resolveArtifactSelections?: (ids: readonly string[]) => Promise<
+    readonly {
+      readonly resource: InputResourceOccurrenceV1;
+      readonly source: NonNullable<ManagedControlFrozen["artifactSources"]>[number];
+    }[]
+  >;
   readonly policy?: FleetPolicy;
   readonly readPlan?: () => Promise<PlanCycleSnapshot | undefined>;
-  readonly resolveFrozenContext?: () => Promise<
+  readonly webTools?: ToolRegistry;
+  readonly resolveRoleTarget?: (input: {
+    readonly role: AgentRoleDefinition;
+    readonly inheritedThinking?: ManagedControlFrozen["thinkingPolicy"];
+    readonly frozen?: ManagedControlFrozen;
+  }) => Promise<{
+    readonly targetIdentity: ModelTargetIdentity;
+    readonly contextProfile: ContextProfile;
+    readonly thinkingPolicy?: ManagedControlFrozen["thinkingPolicy"];
+    readonly model: ModelDriver;
+  }>;
+  readonly roleTargets?: () => Promise<
+    import("@adam-agent/presentation").AgentTypesDisplay["targets"]
+  >;
+  readonly roleCatalog?: ReturnType<typeof import("./role-catalog.js").createAgentRoleCatalog>;
+  readonly resolveSkillSources?: () => Promise<
+    NonNullable<AgentSessionDurableContext["extensionSkillSources"]>
+  >;
+  readonly withCurrentExtensionSkillSources?: AgentSessionDurableContext["withCurrentExtensionSkillSources"];
+  readonly authorizeProjectContextLoad?: AgentSessionDurableContext["authorizeProjectContextLoad"];
+  readonly resolveFrozenContext?: (
+    directThinkingSelection?: ThinkingPolicySelectionV1 | null,
+  ) => Promise<
     Pick<
       ManagedControlFrozen,
       "parentBranchId" | "thinkingPolicy" | "skillContext" | "parentRequest"
@@ -348,6 +436,29 @@ export function createManagedAgentControl(options: {
   readonly [managedAgentRecordBarrier]?: (record: ManagedControlRecord) => Promise<void>;
   readonly [sessionRecordCommittedBarrier]?: (record: SessionRecord) => Promise<void>;
 }): ManagedAgentControl {
+  const resolveFrozenTarget = async (frozen: ManagedControlFrozen | undefined) => {
+    if (frozen?.roleDefinition !== undefined && options.resolveRoleTarget !== undefined)
+      return options.resolveRoleTarget({ role: frozen.roleDefinition, frozen });
+    if (
+      frozen !== undefined &&
+      (!isDeepStrictEqual(frozen.targetIdentity, options.targetIdentity) ||
+        !isDeepStrictEqual(frozen.contextProfile, options.contextProfile))
+    )
+      throw new Error("The thread's frozen target and context are unavailable.");
+    return {
+      model: options.model,
+      targetIdentity: options.targetIdentity,
+      contextProfile: options.contextProfile,
+    };
+  };
+  const frozenTargetAvailable = async (frozen: ManagedControlFrozen | undefined) => {
+    try {
+      await resolveFrozenTarget(frozen);
+      return true;
+    } catch {
+      return false;
+    }
+  };
   const policy = resolveFleetPolicy(options.contextProfile, options.policy);
   const controlStore = options.store.forParent(options.parentSessionId);
   let serial = Promise.resolve();
@@ -425,6 +536,9 @@ export function createManagedAgentControl(options: {
         targetIdentity: frozen?.targetIdentity ?? options.targetIdentity,
         contextProfile: frozen?.contextProfile ?? options.contextProfile,
         promptContext,
+        ...(hasSkillPromptContext(promptContext) && frozen?.skillContext !== undefined
+          ? { skillContext: frozen.skillContext }
+          : {}),
       },
     };
   };
@@ -614,8 +728,7 @@ export function createManagedAgentControl(options: {
             policyAllowsInput &&
             inspected.turn.health !== "stalled" &&
             admission.event.frozen !== undefined &&
-            isDeepStrictEqual(admission.event.frozen.targetIdentity, options.targetIdentity) &&
-            isDeepStrictEqual(admission.event.frozen.contextProfile, options.contextProfile)
+            (await frozenTargetAvailable(admission.event.frozen))
           ) {
             try {
               const childRecords = await (
@@ -623,7 +736,7 @@ export function createManagedAgentControl(options: {
               )?.read();
               if (childRecords === undefined && !thread.turn.hasStarted) actions.push("resume");
               else if (childRecords !== undefined && childRecords[0] !== undefined) {
-                validateManagedChildGenesis(admission, childRecords[0]);
+                validateManagedChildGenesis(admission, childRecords[0], childRecords);
                 const terminal = await managedChildTerminalResult(
                   childRecords,
                   options.workspaceRoot,
@@ -639,7 +752,21 @@ export function createManagedAgentControl(options: {
                   (childRecords.length === 1 ||
                     prepareManagedChildResume(
                       childRecords,
-                      childTools(admission),
+                      childTools(
+                        admission,
+                        hasSkillPromptContext(
+                          admission.event.type === "admitted"
+                            ? admission.event.frozen?.promptContext
+                            : undefined,
+                        ),
+                        admission.event.type === "admitted" &&
+                          admission.event.frozen?.permissionEffects.some(
+                            (effect) => effect === "network",
+                          ),
+                        admission.event.type === "admitted"
+                          ? admission.event.frozen?.roleDefinition
+                          : undefined,
+                      ),
                       options.workspaceRoot,
                     ) !== undefined)
                 )
@@ -816,8 +943,25 @@ export function createManagedAgentControl(options: {
       }
     }
   };
-  const childTools = (identity?: ManagedControlIdentity): ToolRegistry => {
-    const reads = createReadToolRegistry({ workspaceRoot: options.workspaceRoot });
+  const childTools = (
+    identity?: ManagedControlIdentity,
+    skills = false,
+    web = false,
+    role?: AgentRoleDefinition,
+    inputResources: readonly InputResourceOccurrenceV1[] = [],
+  ): ToolRegistry => {
+    const builtins =
+      skills || role !== undefined
+        ? createCodingToolRegistry({ workspaceRoot: options.workspaceRoot })
+        : createReadToolRegistry({ workspaceRoot: options.workspaceRoot });
+    const names = skills
+      ? ["read_file", "search_repository", "activate_skill", "read_skill_resource"]
+      : ["read_file", "search_repository"];
+    if (role !== undefined) names.push("read_input_resource");
+    const reads: ToolRegistry = {
+      definitions: () => builtins.definitions().filter((tool) => names.includes(tool.name)),
+      resolve: (name) => (names.includes(name) ? builtins.resolve(name) : undefined),
+    };
     const adapters = (["report_to_parent", "request_parent_input"] as const).map((name) => {
       const schema =
         name === "report_to_parent"
@@ -961,13 +1105,73 @@ export function createManagedAgentControl(options: {
         "never",
       );
     });
-    return createInternalToolRegistry([
+    const registry = createInternalToolRegistry([
       ...reads.definitions().flatMap((definition) => {
         const adapter = reads.resolve(definition.name);
         return adapter === undefined ? [] : [adapter];
       }),
       ...adapters,
+      ...(web
+        ? (options.webTools?.definitions().flatMap((definition): ToolAdapter[] => {
+            const adapter = options.webTools?.resolve(definition.name);
+            if (
+              adapter === undefined ||
+              !["web_fetch", "web_search", "web_open", "web_find"].includes(definition.name)
+            )
+              return [];
+            if (adapter.effect === "read") return [adapter];
+            return [
+              {
+                ...adapter,
+                prepare(json, source) {
+                  const prepared = adapter.prepare(json, source);
+                  if (prepared.status !== "ready") return prepared;
+                  const subject = prepared.permissionSubject;
+                  if (identity === undefined || subject?.type !== "web_request")
+                    return {
+                      status: "failed",
+                      error: {
+                        code: "invalid_tool_input",
+                        message: "The exact child Web request is unavailable.",
+                      },
+                    };
+                  return {
+                    ...prepared,
+                    permissionSubject: {
+                      type: "managed_agent_web_request",
+                      parentRootId: projectRuntimeRootId,
+                      parentSessionId: identity.parentSessionId,
+                      agentId: identity.threadId,
+                      attemptId: identity.attemptId,
+                      childSessionId: identity.childSessionId,
+                      profile: "research.v3",
+                      operation: subject.operation,
+                      providerOrigin: subject.providerOrigin,
+                      queryOrUrl: subject.operation === "search" ? subject.query : subject.url,
+                      argumentsDigest: managedControlDigest(JSON.parse(json)),
+                    },
+                  };
+                },
+              },
+            ];
+          }) ?? [])
+        : []),
     ]);
+    const filtered =
+      role === undefined
+        ? registry
+        : createInternalToolRegistry(
+            registry.definitions().flatMap((definition) => {
+              const adapter = registry.resolve(definition.name);
+              return adapter !== undefined && role.tools.includes(definition.name) ? [adapter] : [];
+            }),
+          );
+    return options.artifactStore === undefined
+      ? filtered
+      : bindInputResourceToolRegistry(filtered, {
+          artifactStore: options.artifactStore,
+          occurrences: inputResources,
+        });
   };
   const run = async (
     identity: ManagedControlIdentity,
@@ -992,11 +1196,42 @@ export function createManagedAgentControl(options: {
       let cleanupExpired = false;
       let cleanupTimer: { cancel(): void } | undefined;
       try {
+        const target = await resolveFrozenTarget(frozen);
         const tools =
           frozen === undefined
             ? createReadToolRegistry({ workspaceRoot: options.workspaceRoot })
-            : childTools(identity);
-        const promptContext = frozen?.promptContext ?? createPromptContextV1(tools);
+            : childTools(
+                identity,
+                hasSkillPromptContext(frozen.promptContext),
+                frozen.permissionEffects.some((effect) => effect === "network"),
+                frozen.roleDefinition,
+                frozen.inputResources,
+              );
+        let promptContext = frozen?.promptContext ?? createPromptContextV1(tools);
+        let skillContext = hasSkillPromptContext(promptContext) ? frozen?.skillContext : undefined;
+        const restoredRecords = (await preparedStore?.read()) ?? [];
+        if (preparedStore !== undefined) {
+          const records = restoredRecords;
+          const genesis = records[0];
+          if (genesis === undefined || !isGenesisRecord(genesis)) throw new SessionStoreError();
+          const restoredPrompt = promptContextRecordFromRecords(genesis, records);
+          if (restoredPrompt === undefined || restoredPrompt.recordVersion === 3)
+            throw new SessionStoreError();
+          promptContext = restoredPrompt;
+          skillContext = skillContextRecordFromRecords(genesis, records);
+        }
+        const activeSkillContents = await readActiveSkillContentsV1(
+          skillContext,
+          options.artifactStore,
+        );
+        const extensionSkillSources = (await options.resolveSkillSources?.())?.filter((source) =>
+          skillContext?.extensionSources.some(
+            (frozenSource) =>
+              frozenSource.lifecycleDigest === source.lifecycleDigest &&
+              frozenSource.lifecycleRevision === source.lifecycleRevision &&
+              isDeepStrictEqual(frozenSource.locator, source.locator),
+          ),
+        );
         const store =
           preparedStore ?? (await options.childSessionStores.create(identity.childSessionId));
         if (preparedStore === undefined) {
@@ -1022,6 +1257,18 @@ export function createManagedAgentControl(options: {
           previousSessionId === undefined
             ? undefined
             : await options.childSessionStores.open(previousSessionId);
+        const threadRecords: SessionRecord[] = [...restoredRecords];
+        for (const record of await controlStore.read()) {
+          if (
+            record.threadId === identity.threadId &&
+            record.event.type === "admitted" &&
+            record.childSessionId !== identity.childSessionId
+          ) {
+            const prior = await options.childSessionStores.open(record.childSessionId);
+            if (prior === undefined) throw new SessionStoreError();
+            threadRecords.push(...(await prior.read()));
+          }
+        }
         let generation = 0;
         let executing = false;
         let timer: { cancel(): void } | undefined;
@@ -1144,7 +1391,7 @@ export function createManagedAgentControl(options: {
           model: {
             async *stream(request) {
               if (admission?.event.type !== "admitted" || admission.event.envelope === undefined) {
-                yield* options.model.stream(request);
+                yield* target.model.stream(request);
                 return;
               }
               await waitForCeiling(identity, request.signal);
@@ -1195,7 +1442,7 @@ export function createManagedAgentControl(options: {
                     resetInactivity();
                   }
                 });
-                for await (const event of options.model.stream(request)) {
+                for await (const event of target.model.stream(request)) {
                   if (event.type === "usage") {
                     await control.settleUsage({
                       requestId,
@@ -1247,14 +1494,23 @@ export function createManagedAgentControl(options: {
                     frozen?.permissionReadCeiling ?? "allow",
                     options.permissions.decide(input),
                   )
-                : input.effect === "delegate" &&
-                    input.subject.type === "managed_agent_action" &&
-                    input.subject.parentSessionId === identity.parentSessionId &&
-                    input.subject.turnIds.length === 1 &&
-                    input.subject.turnIds[0] === identity.turnId &&
-                    (input.name === "report_to_parent" || input.name === "request_parent_input")
-                  ? ("allow" as const)
-                  : ("deny" as const),
+                : input.effect === "network" &&
+                    frozen?.permissionEffects.some((effect) => effect === "network") &&
+                    input.subject.type === "managed_agent_web_request" &&
+                    input.subject.agentId === identity.threadId &&
+                    input.subject.attemptId === identity.attemptId
+                  ? intersectReadPermission(
+                      frozen.permissionNetworkCeiling ?? "deny",
+                      options.permissions.decide(input),
+                    )
+                  : input.effect === "delegate" &&
+                      input.subject.type === "managed_agent_action" &&
+                      input.subject.parentSessionId === identity.parentSessionId &&
+                      input.subject.turnIds.length === 1 &&
+                      input.subject.turnIds[0] === identity.turnId &&
+                      (input.name === "report_to_parent" || input.name === "request_parent_input")
+                    ? ("allow" as const)
+                    : ("deny" as const),
           },
           store: store as SessionStore,
           [managedAgentRequestBoundary]: async () => {
@@ -1331,7 +1587,24 @@ export function createManagedAgentControl(options: {
             };
           },
           [sessionDurableContext]: {
-            nextSequence: preparedStore === undefined ? 2 : (await preparedStore.read()).length + 1,
+            nextSequence: preparedStore === undefined ? 2 : restoredRecords.length + 1,
+            ...(frozen?.inputResources === undefined
+              ? {}
+              : { inputResources: frozen.inputResources, newRunId: identity.turnId }),
+            skillResourceLineageBytes: skillResourceBytesFromRecords(threadRecords),
+            inputResourceLineageBytes: inputResourceBytesFromRecords(threadRecords),
+            ...(resume === undefined
+              ? {}
+              : {
+                  skillResourceRunBytes: skillResourceBytesFromRecords(
+                    restoredRecords,
+                    resume.agentState.runId,
+                  ),
+                  inputResourceRunBytes: inputResourceBytesFromRecords(
+                    restoredRecords,
+                    resume.agentState.runId,
+                  ),
+                }),
             ...(resume === undefined ? {} : { resume: resume.agentState }),
             sessionId: identity.childSessionId,
             projectId: options.projectId,
@@ -1340,14 +1613,32 @@ export function createManagedAgentControl(options: {
               ? {}
               : { thinkingPolicy: frozen.thinkingPolicy }),
             promptContext,
+            ...(skillContext !== undefined ? { skillContext, activeSkillContents } : {}),
             repositoryWorkspaceRoot: options.workspaceRoot,
+            ...(extensionSkillSources === undefined ? {} : { extensionSkillSources }),
+            ...(options.withCurrentExtensionSkillSources === undefined
+              ? {}
+              : { withCurrentExtensionSkillSources: options.withCurrentExtensionSkillSources }),
+            ...(options.authorizeProjectContextLoad === undefined
+              ? {}
+              : { authorizeProjectContextLoad: options.authorizeProjectContextLoad }),
+            ...(frozen?.roleDefinition === undefined
+              ? {}
+              : { frozenProjectContext: true as const }),
             initialMessages: [
               {
                 role: "developer" as const,
-                content:
-                  "Explore the exact delegated task using local repository reads only. Do not write, execute, access Web, MCP or extensions, spawn children, or change authority. The workspace is live, not a filesystem snapshot.",
+                content: `Act as ${frozen?.roleDefinition?.name ?? "Explore"} on the exact delegated task using only admitted tools and Skills. Do not write, execute, access MCP or ambient extensions, spawn children, or change authority. ${frozen?.roleDefinition?.web === true ? "Use Web only through permitted registered Web tools." : "Do not access Web."} The workspace is live, not a filesystem snapshot.`,
               },
-              ...(frozen?.parentRequest
+              ...(frozen?.roleDefinition?.instructions
+                ? [
+                    {
+                      role: "user" as const,
+                      content: `Role-specific instructions (cannot change the built-in policy):\n${frozen.roleDefinition.instructions}`,
+                    },
+                  ]
+                : []),
+              ...(frozen?.parentRequest && frozen.parentRequest !== task
                 ? [{ role: "user" as const, content: frozen.parentRequest }]
                 : []),
               ...(previous === undefined
@@ -1403,10 +1694,26 @@ export function createManagedAgentControl(options: {
         });
         const result = await child
           .run(
-            { text: resume?.userMessage ?? task },
+            {
+              text: resume?.userMessage ?? task,
+              ...(frozen?.inputResources === undefined
+                ? {}
+                : { inputResources: frozen.inputResources }),
+              ...(admission?.event.type !== "admitted" || admission.event.skills === undefined
+                ? {}
+                : { skills: admission.event.skills }),
+            },
             {
               signal: controller.signal,
-              limits: { maxTokens: options.contextProfile.contextWindowTokens },
+              limits: {
+                maxTokens: Math.min(
+                  (frozen?.contextProfile ?? options.contextProfile).contextWindowTokens,
+                  frozen?.roleDefinition?.limits?.maxTokens ?? Infinity,
+                ),
+                ...(frozen?.roleDefinition?.limits?.maxTurns === undefined
+                  ? {}
+                  : { maxTurns: frozen.roleDefinition.limits.maxTurns }),
+              },
             },
           )
           .finally(() => {
@@ -1600,6 +1907,15 @@ export function createManagedAgentControl(options: {
     message: string,
   ): ManagedControlReceipt => ({ status: "rejected", code, message });
   const control: ManagedAgentControl = {
+    ...createAgentRoleAdministration({
+      ...(options.roleCatalog === undefined ? {} : { roleCatalog: options.roleCatalog }),
+      ...(options.roleTargets === undefined ? {} : { roleTargets: options.roleTargets }),
+      ...(options.resolveRoleTarget === undefined
+        ? {}
+        : { inspectTarget: (role) => options.resolveRoleTarget?.({ role }) ?? Promise.resolve() }),
+      inheritedTargetId: options.targetIdentity.targetId,
+      authorize: authorized,
+    }),
     async publishExport(input) {
       return authorized(async () => {
         const bytes = Buffer.from(input.content, "utf8");
@@ -1684,14 +2000,18 @@ export function createManagedAgentControl(options: {
       );
       return record === undefined ? undefined : managedAcceptedInput(record)?.text;
     },
-    async prepareDelegation(command) {
+    async prepareDelegation(command, limits) {
       const records = await controlStore.read();
       const sessionTokens = fleetSessionCeiling(records, policy);
       const available = fleetBudget(records, sessionTokens).available;
       if (available <= 0) throw new FleetBudgetError("fleet_budget_exhausted");
       return createDelegationEnvelope(policy, {
+        ...(limits === undefined ? {} : { limits }),
         mode: command.mode ?? "background",
         count: command.entries.length,
+        roles: [...new Set(command.entries.map((entry) => entry.role))],
+        context: requestedDelegationContext(command.entries),
+        skills: [...new Set(command.entries.flatMap((entry) => entry.skills ?? []))],
         origin: command.origin ?? { kind: "direct_request", id: randomUUID() },
         sessionTokens,
         availableTokens: available,
@@ -1714,6 +2034,7 @@ export function createManagedAgentControl(options: {
       return createDelegationEnvelope(policy, {
         mode: first.event.lane === "reserved" ? "foreground" : "background",
         count: 1,
+        roles: [first.event.role],
         origin: command.origin ?? { kind: "direct_request", id: command.inputId ?? randomUUID() },
         sessionTokens,
         availableTokens: available,
@@ -1862,6 +2183,8 @@ export function createManagedAgentControl(options: {
         if (error instanceof SessionLogicalQuotaError)
           return rejected("storage_quota_exceeded", error.message);
         if (error instanceof FleetBudgetError) return rejected("budget_exhausted", error.message);
+        if (error instanceof InputResourceError)
+          return rejected("action_unavailable", error.message);
         if (
           error instanceof ManagedAgentStoreError ||
           error instanceof SessionStoreError ||
@@ -1880,7 +2203,11 @@ export function createManagedAgentControl(options: {
   };
   async function dispatchCommand(
     command: ManagedControlCommand,
-    dispatchOptions?: { readonly signal?: AbortSignal },
+    dispatchOptions?: {
+      readonly signal?: AbortSignal;
+      readonly directThinkingSelection?: ThinkingPolicySelectionV1 | null;
+      readonly directResources?: readonly StagedInputResourceSelectionV1[];
+    },
   ): Promise<ManagedControlReceipt> {
     if (
       dispatchOptions?.signal?.aborted &&
@@ -2167,6 +2494,52 @@ export function createManagedAgentControl(options: {
         dispatchOptions,
       );
     }
+    if (command.type === "list_agents" && command.view === "context") {
+      const messages = delegationMessages(
+        (await options.parentSessionStore?.read()) ?? [],
+      ).reverse();
+      const revision = managedControlDigest(
+        messages.map(({ sequence, digest }) => ({ sequence, digest })),
+      );
+      const cursor = command.cursor?.match(/^(sha256:[a-f0-9]{64}):(\d+)$/u);
+      if (
+        command.cursor !== undefined &&
+        (cursor === undefined || cursor === null || cursor[1] !== revision)
+      )
+        return rejected("stale_revision", "Parent messages changed. Read the first page again.");
+      const offset = Number(cursor?.[2] ?? 0);
+      const limit = command.limit ?? 16;
+      return {
+        status: "context_listed",
+        revision,
+        messages: messages.slice(offset, offset + limit),
+        ...(offset + limit < messages.length ? { cursor: `${revision}:${offset + limit}` } : {}),
+      };
+    }
+    if (command.type === "list_agents" && command.view === "roles") {
+      const catalog = await control.inspectRoles();
+      const revision = managedControlDigest(
+        catalog.roles.map((role) => [role.qualifiedId, role.definitionDigest]),
+      );
+      const cursor = command.cursor?.match(/^(sha256:[a-f0-9]{64}):(\d+)$/u);
+      if (
+        command.cursor !== undefined &&
+        (cursor === undefined || cursor === null || cursor[1] !== revision)
+      )
+        return rejected("stale_revision", "The role catalog changed. Read its first page again.");
+      const offset = Number(cursor?.[2] ?? 0);
+      const limit = command.limit ?? 16;
+      return {
+        status: "roles_listed",
+        revision,
+        roles: catalog.roles
+          .slice(offset, offset + limit)
+          .map(({ instructions: _instructions, ...role }) => role),
+        ...(offset + limit < catalog.roles.length
+          ? { cursor: `${revision}:${offset + limit}` }
+          : {}),
+      };
+    }
     if (command.type === "list_agents") {
       const snapshot = await control.inspect({ parentSessionId: command.parentSessionId });
       const cursor = command.cursor?.match(/^(\d+):(\d+)$/u);
@@ -2288,16 +2661,19 @@ export function createManagedAgentControl(options: {
     }
     if (command.type === "post_agent") {
       if (command.mode === "new_turn")
-        return control.dispatch({
-          type: "next_turn",
-          parentSessionId: command.parentSessionId,
-          threadId: command.threadId,
-          expectedTurnId: command.expectedTurnId,
-          task: command.text,
-          inputId: command.inputId,
-          ...(command.origin === undefined ? {} : { origin: command.origin }),
-          ...(command.envelope === undefined ? {} : { envelope: command.envelope }),
-        });
+        return control.dispatch(
+          {
+            type: "next_turn",
+            parentSessionId: command.parentSessionId,
+            threadId: command.threadId,
+            expectedTurnId: command.expectedTurnId,
+            task: command.text,
+            inputId: command.inputId,
+            ...(command.origin === undefined ? {} : { origin: command.origin }),
+            ...(command.envelope === undefined ? {} : { envelope: command.envelope }),
+          },
+          dispatchOptions,
+        );
       return authorized(async () => {
         if (!(await currentCeilingAllows()))
           return rejected("plan_policy_paused", "Paused by current Plan policy");
@@ -2441,7 +2817,7 @@ export function createManagedAgentControl(options: {
             const unstartedStore = await options.childSessionStores.open(admission.childSessionId);
             const existingRecords = await unstartedStore?.read();
             if (existingRecords?.[0] !== undefined)
-              validateManagedChildGenesis(admission, existingRecords[0]);
+              validateManagedChildGenesis(admission, existingRecords[0], existingRecords);
             const childRecords =
               unstartedStore === undefined &&
               !turn.some((record) => record.event.type === "started")
@@ -2564,7 +2940,23 @@ export function createManagedAgentControl(options: {
         )
           return rejected("plan_policy_paused", "Paused by current Plan policy");
         if (command.type === "spawn_agents") {
-          const frozenContext = (await options.resolveFrozenContext?.()) ?? options.frozenContext;
+          const catalog = await control.inspectRoles();
+          if (
+            command.entries.some(
+              (entry) => !catalog.roles.some((role) => role.qualifiedId === entry.role),
+            )
+          )
+            return rejected("action_unavailable", "Select an available exact role definition.");
+          const frozenContext =
+            (await options.resolveFrozenContext?.(
+              command.origin?.kind === "direct_request"
+                ? dispatchOptions?.directThinkingSelection
+                : undefined,
+            )) ?? options.frozenContext;
+          const skillContext =
+            frozenContext?.skillContext === undefined
+              ? undefined
+              : createIndependentSkillContextV1(frozenContext.skillContext);
           const frozen = managedControlFrozenSchema.parse({
             version: 1,
             parentBranchId: frozenContext?.parentBranchId ?? options.parentSessionId,
@@ -2573,11 +2965,19 @@ export function createManagedAgentControl(options: {
             ...(frozenContext?.thinkingPolicy === undefined
               ? {}
               : { thinkingPolicy: frozenContext.thinkingPolicy }),
-            ...(frozenContext?.skillContext === undefined
-              ? {}
-              : { skillContext: frozenContext.skillContext }),
-            promptContext: createPromptContextV1(childTools(), frozenContext?.repository),
-            parentRequest: frozenContext?.parentRequest ?? "",
+            ...(skillContext === undefined ? {} : { skillContext }),
+            promptContext:
+              skillContext === undefined
+                ? createPromptContextV1(childTools(), frozenContext?.repository)
+                : createPromptContextV2(
+                    childTools(undefined, true),
+                    frozenContext?.repository ?? createPromptContextV1(undefined).repository,
+                    skillContext,
+                  ),
+            parentRequest:
+              command.origin?.kind === "direct_request"
+                ? command.entries.map((entry) => entry.task).join("\n")
+                : (frozenContext?.parentRequest ?? ""),
             permissionEffects: ["read"],
             permissionReadCeiling: options.permissions.delegationReadCeiling ?? "deny",
           });
@@ -2590,20 +2990,17 @@ export function createManagedAgentControl(options: {
             command.envelope === undefined
               ? await control.prepareDelegation(command)
               : delegationEnvelopeSchema.parse(command.envelope);
-          const { digest: envelopeDigest, ...envelopeFields } = envelope;
           if (
-            managedControlDigest(envelopeFields) !== envelopeDigest ||
-            managedControlDigest(envelope.policy) !== envelope.policyDigest ||
-            envelope.threads !== command.entries.length ||
-            envelope.threads > envelope.running + envelope.queued ||
-            envelope.skills.length > 0 ||
-            envelope.mode !== (command.mode ?? "background") ||
-            (command.origin !== undefined && !isDeepStrictEqual(envelope.origin, command.origin)) ||
-            envelope.running >
-              policy[envelope.mode === "background" ? "background" : "reserved"].running ||
-            envelope.aggregateTokens > policy.batchTokens ||
-            envelope.threadTokens > policy.threadTokens ||
-            envelope.sessionTokens > fleetSessionCeiling(await controlStore.read(), policy)
+            !delegationEnvelopeMatches(envelope, {
+              policy,
+              roles: command.entries.map((entry) => entry.role),
+              count: command.entries.length,
+              mode: command.mode ?? "background",
+              ...(command.origin === undefined ? {} : { origin: command.origin }),
+              sessionTokens: fleetSessionCeiling(await controlStore.read(), policy),
+              context: requestedDelegationContext(command.entries),
+              skills: command.entries.flatMap((entry) => entry.skills ?? []),
+            })
           )
             return rejected(
               "action_unavailable",
@@ -2622,6 +3019,9 @@ export function createManagedAgentControl(options: {
                   !isDeepStrictEqual(record.event.envelope, envelope) ||
                   record.event.task !== command.entries[index]?.task ||
                   record.event.role !== command.entries[index]?.role ||
+                  record.event.alias !== command.entries[index]?.alias ||
+                  !isDeepStrictEqual(record.event.context, command.entries[index]?.context) ||
+                  !isDeepStrictEqual(record.event.skills, command.entries[index]?.skills) ||
                   record.event.description !== command.entries[index]?.description,
               )
             )
@@ -2671,6 +3071,36 @@ export function createManagedAgentControl(options: {
           const lane =
             command.mode === "foreground" ? ("reserved" as const) : ("background" as const);
           const current = foldManagedControl(await controlStore.read(), options.parentSessionId);
+          const names = new Set(["main"]);
+          for (const thread of current.threads) {
+            names.add(managedNameKey(thread.handle));
+            if (thread.alias !== undefined) names.add(managedNameKey(thread.alias));
+          }
+          for (const entry of command.entries) {
+            if (entry.alias === undefined) continue;
+            const key = managedNameKey(entry.alias);
+            if (names.has(key))
+              return rejected(
+                "action_unavailable",
+                "The alias is already reserved for this Session. Choose a unique lifetime name.",
+              );
+            names.add(key);
+          }
+          let number = current.threads.length + 1;
+          const handles = command.entries.map((entry) => {
+            const role = catalog.roles.find((role) => role.qualifiedId === entry.role);
+            const name =
+              (role?.name ?? "explore")
+                .normalize("NFKC")
+                .toLocaleLowerCase()
+                .replace(/[^\p{L}\p{N}_-]+/gu, "-")
+                .slice(0, 64)
+                .replace(/^-+|-+$/gu, "") || "agent";
+            let handle = `@${name}-${number++}`;
+            while (names.has(managedNameKey(handle))) handle = `@${name}-${number++}`;
+            names.add(managedNameKey(handle));
+            return handle;
+          });
           if (
             current.threads.filter(
               (thread) =>
@@ -2683,15 +3113,199 @@ export function createManagedAgentControl(options: {
               "capacity_exhausted",
               "This lane has no remaining nonterminal admission capacity.",
             );
-          const inputs = command.entries.map((entry) => ({
-            parentSessionId: options.parentSessionId,
-            threadId: randomUUID(),
-            turnId: randomUUID(),
-            attemptId: randomUUID(),
-            childSessionId: randomUUID(),
-            schemaVersion: 3 as const,
-            event: { type: "admitted" as const, ...entry, batchId, lane, frozen, envelope },
-          }));
+          let contexts: string[];
+          try {
+            const messages = delegationMessages((await options.parentSessionStore?.read()) ?? []);
+            contexts = command.entries.map((entry) =>
+              resolveDelegationContext(
+                entry.context ?? {
+                  mode:
+                    catalog.roles.find((role) => role.qualifiedId === entry.role)?.contextMode ??
+                    "current_request",
+                },
+                command.origin?.kind === "direct_request" ? entry.task : frozen.parentRequest,
+                messages,
+              ),
+            );
+          } catch (error) {
+            return rejected(
+              "action_unavailable",
+              error instanceof Error ? error.message : "Selected parent context is unavailable.",
+            );
+          }
+          for (const entry of command.entries) {
+            const role = catalog.roles.find((role) => role.qualifiedId === entry.role);
+            const candidates =
+              skillContext === undefined
+                ? []
+                : createIndependentSkillContextV1(skillContext, role?.skills).registry.candidates;
+            if (
+              (entry.skills ?? []).some(
+                (id) => !candidates.some((candidate) => candidate.qualifiedId === id),
+              ) ||
+              (entry.skills ?? []).reduce(
+                (tokens, id) =>
+                  tokens +
+                  (candidates.find((candidate) => candidate.qualifiedId === id)?.estimatedTokens ??
+                    0),
+                0,
+              ) > 32_768
+            )
+              return rejected(
+                "action_unavailable",
+                "Select exact available Skills within the role's activation limits.",
+              );
+          }
+          const directResources = dispatchOptions?.directResources ?? [];
+          if (
+            directResources.length > 0 &&
+            (command.origin?.kind !== "direct_request" || command.entries.length !== 1)
+          )
+            return rejected(
+              "action_unavailable",
+              "Direct attachments require one exact user-selected role.",
+            );
+          const requestedArtifacts = [
+            ...new Set(command.entries.flatMap((entry) => entry.artifacts ?? [])),
+          ];
+          const parentResourceRecords =
+            requestedArtifacts.length > 0 && options.resolveArtifactSelections === undefined
+              ? ((await options.parentSessionStore?.read()) ?? [])
+              : [];
+          if (requestedArtifacts.length > 0 && options.resolveArtifactSelections === undefined)
+            validateManagedParentHistory(
+              parentResourceRecords,
+              options.parentSessionId,
+              options.projectId,
+              options.workspaceRoot,
+            );
+          const availableResources =
+            requestedArtifacts.length > 0 && options.resolveArtifactSelections !== undefined
+              ? await options.resolveArtifactSelections(requestedArtifacts)
+              : parentResourceRecords.flatMap((record) =>
+                  record.schemaVersion === 3 && record.record.type === "logical_run_started"
+                    ? (record.record.inputResources ?? []).map((resource) => ({
+                        resource,
+                        source: {
+                          parentSessionId: options.parentSessionId,
+                          sequence: record.sequence,
+                          digest: managedTranscriptLink(
+                            parentResourceRecords.filter(
+                              (entry) => entry.sequence <= record.sequence,
+                            ),
+                          ).digest,
+                          occurrenceId: resource.occurrenceId,
+                        },
+                      }))
+                    : [],
+                );
+          const selectedResources = command.entries.map((entry) =>
+            (entry.artifacts ?? []).map((id) =>
+              availableResources.find((source) => source.resource.occurrenceId === id),
+            ),
+          );
+          if (
+            command.entries.some(
+              (entry, index) =>
+                selectedResources[index]?.some((source) => source === undefined) ||
+                (((entry.artifacts?.length ?? 0) > 0 || directResources.length > 0) &&
+                  !catalog.roles
+                    .find((role) => role.qualifiedId === entry.role)
+                    ?.tools.includes("read_input_resource")),
+            )
+          )
+            return rejected(
+              "action_unavailable",
+              "Select exact available attachments for a role that can read input resources.",
+            );
+          const inputs = await Promise.all(
+            command.entries.map(async (entry, index) => {
+              const turnId = randomUUID();
+              const handle = handles[index];
+              if (handle === undefined) throw new Error("Missing allocated thread handle.");
+              const roleDefinition = catalog.roles.find((role) => role.qualifiedId === entry.role);
+              if (roleDefinition === undefined) throw new Error("Role unavailable.");
+              const roleTarget = await options.resolveRoleTarget?.({
+                role: roleDefinition,
+                ...(frozen.thinkingPolicy === undefined
+                  ? {}
+                  : { inheritedThinking: frozen.thinkingPolicy }),
+              });
+              const web = roleDefinition?.web === true && options.webTools !== undefined;
+              const roleSkills =
+                skillContext === undefined
+                  ? undefined
+                  : createIndependentSkillContextV1(skillContext, roleDefinition?.skills);
+              const tools = childTools(undefined, roleSkills !== undefined, web, roleDefinition);
+              const selected =
+                selectedResources[index]?.filter((source) => source !== undefined) ?? [];
+              let inputResources: readonly InputResourceOccurrenceV1[] = [];
+              if (directResources.length > 0 || selected.length > 0) {
+                if (options.artifactStore === undefined) throw new SessionStoreError();
+                inputResources =
+                  directResources.length > 0
+                    ? await ingestLocalInputResourcesV1({
+                        ...(options.artifactRoot === undefined
+                          ? {}
+                          : { artifactRoot: options.artifactRoot }),
+                        artifactStore: options.artifactStore,
+                        runId: turnId,
+                        selections: directResources,
+                        signal: dispatchOptions?.signal ?? new AbortController().signal,
+                      })
+                    : await linkInputResourcesV1({
+                        artifactStore: options.artifactStore,
+                        runId: turnId,
+                        occurrences: selected.map((source) => source.resource),
+                      });
+              }
+              const roleFrozen = managedControlFrozenSchema.parse({
+                ...frozen,
+                ...(roleTarget === undefined
+                  ? {}
+                  : {
+                      targetIdentity: roleTarget.targetIdentity,
+                      contextProfile: roleTarget.contextProfile,
+                      thinkingPolicy: roleTarget.thinkingPolicy,
+                    }),
+                roleDefinition,
+                ...(inputResources.length === 0 ? {} : { inputResources }),
+                ...(selected.length === 0
+                  ? {}
+                  : { artifactSources: selected.map((source) => source.source) }),
+                ...(roleSkills === undefined ? {} : { skillContext: roleSkills }),
+                parentRequest: contexts[index] ?? "",
+                permissionEffects: web ? ["read", "network"] : ["read"],
+                ...(web
+                  ? {
+                      permissionNetworkCeiling:
+                        options.permissions.delegationNetworkCeiling ?? "deny",
+                    }
+                  : {}),
+                promptContext:
+                  roleSkills === undefined
+                    ? createPromptContextV1(tools, frozen.promptContext.repository)
+                    : createPromptContextV2(tools, frozen.promptContext.repository, roleSkills),
+              });
+              return {
+                parentSessionId: options.parentSessionId,
+                threadId: randomUUID(),
+                turnId,
+                attemptId: randomUUID(),
+                childSessionId: randomUUID(),
+                schemaVersion: 3 as const,
+                event: {
+                  type: "admitted" as const,
+                  ...entry,
+                  handle,
+                  batchId,
+                  lane,
+                  frozen: roleFrozen,
+                  envelope,
+                },
+              };
+            }),
+          );
           const capacity = await storageUsage(await controlStore.read());
           if (
             storedRecordBytes(inputs) +
@@ -2884,8 +3498,7 @@ export function createManagedAgentControl(options: {
           if (
             admission.event.type === "admitted" &&
             admission.event.frozen !== undefined &&
-            (!isDeepStrictEqual(admission.event.frozen.targetIdentity, options.targetIdentity) ||
-              !isDeepStrictEqual(admission.event.frozen.contextProfile, options.contextProfile))
+            !(await frozenTargetAvailable(admission.event.frozen))
           )
             return rejected(
               "action_unavailable",
@@ -2919,7 +3532,7 @@ export function createManagedAgentControl(options: {
           const childStore = await options.childSessionStores.open(admission.childSessionId);
           let childRecords = await childStore?.read();
           if (childRecords?.[0] !== undefined)
-            validateManagedChildGenesis(admission, childRecords[0]);
+            validateManagedChildGenesis(admission, childRecords[0], childRecords);
           if (childRecords !== undefined)
             await reconcileInputs(
               admission,
@@ -2928,7 +3541,13 @@ export function createManagedAgentControl(options: {
             );
           const recoveryTools =
             admission.event.type === "admitted" && admission.event.frozen !== undefined
-              ? childTools(admission)
+              ? childTools(
+                  admission,
+                  hasSkillPromptContext(admission.event.frozen.promptContext),
+                  admission.event.frozen.permissionEffects.some((effect) => effect === "network"),
+                  admission.event.frozen.roleDefinition,
+                  admission.event.frozen.inputResources,
+                )
               : createReadToolRegistry({ workspaceRoot: options.workspaceRoot });
           const childGenesis = childRecords?.[0];
           if (
@@ -2938,7 +3557,12 @@ export function createManagedAgentControl(options: {
             childGenesis.record.type === "session_genesis" &&
             childGenesis.record.sessionId === admission.childSessionId &&
             childGenesis.record.projectId === options.projectId &&
-            isDeepStrictEqual(childGenesis.record.targetIdentity, options.targetIdentity)
+            isDeepStrictEqual(
+              childGenesis.record.targetIdentity,
+              admission.event.type === "admitted"
+                ? (admission.event.frozen?.targetIdentity ?? options.targetIdentity)
+                : options.targetIdentity,
+            )
           ) {
             if (
               childRecords.some(
@@ -2984,16 +3608,26 @@ export function createManagedAgentControl(options: {
               genesis.record.type === "session_genesis" &&
               genesis.record.sessionId === admission.childSessionId &&
               genesis.record.projectId === options.projectId &&
-              isDeepStrictEqual(genesis.record.targetIdentity, options.targetIdentity) &&
-              isDeepStrictEqual(genesis.record.contextProfile, options.contextProfile) &&
+              isDeepStrictEqual(
+                genesis.record.targetIdentity,
+                admission.event.frozen?.targetIdentity ?? options.targetIdentity,
+              ) &&
+              isDeepStrictEqual(
+                genesis.record.contextProfile,
+                admission.event.frozen?.contextProfile ?? options.contextProfile,
+              ) &&
               isDeepStrictEqual(
                 genesis.record.promptContext,
-                createPromptContextV1(
-                  recoveryTools,
-                  admission.event.type === "admitted"
-                    ? admission.event.frozen?.promptContext.repository
-                    : undefined,
-                ),
+                admission.event.frozen?.skillContext === undefined
+                  ? createPromptContextV1(
+                      recoveryTools,
+                      admission.event.frozen?.promptContext.repository,
+                    )
+                  : createPromptContextV2(
+                      recoveryTools,
+                      admission.event.frozen.promptContext.repository,
+                      admission.event.frozen.skillContext,
+                    ),
               ) &&
               !turnRecords.some(
                 (record) =>
@@ -3102,8 +3736,9 @@ export function createManagedAgentControl(options: {
               "The child transcript does not match its outcome receipt.",
             );
           if (
-            !isDeepStrictEqual(genesis.record.targetIdentity, options.targetIdentity) ||
-            !isDeepStrictEqual(genesis.record.contextProfile, options.contextProfile)
+            !(await frozenTargetAvailable(
+              firstAdmission?.event.type === "admitted" ? firstAdmission.event.frozen : undefined,
+            ))
           )
             return rejected(
               "action_unavailable",
@@ -3145,6 +3780,7 @@ export function createManagedAgentControl(options: {
         if (
           digest !== managedControlDigest(fields) ||
           envelope.policyDigest !== managedControlDigest(envelope.policy) ||
+          !isDeepStrictEqual(envelope.roles, [inherited.role]) ||
           envelope.threads !== 1 ||
           envelope.running !== 1 ||
           envelope.mode !== (lane === "reserved" ? "foreground" : "background") ||
@@ -3169,13 +3805,77 @@ export function createManagedAgentControl(options: {
           policy[lane].running + policy[lane].queued
         )
           return rejected("capacity_exhausted", "This lane has no remaining admission capacity.");
+        let continuationFrozen = inherited.frozen;
+        const previousAdmission = (await controlStore.read()).find(
+          (record) => record.turnId === previous?.turn.turnId && record.event.type === "admitted",
+        );
+        if (
+          previousAdmission?.event.type === "admitted" &&
+          previousAdmission.event.frozen?.inputResources !== undefined
+        )
+          continuationFrozen = {
+            ...continuationFrozen,
+            inputResources: previousAdmission.event.frozen.inputResources,
+          };
+        const addedResources = dispatchOptions?.directResources ?? [];
+        if (
+          addedResources.length > 0 &&
+          (command.origin?.kind !== "direct_request" ||
+            !continuationFrozen.roleDefinition?.tools.includes("read_input_resource"))
+        )
+          return rejected(
+            "action_unavailable",
+            "This exact child turn cannot accept attached resources.",
+          );
+        if (continuationFrozen.inputResources !== undefined || addedResources.length > 0) {
+          if (options.artifactStore === undefined) throw new SessionStoreError();
+          const added =
+            addedResources.length === 0
+              ? []
+              : await ingestLocalInputResourcesV1({
+                  ...(options.artifactRoot === undefined
+                    ? {}
+                    : { artifactRoot: options.artifactRoot }),
+                  artifactStore: options.artifactStore,
+                  runId: identity.turnId,
+                  selections: addedResources,
+                  signal: dispatchOptions?.signal ?? new AbortController().signal,
+                });
+          continuationFrozen = {
+            ...continuationFrozen,
+            inputResources: [
+              ...(await linkInputResourcesV1({
+                artifactStore: options.artifactStore,
+                runId: identity.turnId,
+                occurrences: [...(continuationFrozen.inputResources ?? []), ...added],
+              })),
+            ],
+          };
+        }
+        if (previous !== undefined && hasSkillPromptContext(continuationFrozen.promptContext)) {
+          const records = await (
+            await options.childSessionStores.open(previous.turn.childSessionId)
+          )?.read();
+          const genesis = records?.[0];
+          if (records === undefined || genesis === undefined || !isGenesisRecord(genesis))
+            throw new SessionStoreError();
+          const skillContext = skillContextRecordFromRecords(genesis, records);
+          if (skillContext === undefined) throw new SessionStoreError();
+          continuationFrozen = {
+            ...continuationFrozen,
+            skillContext,
+            promptContext: replacePromptSkillsV2(continuationFrozen.promptContext, skillContext),
+          };
+        }
         const event: ManagedControlEvent = {
           type: "admitted",
           envelope,
           batchId: envelope.id,
           lane,
-          frozen: inherited.frozen,
+          frozen: continuationFrozen,
           role: previous?.role ?? "builtin:explore",
+          ...(inherited.handle === undefined ? {} : { handle: inherited.handle }),
+          ...(inherited.alias === undefined ? {} : { alias: inherited.alias }),
           description: previous?.description ?? "",
           task: command.task,
           ...(command.inputId === undefined ? {} : { inputId: command.inputId }),
@@ -3249,10 +3949,11 @@ export function createManagedAgentControlToolRegistry(options: {
     expectedTurnId: z.uuid().optional(),
   });
   const schemas = [
-    { name: "spawn_agents" as const, schema: spawnInputSchema },
+    { name: "spawn_agents" as const, schema: managedSpawnInputSchema },
     {
       name: "list_agents" as const,
       schema: z.strictObject({
+        view: z.enum(["threads", "roles", "context"]).optional(),
         limit: z.number().int().min(1).max(32).optional(),
         cursor: z.string().max(128).optional(),
       }),
@@ -3295,7 +3996,7 @@ export function createManagedAgentControlToolRegistry(options: {
               name === "spawn_agents"
                 ? "Atomically admit 1-32 background agents, or join exactly one foreground agent. Target, thinking and authority are Host-owned."
                 : name === "list_agents"
-                  ? "List bounded thread summaries and actions without raw task or transcript."
+                  ? "List bounded threads, current qualified roles, or exact user/assistant parent messages for explicit context selection. Context never includes reasoning or tool arguments."
                   : name === "wait_agents"
                     ? "Wait for any/all exact turns. Handles resolve once at dispatch."
                     : name === "post_agent"
@@ -3320,7 +4021,7 @@ export function createManagedAgentControlToolRegistry(options: {
             if (
               !parsed.success ||
               (name === "spawn_agents" &&
-                (!spawnInputSchema.safeParse(parsed.data).success ||
+                (!managedSpawnInputSchema.safeParse(parsed.data).success ||
                   !("entries" in parsed.data) ||
                   !validSpawnMode(parsed.data)))
             )
@@ -3331,6 +4032,9 @@ export function createManagedAgentControlToolRegistry(options: {
             let prepared:
               | Promise<{ control: ManagedAgentControl; command: ManagedControlCommand }>
               | undefined;
+            let resolved:
+              | { control: ManagedAgentControl; command: ManagedControlCommand }
+              | undefined;
             const prepare = () =>
               (prepared ??= (async () => {
                 const control = await resolveControl();
@@ -3338,10 +4042,14 @@ export function createManagedAgentControlToolRegistry(options: {
                   parentSessionId: options.parentSessionId,
                 });
                 const resolveTarget = (input: z.infer<typeof target>) => {
-                  const thread = snapshot.threads.find(
-                    (thread) =>
-                      thread.threadId === input.threadId || thread.handle === input.threadId,
-                  );
+                  const thread =
+                    snapshot.threads.find((thread) => thread.threadId === input.threadId) ??
+                    snapshot.threads.find(
+                      (thread) =>
+                        managedNameKey(thread.handle) === managedNameKey(input.threadId) ||
+                        (thread.alias !== undefined &&
+                          managedNameKey(thread.alias) === managedNameKey(input.threadId)),
+                    );
                   return {
                     threadId: thread?.threadId ?? input.threadId,
                     expectedTurnId: input.expectedTurnId ?? thread?.turn.turnId,
@@ -3387,7 +4095,8 @@ export function createManagedAgentControlToolRegistry(options: {
                       ...(command.origin === undefined ? {} : { origin: command.origin }),
                     }),
                   };
-                return { control, command };
+                resolved = { control, command };
+                return resolved;
               })());
             return {
               status: "ready",
@@ -3426,6 +4135,106 @@ export function createManagedAgentControlToolRegistry(options: {
                   threadIds: targets.map((target) => target.threadId),
                   turnIds: targets.map((target) => target.expectedTurnId),
                   argumentsDigest: managedControlDigest(command),
+                };
+              },
+              refineDelegation(envelope, selection) {
+                const command = resolved?.command;
+                if (
+                  command?.type === "post_agent" &&
+                  command.mode === "new_turn" &&
+                  command.envelope !== undefined
+                ) {
+                  if (selection !== undefined)
+                    throw new TypeError("A continuation keeps its frozen context and Skills.");
+                  if (
+                    !delegationEnvelopeMatches(envelope, {
+                      policy: command.envelope.policy,
+                      roles: command.envelope.roles,
+                      count: 1,
+                      mode: command.envelope.mode,
+                      origin: command.envelope.origin,
+                      sessionTokens: command.envelope.sessionTokens,
+                      context: command.envelope.context,
+                      skills: command.envelope.skills,
+                    }) ||
+                    envelope.aggregateTokens > command.envelope.aggregateTokens ||
+                    envelope.threadTokens > command.envelope.threadTokens
+                  )
+                    throw new TypeError("A continuation must keep its frozen thread authority.");
+                  const refined = {
+                    ...command,
+                    envelope: delegationEnvelopeSchema.parse(envelope),
+                  };
+                  if (resolved === undefined) throw new TypeError("Delegation is unavailable.");
+                  resolved.command = refined;
+                  return {
+                    type: "managed_agent_action",
+                    parentSessionId: command.parentSessionId,
+                    action: "post_agent",
+                    envelope,
+                    threadIds: [command.threadId],
+                    turnIds: [command.expectedTurnId],
+                    argumentsDigest: managedControlDigest(refined),
+                  };
+                }
+                const context =
+                  selection?.context === undefined
+                    ? undefined
+                    : delegationContextSchema.parse(selection.context);
+                const entries =
+                  command?.type === "spawn_agents"
+                    ? command.entries.map((entry) => ({
+                        ...entry,
+                        ...(context === undefined ? {} : { context: context as DelegationContext }),
+                        ...(selection?.skills === undefined
+                          ? {}
+                          : {
+                              skills: (entry.skills ?? []).filter((id) =>
+                                selection.skills?.includes(id),
+                              ),
+                            }),
+                      }))
+                    : [];
+                if (
+                  selection?.skills?.some(
+                    (id) =>
+                      !command ||
+                      !("envelope" in command) ||
+                      !command.envelope?.skills.includes(id),
+                  )
+                )
+                  throw new TypeError("Only requested Skill pre-activations can be selected.");
+                if (
+                  command?.type !== "spawn_agents" ||
+                  command.envelope === undefined ||
+                  !delegationEnvelopeMatches(envelope, {
+                    policy: command.envelope.policy,
+                    roles: command.envelope.roles,
+                    count: command.entries.length,
+                    mode: envelope.mode,
+                    origin: command.envelope.origin,
+                    sessionTokens: command.envelope.sessionTokens,
+                    context: requestedDelegationContext(entries),
+                    skills: [...new Set(entries.flatMap((entry) => entry.skills ?? []))],
+                  }) ||
+                  envelope.aggregateTokens > command.envelope.aggregateTokens
+                )
+                  throw new TypeError("The selected grant does not match this pending delegation.");
+                const refined = {
+                  ...command,
+                  entries,
+                  mode: envelope.mode,
+                  envelope: delegationEnvelopeSchema.parse(envelope),
+                };
+                if (resolved === undefined) throw new TypeError("Delegation is unavailable.");
+                resolved.command = refined;
+                return {
+                  type: "managed_agent_batch",
+                  parentSessionId: command.parentSessionId,
+                  envelope,
+                  mode: envelope.mode,
+                  count: command.entries.length,
+                  argumentsDigest: managedControlDigest(refined),
                 };
               },
               async execute(context) {

--- a/packages/agent/src/managed-agent-folds.ts
+++ b/packages/agent/src/managed-agent-folds.ts
@@ -17,7 +17,8 @@ export type {
 
 import { z } from "zod";
 import { type ManagedAgentRecord, ManagedAgentStoreError } from "./managed-agent.js";
-import { promptContextRecordV1Schema } from "./prompt-assembly.js";
+import { promptContextRecordV1Schema, promptContextRecordV2Schema } from "./prompt-assembly.js";
+import { agentRoleDefinitionSchema, agentRoleIdSchema } from "./role-catalog.js";
 import {
   contextProfileSchema,
   modelTargetIdentitySchema,
@@ -26,26 +27,59 @@ import {
 } from "./session-store.js";
 import { skillContextRecordV1Schema } from "./skills.js";
 
+export const managedAliasSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[\p{L}\p{N}_-]+$/u);
+const managedHandleSchema = z
+  .string()
+  .max(96)
+  .regex(/^@[\p{L}\p{N}_-]+-[1-9]\d*$/u);
+export const managedNameKey = (value: string): string =>
+  value.replace(/^@/u, "").normalize("NFKC").toLocaleLowerCase();
+
 export { managedControlDigest } from "./fleet-ledger.js";
 
 import {
+  type DelegationContext,
   type DelegationEnvelope,
+  delegationContextSchema,
   delegationEnvelopeSchema,
   type FleetProviderEvent,
   fleetProviderEventSchema,
   managedControlDigest,
 } from "./fleet-ledger.js";
 
+import { inputResourceOccurrenceV1Schema } from "./input-resources.js";
+
 export const managedControlFrozenSchema = z.strictObject({
   version: z.literal(1),
+  roleDefinition: agentRoleDefinitionSchema.optional(),
   parentBranchId: z.uuid(),
   targetIdentity: modelTargetIdentitySchema,
   contextProfile: contextProfileSchema,
   thinkingPolicy: thinkingPolicySnapshotV1Schema.optional(),
-  promptContext: promptContextRecordV1Schema,
+  promptContext: z.union([promptContextRecordV1Schema, promptContextRecordV2Schema]),
   skillContext: skillContextRecordV1Schema.optional(),
+  inputResources: z.array(inputResourceOccurrenceV1Schema).max(8).optional(),
+  artifactSources: z
+    .array(
+      z.strictObject({
+        parentSessionId: z.uuid(),
+        sequence: z.number().int().positive(),
+        digest: z.string().regex(/^sha256:[a-f0-9]{64}$/u),
+        occurrenceId: z.string().min(1).max(256),
+      }),
+    )
+    .max(8)
+    .optional(),
   parentRequest: z.string().max(64 * 1024),
-  permissionEffects: z.tuple([z.literal("read")]),
+  permissionEffects: z.union([
+    z.tuple([z.literal("read")]),
+    z.tuple([z.literal("read"), z.literal("network")]),
+  ]),
+  permissionNetworkCeiling: z.enum(["allow", "ask", "deny"]).optional(),
   permissionReadCeiling: z.enum(["allow", "ask", "deny"]),
 });
 export type ManagedControlFrozen = z.infer<typeof managedControlFrozenSchema>;
@@ -102,7 +136,12 @@ export type ManagedControlEvent =
   | { readonly type: "capacity_acquired" }
   | {
       readonly type: "admitted";
-      readonly role: "builtin:explore";
+      readonly role: string;
+      readonly handle?: string;
+      readonly alias?: string;
+      readonly context?: DelegationContext;
+      readonly skills?: readonly string[];
+      readonly artifacts?: readonly string[];
       readonly description: string;
       readonly task: string;
       readonly lane?: "background" | "reserved";
@@ -209,7 +248,12 @@ const eventSchema = z.discriminatedUnion("type", [
   z.strictObject({ type: z.literal("capacity_acquired") }),
   z.strictObject({
     type: z.literal("admitted"),
-    role: z.literal("builtin:explore"),
+    role: agentRoleIdSchema,
+    handle: managedHandleSchema.optional(),
+    alias: managedAliasSchema.optional(),
+    context: delegationContextSchema.optional(),
+    skills: z.array(z.string().min(1).max(512)).max(8).optional(),
+    artifacts: z.array(z.string().min(1).max(256)).max(8).optional(),
     description: boundedText(256).refine((value) => value.length > 0 && !/\p{Cc}/u.test(value)),
     task: boundedText(16 * 1024).refine((value) => value.trim().length > 0),
     lane: z.enum(["background", "reserved"]).optional(),
@@ -312,6 +356,11 @@ export function validateManagedControlRecord(
     return invalid();
   const turnRecords = previous.filter((entry) => entry.turnId === record.turnId);
   if (record.event.type === "admitted") {
+    if (
+      record.schemaVersion !== 3 &&
+      (record.event.context !== undefined || record.event.skills !== undefined)
+    )
+      return invalid();
     const admittedInputId = record.event.inputId;
     const modern = [
       record.event.lane,
@@ -349,10 +398,28 @@ export function validateManagedControlRecord(
       return invalid();
     if (threadRecords.some((entry) => entry.event.type === "thread_closed")) return invalid();
     const first = threadRecords[0];
+    if (record.event.handle !== undefined || record.event.alias !== undefined) {
+      if (record.schemaVersion !== 3 || record.event.handle === undefined) return invalid();
+      if (first === undefined) {
+        const names = new Set(["main"]);
+        for (const thread of foldManagedControl(previous, record.parentSessionId).threads) {
+          names.add(managedNameKey(thread.handle));
+          if (thread.alias !== undefined) names.add(managedNameKey(thread.alias));
+        }
+        for (const value of [record.event.handle, record.event.alias]) {
+          if (value === undefined) continue;
+          const key = managedNameKey(value);
+          if (names.has(key)) return invalid();
+          names.add(key);
+        }
+      }
+    }
     if (
       first?.event.type === "admitted" &&
       (first.event.role !== record.event.role ||
-        first.event.description !== record.event.description)
+        first.event.description !== record.event.description ||
+        first.event.handle !== record.event.handle ||
+        first.event.alias !== record.event.alias)
     )
       return invalid();
   } else {
@@ -614,8 +681,12 @@ export function foldManagedControl(
           ? {}
           : { previousTurns: [...(existing.previousTurns ?? []), existing.turn] }),
         lifecycle: "open",
-        displayName: "Explore",
-        handle: existing?.handle ?? `@explore-${threads.size + 1}`,
+        displayName: event.frozen?.roleDefinition?.name ?? "Explore",
+        handle:
+          existing?.handle ??
+          event.handle ??
+          `@${event.frozen?.roleDefinition?.name.toLocaleLowerCase() ?? "explore"}-${threads.size + 1}`,
+        ...(event.alias === undefined ? {} : { alias: event.alias }),
         residency: "live",
         threadId: record.threadId,
         role: event.role,

--- a/packages/agent/src/managed-agent-recovery.ts
+++ b/packages/agent/src/managed-agent-recovery.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 import type { ManagedControlOutcome, ManagedControlThread } from "@adam-agent/presentation";
 import type { RunResult } from "./agent-session-contracts.js";
 import type { ArtifactStore } from "./artifact-store.js";
@@ -41,7 +42,7 @@ export async function inspectManagedChildReceipt(
       return thread;
     const genesis = records?.[0];
     if (admission !== undefined && genesis !== undefined)
-      validateManagedChildGenesis(admission, genesis);
+      validateManagedChildGenesis(admission, genesis, records);
     if (
       records === undefined ||
       genesis?.schemaVersion !== 3 ||
@@ -326,6 +327,7 @@ export async function materializeManagedOutcome(
 export function validateManagedChildGenesis(
   admission: ManagedControlRecord,
   genesis: SessionRecord,
+  records?: readonly SessionRecord[],
 ): void {
   if (
     genesis.schemaVersion !== 3 ||
@@ -343,6 +345,17 @@ export function validateManagedChildGenesis(
     parent.attemptId !== admission.attemptId ||
     parent.admission.sequence !== admission.sequence ||
     parent.admission.digest !== managedControlDigest(admission)
+  )
+    throw new SessionStoreError();
+  const run = records?.find(
+    (record) => record.schemaVersion === 3 && record.record.type === "logical_run_started",
+  );
+  if (
+    admission.event.frozen.inputResources !== undefined &&
+    run?.schemaVersion === 3 &&
+    run.record.type === "logical_run_started" &&
+    (run.record.runId !== admission.turnId ||
+      !isDeepStrictEqual(run.record.inputResources, admission.event.frozen.inputResources))
   )
     throw new SessionStoreError();
 }

--- a/packages/agent/src/plan-mode.ts
+++ b/packages/agent/src/plan-mode.ts
@@ -32,6 +32,10 @@ export function isHybridPlanPolicy(
 ): policy is "plan-policy.hybrid-v1" | "plan-policy.hybrid-delegation-v1" {
   return policy === "plan-policy.hybrid-v1" || policy === "plan-policy.hybrid-delegation-v1";
 }
+export function isPlanWebTool(name: string): boolean {
+  return name === "web_fetch" || name === "web_search";
+}
+
 export function isPlanDelegationTool(name: string): boolean {
   return ["spawn_agents", "post_agent", "reply_agent", "cancel_agents"].includes(name);
 }
@@ -170,6 +174,10 @@ export function isPlanToolProfileV1Valid(
         definition.name.length <= 256 &&
         /^sha256:[0-9a-f]{64}$/u.test(definition.definitionDigest) &&
         (definition.effect === "read" ||
+          (policyVersion === "plan-policy.hybrid-delegation-v1" &&
+            definition.source === "builtin" &&
+            definition.effect === "network" &&
+            isPlanWebTool(definition.name)) ||
           (policyVersion === "plan-policy.hybrid-delegation-v1" &&
             definition.source === "builtin" &&
             definition.effect === "delegate" &&

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -1,7 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { join } from "node:path";
 import { isDeepStrictEqual } from "node:util";
-
 import type {
   ArtifactChunk,
   ArtifactRange,
@@ -28,6 +27,7 @@ import {
   agentExportFields,
   defaultAgentUiSettings,
   isAgentUiSettings,
+  leadingMentionRecipients,
   presentationAgentExportMaximumBytes,
   presentationArtifactPageMaximumBytes,
   reconcilePresentationUpdate,
@@ -35,9 +35,17 @@ import {
 } from "@adam-agent/presentation";
 import type { RuntimeEvent } from "./agent-session-contracts.js";
 import { readFileArtifact, readFileArtifactRange } from "./artifact-store.js";
+import { delegationMessages, resolveDelegationContext } from "./delegation-context.js";
 import { maximumModelResponseContentBytes } from "./durable-model-response-policy.js";
 import type { ExtensionHost } from "./extension-host.js";
+import {
+  createDelegationEnvelope,
+  type DelegationContext,
+  delegationContextSchema,
+  delegationEnvelopeMatches,
+} from "./fleet-ledger.js";
 import { createFileTurnComposerResourceStager } from "./input-resource-staging.js";
+import { managedSpawnInputSchema } from "./managed-agent-control.js";
 import {
   type ModelTargetIdentity,
   type ModelTargetSnapshot,
@@ -111,7 +119,11 @@ export const presentationHydrationBarrier = Symbol("adam-agent.presentation-hydr
 export const presentationHistoryPageSize = Symbol("adam-agent.presentation-history-page-size");
 export const presentationCatalogPageSize = Symbol("adam-agent.presentation-catalog-page-size");
 
-import { sessionManagedControl, sessionManagedTransition } from "./session-lifecycle.js";
+import {
+  sessionDraftRoles,
+  sessionManagedControl,
+  sessionManagedTransition,
+} from "./session-lifecycle.js";
 
 export const presentationManagedAgentTranscriptPageSize = Symbol(
   "adam-agent.presentation-managed-agent-transcript-page-size",
@@ -642,6 +654,9 @@ export async function createPresentationSession(
     let planRevisionIntent: PresentationDisplayState["composer"]["revisionIntent"] = null;
     let state: PresentationDisplayState = {
       agentUiSettings,
+      ...(initialDraft?.agentRoles === undefined
+        ? {}
+        : { agentRoles: initialDraft.agentRoles.roles }),
       revision: 1,
       authoritative,
       draft:
@@ -822,6 +837,12 @@ export async function createPresentationSession(
       if (control === undefined || observer.signal.aborted) return;
       const firstFrame = Promise.withResolvers<void>();
       controlObservation = (async () => {
+        const agentRoles = (await control.inspectRoles()).roles;
+        if (closed || observer.signal.aborted) {
+          firstFrame.resolve();
+          return;
+        }
+        state = { ...state, agentRoles };
         for await (const frame of control.observe({ parentSessionId, signal: observer.signal })) {
           if (
             closed ||
@@ -1641,6 +1662,9 @@ export async function createPresentationSession(
       const { managedControl: _previousControl, ...previousAuthority } = state.authoritative;
       state = {
         revision: state.revision + 1,
+        ...(activatedControlSnapshot === undefined
+          ? {}
+          : { agentRoles: (await activatedControl?.inspectRoles())?.roles ?? [] }),
         authoritative: {
           ...previousAuthority,
           ...(activatedControlSnapshot === undefined
@@ -2674,6 +2698,500 @@ export async function createPresentationSession(
               error instanceof Error ? error.message : "Agent UI settings could not be saved.",
           };
         }
+      }
+      if (command.type === "refresh_agent_types" || command.type === "mutate_agent_types") {
+        if (state.authoritative.active?.session.id !== command.sessionId)
+          return {
+            status: "rejected",
+            code: "stale_interaction",
+            message: "The active Session changed.",
+          };
+        try {
+          const control = await options.lifecycle[sessionManagedControl](command.sessionId);
+          if (control === undefined) throw new Error("Agent types are unavailable.");
+          if (command.type === "mutate_agent_types") {
+            if (command.confirmed !== true)
+              throw new Error("Preview and confirm this role change first.");
+            await control.mutateAgentTypes(command.mutation);
+          } else await control.inspectRoles({ reload: true });
+          state = {
+            ...state,
+            agentRoles: (await control.inspectRoles()).roles,
+            agentTypes: await control.inspectAgentTypes(),
+            revision: state.revision + 1,
+          };
+          publishStateChange();
+          return { status: "admitted", commandId: randomUUID(), resource: null };
+        } catch (error) {
+          return {
+            status: "rejected",
+            code: "action_unavailable",
+            message: error instanceof Error ? error.message : "Role change failed.",
+          };
+        }
+      }
+      if (command.type === "configure_role_target") {
+        const parentId = state.authoritative.active?.session.id;
+        const composer = turnComposer.snapshot();
+        const element = composer.elements.find(
+          (entry) =>
+            entry.type === "mention" &&
+            entry.kind === "role" &&
+            entry.qualifiedRoleId === command.qualifiedId &&
+            entry.definitionDigest === command.definitionDigest,
+        );
+        const control =
+          parentId === undefined
+            ? draftTargetIdentity === null
+              ? undefined
+              : options.lifecycle[sessionDraftRoles](draftTargetIdentity)
+            : await options.lifecycle[sessionManagedControl](parentId);
+        if (
+          control === undefined ||
+          composer.revision !== command.draftRevision ||
+          element === undefined ||
+          command.confirmed !== true
+        )
+          return {
+            status: "rejected",
+            code: "stale_interaction",
+            message: "The selected role draft changed.",
+          };
+        try {
+          const role = await control.configureRoleTarget(command);
+          turnComposer.refreshRoleMention(
+            element.elementId,
+            command.definitionDigest,
+            role.definitionDigest,
+          );
+          state = {
+            ...state,
+            agentRoles: (await control.inspectRoles()).roles,
+            revision: state.revision + 1,
+          };
+          await persistCurrentTurnDraft();
+          publishStateChange();
+          return { status: "admitted", commandId: randomUUID(), resource: null };
+        } catch (error) {
+          return {
+            status: "rejected",
+            code: "action_unavailable",
+            message: error instanceof Error ? error.message : "Role target could not be updated.",
+          };
+        }
+      }
+      if (command.type === "direct_delegation") {
+        const composer = turnComposer.snapshot();
+        const submittedScope = currentDraftScope();
+        if (leadingMentionRecipients(composer.elements).length > 1)
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message: "Choose one recipient or remove the extra recipients before sending.",
+          };
+        const first = composer.elements.find(
+          (element) => element.type !== "text" || element.text.trim().length > 0,
+        );
+        let parentSessionId = state.authoritative.active?.session.id;
+        let control =
+          parentSessionId === undefined
+            ? undefined
+            : await options.lifecycle[sessionManagedControl](parentSessionId);
+        let draftPreview: Awaited<ReturnType<SessionLifecycle["previewNewSession"]>> | undefined;
+        if (parentSessionId === undefined && draftTargetIdentity !== null) {
+          try {
+            draftPreview = await options.lifecycle.previewNewSession({
+              targetIdentity: draftTargetIdentity,
+              ...(command.thinkingSelection == null
+                ? {}
+                : { thinkingSelection: command.thinkingSelection }),
+            });
+          } catch (error) {
+            if (!(error instanceof SessionLifecycleError)) throw error;
+            return { status: "rejected", code: "not_available", message: error.message };
+          }
+        }
+        const roleAdministration =
+          control ??
+          (draftTargetIdentity === null
+            ? undefined
+            : options.lifecycle[sessionDraftRoles](draftTargetIdentity));
+        const catalog = (await control?.inspectRoles()) ?? draftPreview?.agentRoles;
+        const role =
+          first?.type === "mention" && first.kind === "role"
+            ? catalog?.roles.find(
+                (role) =>
+                  role.qualifiedId === first.qualifiedRoleId &&
+                  role.definitionDigest === first.definitionDigest,
+              )
+            : undefined;
+        if (
+          first === undefined ||
+          first.type !== "mention" ||
+          first.kind !== "role" ||
+          role === undefined ||
+          (parentSessionId === undefined && draftPreview?.delegationPolicy === undefined) ||
+          composer.revision !== command.draftRevision ||
+          (command.confirmedEnvelope !== undefined &&
+            command.confirmedEnvelope.origin.kind !== "direct_request")
+        )
+          return {
+            status: "rejected",
+            code: "stale_interaction",
+            message: "Select a current role and retry this exact draft.",
+          };
+        if (control === undefined && draftPreview?.delegationPolicy === undefined)
+          return {
+            status: "rejected",
+            code: "not_available",
+            message: "Managed control is unavailable for this Session.",
+          };
+        let task: string;
+        try {
+          task = directMentionText(turnComposer, first.literal);
+        } catch (error) {
+          if (!(error instanceof TurnComposerError)) throw error;
+          return { status: "rejected", code: "invalid_command", message: error.message };
+        }
+        const description =
+          command.description ??
+          [
+            ...(task
+              .split("\n")
+              .find((line) => line.trim().length > 0)
+              ?.trim() ?? ""),
+          ]
+            .slice(0, 64)
+            .join("")
+            .replace(/\p{Cc}/gu, " ");
+        const requestedSkills = [
+          ...new Set(
+            composer.elements.flatMap((element) =>
+              element.type === "skill" ? [element.qualifiedId] : [],
+            ),
+          ),
+        ];
+        const skills = command.skills ?? requestedSkills;
+        if (skills.some((skill) => !requestedSkills.includes(skill)))
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message: "Choose pre-activation only from this draft's selected Skills.",
+          };
+        if (
+          draftPreview !== undefined &&
+          skills.some(
+            (id) =>
+              !draftPreview.skillContext.catalog.entries.some(
+                (entry) => entry.qualifiedId === id,
+              ) ||
+              role.skills === false ||
+              (Array.isArray(role.skills) && !role.skills.includes(id)),
+          )
+        )
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message: "A selected Skill is unavailable for this role.",
+          };
+        if (
+          composer.resources.some((resource) => resource.state !== "removed") &&
+          !role.tools.includes("read_input_resource")
+        )
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message:
+              "This role cannot read attachments. Choose a role with input-resource read access.",
+          };
+        const context = command.context ?? { mode: role.contextMode ?? "current_request" };
+        if (
+          !managedSpawnInputSchema.safeParse({
+            entries: [{ role: role.qualifiedId, task, description, context, skills }],
+          }).success
+        )
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message: "Add a nonempty task of at most 16 KiB after the selected role.",
+          };
+        if (parentSessionId === undefined && context.mode === "selected_messages")
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message: "A blank draft has no earlier parent messages to select.",
+          };
+        const spawn = {
+          type: "spawn_agents" as const,
+          mode: command.confirmedEnvelope?.mode ?? command.limits?.mode ?? "background",
+          parentSessionId: parentSessionId ?? randomUUID(),
+          entries: [{ role: role.qualifiedId, task, description, context, skills }],
+          origin: {
+            kind: "direct_request" as const,
+            id: command.confirmedEnvelope?.origin.id ?? randomUUID(),
+          },
+        };
+        const target = await roleAdministration?.inspectRoleTarget(role.qualifiedId);
+        if (target?.status === "unavailable") {
+          if (command.confirmedEnvelope !== undefined)
+            return { status: "rejected", code: "action_unavailable", message: target.message };
+          return {
+            status: "admitted",
+            commandId: randomUUID(),
+            resource: null,
+            roleTarget: {
+              qualifiedId: role.qualifiedId,
+              definitionDigest: role.definitionDigest,
+              source: role.source?.path ?? role.qualifiedId,
+              message: target.message,
+              targets: target.targets,
+            },
+          };
+        }
+        if (command.confirmedEnvelope === undefined) {
+          const policy = draftPreview?.delegationPolicy;
+          const envelope =
+            control !== undefined
+              ? await control.prepareDelegation(spawn, command.limits)
+              : policy === undefined
+                ? undefined
+                : createDelegationEnvelope(policy, {
+                    context: context.mode,
+                    skills,
+                    mode: spawn.mode,
+                    ...(command.limits === undefined ? {} : { limits: command.limits }),
+                    count: 1,
+                    roles: [role.qualifiedId],
+                    origin: spawn.origin,
+                    sessionTokens: policy.sessionTokens,
+                  });
+          if (envelope === undefined)
+            return {
+              status: "rejected",
+              code: "not_available",
+              message: "Delegation is unavailable.",
+            };
+          const contextPage = await control?.dispatch({
+            type: "list_agents",
+            parentSessionId: spawn.parentSessionId,
+            view: "context",
+            limit: 32,
+          });
+          return {
+            status: "admitted",
+            commandId: envelope.id,
+            resource: null,
+            delegation: {
+              envelope,
+              description,
+              messages: contextPage?.status === "context_listed" ? contextPage.messages : [],
+            },
+          };
+        }
+        if (
+          parentSessionId === undefined &&
+          draftPreview?.delegationPolicy !== undefined &&
+          !delegationEnvelopeMatches(command.confirmedEnvelope, {
+            policy: draftPreview.delegationPolicy,
+            roles: [role.qualifiedId],
+            count: 1,
+            mode: spawn.mode,
+            context: context.mode,
+            skills,
+            origin: spawn.origin,
+            sessionTokens: draftPreview.delegationPolicy.sessionTokens,
+          })
+        )
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message: "The exact delegation envelope is invalid or exceeds current authority.",
+          };
+        const directResources = composer.elements.some((element) => element.type === "resource")
+          ? await turnComposer
+              .seal(new AbortController().signal)
+              .then((sealed) => sealed.selections)
+              .finally(() => turnComposer.unseal())
+          : [];
+        if (parentSessionId === undefined && draftTargetIdentity !== null) {
+          const snapshot = await options.lifecycle.create({
+            targetIdentity: draftTargetIdentity,
+            mode: state.draft?.mode ?? "default",
+          });
+          parentSessionId = snapshot.sessionId;
+          await activateSnapshot(snapshot);
+          control = await options.lifecycle[sessionManagedControl](parentSessionId);
+        }
+        if (control === undefined || parentSessionId === undefined)
+          return {
+            status: "rejected",
+            code: "not_available",
+            message: "Managed control is unavailable.",
+          };
+        const receipt = await control.dispatch(
+          { ...spawn, parentSessionId, envelope: command.confirmedEnvelope },
+          { directThinkingSelection: command.thinkingSelection ?? null, directResources },
+        );
+        if (receipt.status === "rejected") return receipt;
+        if (turnComposer.snapshot().revision === command.draftRevision) {
+          await turnComposer.clear();
+          await persistCurrentTurnDraft();
+          if (recoverableDrafts !== null && submittedScope !== null)
+            await recoverableDrafts.delete(submittedScope);
+        }
+        return {
+          status: "admitted",
+          commandId: command.confirmedEnvelope.id,
+          resource: null,
+          control: receipt,
+        };
+      }
+      if (command.type === "direct_agent_input") {
+        const composer = turnComposer.snapshot();
+        const recipients = leadingMentionRecipients(composer.elements);
+        const recipient = recipients[0];
+        const parentSessionId = state.authoritative.active?.session.id;
+        if (
+          composer.revision !== command.draftRevision ||
+          recipients.length !== 1 ||
+          recipient?.kind !== "agent" ||
+          parentSessionId !== recipient.parentSessionId
+        )
+          return {
+            status: "rejected",
+            code: "stale_interaction",
+            message: "Select one available exact thread and retry this draft.",
+          };
+        const control = await options.lifecycle[sessionManagedControl](parentSessionId);
+        const current = await control?.inspect({ parentSessionId });
+        const thread = current?.threads.find(
+          (entry) =>
+            entry.threadId === recipient.threadId &&
+            entry.handle === recipient.handle &&
+            entry.lifecycle === "open",
+        );
+        if (thread === undefined || control === undefined)
+          return {
+            status: "rejected",
+            code: "stale_interaction",
+            message: "The selected exact thread is unavailable.",
+          };
+        let text: string;
+        try {
+          text = directMentionText(turnComposer, recipient.literal);
+        } catch (error) {
+          if (!(error instanceof TurnComposerError)) throw error;
+          return { status: "rejected", code: "invalid_command", message: error.message };
+        }
+        if (text.length === 0 || Buffer.byteLength(text, "utf8") > 16 * 1024)
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message: "Add a nonempty message of at most 16 KiB after the selected thread.",
+          };
+        const actions = (thread.actions ?? []).filter(
+          (action): action is "cooperative" | "interrupt" | "new_turn" | "reply" =>
+            action === "cooperative" ||
+            action === "interrupt" ||
+            action === "new_turn" ||
+            action === "reply",
+        );
+        const hasAttachments = composer.elements.some((element) => element.type === "resource");
+        if (hasAttachments && !actions.includes("new_turn"))
+          return {
+            status: "rejected",
+            code: "action_unavailable",
+            message:
+              "Attachments require a new child turn. Keep this draft until the current turn settles.",
+          };
+        if (actions.length === 0)
+          return {
+            status: "rejected",
+            code: "action_unavailable",
+            message: "This turn cannot accept input. Inspect its available actions.",
+          };
+        if (command.confirmedInput === undefined) {
+          const input = {
+            parentSessionId,
+            threadId: thread.threadId,
+            expectedTurnId: thread.turn.turnId,
+            inputId: randomUUID(),
+            text,
+            ...(actions.includes("reply") && thread.turn.attention?.kind === "parent_input"
+              ? { attentionId: thread.turn.attention.id }
+              : {}),
+          };
+          const envelope = actions.includes("new_turn")
+            ? await control.prepareContinuation({
+                type: "next_turn",
+                parentSessionId,
+                threadId: thread.threadId,
+                expectedTurnId: thread.turn.turnId,
+                inputId: input.inputId,
+                task: text,
+                origin: { kind: "direct_request", id: input.inputId },
+              })
+            : undefined;
+          return {
+            status: "admitted",
+            commandId: input.inputId,
+            resource: null,
+            agentInput: { input, actions, ...(envelope === undefined ? {} : { envelope }) },
+          };
+        }
+        const input = command.confirmedInput;
+        if (
+          input.parentSessionId !== parentSessionId ||
+          input.threadId !== thread.threadId ||
+          input.expectedTurnId !== thread.turn.turnId ||
+          input.text !== text ||
+          input.inputId === undefined ||
+          !actions.includes(input.mode) ||
+          (input.mode === "reply" &&
+            (thread.turn.attention?.kind !== "parent_input" ||
+              thread.turn.attention.id !== input.attentionId)) ||
+          (input.mode === "new_turn" && command.confirmedEnvelope === undefined)
+        )
+          return {
+            status: "rejected",
+            code: "stale_interaction",
+            message: "The exact turn or input action changed. Inspect and retry.",
+          };
+        const common = {
+          parentSessionId,
+          threadId: thread.threadId,
+          expectedTurnId: input.expectedTurnId,
+          inputId: input.inputId,
+          text,
+        };
+        const directResources = hasAttachments
+          ? await turnComposer
+              .seal(new AbortController().signal)
+              .then((sealed) => sealed.selections)
+              .finally(() => turnComposer.unseal())
+          : [];
+        const receipt = await control.dispatch(
+          input.mode === "reply"
+            ? { ...common, type: "reply_agent", attentionId: input.attentionId ?? "" }
+            : {
+                ...common,
+                type: "post_agent",
+                mode: input.mode,
+                ...(input.mode === "new_turn" && command.confirmedEnvelope !== undefined
+                  ? {
+                      envelope: command.confirmedEnvelope,
+                      origin: { kind: "direct_request" as const, id: input.inputId },
+                    }
+                  : {}),
+              },
+          { directResources },
+        );
+        if (receipt.status === "rejected") return receipt;
+        if (turnComposer.snapshot().revision === command.draftRevision) {
+          await turnComposer.clear();
+          await persistCurrentTurnDraft();
+        }
+        return { status: "admitted", commandId: input.inputId, resource: null, control: receipt };
       }
       if (command.type === "managed_control") {
         const parentSessionId = command.command.parentSessionId;
@@ -3895,6 +4413,7 @@ export async function createPresentationSession(
           state.authoritative.active === null ? (state.draft?.mode ?? "default") : "default";
         state = {
           revision: state.revision + 1,
+          ...(preview.agentRoles === undefined ? {} : { agentRoles: preview.agentRoles.roles }),
           authoritative: {
             ...state.authoritative,
             continuity: {
@@ -4077,6 +4596,59 @@ export async function createPresentationSession(
           };
         }
       }
+      if (command.type === "resolve_draft_recipient") {
+        if (activeRun !== undefined)
+          return {
+            status: "rejected",
+            code: "conflict",
+            message: "The current turn cannot change while it is active.",
+          };
+        if (command.action === "retarget") {
+          const replacement = command.replacement;
+          const sessionId = state.authoritative.active?.session.id;
+          const control =
+            sessionId === undefined
+              ? undefined
+              : await options.lifecycle[sessionManagedControl](sessionId);
+          const available =
+            replacement?.kind === "main" ||
+            (replacement?.kind === "role" &&
+              (await control?.inspectRoles())?.roles.some(
+                (role) =>
+                  role.qualifiedId === replacement.qualifiedRoleId &&
+                  role.definitionDigest === replacement.definitionDigest,
+              )) ||
+            (replacement?.kind === "agent" &&
+              sessionId !== undefined &&
+              replacement.parentSessionId === sessionId &&
+              (await control?.inspect({ parentSessionId: sessionId }))?.threads.some(
+                (thread) =>
+                  thread.threadId === replacement.threadId &&
+                  thread.handle === replacement.handle &&
+                  thread.lifecycle === "open",
+              ));
+          if (!available)
+            return {
+              status: "rejected",
+              code: "stale_interaction",
+              message: "Choose an available exact recipient.",
+            };
+        }
+        const resolved = await turnComposer.resolveRecipient(
+          command.baseRevision,
+          command.elementId,
+          command.action,
+          persistCurrentTurnDraft,
+          command.replacement,
+        );
+        return resolved
+          ? { status: "admitted", commandId: randomUUID(), resource: null }
+          : {
+              status: "rejected",
+              code: "stale_interaction",
+              message: "The selected recipient is no longer current.",
+            };
+      }
       if (command.type === "remove_draft_element") {
         if (activeRun !== undefined || state.composer.sealed) {
           return {
@@ -4106,9 +4678,11 @@ export async function createPresentationSession(
               ? await turnComposer.remove(element.resourceId, persistCurrentTurnDraft)
               : element.type === "pasted_text"
                 ? await turnComposer.removePastedText(element.pastedTextId, persistCurrentTurnDraft)
-                : element.type === "path"
-                  ? await turnComposer.removePath(element.elementId, persistCurrentTurnDraft)
-                  : await turnComposer.removeSkill(element.elementId, persistCurrentTurnDraft);
+                : element.type === "mention"
+                  ? await turnComposer.removeMention(element.elementId, persistCurrentTurnDraft)
+                  : element.type === "path"
+                    ? await turnComposer.removePath(element.elementId, persistCurrentTurnDraft)
+                    : await turnComposer.removeSkill(element.elementId, persistCurrentTurnDraft);
           return removed
             ? { status: "admitted", commandId: randomUUID(), resource: null }
             : {
@@ -4254,6 +4828,13 @@ export async function createPresentationSession(
             };
       }
       if (command.type === "submit_prompt") {
+        const recipients = leadingMentionRecipients(turnComposer.snapshot().elements);
+        if (recipients.length > 1 || recipients.some((atom) => atom.kind !== "main"))
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message: "Resolve the selected recipient through direct routing before sending.",
+          };
         if (
           command.sessionId !== state.authoritative.active?.session.id ||
           (command.text.trim().length === 0 &&
@@ -4477,6 +5058,13 @@ export async function createPresentationSession(
         return { status: "admitted", commandId, resource: null };
       }
       if (command.type === "submit_draft_prompt") {
+        const recipients = leadingMentionRecipients(turnComposer.snapshot().elements);
+        if (recipients.length > 1 || recipients.some((atom) => atom.kind !== "main"))
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message: "Resolve the selected recipient through direct routing before sending.",
+          };
         const draft = state.draft;
         if (
           draft === null ||
@@ -4744,6 +5332,67 @@ export async function createPresentationSession(
             status: "rejected",
             code: "authority_rejected",
             message: "The exact branch boundary was not accepted.",
+          };
+        }
+      }
+      if (command.type === "preview_permission_delegation") {
+        const pending = state.authoritative.active?.pendingInteractions.find(
+          (interaction) => interaction.requestId === command.requestId,
+        );
+        if (pending?.delegation === undefined || !pending.canAllow)
+          return {
+            status: "rejected",
+            code: "stale_interaction",
+            message: "The delegation request is no longer pending.",
+          };
+        const original = pending.delegation;
+        if (
+          pending.delegationCanChangeMode !== true &&
+          command.limits.mode !== undefined &&
+          command.limits.mode !== original.mode
+        )
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message: "A continuation keeps its frozen execution mode.",
+          };
+        try {
+          const selectedContext =
+            command.selection?.context === undefined
+              ? undefined
+              : (delegationContextSchema.parse(command.selection.context) as DelegationContext);
+          if (pending.delegationCanChangeMode !== true && command.selection !== undefined)
+            throw new TypeError("A continuation keeps its frozen context and Skills.");
+          if (command.selection?.skills?.some((id) => !original.skills.includes(id)))
+            throw new TypeError("Choose only requested Skill pre-activations.");
+          if (selectedContext !== undefined)
+            resolveDelegationContext(selectedContext, "", pending.delegationMessages ?? []);
+          const envelope = createDelegationEnvelope(original.policy, {
+            mode: command.limits.mode ?? original.mode,
+            count: original.threads,
+            origin: original.origin,
+            roles: [...original.roles],
+            sessionTokens: original.sessionTokens,
+            availableTokens: original.aggregateTokens,
+            context: selectedContext?.mode ?? original.context,
+            skills: command.selection?.skills ?? original.skills,
+            limits: command.limits,
+          });
+          return {
+            status: "admitted",
+            commandId: envelope.id,
+            resource: null,
+            delegation: {
+              envelope,
+              description: `${envelope.threads} child delegation`,
+              messages: pending.delegationMessages ?? [],
+            },
+          };
+        } catch {
+          return {
+            status: "rejected",
+            code: "invalid_command",
+            message: "The selected limits exceed this pending delegation's authority.",
           };
         }
       }
@@ -6338,6 +6987,17 @@ async function projectPendingInteractions(
   return Promise.all(
     projectPendingPermissionCandidates(records).map(async (interaction) => ({
       ...interaction,
+      ...(interaction.delegation === undefined
+        ? {}
+        : {
+            delegationMessages: delegationMessages(
+              records
+                .filter((record) => record.sessionId === activeSessionId)
+                .map(({ entry }) => entry),
+            )
+              .slice(-32)
+              .reverse(),
+          }),
       canAllow:
         interaction.canAllow ||
         (await isActionableChangePreview(records, activeSessionId, interaction.requestId, options)),
@@ -6782,6 +7442,10 @@ function projectSessionTitleGeneration(
       return unreachable;
     }
   }
+}
+
+function directMentionText(composer: TurnComposer, recipient: string): string {
+  return composer.readExpandedText().trimStart().slice(recipient.length).trim();
 }
 
 function emptyUserModelPolicyDisplay() {

--- a/packages/agent/src/presentation-tool-projection.ts
+++ b/packages/agent/src/presentation-tool-projection.ts
@@ -226,6 +226,14 @@ export function projectPendingPermissionCandidates(
                     : "This public operator can receive this exact Web request and network address. Adam will not verify, replace, or fall back from this endpoint.",
                 }
               : {}),
+        ...(entry.record.event.subject?.type === "managed_agent_batch" ||
+        (entry.record.event.subject?.type === "managed_agent_action" &&
+          entry.record.event.subject.envelope !== undefined)
+          ? {
+              delegation: entry.record.event.subject.envelope,
+              delegationCanChangeMode: entry.record.event.subject.type === "managed_agent_batch",
+            }
+          : {}),
         canAllow:
           entry.record.event.name !== "write_file" && entry.record.event.name !== "edit_file",
         changePreviewRef,

--- a/packages/agent/src/recoverable-turn-draft.os.test.ts
+++ b/packages/agent/src/recoverable-turn-draft.os.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -7,6 +7,50 @@ import { expect, test } from "vitest";
 import { createRecoverableTurnDraftRepository } from "./recoverable-turn-draft.js";
 
 const projectId = `sha256:${"b".repeat(64)}` as const;
+
+test("v4 serializes selected role and agent references and restores their exact identities", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-mention-draft-"));
+  const repository = await createRecoverableTurnDraftRepository({ projectId, stateRoot: root });
+  const draft = {
+    schemaVersion: 4 as const,
+    scope: { type: "new_session" as const, targetId: "deepseek-v4-flash.direct" },
+    nextOrdinal: 1,
+    elements: [
+      {
+        type: "mention" as const,
+        kind: "role" as const,
+        elementId: "role",
+        literal: "@Explore",
+        qualifiedRoleId: "builtin:explore",
+        definitionDigest: `sha256:${"a".repeat(64)}`,
+      },
+      {
+        type: "mention" as const,
+        kind: "agent" as const,
+        elementId: "agent",
+        literal: "@explore-1",
+        parentSessionId: "00000000-0000-4000-8000-000000000001",
+        threadId: "00000000-0000-4000-8000-000000000002",
+        handle: "@explore-1",
+      },
+    ],
+    resources: [],
+  };
+  try {
+    await repository.save(draft);
+    const directory = join(root, "drafts", "b".repeat(64));
+    const name = (await readdir(directory))[0];
+    const serialized = JSON.parse(await readFile(join(directory, name ?? ""), "utf8"));
+    expect(serialized.elements.map((element: { type: string }) => element.type)).toEqual([
+      "role_ref",
+      "agent_ref",
+    ]);
+    const reopened = await createRecoverableTurnDraftRepository({ projectId, stateRoot: root });
+    await expect(reopened.load(draft.scope)).resolves.toEqual(draft);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
 
 test("late input acceptance clears only its exact owner-private child draft", async () => {
   const root = await mkdtemp(join(tmpdir(), "adam-child-draft-clear-"));

--- a/packages/agent/src/recoverable-turn-draft.ts
+++ b/packages/agent/src/recoverable-turn-draft.ts
@@ -3,9 +3,10 @@ import { constants } from "node:fs";
 import { chmod, mkdir, open, rename, unlink } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { isDeepStrictEqual } from "node:util";
-import type { ManagedComposerDraft } from "@adam-agent/presentation";
+import type { DraftMentionElement, ManagedComposerDraft } from "@adam-agent/presentation";
 
 import { z } from "zod";
+import { deserializeMention, draftMentionElementSchema, serializeMention } from "./at-mention.js";
 import type { StagedPastedTextSelectionV1 } from "./pasted-text.js";
 
 const maximumManifestBytes = 1024 * 1024;
@@ -102,14 +103,20 @@ export type RecoverableTurnDraftV3 = Omit<RecoverableTurnDraftV2, "elements" | "
   )[];
 };
 
+export type RecoverableTurnDraftV4 = Omit<RecoverableTurnDraftV3, "elements" | "schemaVersion"> & {
+  readonly schemaVersion: 4;
+  readonly elements: readonly (RecoverableTurnDraftV3["elements"][number] | DraftMentionElement)[];
+};
+
 export type RecoverableTurnDraft =
   | RecoverableTurnDraftV1
   | RecoverableTurnDraftV2
-  | RecoverableTurnDraftV3;
+  | RecoverableTurnDraftV3
+  | RecoverableTurnDraftV4;
 
 export type RecoverableTurnDraftRepository = {
   load(scope: TurnDraftScopeV1): Promise<RecoverableTurnDraft | null>;
-  save(draft: RecoverableTurnDraftV3): Promise<void>;
+  save(draft: RecoverableTurnDraftV3 | RecoverableTurnDraftV4): Promise<void>;
   delete(scope: TurnDraftScopeV1): Promise<void>;
   loadManaged(
     scope: Pick<ManagedComposerDraft, "parentSessionId" | "threadId">,
@@ -343,14 +350,34 @@ const draftV3Schema = z
   })
   .superRefine((draft, context) => validateDraftGraph(draft, context));
 
+const draftV4Schema = z
+  .strictObject({
+    ...draftV3Schema.shape,
+    schemaVersion: z.literal(4),
+    elements: z
+      .array(
+        z.union([
+          textElementSchema,
+          resourceElementSchema,
+          pastedTextElementSchema,
+          skillElementSchema,
+          pathElementSchema,
+          draftMentionElementSchema,
+        ]),
+      )
+      .max(17),
+  })
+  .superRefine((draft, context) => validateDraftGraph(draft, context));
+
 const recoverableDraftSchema = z.discriminatedUnion("schemaVersion", [
   draftV1Schema,
   draftV2Schema,
   draftV3Schema,
+  draftV4Schema,
 ]);
 
 function validateDraftGraph(draft: RecoverableTurnDraft, context: z.RefinementCtx): void {
-  const allElements: readonly RecoverableTurnDraftV3["elements"][number][] = draft.elements;
+  const allElements: readonly RecoverableTurnDraftV4["elements"][number][] = draft.elements;
   const resourceElements = allElements.filter(
     (
       element,
@@ -375,11 +402,13 @@ function validateDraftGraph(draft: RecoverableTurnDraft, context: z.RefinementCt
         length +
         (element.type === "text"
           ? Buffer.byteLength(element.text, "utf8")
-          : element.type === "skill"
-            ? Buffer.byteLength(`$${element.name}`, "utf8")
-            : element.type === "path"
-              ? Buffer.byteLength(`@${element.path}`, "utf8")
-              : 0),
+          : element.type === "mention"
+            ? Buffer.byteLength(element.literal, "utf8")
+            : element.type === "skill"
+              ? Buffer.byteLength(`$${element.name}`, "utf8")
+              : element.type === "path"
+                ? Buffer.byteLength(`@${element.path}`, "utf8")
+                : 0),
       0,
     ) +
       pastedTexts.reduce((total, pastedText) => total + pastedText.byteCount, 0) >
@@ -511,7 +540,16 @@ export async function createRecoverableTurnDraftRepository(options: {
       const path = join(root, manifestName(scope));
       const value = await readOwnerPrivateManifest(path);
       if (value === undefined) return null;
-      const parsed = recoverableDraftSchema.safeParse(value);
+      const decoded =
+        typeof value === "object" &&
+        value !== null &&
+        "schemaVersion" in value &&
+        value.schemaVersion === 4 &&
+        "elements" in value &&
+        Array.isArray(value.elements)
+          ? { ...value, elements: value.elements.map(deserializeMention) }
+          : value;
+      const parsed = recoverableDraftSchema.safeParse(decoded);
       if (!parsed.success || !matchesScope(parsed.data.scope, scope)) {
         throw new TypeError("The recoverable draft manifest is invalid.");
       }
@@ -519,8 +557,8 @@ export async function createRecoverableTurnDraftRepository(options: {
     },
     save(draft) {
       return enqueueMutation(async () => {
-        const validated = draftV3Schema.parse(draft);
-        const serialized = `${JSON.stringify(validated)}\n`;
+        const validated = (draft.schemaVersion === 4 ? draftV4Schema : draftV3Schema).parse(draft);
+        const serialized = `${JSON.stringify({ ...validated, elements: validated.elements.map((element) => (element.type === "mention" ? serializeMention(element) : element)) })}\n`;
         if (Buffer.byteLength(serialized, "utf8") > maximumManifestBytes) {
           throw new TypeError("The recoverable draft manifest is too large.");
         }

--- a/packages/agent/src/role-administration.ts
+++ b/packages/agent/src/role-administration.ts
@@ -1,0 +1,108 @@
+import type { AgentRoleMutation, AgentTypesDisplay } from "@adam-agent/presentation";
+import {
+  type AgentRoleCatalog,
+  type AgentRoleDefinition,
+  builtinAgentRoles,
+  type createAgentRoleCatalog,
+} from "./role-catalog.js";
+
+export type AgentRoleAdministration = {
+  inspectAgentTypes(): Promise<AgentTypesDisplay>;
+  mutateAgentTypes(input: AgentRoleMutation): Promise<void>;
+
+  inspectRoleTarget(qualifiedId: string): Promise<
+    | { readonly status: "available" }
+    | {
+        readonly status: "unavailable";
+        readonly message: string;
+        readonly targets: readonly { readonly targetId: string; readonly label: string }[];
+      }
+  >;
+  configureRoleTarget(input: {
+    readonly qualifiedId: string;
+    readonly definitionDigest: string;
+    readonly model: string | null;
+  }): Promise<AgentRoleDefinition>;
+  inspectRoles(options?: { readonly reload?: boolean }): Promise<AgentRoleCatalog>;
+};
+
+export function createAgentRoleAdministration(options: {
+  readonly roleCatalog?: ReturnType<typeof createAgentRoleCatalog>;
+  readonly roleTargets?: () => Promise<AgentTypesDisplay["targets"]>;
+  readonly inspectTarget?: (role: AgentRoleDefinition) => Promise<unknown>;
+  readonly inheritedTargetId: string;
+  readonly authorize: <T>(operation: () => Promise<T>) => Promise<T>;
+}): AgentRoleAdministration {
+  const control: AgentRoleAdministration = {
+    async inspectAgentTypes() {
+      const catalog = await control.inspectRoles();
+      return {
+        sources: (await options.roleCatalog?.sources()) ?? [],
+        definitions: (catalog.definitions ?? catalog.roles).map((role) => ({
+          ...role,
+          enabled: !catalog.disabledIds?.includes(role.qualifiedId),
+          available: catalog.roles.some((entry) => entry.qualifiedId === role.qualifiedId),
+        })),
+        diagnostics: catalog.diagnostics,
+        targets: (await options.roleTargets?.()) ?? [],
+      };
+    },
+    async mutateAgentTypes(input) {
+      await options.authorize(async () => {
+        if (options.roleCatalog === undefined)
+          throw new Error("Role configuration is unavailable.");
+        if (
+          input.action === "create" &&
+          input.fields.model !== undefined &&
+          !(await options.roleTargets?.())?.some((target) => target.targetId === input.fields.model)
+        )
+          throw new Error("Select an available certified target.");
+        if (input.action === "create" && input.fields.thinking !== undefined) {
+          const target = (await options.roleTargets?.())?.find(
+            (target) => target.targetId === (input.fields.model ?? options.inheritedTargetId),
+          );
+          if (!target?.thinkingLevels?.some((level) => level.id === input.fields.thinking))
+            throw new Error("Select thinking supported by this certified target.");
+        }
+        await options.roleCatalog.mutate(input);
+      });
+    },
+    async inspectRoleTarget(qualifiedId) {
+      const role = (await control.inspectRoles()).roles.find(
+        (entry) => entry.qualifiedId === qualifiedId,
+      );
+      try {
+        if (role === undefined) throw new Error("Role unavailable.");
+        await options.inspectTarget?.(role);
+        return { status: "available" };
+      } catch (error) {
+        return {
+          status: "unavailable",
+          message: error instanceof Error ? error.message : "Role target unavailable.",
+          targets: (await options.roleTargets?.()) ?? [],
+        };
+      }
+    },
+    async configureRoleTarget(input) {
+      return options.authorize(async () => {
+        if (options.roleCatalog === undefined)
+          throw new Error("Role configuration is unavailable.");
+        if (
+          input.model !== null &&
+          !(await options.roleTargets?.())?.some((target) => target.targetId === input.model)
+        )
+          throw new Error("Select an available certified target.");
+        return options.roleCatalog.configureTarget(input);
+      });
+    },
+    async inspectRoles(input) {
+      return (
+        (input?.reload ? options.roleCatalog?.reload() : options.roleCatalog?.inspect()) ?? {
+          roles: builtinAgentRoles,
+          diagnostics: [],
+        }
+      );
+    },
+  };
+  return control;
+}

--- a/packages/agent/src/role-catalog.os.test.ts
+++ b/packages/agent/src/role-catalog.os.test.ts
@@ -1,0 +1,134 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { createAgentRoleCatalog } from "./role-catalog.js";
+
+test("catalog trust, strict narrowing, exact override and qualified collisions isolate malformed definitions", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-role-discovery-"));
+  const project = join(root, "project");
+  const directory = join(project, ".agents", "agents");
+  const userDirectory = join(root, "user");
+  await mkdir(directory, { recursive: true });
+  await mkdir(userDirectory);
+  let trusted = false;
+  const catalog = createAgentRoleCatalog({
+    workspaceRoot: project,
+    userDirectory,
+    projectTrusted: async () => trusted,
+  });
+  const definition = (name: string, extra = "") =>
+    `---\nname: ${name}\ndescription: Inspect exact evidence.\nbase: explore\n${extra}---\nLocal instructions.\n`;
+  try {
+    await writeFile(join(userDirectory, "same.md"), definition("Auditor"));
+    await writeFile(join(directory, "same.md"), definition("Auditor"));
+    await writeFile(join(directory, "unsafe.md"), definition("Unsafe", "tools: [shell]\n"));
+    await writeFile(join(directory, "unknown.md"), definition("Unknown", "secret_grant: true\n"));
+    await writeFile(join(directory, "web.md"), definition("Web", "web: true\n"));
+    await writeFile(join(directory, "explore.md"), definition("Explore"));
+    await symlink(join(userDirectory, "same.md"), join(directory, "escape.md"));
+    expect((await catalog.inspect()).roles.map((role) => role.qualifiedId)).toEqual([
+      "builtin:explore",
+      "builtin:research",
+      "user:Auditor",
+    ]);
+    trusted = true;
+    const loaded = await catalog.reload();
+    expect(loaded.roles.map((role) => role.qualifiedId)).toEqual([
+      "builtin:explore",
+      "builtin:research",
+      "user:Auditor",
+      "project:Auditor",
+    ]);
+    expect(loaded.diagnostics.map((item) => item.source.split("/").at(-1)).sort()).toEqual([
+      "escape.md",
+      "explore.md",
+      "unknown.md",
+      "unsafe.md",
+      "web.md",
+    ]);
+    await writeFile(
+      join(directory, "explore.md"),
+      definition("Explore", "overrides: builtin:explore\n"),
+    );
+    const reloaded = await catalog.reload();
+    expect(reloaded.roles.map((role) => role.qualifiedId)).toEqual([
+      "builtin:research",
+      "user:Auditor",
+      "project:Explore",
+      "project:Auditor",
+    ]);
+    expect(loaded.roles.some((role) => role.qualifiedId === "builtin:explore")).toBe(true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("Owner role writes preserve conflicts and reject untrusted or redirected project sources", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-role-write-"));
+  const workspaceRoot = join(root, "project");
+  const userDirectory = join(root, "user");
+  await mkdir(workspaceRoot);
+  let trusted = false;
+  const catalog = createAgentRoleCatalog({
+    workspaceRoot,
+    userDirectory,
+    projectTrusted: async () => trusted,
+  });
+  const create = {
+    action: "create",
+    source: "project",
+    fields: { name: "Audit", description: "Read evidence.", base: "explore", skills: false },
+    instructions: "Read one file.",
+  } as const;
+  try {
+    await expect(catalog.mutate(create)).rejects.toThrow("Trust the project");
+    trusted = true;
+    await symlink(userDirectory, join(workspaceRoot, ".agents"));
+    await expect(catalog.mutate(create)).rejects.toThrow();
+    await rm(join(workspaceRoot, ".agents"));
+    const saved = await catalog.mutate(create);
+    const role = saved.roles.find((role) => role.name === "Audit");
+    expect(role?.tools).not.toContain("activate_skill");
+    expect(role?.tools).not.toContain("read_skill_resource");
+    await expect(catalog.mutate({ ...create, instructions: "Overwrite." })).rejects.toThrow(
+      "already exists",
+    );
+    expect((await catalog.reload()).roles.find((role) => role.name === "Audit")?.instructions).toBe(
+      "Read one file.",
+    );
+    await catalog.mutate({ ...create, source: "user" });
+    expect(
+      (await catalog.reload()).roles
+        .filter((role) => role.name === "Audit")
+        .map((role) => role.qualifiedId),
+    ).toEqual(["user:Audit", "project:Audit"]);
+    const builtin = saved.definitions?.find((role) => role.qualifiedId === "builtin:explore");
+    if (builtin === undefined) throw new Error("Missing builtin.");
+    await catalog.mutate({
+      action: "toggle",
+      qualifiedId: builtin.qualifiedId,
+      definitionDigest: builtin.definitionDigest,
+      enabled: false,
+    });
+    const fresh = createAgentRoleCatalog({
+      workspaceRoot,
+      userDirectory,
+      projectTrusted: async () => trusted,
+    });
+    expect(
+      (await fresh.inspect()).roles.some((role) => role.qualifiedId === builtin.qualifiedId),
+    ).toBe(false);
+    await fresh.mutate({
+      action: "toggle",
+      qualifiedId: builtin.qualifiedId,
+      definitionDigest: builtin.definitionDigest,
+      enabled: true,
+    });
+    expect(
+      (await fresh.inspect()).roles.some((role) => role.qualifiedId === builtin.qualifiedId),
+    ).toBe(true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/agent/src/role-catalog.ts
+++ b/packages/agent/src/role-catalog.ts
@@ -1,0 +1,489 @@
+import { createHash, randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { link, lstat, mkdir, open, readdir, realpath, rename, unlink } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { parseDocument, stringify } from "yaml";
+import { z } from "zod";
+
+export const agentRoleIdSchema = z
+  .string()
+  .regex(/^(builtin:(explore|research)|(project|user):[^\s\p{Cc}:]+)$/u)
+  .max(512);
+const nameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(64)
+  .refine((name) => !/[\p{Cc}:]/u.test(name));
+const namesSchema = z.union([z.array(z.string().min(1)).max(32), z.string()]).transform((value) =>
+  typeof value === "string"
+    ? value
+        .split(",")
+        .map((name) => name.trim())
+        .filter(Boolean)
+    : value,
+);
+const limitsSchema = z.strictObject({
+  maxTokens: z.number().int().positive().optional(),
+  maxTurns: z.number().int().min(1).max(128).optional(),
+});
+export const agentRoleDefinitionSchema = z.strictObject({
+  qualifiedId: agentRoleIdSchema,
+  name: nameSchema,
+  displayName: nameSchema.optional(),
+  description: z.string().min(1).max(1024),
+  base: z.enum(["explore", "research"]),
+  tools: z.array(z.string()).max(32).readonly(),
+  web: z.boolean(),
+  source: z
+    .strictObject({ kind: z.enum(["builtin", "project", "user"]), path: z.string().optional() })
+    .optional(),
+  baseVersion: z.literal("non-mutating-role.v1").optional(),
+  instructions: z.string().max(65536).optional(),
+  color: z.string().min(1).max(32).optional(),
+  model: z.string().min(1).max(256).optional(),
+  thinking: z.string().min(1).max(128).optional(),
+  skills: z.union([z.boolean(), z.array(z.string()).max(128)]).optional(),
+  contextMode: z.enum(["task", "current_request"]).optional(),
+  limits: limitsSchema.optional(),
+  overrides: agentRoleIdSchema.optional(),
+  definitionDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/u),
+});
+export type AgentRoleDefinition = z.infer<typeof agentRoleDefinitionSchema>;
+export type AgentRoleCatalog = {
+  readonly roles: readonly AgentRoleDefinition[];
+  readonly definitions?: readonly AgentRoleDefinition[];
+  readonly disabledIds?: readonly string[];
+  readonly diagnostics: readonly { readonly source: string; readonly message: string }[];
+};
+const withDigest = (role: Omit<AgentRoleDefinition, "definitionDigest">): AgentRoleDefinition => ({
+  ...role,
+  definitionDigest: `sha256:${createHash("sha256").update(JSON.stringify(role)).digest("hex")}`,
+});
+const explore = {
+  qualifiedId: "builtin:explore",
+  name: "Explore",
+  description: "Explore repository evidence with read tools and Skills.",
+  base: "explore",
+  tools: [
+    "read_file",
+    "search_repository",
+    "read_input_resource",
+    "activate_skill",
+    "read_skill_resource",
+    "report_to_parent",
+    "request_parent_input",
+  ],
+  web: false,
+  source: { kind: "builtin" },
+  baseVersion: "non-mutating-role.v1",
+  skills: true,
+  contextMode: "current_request",
+} as const;
+export const builtinAgentRoles: readonly AgentRoleDefinition[] = [
+  withDigest(explore),
+  withDigest({
+    ...explore,
+    qualifiedId: "builtin:research",
+    name: "Research",
+    description: "Research evidence with Skills and permitted Web tools.",
+    base: "research",
+    web: true,
+    tools: [...explore.tools, "web_fetch", "web_search", "web_open", "web_find"],
+  }),
+];
+const frontmatterSchema = z.strictObject({
+  name: nameSchema,
+  display_name: nameSchema.optional(),
+  description: z.string().trim().min(1).max(1024),
+  color: z.string().min(1).max(32).optional(),
+  base: z.enum(["explore", "research"]),
+  overrides: agentRoleIdSchema.optional(),
+  model: z.string().min(1).max(256).optional(),
+  thinking: z.string().min(1).max(128).optional(),
+  tools: namesSchema.optional(),
+  skills: z.union([z.boolean(), namesSchema]).optional(),
+  web: z.boolean().optional(),
+  context_mode: z.enum(["task", "current_request"]).optional(),
+  limits: limitsSchema.optional(),
+});
+
+export type RoleDefinitionInput = z.input<typeof frontmatterSchema>;
+export type RoleCatalogMutation =
+  | {
+      readonly action: "create";
+      readonly source: "project" | "user";
+      readonly fields: RoleDefinitionInput;
+      readonly instructions: string;
+      readonly original?: { readonly qualifiedId: string; readonly definitionDigest: string };
+    }
+  | {
+      readonly action: "toggle";
+      readonly qualifiedId: string;
+      readonly definitionDigest: string;
+      readonly enabled: boolean;
+    };
+
+function parseDefinition(
+  text: string,
+  kind: "project" | "user",
+  path: string,
+): AgentRoleDefinition {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)([\s\S]*)$/u.exec(text);
+  if (match === null) throw new Error("Add YAML frontmatter with name, description, and base.");
+  const document = parseDocument(match[1] ?? "", { uniqueKeys: true });
+  if (document.errors.length > 0) throw new Error(document.errors[0]?.message);
+  const fields = frontmatterSchema.parse(document.toJS({ maxAliasCount: 0 }));
+  const base = builtinAgentRoles.find((role) => role.base === fields.base);
+  if (base === undefined) throw new Error("Select Explore or Research base.");
+  const declaredTools = fields.tools ?? base.tools;
+  const tools = declaredTools.filter(
+    (tool) =>
+      (fields.skills !== false || (tool !== "activate_skill" && tool !== "read_skill_resource")) &&
+      (fields.web !== false || !["web_fetch", "web_search", "web_open", "web_find"].includes(tool)),
+  );
+  if (declaredTools.some((tool) => !base.tools.includes(tool)))
+    throw new Error("Tools may only narrow the declared base; remove unsupported tools.");
+  if (fields.web === true && !base.web) throw new Error("Web requires Research base.");
+  if (fields.overrides !== undefined && fields.overrides !== base.qualifiedId)
+    throw new Error("overrides must name the exact built-in matching this base.");
+  const collision = builtinAgentRoles.find(
+    (role) => role.name.toLocaleLowerCase() === fields.name.toLocaleLowerCase(),
+  );
+  if (collision !== undefined && fields.overrides !== collision.qualifiedId)
+    throw new Error(`Built-in name conflict; set overrides: ${collision.qualifiedId} explicitly.`);
+  const role = withDigest({
+    qualifiedId: `${kind}:${encodeURIComponent(fields.name)}`,
+    name: fields.name,
+    description: fields.description,
+    base: fields.base,
+    tools,
+    web: fields.web ?? base.web,
+    source: { kind, path },
+    baseVersion: "non-mutating-role.v1",
+    instructions: match[2]?.trim() ?? "",
+    skills: fields.skills ?? true,
+    contextMode: fields.context_mode ?? "current_request",
+    ...(fields.display_name === undefined ? {} : { displayName: fields.display_name }),
+    ...Object.fromEntries(
+      ["color", "overrides", "model", "thinking", "limits"].flatMap((key) => {
+        const value = Reflect.get(fields, key);
+        return value === undefined ? [] : [[key, value]];
+      }),
+    ),
+  });
+  return agentRoleDefinitionSchema.parse(role);
+}
+
+/** The lifecycle owns this catalog; reload changes future admissions only. */
+export function createAgentRoleCatalog(options: {
+  readonly workspaceRoot: string;
+  readonly userDirectory: string;
+  readonly projectTrusted: () => Promise<boolean>;
+}) {
+  let snapshot: AgentRoleCatalog | undefined;
+  const reload = async (): Promise<AgentRoleCatalog> => {
+    const roles: AgentRoleDefinition[] = [...builtinAgentRoles];
+    const diagnostics: { source: string; message: string }[] = [];
+    const disabledIds: string[] = [];
+    const roots: { kind: "project" | "user"; path: string }[] = [
+      { kind: "user", path: options.userDirectory },
+    ];
+    if (await options.projectTrusted())
+      roots.push({ kind: "project", path: join(options.workspaceRoot, ".agents", "agents") });
+    for (const root of roots) {
+      try {
+        const canonical = await realpath(root.path);
+        if (
+          (await lstat(root.path)).isSymbolicLink() ||
+          (root.kind === "project" &&
+            relative(await realpath(options.workspaceRoot), canonical)
+              .split(/[\\/]/u)
+              .includes(".."))
+        )
+          throw new Error("Role directory must remain inside its trusted source.");
+        const names = await readdir(root.path);
+        if (root.kind === "user") {
+          for (const marker of names.filter((name) => name.startsWith("disabled-"))) {
+            try {
+              const id = agentRoleIdSchema.parse(decodeURIComponent(marker.slice(9)));
+              if (!(await lstat(join(root.path, marker))).isFile())
+                throw new Error("Disabled role marker must be a regular file.");
+              disabledIds.push(id);
+            } catch (error) {
+              diagnostics.push({
+                source: join(root.path, marker),
+                message: error instanceof Error ? error.message : "Invalid disabled role marker.",
+              });
+            }
+          }
+        }
+        const files = names.filter((file) => file.endsWith(".md")).sort();
+        if (files.length > 128) throw new Error("Keep at most 128 role definitions per source.");
+        for (const file of files) {
+          const path = join(root.path, file);
+          try {
+            const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+            let text: string;
+            try {
+              const stat = await handle.stat();
+              if (!stat.isFile() || stat.size > 65536)
+                throw new Error(
+                  "Role definition must be a regular Markdown file of at most 64 KiB.",
+                );
+              text = await handle.readFile("utf8");
+            } finally {
+              await handle.close();
+            }
+            roles.push(parseDefinition(text, root.kind, path));
+          } catch (error) {
+            diagnostics.push({
+              source: path,
+              message: error instanceof Error ? error.message : "Invalid role definition.",
+            });
+          }
+        }
+      } catch (error) {
+        if (!(error instanceof Error && "code" in error && error.code === "ENOENT"))
+          diagnostics.push({
+            source: root.path,
+            message: error instanceof Error ? error.message : "Role directory unavailable.",
+          });
+      }
+    }
+    const collisions = new Set(
+      roles
+        .filter((role, index) =>
+          roles.some(
+            (other, otherIndex) =>
+              index !== otherIndex &&
+              (other.qualifiedId === role.qualifiedId ||
+                (role.overrides !== undefined && role.overrides === other.overrides)),
+          ),
+        )
+        .map((role) => role.qualifiedId),
+    );
+    for (const role of roles.filter((role) => collisions.has(role.qualifiedId)))
+      diagnostics.push({
+        source: role.source?.path ?? role.qualifiedId,
+        message: "Duplicate role identity or override; keep one definition.",
+      });
+    const valid = roles.filter((role) => !collisions.has(role.qualifiedId));
+    snapshot = {
+      definitions: valid,
+      disabledIds,
+      roles: valid.filter(
+        (role) =>
+          !disabledIds.includes(role.qualifiedId) &&
+          !valid.some(
+            (other) =>
+              !disabledIds.includes(other.qualifiedId) && other.overrides === role.qualifiedId,
+          ),
+      ),
+      diagnostics,
+    };
+    return snapshot;
+  };
+  const inDirectory = async <T>(
+    kind: "project" | "user",
+    action: (root: string, sync: () => Promise<void>) => Promise<T>,
+  ): Promise<T> => {
+    if (kind === "project" && !(await options.projectTrusted()))
+      throw new Error("Trust the project before changing its role definitions.");
+    const root =
+      kind === "project" ? join(options.workspaceRoot, ".agents", "agents") : options.userDirectory;
+    // Pin each project component before creating the next, so .agents cannot redirect writes.
+    const parent = kind === "project" ? options.workspaceRoot : join(root, "..");
+    if (kind === "user") await mkdir(parent, { recursive: true, mode: 0o700 });
+    let directory = await open(
+      parent,
+      constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+    );
+    try {
+      const components =
+        kind === "project" ? [".agents", "agents"] : [root.split("/").at(-1) ?? "agents"];
+      for (const component of components) {
+        const next = join(`/proc/self/fd/${directory.fd}`, component);
+        await mkdir(next, { mode: 0o700 }).catch((error) => {
+          if (error.code !== "EEXIST") throw error;
+        });
+        const opened = await open(
+          next,
+          constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW,
+        );
+        await directory.close();
+        directory = opened;
+      }
+      return await action(`/proc/self/fd/${directory.fd}`, () => directory.sync());
+    } finally {
+      await directory.close();
+    }
+  };
+  const atomicWrite = async (
+    kind: "project" | "user",
+    name: string,
+    content: string,
+    replace = false,
+  ) => {
+    if (name.includes("/") || name.includes("\\") || Buffer.byteLength(content, "utf8") > 65536)
+      throw new Error("Invalid role file.");
+    await inDirectory(kind, async (root, sync) => {
+      const temporary = join(root, `.role-${randomUUID()}.tmp`);
+      try {
+        const file = await open(
+          temporary,
+          constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+          0o600,
+        );
+        try {
+          await file.writeFile(content, "utf8");
+          await file.sync();
+        } finally {
+          await file.close();
+        }
+        if (replace) await rename(temporary, join(root, name));
+        else await link(temporary, join(root, name));
+        await sync();
+      } finally {
+        await unlink(temporary).catch(() => undefined);
+      }
+    });
+  };
+  return {
+    async sources() {
+      return [
+        {
+          kind: "project" as const,
+          path: join(options.workspaceRoot, ".agents", "agents"),
+          writable: await options.projectTrusted(),
+        },
+        { kind: "user" as const, path: options.userDirectory, writable: true },
+      ];
+    },
+    async inspect(): Promise<AgentRoleCatalog> {
+      const current = snapshot ?? (await reload());
+      if (await options.projectTrusted()) return current;
+      const definitions = (current.definitions ?? current.roles).filter(
+        (role) => role.source?.kind !== "project",
+      );
+      const disabledIds = current.disabledIds ?? [];
+      return {
+        definitions,
+        disabledIds,
+        roles: definitions.filter(
+          (role) =>
+            !disabledIds.includes(role.qualifiedId) &&
+            !definitions.some(
+              (other) =>
+                !disabledIds.includes(other.qualifiedId) && other.overrides === role.qualifiedId,
+            ),
+        ),
+        diagnostics: current.diagnostics,
+      };
+    },
+    reload,
+    async mutate(input: RoleCatalogMutation): Promise<AgentRoleCatalog> {
+      const current = await reload();
+      const definitions = current.definitions ?? current.roles;
+      if (input.action === "toggle") {
+        const role = definitions.find(
+          (role) =>
+            role.qualifiedId === input.qualifiedId &&
+            role.definitionDigest === input.definitionDigest,
+        );
+        if (role === undefined)
+          throw new Error("The selected role changed; reload and select it again.");
+        const marker = `disabled-${encodeURIComponent(role.qualifiedId)}`;
+        if (input.enabled)
+          await inDirectory("user", async (root, sync) => {
+            await unlink(join(root, marker));
+            await sync();
+          });
+        else await atomicWrite("user", marker, "disabled\n");
+      } else {
+        const fields = frontmatterSchema.parse(input.fields);
+        const original =
+          input.original === undefined
+            ? undefined
+            : definitions.find(
+                (role) =>
+                  role.qualifiedId === input.original?.qualifiedId &&
+                  role.definitionDigest === input.original.definitionDigest,
+              );
+        if (input.original !== undefined && original === undefined)
+          throw new Error("The original role changed; reload first.");
+        const root =
+          input.source === "project"
+            ? join(options.workspaceRoot, ".agents", "agents")
+            : options.userDirectory;
+        const name = `${encodeURIComponent(fields.name)}.md`;
+        const content = `---\n${stringify(fields)}---\n${input.instructions}\n`;
+        const role = parseDefinition(content, input.source, join(root, name));
+        if (
+          definitions.some(
+            (other) =>
+              other.qualifiedId === role.qualifiedId ||
+              (role.overrides !== undefined && role.overrides === other.overrides),
+          )
+        )
+          throw new Error(
+            "This role identity or override already exists; choose another name or source.",
+          );
+        await atomicWrite(input.source, name, content);
+      }
+      return reload();
+    },
+    async configureTarget(input: {
+      readonly qualifiedId: string;
+      readonly definitionDigest: string;
+      readonly model: string | null;
+    }): Promise<AgentRoleDefinition> {
+      const current = await reload();
+      const role = current.roles.find(
+        (entry) =>
+          entry.qualifiedId === input.qualifiedId &&
+          entry.definitionDigest === input.definitionDigest,
+      );
+      if (role?.source?.path === undefined || role.source.kind === "builtin")
+        throw new Error("Select an unchanged custom role definition.");
+      if (role.source.kind === "project" && !(await options.projectTrusted()))
+        throw new Error("Trust the project before changing its role definition.");
+      const root =
+        role.source.kind === "project"
+          ? join(options.workspaceRoot, ".agents", "agents")
+          : options.userDirectory;
+      const fileName = role.source.path.slice(root.length + 1);
+      const file = await open(role.source.path, constants.O_RDONLY | constants.O_NOFOLLOW);
+      let text: string;
+      try {
+        text = await file.readFile("utf8");
+      } finally {
+        await file.close();
+      }
+      if (
+        parseDefinition(text, role.source.kind, role.source.path).definitionDigest !==
+        input.definitionDigest
+      )
+        throw new Error("The role definition changed; reload first.");
+      const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)([\s\S]*)$/u.exec(text);
+      if (match === null) throw new Error("The role definition changed; reload first.");
+      const document = parseDocument(match[1] ?? "", { uniqueKeys: true });
+      if (input.model === null) document.delete("model");
+      else document.set("model", input.model);
+      document.delete("thinking");
+      frontmatterSchema.parse(document.toJS({ maxAliasCount: 0 }));
+      await atomicWrite(
+        role.source.kind,
+        fileName,
+        `---\n${document.toString()}---\n${match[2] ?? ""}`,
+        true,
+      );
+      const updated = (await reload()).roles.find(
+        (entry) => entry.qualifiedId === input.qualifiedId,
+      );
+      if (updated === undefined)
+        throw new Error("The updated role is unavailable; inspect diagnostics.");
+      return updated;
+    },
+  };
+}

--- a/packages/agent/src/session-durable-context.ts
+++ b/packages/agent/src/session-durable-context.ts
@@ -57,6 +57,7 @@ export type AgentSessionDurableContext = {
     | undefined;
   readonly referencedModelResponseArtifactBytes?: number;
   readonly repositoryWorkspaceRoot?: string;
+  readonly frozenProjectContext?: true;
   readonly authorizeProjectContextLoad?: (() => Promise<boolean>) | undefined;
   readonly skillResourceLineageBytes?: number;
   readonly skillResourceRunBytes?: number;

--- a/packages/agent/src/session-history-folds.ts
+++ b/packages/agent/src/session-history-folds.ts
@@ -1,6 +1,9 @@
 import type { ContextUsageTotals } from "./agent-session-contracts.js";
 import { createContextProjectionMessage, estimateActiveContextTokens } from "./durable-context.js";
-import { createInputResourceProjectionMessageV1 } from "./input-resources.js";
+import {
+  createInputResourceProjectionMessageV1,
+  inputResourceLimitsV1,
+} from "./input-resources.js";
 import type { ModelTargetIdentity } from "./model-targets.js";
 import type { PlanCycleSnapshot } from "./plan-mode.js";
 import {
@@ -34,6 +37,57 @@ import {
   skillContextSnapshot,
 } from "./skills.js";
 import { hasTodoToolProfileV1, todoStoreSnapshotFromRecordsV1, todoSummaryV1 } from "./todo.js";
+
+export function skillResourceBytesFromRecords(
+  records: readonly SessionRecord[],
+  runId?: string,
+): number {
+  const total = records.reduce(
+    (sum, record) =>
+      record.schemaVersion === 3 &&
+      record.record.type === "skill_resource_read_committed" &&
+      (runId === undefined || record.record.runId === runId)
+        ? sum + record.record.byteCount
+        : sum,
+    0,
+  );
+  if (
+    !Number.isSafeInteger(total) ||
+    total < 0 ||
+    total > (runId === undefined ? 8 : 1) * 1024 * 1024
+  )
+    throw new SessionLifecycleError("session_invalid");
+  return total;
+}
+
+export function inputResourceBytesFromRecords(
+  records: readonly SessionRecord[],
+  runId?: string,
+): number {
+  const total = records.reduce(
+    (sum, record) =>
+      record.schemaVersion === 3 &&
+      (record.record.type === "input_resource_read_committed" ||
+        record.record.type === "input_resource_image_read_committed") &&
+      (runId === undefined || record.record.runId === runId)
+        ? sum +
+          (record.record.type === "input_resource_read_committed"
+            ? record.record.byteCount
+            : record.record.image.byteCount)
+        : sum,
+    0,
+  );
+  if (
+    !Number.isSafeInteger(total) ||
+    total < 0 ||
+    total >
+      (runId === undefined
+        ? inputResourceLimitsV1.maximumMaterializedBytesPerLineage
+        : inputResourceLimitsV1.maximumMaterializedBytesPerRun)
+  )
+    throw new SessionLifecycleError("session_invalid");
+  return total;
+}
 
 export function isSkillContextCatalogSuccessor(
   previous: SkillContextRecordV1,

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -43,6 +43,7 @@ import {
   projectExecutionDomainForExtensionHost,
   withInternalExtensionSkillSourcesCurrent,
 } from "./extension-host.js";
+import { resolveFleetPolicy } from "./fleet-ledger.js";
 import {
   InputResourceError,
   type InputResourceOccurrenceV1,
@@ -118,6 +119,7 @@ import {
   digestApprovedPlanProjectionV1,
   isHybridPlanPolicy,
   isPlanDelegationTool,
+  isPlanWebTool,
   type PlanApprovalIntentV1,
   type PlanEligibleToolProfileV1,
   type PlanPolicyVersion,
@@ -159,6 +161,11 @@ import {
   RepositoryInstructionsError,
 } from "./repository-instructions.js";
 import {
+  type AgentRoleAdministration,
+  createAgentRoleAdministration,
+} from "./role-administration.js";
+import { createAgentRoleCatalog } from "./role-catalog.js";
+import {
   createWorkspaceTrust,
   resolveCanonicalWorkspaceIdentity,
   type WorkspaceTrustController,
@@ -178,6 +185,7 @@ import {
   attemptStatus,
   contextSnapshotFromRecords,
   contextUsageSnapshotFromRecords,
+  inputResourceBytesFromRecords,
   isCompleteBranchBoundary,
   isGenesisRecord,
   type ModelResponseArtifactDegradation,
@@ -186,6 +194,7 @@ import {
   promptContextRecordFromRecords,
   sessionNamingStateFromRecords,
   skillContextRecordFromRecords,
+  skillResourceBytesFromRecords,
   snapshotFromGenesis,
   snapshotFromRecords,
 } from "./session-history-folds.js";
@@ -228,6 +237,7 @@ import {
   buildSkillResourceManifestV1,
   createInitialSkillContextV1,
   type ExtensionSkillSourceV1,
+  readActiveSkillContentsV1,
   reconcileExtensionSkillContextV1,
   reloadSkillContextV1,
   type SkillContextRecordV1,
@@ -457,6 +467,7 @@ export type WorkspaceMcpLeaseTransitionBarrier = {
 /** Internal candidate composition; the default entry remains unchanged until cutover. */
 export const sessionManagedTransition = Symbol("adam-agent.session-managed-transition");
 export const sessionManagedControl = Symbol("adam-agent.session-managed-control");
+export const sessionDraftRoles = Symbol("adam-agent.session-draft-roles");
 
 export type SessionLifecycleOptions = {
   readonly [sessionManagedControl]?: {
@@ -466,6 +477,7 @@ export type SessionLifecycleOptions = {
     >;
     readonly [sessionRecordCommittedBarrier]?: (record: SessionRecord) => Promise<void>;
     readonly planPolicyVersion?: PlanPolicyVersion;
+    readonly userRoleDirectory?: string;
     readonly policy?: import("./fleet-ledger.js").FleetPolicy;
     readonly store: import("./managed-agent-folds.js").ManagedControlStore;
     readonly childSessionStores: SessionStoreDirectory<SessionRecord>;
@@ -539,6 +551,8 @@ export type NewSessionDraftSnapshot = {
   readonly targetIdentity: ModelTargetIdentity;
   readonly contextProfile: ContextProfile;
   readonly skillContext: SkillContextSnapshot;
+  readonly agentRoles?: import("./role-catalog.js").AgentRoleCatalog;
+  readonly delegationPolicy?: import("./fleet-ledger.js").FleetPolicy;
 };
 
 export type SessionAdmissionReceipt = {
@@ -768,6 +782,9 @@ export interface SessionLifecycle {
     readonly transitionId?: string;
     readonly decision?: "stay" | "wait" | "suspend";
   }) => Promise<ManagedSessionTransitionResult>;
+  readonly [sessionDraftRoles]: (
+    targetIdentity: ModelTargetIdentity,
+  ) => AgentRoleAdministration | undefined;
   readonly [sessionManagedControl]: (
     sessionId: string,
   ) => Promise<import("./managed-agent-control.js").ManagedAgentControl | undefined>;
@@ -831,7 +848,10 @@ export interface SessionLifecycle {
   configureWorkspaceTrust(
     command: WorkspaceTrustCommand,
   ): Promise<WorkspaceTrustConfigurationResult>;
-  create(input: { readonly targetIdentity: ModelTargetIdentity }): Promise<CurrentSessionSnapshot>;
+  create(input: {
+    readonly targetIdentity: ModelTargetIdentity;
+    readonly mode?: "default" | "plan";
+  }): Promise<CurrentSessionSnapshot>;
   decidePermission(command: PermissionDecisionCommand): PermissionDecisionCommandResult;
   enableAutomaticTitles(): void;
   ensureAutomaticTitle(input: { readonly sessionId: string }): Promise<SessionNamingResult>;
@@ -902,6 +922,7 @@ export interface SessionLifecycle {
   }): Promise<ProjectSessionCatalogPage>;
   previewNewSession(input: {
     readonly targetIdentity: ModelTargetIdentity;
+    readonly thinkingSelection?: ThinkingPolicySelectionV1;
     readonly signal?: AbortSignal;
   }): Promise<NewSessionDraftSnapshot>;
   reloadRepositoryInstructions(input: {
@@ -945,7 +966,7 @@ export interface SessionLifecycle {
 }
 
 function resolveRunThinkingPolicy(
-  resolved: Awaited<ReturnType<ModelTargets["resolve"]>>,
+  resolved: Pick<Awaited<ReturnType<ModelTargets["resolve"]>>, "identity" | "thinkingCapability">,
   selection: ThinkingPolicySelectionV1 | undefined,
 ): ThinkingPolicySnapshotV1 | undefined {
   if (resolved.thinkingCapability === undefined) {
@@ -1395,6 +1416,107 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       return { status: "ready" };
     });
   };
+  const { XDG_CONFIG_HOME: roleConfigHome } = process.env;
+  const agentRoleCatalog = createAgentRoleCatalog({
+    workspaceRoot: options.workspaceRoot,
+    userDirectory:
+      options[sessionManagedControl]?.userRoleDirectory ??
+      join(roleConfigHome || join(homedir(), ".config"), "adam-agent", "agents"),
+    projectTrusted: async () => (await inspectWorkspaceTrust()).status === "trusted",
+  });
+  const roleTargets = async () =>
+    (await options.modelTargets?.snapshot({ signal: new AbortController().signal }))?.targets
+      .filter(
+        (target) =>
+          target.identity.certification === "certified" && target.readiness.status === "available",
+      )
+      .map((target) => ({
+        targetId: target.identity.targetId,
+        label: target.catalog?.displayName ?? target.identity.targetId,
+        thinkingLevels:
+          target.thinkingCapability?.levels.map((level) => ({
+            id: level.id,
+            label: level.label,
+          })) ?? [],
+      })) ?? [];
+  const resolveRoleTarget = async (
+    inheritedTargetIdentity: ModelTargetIdentity,
+    input: Parameters<
+      NonNullable<Parameters<typeof createManagedAgentControl>[0]["resolveRoleTarget"]>
+    >[0],
+    inheritedContextProfile?: ContextProfile,
+  ) => {
+    const frozen = input.frozen;
+    const targetId =
+      frozen?.targetIdentity.targetId ?? input.role.model ?? inheritedTargetIdentity.targetId;
+    const targets = await options.modelTargets?.snapshot({
+      signal: new AbortController().signal,
+    });
+    const candidate = targets?.targets.find(
+      (target) =>
+        target.identity.targetId === targetId &&
+        target.identity.certification === "certified" &&
+        target.readiness.status === "available",
+    );
+    if (candidate === undefined)
+      throw new Error(
+        `Configured role target ${targetId} is unavailable. Choose Use inherited, Update, or Cancel.`,
+      );
+    const target = await options.modelTargets?.resolve({
+      targetId,
+      targetIdentity:
+        frozen?.targetIdentity ??
+        (input.role.model === undefined ? inheritedTargetIdentity : candidate.identity),
+      allowExperimental: false,
+      signal: new AbortController().signal,
+    });
+    if (
+      target === undefined ||
+      target.identity.certification !== "certified" ||
+      !sameModelTargetIdentity(
+        target.identity,
+        frozen?.targetIdentity ??
+          (input.role.model === undefined ? inheritedTargetIdentity : candidate.identity),
+      )
+    )
+      throw new SessionLifecycleError("session_model_target_incompatible");
+    const inherited = input.inheritedThinking;
+    let thinkingPolicy = frozen?.thinkingPolicy;
+    if (frozen !== undefined) {
+      if (!isHistoricalContextProfileSupported(target.contextProfile, frozen.contextProfile))
+        throw new SessionLifecycleError("session_model_target_incompatible");
+      if (thinkingPolicy !== undefined)
+        thinkingPolicy = requireRecoveredThinkingPolicy(
+          target,
+          thinkingPolicy as ThinkingPolicySnapshotV1,
+        );
+    } else if (
+      input.role.thinking !== undefined ||
+      (input.role.model !== undefined && inherited !== undefined)
+    ) {
+      if (target.thinkingCapability === undefined)
+        throw new SessionLifecycleError("session_thinking_policy_unsupported");
+      thinkingPolicy = resolveThinkingPolicy(
+        target.thinkingCapability,
+        input.role.thinking ?? inherited?.effectiveLevelId,
+        target.identity,
+      );
+    } else thinkingPolicy = inherited ?? resolveRunThinkingPolicy(target, undefined);
+    const configuredContext =
+      frozen === undefined && input.role.model !== undefined && options.preferences !== undefined
+        ? await options.preferences.resolveContextProfile(target.contextProfile)
+        : target.contextProfile;
+    return {
+      targetIdentity: target.identity,
+      contextProfile:
+        frozen?.contextProfile ??
+        (input.role.model === undefined
+          ? (inheritedContextProfile ?? target.contextProfile)
+          : configuredContext),
+      ...(thinkingPolicy === undefined ? {} : { thinkingPolicy }),
+      model: target.driver,
+    };
+  };
   const managedControls = new Map<string, Promise<ManagedAgentControl | undefined>>();
   const resolveManagedControl = async (
     sessionId: string,
@@ -1431,7 +1553,13 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           !isHistoricalContextProfileSupported(resolved.contextProfile, contextProfile)
         )
           throw new SessionLifecycleError("session_model_target_incompatible");
+        const webTools = await toolsForWebProfile(genesis.record.webEvidence);
         return createManagedAgentControl({
+          roleCatalog: agentRoleCatalog,
+          roleTargets,
+          resolveRoleTarget: (input) =>
+            resolveRoleTarget(snapshot.targetIdentity, input, contextProfile),
+          ...(webTools === undefined ? {} : { webTools }),
           parentSessionId: sessionId,
           projectId: snapshot.projectId as `sha256:${string}`,
           workspaceRoot: options.workspaceRoot,
@@ -1457,11 +1585,62 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
               return operation();
             }),
           artifactStore: sharedArtifactStore,
+          artifactRoot: join(effectiveStateRoot, "artifacts"),
+          resolveArtifactSelections: async (ids) => {
+            const records = await readSessionRecords(options, sessionId);
+            const genesis = records[0];
+            const boundary = records.at(-1);
+            if (genesis === undefined || !isGenesisRecord(genesis) || boundary === undefined)
+              throw new SessionLifecycleError("session_invalid");
+            validateCurrentSessionHistory(genesis, records, options.workspaceRoot);
+            const visible = await inputResourcesFromLineage(lineage, genesis, records);
+            const selected = ids.map((id) =>
+              visible.find((resource) => resource.occurrenceId === id),
+            );
+            if (selected.some((resource) => resource === undefined))
+              throw new InputResourceError(
+                "input_resource_invalid_selection",
+                "Select an exact available parent attachment.",
+              );
+            return selected
+              .filter((resource) => resource !== undefined)
+              .map((resource) => ({
+                resource,
+                source: {
+                  parentSessionId: sessionId,
+                  sequence: boundary.sequence,
+                  digest: managedTranscriptLink(records).digest,
+                  occurrenceId: resource.occurrenceId,
+                },
+              }));
+          },
+          resolveSkillSources: () => resolveExtensionSkillSources(options),
+          authorizeProjectContextLoad: async () =>
+            (await inspectWorkspaceTrust()).status === "trusted",
+          ...(options.extensionHost === undefined
+            ? {}
+            : {
+                withCurrentExtensionSkillSources: <T>(
+                  sources: readonly ExtensionSkillSourceV1[],
+                  operation: () => Promise<T>,
+                ) =>
+                  withInternalExtensionSkillSourcesCurrent(
+                    options.extensionHost as ExtensionHost,
+                    sources.map((source) => ({
+                      extensionId: source.locator.extensionId,
+                      packageName: source.locator.packageName,
+                      packageVersion: source.locator.packageVersion,
+                      lifecycleRevision: source.lifecycleRevision,
+                      lifecycleDigest: source.lifecycleDigest,
+                    })),
+                    operation,
+                  ),
+              }),
           readPlan: async () => {
             const current = await inspectSession({ sessionId });
             return current.schemaVersion === 3 ? current.plan : undefined;
           },
-          resolveFrozenContext: async () => {
+          resolveFrozenContext: async (directThinkingSelection) => {
             const current = await readSessionRecords(options, sessionId);
             const first = current[0];
             if (first === undefined || !isGenesisRecord(first))
@@ -1472,17 +1651,19 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
               (record) =>
                 record.schemaVersion === 3 && record.record.type === "logical_run_started",
             );
+            const thinkingPolicy =
+              directThinkingSelection !== undefined
+                ? resolveRunThinkingPolicy(resolved, directThinkingSelection ?? undefined)
+                : run?.schemaVersion === 3 && run.record.type === "logical_run_started"
+                  ? run.record.thinkingPolicy
+                  : undefined;
             return {
               parentBranchId: sessionId,
               parentRequest:
                 run?.schemaVersion === 3 && run.record.type === "logical_run_started"
                   ? run.record.userMessage
                   : "",
-              ...(run?.schemaVersion === 3 &&
-              run.record.type === "logical_run_started" &&
-              run.record.thinkingPolicy !== undefined
-                ? { thinkingPolicy: run.record.thinkingPolicy }
-                : {}),
+              ...(thinkingPolicy === undefined ? {} : { thinkingPolicy }),
               ...(promptContext === undefined ? {} : { repository: promptContext.repository }),
               ...(skillContext === undefined ? {} : { skillContext }),
             };
@@ -1521,6 +1702,45 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     }
     return pending;
   };
+  const toolsForWebProfile = async (
+    webEvidence: WebEvidenceProfileV1 | undefined,
+  ): Promise<ToolRegistry | undefined> => {
+    if (webEvidence === undefined) return undefined;
+    if (options.webHttp === undefined || options.webSearchConfiguration === undefined) {
+      throw new SessionLifecycleError("session_invalid");
+    }
+    const currentConfiguration = await options.webSearchConfiguration.load();
+    const desiredProvider = webEvidence.searchProvider;
+    const searchAvailable = async () => {
+      const current = await options.webSearchConfiguration?.load();
+      return (
+        desiredProvider !== null &&
+        current?.status === "configured" &&
+        current.provider !== null &&
+        isDeepStrictEqual(current.provider, desiredProvider)
+      );
+    };
+    return createWebEvidenceProduction({
+      artifactStore: sharedArtifactStore,
+      configuration:
+        desiredProvider === null
+          ? {
+              status: "unconfigured",
+              provider: null,
+              syntheticDnsRange: currentConfiguration.syntheticDnsRange ?? null,
+              diagnostic: null,
+            }
+          : {
+              status: "configured",
+              provider: desiredProvider,
+              syntheticDnsRange: currentConfiguration.syntheticDnsRange ?? null,
+              diagnostic: null,
+            },
+      http: options.webHttp,
+      ...(desiredProvider === null ? {} : { searchAvailable }),
+      store: webEvidenceStore,
+    });
+  };
   const toolsForSession = async (
     sessionId: string,
     targetIdentity: ModelTargetIdentity,
@@ -1530,43 +1750,9 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
   ): Promise<ToolRegistry> => {
     const base = options.tools;
     let baseWithWeb = base;
-    if (webEvidence !== undefined) {
-      if (
-        options.webHttp === undefined ||
-        options.webSearchConfiguration === undefined ||
-        base === undefined
-      ) {
-        throw new SessionLifecycleError("session_invalid");
-      }
-      const currentConfiguration = await options.webSearchConfiguration.load();
-      const desiredProvider = webEvidence.searchProvider;
-      const searchAvailable =
-        desiredProvider !== null &&
-        currentConfiguration.status === "configured" &&
-        currentConfiguration.provider !== null &&
-        isDeepStrictEqual(currentConfiguration.provider, desiredProvider);
-      const webTools = await createWebEvidenceProduction({
-        artifactStore: sharedArtifactStore,
-        configuration:
-          desiredProvider === null
-            ? {
-                status: "unconfigured",
-                provider: null,
-                syntheticDnsRange: currentConfiguration.syntheticDnsRange ?? null,
-                diagnostic: null,
-              }
-            : {
-                status: "configured",
-                provider: desiredProvider,
-                syntheticDnsRange: currentConfiguration.syntheticDnsRange ?? null,
-                diagnostic: null,
-              },
-        http: options.webHttp,
-        ...(desiredProvider === null ? {} : { searchAvailable }),
-        store: webEvidenceStore,
-      });
+    const webTools = await toolsForWebProfile(webEvidence);
+    if (webTools !== undefined && base !== undefined)
       baseWithWeb = combineToolRegistries(base, webTools);
-    }
     if (
       options[sessionManagedControl] !== undefined &&
       managedAgentTools === undefined &&
@@ -3410,7 +3596,77 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     };
   };
 
+  const resolveCreationTarget = async (
+    targetIdentity: ModelTargetIdentity,
+    signal?: AbortSignal,
+  ) => {
+    const officialResolved = await options.modelTargets?.resolve({
+      targetId: targetIdentity.targetId,
+      targetIdentity: targetIdentity,
+      allowExperimental: targetIdentity.certification === "experimental",
+      signal: signal ?? new AbortController().signal,
+    });
+    let resolved = officialResolved;
+    if (officialResolved !== undefined && options.preferences !== undefined) {
+      try {
+        resolved = {
+          ...officialResolved,
+          contextProfile: await options.preferences.resolveContextProfile(
+            officialResolved.contextProfile,
+          ),
+        };
+      } catch {
+        throw new SessionLifecycleError("session_user_configuration_invalid");
+      }
+    }
+    if (
+      resolved === undefined ||
+      !sameModelTargetIdentity(resolved.identity, targetIdentity) ||
+      !modelTargetUsesContextProfile(targetIdentity, resolved.contextProfile) ||
+      !isContextProfileSupported(resolved.contextProfile)
+    ) {
+      throw new SessionLifecycleError("session_model_target_incompatible");
+    }
+    return resolved;
+  };
+
+  const prepareCreationPlan = async (
+    prepared: Awaited<ReturnType<typeof prepareSessionCreation>>,
+    mode?: "default" | "plan",
+  ) => {
+    let plan: SessionPlanCycleEnteredRecord | undefined;
+    if (mode === "plan") {
+      const promptContext = prepared.genesis.record.promptContext;
+      if (promptContext === undefined) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      plan = await preparePlanCycleEntry(
+        2,
+        planToolProfileFromAuthority(
+          promptContext.toolProfile,
+          prepared.tools,
+          undefined,
+          options[sessionManagedControl]?.planPolicyVersion ??
+            (options[sessionManagedControl] === undefined
+              ? "plan-policy.hybrid-v1"
+              : "plan-policy.hybrid-delegation-v1"),
+        ),
+      );
+    }
+    return plan;
+  };
+
   return {
+    [sessionDraftRoles](targetIdentity) {
+      if (options[sessionManagedControl] === undefined || lifecycleClosing) return undefined;
+      return createAgentRoleAdministration({
+        roleCatalog: agentRoleCatalog,
+        roleTargets,
+        inheritedTargetId: targetIdentity.targetId,
+        inspectTarget: (role) => resolveRoleTarget(targetIdentity, { role }),
+        authorize: (operation) => withOwner(operation),
+      });
+    },
     [sessionManagedControl]: resolveManagedControl,
     [sessionManagedTransition]: transitionManagedParent,
     async admit(input) {
@@ -3428,33 +3684,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       }
       const created = await withOwner(async () => {
         await requireTrustedWorkspace();
-        const officialResolved = await options.modelTargets?.resolve({
-          targetId: input.targetIdentity.targetId,
-          targetIdentity: input.targetIdentity,
-          allowExperimental: input.targetIdentity.certification === "experimental",
-          signal: input.signal ?? new AbortController().signal,
-        });
-        let resolved = officialResolved;
-        if (officialResolved !== undefined && options.preferences !== undefined) {
-          try {
-            resolved = {
-              ...officialResolved,
-              contextProfile: await options.preferences.resolveContextProfile(
-                officialResolved.contextProfile,
-              ),
-            };
-          } catch {
-            throw new SessionLifecycleError("session_user_configuration_invalid");
-          }
-        }
-        if (
-          resolved === undefined ||
-          !sameModelTargetIdentity(resolved.identity, input.targetIdentity) ||
-          !modelTargetUsesContextProfile(input.targetIdentity, resolved.contextProfile) ||
-          !isContextProfileSupported(resolved.contextProfile)
-        ) {
-          throw new SessionLifecycleError("session_model_target_incompatible");
-        }
+        const resolved = await resolveCreationTarget(input.targetIdentity, input.signal);
         const thinkingPolicy = resolveRunThinkingPolicy(resolved, input.thinkingSelection);
         const prepared = await prepareSessionCreation({
           targetIdentity: input.targetIdentity,
@@ -3463,25 +3693,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           ...(input.input.skills === undefined ? {} : { skills: input.input.skills }),
           resolved,
         });
-        let plan: SessionPlanCycleEnteredRecord | undefined;
-        if (input.mode === "plan") {
-          const promptContext = prepared.genesis.record.promptContext;
-          if (promptContext === undefined) {
-            throw new SessionLifecycleError("session_invalid");
-          }
-          plan = await preparePlanCycleEntry(
-            2,
-            planToolProfileFromAuthority(
-              promptContext.toolProfile,
-              prepared.tools,
-              undefined,
-              options[sessionManagedControl]?.planPolicyVersion ??
-                (options[sessionManagedControl] === undefined
-                  ? "plan-policy.hybrid-v1"
-                  : "plan-policy.hybrid-delegation-v1"),
-            ),
-          );
-        }
+        const plan = await prepareCreationPlan(prepared, input.mode);
         input.signal?.throwIfAborted();
         let snapshot: CurrentSessionSnapshot;
         try {
@@ -4035,9 +4247,14 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       await requireManagedSelection(null);
       const snapshot = await withOwner(async () => {
         await requireTrustedWorkspace();
-        return persistPreparedSession(
-          await prepareSessionCreation({ targetIdentity: input.targetIdentity }),
-        );
+        const resolved =
+          input.mode === undefined ? undefined : await resolveCreationTarget(input.targetIdentity);
+        const prepared = await prepareSessionCreation({
+          targetIdentity: input.targetIdentity,
+          ...(resolved === undefined ? {} : { resolved }),
+        });
+        const plan = await prepareCreationPlan(prepared, input.mode);
+        return persistPreparedSession({ ...prepared, ...(plan === undefined ? {} : { plan }) });
       });
       if (options[sessionManagedControl] !== undefined)
         await serializeFamily(async () => {
@@ -4738,11 +4955,11 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
             ...(resumeState === undefined
               ? {}
               : {
-                  inputResourceRunBytes: inputResourceBytesForRun(
+                  inputResourceRunBytes: inputResourceBytesFromRecords(
                     replayRecords,
                     resumeState.agentState.runId,
                   ),
-                  skillResourceRunBytes: skillResourceBytesForRun(
+                  skillResourceRunBytes: skillResourceBytesFromRecords(
                     replayRecords,
                     resumeState.agentState.runId,
                   ),
@@ -5841,7 +6058,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         const genesis = childRecords?.[0];
         if (childRecords === undefined || genesis === undefined || !isGenesisRecord(genesis))
           throw new SessionLifecycleError("session_invalid");
-        validateManagedChildGenesis(admission, genesis);
+        validateManagedChildGenesis(admission, genesis, childRecords);
         validateCurrentSessionHistory(genesis, childRecords, options.workspaceRoot);
         const outcome = controlRecords.find(
           (record) => record.turnId === input.turnId && record.event.type === "outcome",
@@ -6056,6 +6273,8 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         if (target === undefined || target.readiness.status !== "available") {
           throw new SessionLifecycleError("session_model_target_unavailable");
         }
+        if (input.thinkingSelection !== undefined)
+          resolveRunThinkingPolicy(target, input.thinkingSelection);
         if (
           !modelTargetUsesContextProfile(input.targetIdentity, target.contextProfile) ||
           !isContextProfileSupported(target.contextProfile)
@@ -6087,6 +6306,15 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           targetIdentity: input.targetIdentity,
           contextProfile,
           skillContext: skillContextSnapshot(skillContext),
+          ...(options[sessionManagedControl] === undefined
+            ? {}
+            : {
+                agentRoles: await agentRoleCatalog.inspect(),
+                delegationPolicy: resolveFleetPolicy(
+                  contextProfile,
+                  options[sessionManagedControl].policy,
+                ),
+              }),
         };
       });
     },
@@ -8418,34 +8646,12 @@ function reportedTokensForRun(
   return combined;
 }
 
-function skillResourceBytesForRun(records: readonly SessionRecord[], runId: string): number {
-  const total = records.reduce(
-    (sum, record) =>
-      record.schemaVersion === 3 &&
-      record.record.type === "skill_resource_read_committed" &&
-      record.record.runId === runId
-        ? sum + record.record.byteCount
-        : sum,
-    0,
-  );
-  if (!Number.isSafeInteger(total) || total < 0 || total > 1024 * 1024) {
-    throw new SessionLifecycleError("session_invalid");
-  }
-  return total;
-}
-
 async function skillResourceBytesFromLineage(
   lineage: SessionLineageTraversal,
   genesis: SessionGenesisRecord,
   records: readonly SessionRecord[],
 ): Promise<number> {
-  const ownBytes = records.reduce(
-    (sum, record) =>
-      record.schemaVersion === 3 && record.record.type === "skill_resource_read_committed"
-        ? sum + record.record.byteCount
-        : sum,
-    0,
-  );
+  const ownBytes = skillResourceBytesFromRecords(records);
   const inheritedBytes =
     genesis.record.lineage === undefined
       ? 0
@@ -8461,47 +8667,12 @@ async function skillResourceBytesFromLineage(
   return total;
 }
 
-function inputResourceBytesForRun(records: readonly SessionRecord[], runId: string): number {
-  const total = records.reduce(
-    (sum, record) =>
-      record.schemaVersion === 3 &&
-      (record.record.type === "input_resource_read_committed" ||
-        record.record.type === "input_resource_image_read_committed") &&
-      record.record.runId === runId
-        ? sum +
-          (record.record.type === "input_resource_read_committed"
-            ? record.record.byteCount
-            : record.record.image.byteCount)
-        : sum,
-    0,
-  );
-  if (
-    !Number.isSafeInteger(total) ||
-    total < 0 ||
-    total > inputResourceLimitsV1.maximumMaterializedBytesPerRun
-  ) {
-    throw new SessionLifecycleError("session_invalid");
-  }
-  return total;
-}
-
 async function inputResourceBytesFromLineage(
   lineage: SessionLineageTraversal,
   genesis: SessionGenesisRecord,
   records: readonly SessionRecord[],
 ): Promise<number> {
-  const ownBytes = records.reduce(
-    (sum, record) =>
-      record.schemaVersion === 3 &&
-      (record.record.type === "input_resource_read_committed" ||
-        record.record.type === "input_resource_image_read_committed")
-        ? sum +
-          (record.record.type === "input_resource_read_committed"
-            ? record.record.byteCount
-            : record.record.image.byteCount)
-        : sum,
-    0,
-  );
+  const ownBytes = inputResourceBytesFromRecords(records);
   const inheritedBytes =
     genesis.record.lineage === undefined
       ? 0
@@ -8847,38 +9018,19 @@ async function materializeActiveSkillContents(
   options: SessionLifecycleOptions,
   context: SkillContextRecordV1 | undefined,
 ): Promise<ReadonlyMap<string, string>> {
-  const contents = new Map<string, string>();
-  if (context === undefined) {
-    return contents;
-  }
   const root = join(effectiveSessionStateRoot(options.stateRoot), "artifacts");
-  for (const activation of context.active) {
-    let bytes: Uint8Array | undefined;
-    try {
-      bytes = await readFileArtifact({
-        root,
-        id: activation.artifact.id,
-        maximumBytes: activation.byteCount,
-      });
-    } catch {
-      throw new SessionLifecycleError("session_invalid");
-    }
-    if (
-      bytes === undefined ||
-      bytes.byteLength !== activation.byteCount ||
-      `sha256:${createHash("sha256").update(bytes).digest("hex")}` !== activation.skillMdDigest
-    ) {
-      throw new SessionLifecycleError("session_invalid");
-    }
-    let content: string;
-    try {
-      content = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-    } catch {
-      throw new SessionLifecycleError("session_invalid");
-    }
-    contents.set(activation.qualifiedId, content);
+  try {
+    return await readActiveSkillContentsV1(context, {
+      read: (id, limits) =>
+        readFileArtifact({
+          root,
+          id,
+          ...(limits?.maximumBytes === undefined ? {} : { maximumBytes: limits.maximumBytes }),
+        }),
+    });
+  } catch {
+    throw new SessionLifecycleError("session_invalid");
   }
-  return contents;
 }
 
 async function inspectModelResponseArtifactLineage(
@@ -9418,6 +9570,9 @@ function planToolProfileFromAuthority(
     }
     if (
       adapter.effect === "read" ||
+      (policyVersion === "plan-policy.hybrid-delegation-v1" &&
+        adapter.effect === "network" &&
+        isPlanWebTool(definition.name)) ||
       (policyVersion === "plan-policy.hybrid-delegation-v1" &&
         adapter.effect === "delegate" &&
         isPlanDelegationTool(definition.name)) ||

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -1632,7 +1632,7 @@ const managedAgentWebRequestPermissionSubjectSchema = z.strictObject({
   agentId: z.uuid(),
   attemptId: z.uuid(),
   childSessionId: z.uuid(),
-  profile: z.enum(["research.v1", "research.v2"]),
+  profile: z.enum(["research.v1", "research.v2", "research.v3"]),
   providerOrigin: z.url(),
   queryOrUrl: z.string().min(1).max(4_096),
   argumentsDigest: z.string().regex(/^sha256:[0-9a-f]{64}$/u),

--- a/packages/agent/src/skills.ts
+++ b/packages/agent/src/skills.ts
@@ -742,6 +742,47 @@ export function reconcileExtensionSkillContextV1(input: {
   };
 }
 
+export async function readActiveSkillContentsV1(
+  context: SkillContextRecordV1 | undefined,
+  artifacts: Pick<ArtifactStore, "read"> | undefined,
+): Promise<ReadonlyMap<string, string>> {
+  const contents = new Map<string, string>();
+  for (const activation of context?.active ?? []) {
+    const bytes = await artifacts?.read(activation.artifact.id, {
+      maximumBytes: activation.byteCount,
+    });
+    if (
+      bytes === undefined ||
+      bytes.byteLength !== activation.byteCount ||
+      `sha256:${createHash("sha256").update(bytes).digest("hex")}` !== activation.skillMdDigest
+    )
+      throw new SkillsError("skill_catalog_unavailable");
+    contents.set(activation.qualifiedId, new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+  }
+  return contents;
+}
+
+export function createIndependentSkillContextV1(
+  context: SkillContextRecordV1,
+  selection: boolean | readonly string[] = true,
+): SkillContextRecordV1 {
+  return createSkillContextV1({
+    userHomeDigest: context.userHomeDigest,
+    revision: context.registry.revision,
+    activeProjectScopes: context.activeProjectScopes,
+    effectiveContextTokens: context.budget.effectiveContextTokens,
+    estimatorVersion: context.budget.estimatorVersion,
+    candidates: context.registry.candidates.filter(
+      (candidate) =>
+        selection === true || (selection !== false && selection.includes(candidate.qualifiedId)),
+    ),
+    diagnostics: context.registry.diagnostics,
+    extensionSources: context.extensionSources,
+    activationCounter: 0,
+    revocations: [],
+  });
+}
+
 export function createEmptySkillContextV1(input: {
   readonly effectiveContextTokens: number;
   readonly estimatorVersion: 1;

--- a/packages/agent/src/tool-runtime.ts
+++ b/packages/agent/src/tool-runtime.ts
@@ -4,7 +4,10 @@ import { constants } from "node:fs";
 import { chmod, type FileHandle, mkdir, mkdtemp, open, realpath, rm } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
-import type { ManagedDelegationEnvelope } from "@adam-agent/presentation";
+import type {
+  ManagedDelegationEnvelope,
+  ManagedDelegationSelection,
+} from "@adam-agent/presentation";
 
 import { z } from "zod";
 
@@ -264,6 +267,10 @@ type PreparedToolCall = {
   readonly status: "ready";
   readonly permissionSubject: PermissionSubject;
   resolvePermissionSubject?(): Promise<PermissionSubject>;
+  refineDelegation?(
+    envelope: ManagedDelegationEnvelope,
+    selection?: ManagedDelegationSelection,
+  ): PermissionSubject;
   readonly changePreview?: { readonly text: string };
   validateBeforeDispatch?(): FailedToolResult | undefined;
   execute(context: ToolExecutionContext): Promise<ToolResult>;
@@ -486,7 +493,7 @@ export type PermissionSubject =
       readonly agentId: string;
       readonly attemptId: string;
       readonly childSessionId: string;
-      readonly profile: "research.v1" | "research.v2";
+      readonly profile: "research.v1" | "research.v2" | "research.v3";
       readonly providerOrigin: string;
       readonly queryOrUrl: string;
       readonly argumentsDigest: `sha256:${string}`;
@@ -523,6 +530,7 @@ export type PermissionPolicyInput = {
 export type PermissionPolicy = {
   /** Serializable read ceiling for delegated work; arbitrary policy functions grant none. */
   readonly delegationReadCeiling?: PermissionDecision;
+  readonly delegationNetworkCeiling?: PermissionDecision;
   decide(input: PermissionPolicyInput): PermissionDecision;
 };
 
@@ -533,6 +541,11 @@ export function createPermissionPolicy(options: {
   const allowedEffects = new Set(options.allowedEffects);
   const askedEffects = new Set(options.askedEffects ?? []);
   return {
+    delegationNetworkCeiling: allowedEffects.has("network")
+      ? "allow"
+      : askedEffects.has("network")
+        ? "ask"
+        : "deny",
     delegationReadCeiling: allowedEffects.has("read")
       ? "allow"
       : askedEffects.has("read")

--- a/packages/agent/src/turn-composer.test.ts
+++ b/packages/agent/src/turn-composer.test.ts
@@ -740,7 +740,7 @@ test("TurnComposer captures and restores one recoverable ordered draft through r
       type: "new_session",
       targetId: "deepseek-v4-flash.direct",
     });
-    expect(draft.schemaVersion).toBe(3);
+    expect(draft.schemaVersion).toBe(4);
     expect(retained).toHaveLength(2);
     const legacyDraft: RecoverableTurnDraftV1 = {
       ...draft,

--- a/packages/agent/src/turn-composer.ts
+++ b/packages/agent/src/turn-composer.ts
@@ -1,5 +1,12 @@
 import { randomUUID } from "node:crypto";
-import { isUnsafePresentationControl, stripTerminalSequences } from "@adam-agent/presentation";
+import { isDeepStrictEqual } from "node:util";
+import type { AtMentionAtom, DraftMentionElement } from "@adam-agent/presentation";
+import {
+  isUnsafePresentationControl,
+  leadingMentionRecipients,
+  stripTerminalSequences,
+} from "@adam-agent/presentation";
+import { draftMentionElementSchema } from "./at-mention.js";
 import type { TurnComposerResourceStager } from "./input-resource-staging.js";
 import {
   type InputResourceOccurrenceV1,
@@ -12,7 +19,11 @@ import {
   pastedTextLimitsV1,
   type StagedPastedTextSelectionV1,
 } from "./pasted-text.js";
-import type { RecoverableTurnDraft, RecoverableTurnDraftV3 } from "./recoverable-turn-draft.js";
+import type {
+  RecoverableTurnDraft,
+  RecoverableTurnDraftV3,
+  RecoverableTurnDraftV4,
+} from "./recoverable-turn-draft.js";
 import type { StagedUserContentElementV1 } from "./structured-user-content.js";
 
 export {
@@ -41,6 +52,7 @@ export type TurnComposerDraftPoint =
   | { readonly elementId: string; readonly offset: number };
 
 export type TurnComposerElementSnapshot =
+  | DraftMentionElement
   | { readonly elementId: string; readonly type: "text"; readonly text: string }
   | {
       readonly elementId: string;
@@ -64,6 +76,7 @@ export type TurnComposerElementSnapshot =
   | { readonly type: "path"; readonly elementId: string; readonly path: string };
 
 export type TurnComposerSealedElement =
+  | (DraftMentionElement & { readonly text: string })
   | { readonly type: "text"; readonly text: string }
   | {
       readonly type: "resource";
@@ -154,6 +167,7 @@ export class TurnComposerError extends Error {
 }
 
 export type TurnComposer = {
+  refreshRoleMention(elementId: string, expectedDigest: string, definitionDigest: string): boolean;
   stage(
     path: string,
     mutation?: { readonly at: TurnComposerDraftPoint; readonly baseRevision: number },
@@ -168,6 +182,7 @@ export type TurnComposer = {
     input: {
       readonly baseRevision: number;
       readonly document: readonly (
+        | DraftMentionElement
         | { readonly type: "text"; readonly text: string }
         | { readonly type: "resource"; readonly elementId: string }
         | { readonly type: "pasted_text"; readonly elementId: string }
@@ -182,13 +197,23 @@ export type TurnComposer = {
     },
     commit?: () => Promise<void>,
   ): Promise<boolean>;
-  captureDraft(scope: RecoverableTurnDraftV3["scope"]): Promise<RecoverableTurnDraftV3>;
+  captureDraft(
+    scope: RecoverableTurnDraftV3["scope"],
+  ): Promise<RecoverableTurnDraftV3 | RecoverableTurnDraftV4>;
   restoreDraft(draft: RecoverableTurnDraft): Promise<void>;
   undo(baseRevision: number, commit?: () => Promise<void>): Promise<boolean>;
   cancel(id: string): Promise<boolean>;
   remove(id: string, commit?: () => Promise<void>): Promise<boolean>;
   removePastedText(id: string, commit?: () => Promise<void>): Promise<boolean>;
   removePath(elementId: string, commit?: () => Promise<void>): Promise<boolean>;
+  removeMention(elementId: string, commit?: () => Promise<void>): Promise<boolean>;
+  resolveRecipient(
+    baseRevision: number,
+    elementId: string,
+    action: "keep" | "literal" | "retarget",
+    commit: () => Promise<void>,
+    replacement?: AtMentionAtom,
+  ): Promise<boolean>;
   removeSkill(elementId: string, commit?: () => Promise<void>): Promise<boolean>;
   setText(text: string): void;
   commitText(text: string, commit: () => Promise<void>): Promise<void>;
@@ -294,11 +319,16 @@ export async function createTurnComposer(options: {
       .map((element) =>
         element.type === "text"
           ? element.text
-          : element.type === "skill"
-            ? `$${element.name}`
-            : element.type === "path"
-              ? `@${element.path}`
-              : atomToken(element.type === "pasted_text" ? "text" : element.kind, element.ordinal),
+          : element.type === "mention"
+            ? element.literal
+            : element.type === "skill"
+              ? `$${element.name}`
+              : element.type === "path"
+                ? `@${element.path}`
+                : atomToken(
+                    element.type === "pasted_text" ? "text" : element.kind,
+                    element.ordinal,
+                  ),
       )
       .join("");
 
@@ -313,11 +343,13 @@ export async function createTurnComposer(options: {
     candidateElements.reduce(
       (total, element) =>
         total +
-        (element.type === "skill"
-          ? Buffer.byteLength(`$${element.name}`, "utf8")
-          : element.type === "path"
-            ? Buffer.byteLength(`@${element.path}`, "utf8")
-            : 0),
+        (element.type === "mention"
+          ? Buffer.byteLength(element.literal, "utf8")
+          : element.type === "skill"
+            ? Buffer.byteLength(`$${element.name}`, "utf8")
+            : element.type === "path"
+              ? Buffer.byteLength(`@${element.path}`, "utf8")
+              : 0),
       0,
     ) +
     [...pastedTexts.values()]
@@ -415,6 +447,39 @@ export async function createTurnComposer(options: {
           );
   };
 
+  // A trailing token stays editable until its boundary arrives. Sealing completes it.
+  const promoteLiteralMentions = (
+    source: readonly TurnComposerElementSnapshot[],
+    complete = false,
+  ): TurnComposerElementSnapshot[] =>
+    source.flatMap((element, index) => {
+      if (element.type !== "text") return [element];
+      const result: TurnComposerElementSnapshot[] = [];
+      let end = 0;
+      for (const match of element.text.matchAll(/(^|\s)(@[^\s\p{Cc}]+)(?=\s|$)/gu)) {
+        const literal = match[2];
+        const start = match.index + (match[1]?.length ?? 0);
+        if (
+          literal === undefined ||
+          (start === 0 && index > 0) ||
+          (!complete && start + literal.length === element.text.length)
+        )
+          continue;
+        if (start > end)
+          result.push({
+            ...element,
+            elementId: end === 0 ? element.elementId : randomUUID(),
+            text: element.text.slice(end, start),
+          });
+        result.push({ type: "mention", kind: "literal", elementId: randomUUID(), literal });
+        end = start + literal.length;
+      }
+      if (end === 0) return [element];
+      if (end < element.text.length)
+        result.push({ type: "text", elementId: randomUUID(), text: element.text.slice(end) });
+      return result;
+    });
+
   const insertAtomicElement = (
     element: Exclude<TurnComposerElementSnapshot, { readonly type: "text" }>,
     mutation: { readonly at: TurnComposerDraftPoint; readonly baseRevision: number } | undefined,
@@ -498,7 +563,7 @@ export async function createTurnComposer(options: {
 
   const removeInlineAtomElement = (
     elementId: string,
-    type: "path" | "skill",
+    type: "path" | "skill" | "mention",
   ):
     | {
         readonly previousElements: readonly TurnComposerElementSnapshot[];
@@ -517,6 +582,34 @@ export async function createTurnComposer(options: {
     ]);
     revision += 1;
     return { previousElements };
+  };
+
+  const removeInline = async (
+    elementId: string,
+    kind: "path" | "skill" | "mention",
+    commit?: () => Promise<void>,
+  ): Promise<boolean> => {
+    if (closed || sealed) return false;
+    const previousElements = elements;
+    const previousText = text;
+    const previousRevision = revision;
+    const previousUndoStack = [...undoStack];
+    const removed = removeInlineAtomElement(elementId, kind);
+    if (removed === undefined) return false;
+    text = literalText();
+    pushUndo({ previousElements: removed.previousElements });
+    try {
+      await commit?.();
+    } catch (error) {
+      elements = previousElements;
+      text = previousText;
+      revision = previousRevision;
+      undoStack.length = 0;
+      undoStack.push(...previousUndoStack);
+      throw error;
+    }
+    publish();
+    return true;
   };
 
   return {
@@ -571,7 +664,7 @@ export async function createTurnComposer(options: {
         }
       }
       return {
-        schemaVersion: 3,
+        schemaVersion: 4,
         scope,
         nextOrdinal,
         elements: elements.map((element) => ({ ...element })),
@@ -695,6 +788,24 @@ export async function createTurnComposer(options: {
       revision += 1;
       publish();
     },
+    refreshRoleMention(elementId, expectedDigest, definitionDigest) {
+      if (sealed || closed) return false;
+      const element = elements.find((entry) => entry.elementId === elementId);
+      if (
+        element?.type !== "mention" ||
+        element.kind !== "role" ||
+        element.definitionDigest !== expectedDigest ||
+        !/^sha256:[a-f0-9]{64}$/u.test(definitionDigest)
+      )
+        return false;
+      pushUndo({ previousElements: [...elements] });
+      elements = elements.map((entry) =>
+        entry === element ? { ...element, definitionDigest } : entry,
+      );
+      revision += 1;
+      publish();
+      return true;
+    },
     async replaceText(input, commit) {
       if (
         closed ||
@@ -747,8 +858,15 @@ export async function createTurnComposer(options: {
             if (atom.type === "path" && (part.type !== "path" || atom.path !== part.path)) {
               return false;
             }
+            if (atom.type === "mention" && !isDeepStrictEqual(atom, part)) return false;
             nextElements.push(atom);
             currentAtomIndex += 1;
+          } else if (
+            part.type === "mention" &&
+            draftMentionElementSchema.safeParse(part).success &&
+            !elements.some((element) => element.elementId === part.elementId)
+          ) {
+            nextElements.push({ ...part });
           } else if (
             part.type === "skill" &&
             isValidSkillIdentity(part.name, part.qualifiedId) &&
@@ -803,8 +921,8 @@ export async function createTurnComposer(options: {
       const previousText = text;
       const previousRevision = revision;
       const previousUndoStack = [...undoStack];
-      elements = nextElements;
-      text = nextText;
+      elements = promoteLiteralMentions(nextElements);
+      text = literalText();
       pushUndo({ previousElements });
       revision += 1;
       try {
@@ -929,45 +1047,48 @@ export async function createTurnComposer(options: {
       publish();
       return true;
     },
-    async removeSkill(elementId, commit) {
-      if (closed || sealed) {
-        return false;
-      }
-      const previousElements = elements;
-      const previousText = text;
-      const previousRevision = revision;
-      const previousUndoStack = [...undoStack];
-      const removed = removeInlineAtomElement(elementId, "skill");
-      if (removed === undefined) {
-        return false;
-      }
-      text = literalText();
-      pushUndo({ previousElements: removed.previousElements });
-      try {
-        await commit?.();
-      } catch (error) {
-        elements = previousElements;
-        text = previousText;
-        revision = previousRevision;
-        undoStack.length = 0;
-        undoStack.push(...previousUndoStack);
-        throw error;
-      }
-      publish();
-      return true;
+    removeSkill(elementId, commit) {
+      return removeInline(elementId, "skill", commit);
     },
-    async removePath(elementId, commit) {
-      if (closed || sealed) return false;
+    removePath(elementId, commit) {
+      return removeInline(elementId, "path", commit);
+    },
+    removeMention(elementId, commit) {
+      return removeInline(elementId, "mention", commit);
+    },
+    async resolveRecipient(baseRevision, elementId, action, commit, replacement) {
+      if (closed || sealed || revision !== baseRevision) return false;
+      const recipients = leadingMentionRecipients(elements);
+      if (!recipients.some((element) => element.elementId === elementId)) return false;
+      if (
+        action === "retarget" &&
+        !draftMentionElementSchema.safeParse({ ...replacement, elementId }).success
+      )
+        return false;
       const previousElements = elements;
       const previousText = text;
       const previousRevision = revision;
       const previousUndoStack = [...undoStack];
-      const removed = removeInlineAtomElement(elementId, "path");
-      if (removed === undefined) return false;
+      const otherIds = new Set(
+        recipients
+          .filter((element) => element.elementId !== elementId)
+          .map((element) => element.elementId),
+      );
+      elements = normalizeTextElements(
+        elements.flatMap((element): TurnComposerElementSnapshot[] => {
+          if (action === "keep" && otherIds.has(element.elementId)) return [];
+          if (action === "literal" && element.type === "mention" && element.elementId === elementId)
+            return [{ type: "mention", kind: "literal", elementId, literal: element.literal }];
+          if (action === "retarget" && element.elementId === elementId && replacement !== undefined)
+            return [{ ...replacement, elementId }];
+          return [element];
+        }),
+      );
       text = literalText();
-      pushUndo({ previousElements: removed.previousElements });
+      pushUndo({ previousElements });
+      revision += 1;
       try {
-        await commit?.();
+        await commit();
       } catch (error) {
         elements = previousElements;
         text = previousText;
@@ -1326,6 +1447,8 @@ export async function createTurnComposer(options: {
       if (closed || sealed) {
         throw new TurnComposerError("failed", "The turn composer cannot be sealed.");
       }
+      elements = promoteLiteralMentions(elements, true);
+      text = literalText();
       sealed = true;
       publish();
       const cancelStaging = (): void => {
@@ -1448,6 +1571,7 @@ export async function createTurnComposer(options: {
               selection: pastedText.staged,
             };
           }
+          if (element.type === "mention") return { ...element, text: element.literal };
           if (element.type === "skill") {
             return { ...element, text: `$${element.name}` };
           }
@@ -1491,6 +1615,7 @@ export async function createTurnComposer(options: {
                 draftOrdinal: element.ordinal,
               };
             }
+            if (element.type === "mention") return { type: "text", text: element.literal };
             if (element.type === "skill") {
               return { type: "text", text: `$${element.name}` };
             }
@@ -1515,11 +1640,13 @@ export async function createTurnComposer(options: {
           .flatMap((element) =>
             element.type === "text"
               ? [element.text]
-              : element.type === "skill"
-                ? [`$${element.name}`]
-                : element.type === "path"
-                  ? [`@${element.path}`]
-                  : [],
+              : element.type === "mention"
+                ? [element.literal]
+                : element.type === "skill"
+                  ? [`$${element.name}`]
+                  : element.type === "path"
+                    ? [`@${element.path}`]
+                    : [],
           )
           .join(""),
         selections: retained.map((resource) => resource.staged as StagedInputResourceSelectionV1),
@@ -1586,6 +1713,7 @@ export async function createTurnComposer(options: {
           if (element.type === "resource") {
             return atomToken(element.kind, element.ordinal);
           }
+          if (element.type === "mention") return element.literal;
           if (element.type === "skill") {
             return `$${element.name}`;
           }
@@ -1623,6 +1751,8 @@ export async function createTurnComposer(options: {
         const previousUndoStack = [...undoStack];
         text = nextText;
         replaceAggregateText(nextText);
+        elements = promoteLiteralMentions(elements);
+        text = literalText();
         undoStack.length = 0;
         revision += 1;
         try {

--- a/packages/agent/src/web-evidence-production.ts
+++ b/packages/agent/src/web-evidence-production.ts
@@ -13,7 +13,7 @@ export async function createWebEvidenceProduction(options: {
   readonly artifactStore: ArtifactStore;
   readonly configuration: WebSearchConfigurationSnapshot;
   readonly http: WebHttpAdapter;
-  readonly searchAvailable?: boolean;
+  readonly searchAvailable?: boolean | (() => Promise<boolean>);
   readonly store: WebEvidenceStore;
 }): Promise<ToolRegistry> {
   const providerConfiguration = options.configuration.provider;
@@ -32,6 +32,19 @@ export async function createWebEvidenceProduction(options: {
       default:
         assertNever(providerConfiguration.kind);
     }
+  }
+  if (searchProvider !== undefined && typeof options.searchAvailable === "function") {
+    const provider = searchProvider;
+    const available = options.searchAvailable;
+    searchProvider = {
+      kind: provider.kind,
+      origin: provider.origin,
+      async search(input) {
+        if (!(await available()))
+          return unavailableSearxngSearchProvider(provider.origin).search(input);
+        return provider.search(input);
+      },
+    };
   }
   return createWebEvidenceToolRegistry({
     artifactStore: options.artifactStore,

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -832,6 +832,9 @@ export type RepositoryInstructionsDisplay = {
 };
 
 export type PendingInteraction = {
+  readonly delegation?: ManagedDelegationEnvelope;
+  readonly delegationCanChangeMode?: boolean;
+  readonly delegationMessages?: readonly ManagedDelegationMessage[];
   readonly type: "permission";
   readonly requestId: string;
   readonly callId: string;
@@ -859,7 +862,40 @@ export type DraftPoint =
   | { readonly elementId: string; readonly edge: "before" | "after" }
   | { readonly elementId: string; readonly offset: number };
 
+export type AtMentionAtom = { readonly type: "mention"; readonly literal: string } & (
+  | { readonly kind: "literal" }
+  | { readonly kind: "path"; readonly path: string }
+  | { readonly kind: "role"; readonly qualifiedRoleId: string; readonly definitionDigest: string }
+  | {
+      readonly kind: "agent";
+      readonly parentSessionId: string;
+      readonly threadId: string;
+      readonly handle: string;
+    }
+  | { readonly kind: "main" }
+);
+
+export type DraftMentionElement = AtMentionAtom & { readonly elementId: string };
+
+export function leadingMentionRecipients(
+  elements: readonly ({ readonly type: string; readonly text?: string } | DraftMentionElement)[],
+): readonly DraftMentionElement[] {
+  const recipients: DraftMentionElement[] = [];
+  for (const element of elements) {
+    if (element.type === "text" && "text" in element && element.text?.trim().length === 0) continue;
+    if (
+      element.type !== "mention" ||
+      !("kind" in element) ||
+      !["role", "agent", "main"].includes(element.kind)
+    )
+      break;
+    recipients.push(element);
+  }
+  return recipients;
+}
+
 export type DraftTextDocumentPart =
+  | DraftMentionElement
   | { readonly type: "text"; readonly text: string }
   | { readonly type: "resource"; readonly elementId: string }
   | { readonly type: "pasted_text"; readonly elementId: string }
@@ -875,6 +911,7 @@ export type TurnComposerDisplay = {
   readonly attachmentAvailable: boolean;
   readonly draftRevision: number;
   readonly elements: readonly (
+    | DraftMentionElement
     | { readonly elementId: string; readonly type: "text"; readonly text: string }
     | {
         readonly elementId: string;
@@ -1158,7 +1195,79 @@ export function isAgentUiSettings(value: unknown): value is AgentUiSettings {
   );
 }
 
+export type AgentRoleTypeDisplay = {
+  readonly qualifiedId: string;
+  readonly name: string;
+  readonly description: string;
+  readonly definitionDigest: string;
+  readonly base: "explore" | "research";
+  readonly tools: readonly string[];
+  readonly web: boolean;
+  readonly source?:
+    | { readonly kind: "builtin" | "project" | "user"; readonly path?: string | undefined }
+    | undefined;
+  readonly instructions?: string | undefined;
+  readonly model?: string | undefined;
+  readonly thinking?: string | undefined;
+  readonly skills?: boolean | string[] | undefined;
+  readonly contextMode?: "task" | "current_request" | undefined;
+  readonly limits?:
+    | { readonly maxTokens?: number | undefined; readonly maxTurns?: number | undefined }
+    | undefined;
+};
+export type AgentRoleDefinitionInput = {
+  name: string;
+  description: string;
+  base: "explore" | "research";
+  tools?: string[];
+  skills?: boolean | string[];
+  web?: boolean;
+  context_mode?: "task" | "current_request";
+  model?: string;
+  thinking?: string;
+  limits?: { maxTokens?: number | undefined; maxTurns?: number | undefined };
+  overrides?: string;
+};
+export type AgentRoleMutation =
+  | {
+      readonly action: "create";
+      readonly source: "project" | "user";
+      readonly fields: AgentRoleDefinitionInput;
+      readonly instructions: string;
+      readonly original?: { readonly qualifiedId: string; readonly definitionDigest: string };
+    }
+  | {
+      readonly action: "toggle";
+      readonly qualifiedId: string;
+      readonly definitionDigest: string;
+      readonly enabled: boolean;
+    };
+export type AgentTypesDisplay = {
+  readonly sources: readonly {
+    readonly kind: "project" | "user";
+    readonly path: string;
+    readonly writable: boolean;
+  }[];
+  readonly definitions: readonly (AgentRoleTypeDisplay & {
+    readonly enabled: boolean;
+    readonly available: boolean;
+  })[];
+  readonly diagnostics: readonly { readonly source: string; readonly message: string }[];
+  readonly targets: readonly {
+    readonly targetId: string;
+    readonly label: string;
+    readonly thinkingLevels?: readonly { readonly id: string; readonly label: string }[];
+  }[];
+};
+
 export type PresentationDisplayState = {
+  readonly agentTypes?: AgentTypesDisplay;
+  readonly agentRoles?: readonly {
+    readonly qualifiedId: string;
+    readonly name: string;
+    readonly description: string;
+    readonly definitionDigest: string;
+  }[];
   readonly agentUiSettings?: AgentUiSettings;
   readonly managedAttention?: readonly ManagedAttentionItem[];
   readonly managedDrafts?: readonly Pick<
@@ -1217,6 +1326,23 @@ export type CommandReceipt =
       readonly commandId: string;
       readonly resource: ArtifactChunk | null;
       readonly draftText?: string;
+      readonly roleTarget?: {
+        readonly qualifiedId: string;
+        readonly definitionDigest: string;
+        readonly source: string;
+        readonly message: string;
+        readonly targets: readonly { readonly targetId: string; readonly label: string }[];
+      };
+      readonly delegation?: {
+        readonly messages: readonly ManagedDelegationMessage[];
+        readonly envelope: ManagedDelegationEnvelope;
+        readonly description: string;
+      };
+      readonly agentInput?: {
+        readonly input: Omit<ManagedComposerDraft, "mode">;
+        readonly actions: readonly ManagedComposerDraft["mode"][];
+        readonly envelope?: ManagedDelegationEnvelope;
+      };
       readonly todo?: TodoPageResource | TodoEntityResource;
       readonly managedAgentTranscript?: ManagedAgentTranscriptPageResource;
       readonly managedDraft?: ManagedComposerDraft | null;
@@ -1311,6 +1437,37 @@ export type ManagedAgentTranscriptPageResource = {
 };
 
 export type PresentationCommand =
+  | {
+      readonly type: "direct_agent_input";
+      readonly draftRevision: number;
+      readonly confirmedInput?: ManagedComposerDraft;
+      readonly confirmedEnvelope?: ManagedDelegationEnvelope;
+    }
+  | { readonly type: "refresh_agent_types"; readonly sessionId: string }
+  | {
+      readonly type: "mutate_agent_types";
+      readonly sessionId: string;
+      readonly confirmed: true;
+      readonly mutation: AgentRoleMutation;
+    }
+  | {
+      readonly type: "configure_role_target";
+      readonly qualifiedId: string;
+      readonly definitionDigest: string;
+      readonly model: string | null;
+      readonly draftRevision: number;
+      readonly confirmed: true;
+    }
+  | {
+      readonly type: "direct_delegation";
+      readonly description?: string;
+      readonly limits?: ManagedDelegationLimits;
+      readonly skills?: readonly string[];
+      readonly context?: ManagedDelegationContext;
+      readonly draftRevision: number;
+      readonly thinkingSelection?: ThinkingPolicySelectionDisplay | null;
+      readonly confirmedEnvelope?: ManagedDelegationEnvelope;
+    }
   | {
       readonly type: "export_agent";
       readonly confirmed: true;
@@ -1627,6 +1784,13 @@ export type PresentationCommand =
       readonly elementId: string;
     }
   | {
+      readonly type: "resolve_draft_recipient";
+      readonly baseRevision: number;
+      readonly elementId: string;
+      readonly action: "keep" | "literal" | "retarget";
+      readonly replacement?: AtMentionAtom;
+    }
+  | {
       readonly type: "undo_draft";
       readonly baseRevision: number;
     }
@@ -1672,6 +1836,14 @@ export type PresentationCommand =
       readonly type: "decide_permission";
       readonly requestId: string;
       readonly decision: "allow" | "deny";
+      readonly delegation?: ManagedDelegationEnvelope;
+      readonly delegationSelection?: ManagedDelegationSelection;
+    }
+  | {
+      readonly type: "preview_permission_delegation";
+      readonly requestId: string;
+      readonly limits: ManagedDelegationLimits;
+      readonly selection?: ManagedDelegationSelection;
     }
   | ({
       readonly type: "branch_session";
@@ -1844,9 +2016,10 @@ export type ManagedControlThread = {
   readonly lifecycle: "open" | "closed";
   readonly displayName: string;
   readonly handle: string;
+  readonly alias?: string;
   readonly residency: "live" | "unloaded";
   readonly threadId: string;
-  readonly role: "builtin:explore";
+  readonly role: string;
   readonly description: string;
   readonly turn: {
     readonly startedAtUnixMilliseconds?: number;
@@ -1953,6 +2126,27 @@ export type ManagedFleetPolicy = {
   readonly sessionTokens: number;
   readonly storageBytes: number;
 };
+export type ManagedDelegationMessage = ManagedControlLink & {
+  readonly role: "user" | "assistant";
+  readonly text: string;
+};
+export type ManagedDelegationContext =
+  | { readonly mode: "task" }
+  | { readonly mode: "current_request" }
+  | { readonly mode: "selected_messages"; readonly messages: readonly ManagedControlLink[] };
+
+export type ManagedDelegationSelection = {
+  readonly context?: ManagedDelegationContext;
+  readonly skills?: readonly string[];
+};
+
+export type ManagedDelegationLimits = Partial<
+  Pick<
+    ManagedDelegationEnvelope,
+    "mode" | "running" | "queued" | "aggregateTokens" | "threadTokens" | "sessionTokens"
+  >
+>;
+
 export type ManagedDelegationEnvelope = {
   readonly version: 1;
   readonly id: string;
@@ -1962,7 +2156,7 @@ export type ManagedDelegationEnvelope = {
     readonly id: string;
     readonly callId?: string | undefined;
   };
-  readonly roles: readonly ["builtin:explore"];
+  readonly roles: readonly string[];
   readonly mode: "background" | "foreground";
   readonly threads: number;
   readonly running: number;
@@ -1970,7 +2164,7 @@ export type ManagedDelegationEnvelope = {
   readonly aggregateTokens: number;
   readonly threadTokens: number;
   readonly sessionTokens: number;
-  readonly context: "current_request";
+  readonly context: "task" | "current_request" | "selected_messages";
   readonly skills: readonly string[];
   readonly policy: ManagedFleetPolicy;
   readonly policyDigest: `sha256:${string}`;
@@ -2035,6 +2229,7 @@ export type ManagedControlCommand =
     }
   | {
       readonly type: "list_agents";
+      readonly view?: "threads" | "roles" | "context";
       readonly parentSessionId: string;
       readonly limit?: number;
       readonly cursor?: string;
@@ -2064,7 +2259,11 @@ export type ManagedControlCommand =
         readonly callId?: string;
       };
       readonly entries: readonly {
-        readonly role: "builtin:explore";
+        readonly role: string;
+        readonly alias?: string;
+        readonly context?: ManagedDelegationContext;
+        readonly skills?: readonly string[];
+        readonly artifacts?: readonly string[];
         readonly task: string;
         readonly description: string;
       }[];
@@ -2087,7 +2286,7 @@ export type ManagedControlCommand =
   | {
       readonly type: "start_thread";
       readonly parentSessionId: string;
-      readonly role: "builtin:explore";
+      readonly role: string;
       readonly task: string;
       readonly description: string;
     }
@@ -2110,6 +2309,18 @@ export type ManagedControlCommand =
   | { readonly type: "close"; readonly parentSessionId: string; readonly reason?: "exit" };
 
 export type ManagedControlReceipt =
+  | {
+      readonly status: "context_listed";
+      readonly messages: readonly ManagedDelegationMessage[];
+      readonly cursor?: string;
+      readonly revision: string;
+    }
+  | {
+      readonly status: "roles_listed";
+      readonly roles: readonly Omit<AgentRoleTypeDisplay, "instructions">[];
+      readonly cursor?: string;
+      readonly revision: string;
+    }
   | { readonly status: "suspended" }
   | { readonly status: "resumed"; readonly results: readonly ManagedControlReceipt[] }
   | { readonly status: "input_accepted"; readonly inputId: string; readonly turnId: string }


### PR DESCRIPTION
Managed delegation now supports frozen Explore/Research roles, trusted custom definitions, and direct role or exact-thread input through the candidate TUI composition. A confirmed direct request creates its parent Session and child without a hidden Main provider turn.

- Share one editable permission envelope across direct and model delegation, including context, optional Skill activation, bounded numeric grants and complete grant identities.
- Preserve semantic mention identities through editing and recovery; reject stale or multiple recipients and retain drafts on failed admission.
- Give each child independent frozen Skills, explicitly selected immutable attachments and permitted Web access. Preserve these across continuation and recovery while enforcing current authority and cumulative quotas.
- Keep the default product execution path and public extension contracts unchanged.

Validation: independent specification and standards reviews finished with no remaining findings. Full Linux `pnpm quality:check` passed (105 test files; 2,062 tests passed and 18 existing opt-in skips). Caller-visible coverage includes direct input, exact attachment selection, three-turn attachment recovery, Skills/Web, custom target recovery and editable grants. The real candidate PTY/JSONL spine verifies Enter delivery, layered Escape, Main responsiveness and settled continuation. Live Control projection remains synchronous after initial role discovery so acceptance/export acknowledgments expose the matching authoritative state.
