### PR TITLE
fix: enforce repository search bounds and discovery rules

### DIFF
--- a/apps/tui/src/search-failure.os.test.ts
+++ b/apps/tui/src/search-failure.os.test.ts
@@ -22,183 +22,213 @@ import { expect, test } from "vitest";
 import { runTui } from "./tui-app.js";
 import { VirtualTerminal } from "./virtual-terminal.test-support.js";
 
-test("production TUI handles a wide search failure and durably accepts the next Main prompt", async () => {
-  const root = await mkdtemp(join(tmpdir(), "adam-search-tui-feedback-"));
-  const workspaceRoot = join(root, "workspace");
-  const stateRoot = join(root, "state");
-  await mkdir(workspaceRoot);
-  await Promise.all(
-    Array.from({ length: 300 }, (_, index) =>
-      writeFile(
-        join(workspaceRoot, `file-${String(index).padStart(3, "0")}.ts`),
-        `export const extension${index} = true;\n`,
+test.each(["bounded results", "invalid cursor"] as const)(
+  "production TUI handles %s and durably accepts the next Main prompt",
+  async (scenario) => {
+    const invalidCursor = scenario === "invalid cursor";
+    const firstAnswer = invalidCursor ? "Search failure handled." : "Search results handled.";
+    const root = await mkdtemp(join(tmpdir(), "adam-search-tui-feedback-"));
+    const workspaceRoot = join(root, "workspace");
+    const stateRoot = join(root, "state");
+    await mkdir(workspaceRoot);
+    await Promise.all(
+      Array.from({ length: 300 }, (_, index) =>
+        writeFile(
+          join(workspaceRoot, `file-${String(index).padStart(3, "0")}.ts`),
+          `export const extension${index} = true;\n`,
+        ),
       ),
-    ),
-  );
-  const identity: ModelTargetIdentity = {
-    targetId: "deepseek-v4-flash.direct",
-    vendor: "deepseek",
-    modelId: "deepseek-v4-flash",
-    route: "direct",
-    profileVersion: 2,
-    certification: "certified",
-  };
-  const releaseAnswer = Promise.withResolvers<void>();
-  let feedback: ToolResult | undefined;
-  const modelTargets: ModelTargets = {
-    async resolve() {
-      return {
-        identity,
-        contextProfile: preparedDirectDeepSeekV2ContextProfile,
-        driver: {
-          async *stream(request) {
-            const last = request.messages.at(-1);
-            if (last?.role === "user" && last.content === "Find all extensions.") {
-              yield { type: "tool_call_start", id: "wide-search", name: "search_repository" };
-              yield {
-                type: "tool_call_delta",
-                id: "wide-search",
-                json: '{"kind":"content","query":"extension","mode":"literal","case":"insensitive","include":["*.ts"],"limit":50}',
-              };
-              yield { type: "tool_call_end", id: "wide-search" };
+    );
+    const identity: ModelTargetIdentity = {
+      targetId: "deepseek-v4-flash.direct",
+      vendor: "deepseek",
+      modelId: "deepseek-v4-flash",
+      route: "direct",
+      profileVersion: 2,
+      certification: "certified",
+    };
+    const releaseAnswer = Promise.withResolvers<void>();
+    let feedback: ToolResult | undefined;
+    const modelTargets: ModelTargets = {
+      async resolve() {
+        return {
+          identity,
+          contextProfile: preparedDirectDeepSeekV2ContextProfile,
+          driver: {
+            async *stream(request) {
+              const last = request.messages.at(-1);
+              if (last?.role === "user" && last.content === "Find all extensions.") {
+                yield { type: "tool_call_start", id: "wide-search", name: "search_repository" };
+                yield {
+                  type: "tool_call_delta",
+                  id: "wide-search",
+                  json: JSON.stringify({
+                    kind: "content",
+                    query: "extension",
+                    mode: "literal",
+                    case: "insensitive",
+                    include: ["*.ts"],
+                    limit: 50,
+                    ...(invalidCursor ? { cursor: "not-a-cursor" } : {}),
+                  }),
+                };
+                yield { type: "tool_call_end", id: "wide-search" };
+                yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+                yield { type: "finish", reason: "tool_calls" };
+                return;
+              }
+              if (last?.role === "tool") {
+                feedback = last.result;
+                await releaseAnswer.promise;
+                yield { type: "text_delta", text: firstAnswer };
+              } else {
+                yield { type: "text_delta", text: "Next Main prompt completed." };
+              }
               yield { type: "usage", inputTokens: 100, outputTokens: 20 };
-              yield { type: "finish", reason: "tool_calls" };
-              return;
-            }
-            if (last?.role === "tool") {
-              feedback = last.result;
-              await releaseAnswer.promise;
-              yield { type: "text_delta", text: "Search failure handled." };
-            } else {
-              yield { type: "text_delta", text: "Next Main prompt completed." };
-            }
-            yield { type: "usage", inputTokens: 100, outputTokens: 20 };
-            yield { type: "finish", reason: "stop" };
+              yield { type: "finish", reason: "stop" };
+            },
           },
-        },
-      };
-    },
-    async snapshot() {
-      return {
-        targets: [
-          {
-            identity,
-            contextProfile: preparedDirectDeepSeekV2ContextProfile,
-            readiness: { status: "available", credentialSource: "test" },
-          },
-        ],
-      };
-    },
-  };
-  const lifecycle = createSessionLifecycle({
-    workspaceRoot,
-    stateRoot,
-    modelTargets,
-    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
-    workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
-    [sessionAutomaticTitlesEnabled]: false,
-  });
-  const terminal = new VirtualTerminal();
-  let running: Promise<void> | undefined;
-  try {
-    const created = await lifecycle.create({ targetIdentity: identity });
-    const presentation = await createPresentationSession({
-      lifecycle,
+        };
+      },
+      async snapshot() {
+        return {
+          targets: [
+            {
+              identity,
+              contextProfile: preparedDirectDeepSeekV2ContextProfile,
+              readiness: { status: "available", credentialSource: "test" },
+            },
+          ],
+        };
+      },
+    };
+    const lifecycle = createSessionLifecycle({
+      workspaceRoot,
+      stateRoot,
       modelTargets,
-      workspaceRoot,
-      stateRoot,
-      sessionId: created.sessionId,
-      projectLabel: "workspace",
+      permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+      workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
+      [sessionAutomaticTitlesEnabled]: false,
     });
-    running = runTui({
-      terminal,
-      presentation,
-      closeRuntime: async () => {
-        await presentation.close();
-        await lifecycle.close();
-      },
-    });
-    await terminal.waitForFrameAfter(" · idle", 0);
-    expect(presentation.getState().authoritative.active?.parentRun).toEqual({
-      phase: "ready",
-      editor: "ready",
-    });
-    const beforeDraft = terminal.output().length;
-    terminal.input("Find all extensions.");
-    await terminal.waitForFrameAfter("Find all extensions.", beforeDraft);
-    const beforeSearch = terminal.output().length;
-    terminal.input("\r");
-    await terminal.waitForFrameAfter("search_quota_exceeded", beforeSearch);
-    expect(terminal.lines().join("\n")).toContain("search_quota_exceeded");
-    expect(terminal.lines().join("\n")).not.toContain("Interrupted session");
-    releaseAnswer.resolve();
-    await terminal.waitForFrameAfter("Search failure handled.", beforeSearch);
-    await terminal.waitForScreen(" · idle");
-    expect(feedback).toMatchObject({
-      status: "failed",
-      error: {
-        code: "search_quota_exceeded",
-        message: "The repository search page metadata exceeded its UTF-8 byte limit.",
-      },
-    });
-    expect(presentation.getState().authoritative.active?.parentRun).toEqual({
-      phase: "ready",
-      editor: "ready",
-    });
+    const terminal = new VirtualTerminal();
+    let running: Promise<void> | undefined;
+    try {
+      const created = await lifecycle.create({ targetIdentity: identity });
+      const presentation = await createPresentationSession({
+        lifecycle,
+        modelTargets,
+        workspaceRoot,
+        stateRoot,
+        sessionId: created.sessionId,
+        projectLabel: "workspace",
+      });
+      running = runTui({
+        terminal,
+        presentation,
+        closeRuntime: async () => {
+          await presentation.close();
+          await lifecycle.close();
+        },
+      });
+      await terminal.waitForFrameAfter(" · idle", 0);
+      expect(presentation.getState().authoritative.active?.parentRun).toEqual({
+        phase: "ready",
+        editor: "ready",
+      });
+      const beforeDraft = terminal.output().length;
+      terminal.input("Find all extensions.");
+      await terminal.waitForFrameAfter("Find all extensions.", beforeDraft);
+      const beforeSearch = terminal.output().length;
+      terminal.input("\r");
+      const toolSummary = invalidCursor ? "search_cursor_invalid" : "50 results";
+      await terminal.waitForFrameAfter(toolSummary, beforeSearch);
+      expect(terminal.lines().join("\n")).toContain(toolSummary);
+      expect(terminal.lines().join("\n")).not.toContain("Interrupted session");
+      releaseAnswer.resolve();
+      await terminal.waitForFrameAfter(firstAnswer, beforeSearch);
+      await terminal.waitForScreen(" · idle");
+      expect(feedback).toMatchObject(
+        invalidCursor
+          ? {
+              status: "failed",
+              error: {
+                code: "search_cursor_invalid",
+                message: "The repository search cursor is malformed.",
+              },
+            }
+          : {
+              status: "completed",
+              output: { resultCount: 50, snapshotResultCount: 300, remainingResultCount: 250 },
+            },
+      );
+      if (feedback?.status === "completed") {
+        expect(Buffer.byteLength(JSON.stringify(feedback.output), "utf8")).toBeLessThanOrEqual(
+          16 * 1024,
+        );
+      }
+      expect(presentation.getState().authoritative.active?.parentRun).toEqual({
+        phase: "ready",
+        editor: "ready",
+      });
 
-    const store = await openJsonlSessionStore<SessionRecord>({
-      workspaceRoot,
-      stateRoot,
-      sessionId: created.sessionId,
-    });
-    const firstRun = await store.read();
-    expect(firstRun).toContainEqual(
-      expect.objectContaining({
-        record: expect.objectContaining({
-          type: "runtime_event",
-          event: expect.objectContaining({
-            type: "tool_failed",
-            callId: "wide-search",
-            error: expect.objectContaining({ code: "search_quota_exceeded" }),
+      const store = await openJsonlSessionStore<SessionRecord>({
+        workspaceRoot,
+        stateRoot,
+        sessionId: created.sessionId,
+      });
+      const firstRun = await store.read();
+      expect(firstRun).toContainEqual(
+        expect.objectContaining({
+          record: expect.objectContaining({
+            type: "runtime_event",
+            event: expect.objectContaining({
+              type: invalidCursor ? "tool_failed" : "tool_completed",
+              callId: "wide-search",
+              ...(invalidCursor
+                ? { error: expect.objectContaining({ code: "search_cursor_invalid" }) }
+                : {
+                    output: expect.objectContaining({ resultCount: 50, snapshotResultCount: 300 }),
+                  }),
+            }),
           }),
         }),
-      }),
-    );
-    const beforeNextDraft = terminal.output().length;
-    terminal.input("Continue Main after search.");
-    await terminal.waitForFrameAfter("Continue Main after search.", beforeNextDraft);
-    const beforeNextPrompt = terminal.output().length;
-    terminal.input("\r");
-    await terminal.waitForFrameAfter("Next Main prompt completed.", beforeNextPrompt);
-    await terminal.waitForScreen(" · idle");
-    const nextRun = (await store.read()).slice(firstRun.length);
-    expect(nextRun).toContainEqual(
-      expect.objectContaining({
-        record: expect.objectContaining({
-          type: "runtime_event",
-          event: { type: "user_message", text: "Continue Main after search." },
+      );
+      const beforeNextDraft = terminal.output().length;
+      terminal.input("Continue Main after search.");
+      await terminal.waitForFrameAfter("Continue Main after search.", beforeNextDraft);
+      const beforeNextPrompt = terminal.output().length;
+      terminal.input("\r");
+      await terminal.waitForFrameAfter("Next Main prompt completed.", beforeNextPrompt);
+      await terminal.waitForScreen(" · idle");
+      const nextRun = (await store.read()).slice(firstRun.length);
+      expect(nextRun).toContainEqual(
+        expect.objectContaining({
+          record: expect.objectContaining({
+            type: "runtime_event",
+            event: { type: "user_message", text: "Continue Main after search." },
+          }),
         }),
-      }),
-    );
-    expect(nextRun).toContainEqual(
-      expect.objectContaining({
-        record: expect.objectContaining({
-          type: "runtime_event",
-          event: {
-            type: "session_settled",
-            result: { status: "completed", answer: "Next Main prompt completed." },
-          },
+      );
+      expect(nextRun).toContainEqual(
+        expect.objectContaining({
+          record: expect.objectContaining({
+            type: "runtime_event",
+            event: {
+              type: "session_settled",
+              result: { status: "completed", answer: "Next Main prompt completed." },
+            },
+          }),
         }),
-      }),
-    );
-    await expect(lifecycle.inspect({ sessionId: created.sessionId })).resolves.toMatchObject({
-      status: "settled",
-    });
-  } finally {
-    releaseAnswer.resolve();
-    if (terminal.running()) terminal.input("\u0011");
-    await running;
-    await lifecycle.close();
-    await rm(root, { recursive: true, force: true });
-  }
-});
+      );
+      await expect(lifecycle.inspect({ sessionId: created.sessionId })).resolves.toMatchObject({
+        status: "settled",
+      });
+    } finally {
+      releaseAnswer.resolve();
+      if (terminal.running()) terminal.input("\u0011");
+      await running;
+      await lifecycle.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/packages/agent/src/repository-search.ts
+++ b/packages/agent/src/repository-search.ts
@@ -2,7 +2,7 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { constants, lstatSync, realpathSync } from "node:fs";
 import { lstat, open } from "node:fs/promises";
-import { isAbsolute, relative, resolve, sep } from "node:path";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 
 import { rgPath } from "@vscode/ripgrep";
@@ -57,14 +57,20 @@ const searchRepositoryInputSchema = z.discriminatedUnion("kind", [
   }),
 ]);
 
+const snippetSchema = z
+  .string()
+  .refine(
+    (value) => value.isWellFormed() && Array.from(value).length <= maximumSnippetCharacters,
+    "Search snippets must contain at most 500 complete Unicode characters.",
+  );
 const contextLineSchema = z.strictObject({
   line: z.number().int().positive(),
-  snippet: z.string().max(maximumSnippetCharacters),
+  snippet: snippetSchema,
 });
 const contentMatchSchema = z.strictObject({
   line: z.number().int().positive(),
   column: z.number().int().positive(),
-  snippet: z.string().max(maximumSnippetCharacters),
+  snippet: snippetSchema,
   rankReason: z.enum(["literal", "regex"]),
   contextBefore: z.array(contextLineSchema).max(3),
   contextAfter: z.array(contextLineSchema).max(3),
@@ -302,11 +308,21 @@ class SearchSnapshotRegistry {
     readonly limit: number;
   }) {
     const boundedMatches = input.matches.slice(0, maximumSnapshotResults);
+    const identity: ContentPageIdentity = {
+      id: randomUUID(),
+      query: input.query,
+      path: input.path,
+      mode: input.mode,
+      case: input.case,
+      context: input.context,
+      resultCount: boundedMatches.length,
+    };
     const pages = createContentPages(
       boundedMatches,
       input.limit,
       input.matches.length,
       input.omissions,
+      identity,
     );
     const byteCount = Buffer.byteLength(JSON.stringify(pages), "utf8");
     if (byteCount > maximumSnapshotBytes) {
@@ -318,7 +334,7 @@ class SearchSnapshotRegistry {
     const now = Date.now();
     this.#pruneExpired(now);
     const snapshot: SearchSnapshot = {
-      id: randomUUID(),
+      id: identity.id,
       sessionId: input.sessionId,
       toolProfileDigest: input.toolProfileDigest,
       requestKey: input.requestKey,
@@ -349,11 +365,19 @@ class SearchSnapshotRegistry {
     readonly limit: number;
   }) {
     const boundedEntries = input.entries.slice(0, maximumSnapshotResults);
+    const identity: PathPageIdentity = {
+      id: randomUUID(),
+      query: input.query,
+      path: input.path,
+      mode: input.mode,
+      resultCount: boundedEntries.length,
+    };
     const pages = createPathPages(
       boundedEntries,
       input.limit,
       input.entries.length,
       input.omissions,
+      identity,
     );
     const byteCount = Buffer.byteLength(JSON.stringify(pages), "utf8");
     if (byteCount > maximumSnapshotBytes) {
@@ -365,7 +389,7 @@ class SearchSnapshotRegistry {
     const now = Date.now();
     this.#pruneExpired(now);
     const snapshot: PathSearchSnapshot = {
-      id: randomUUID(),
+      id: identity.id,
       sessionId: input.sessionId,
       toolProfileDigest: input.toolProfileDigest,
       requestKey: input.requestKey,
@@ -426,64 +450,37 @@ class SearchSnapshotRegistry {
   }
 
   #output(snapshot: SearchSnapshot, pageIndex: number) {
-    const nextPageIndex = pageIndex + 1;
+    const hasNext = pageIndex + 1 < snapshot.pages.length;
     if (snapshot.kind === "path") {
       const page = snapshot.pages[pageIndex] ?? { entries: [], omissions: [] };
       const consumed = snapshot.pages
-        .slice(0, nextPageIndex)
+        .slice(0, pageIndex + 1)
         .reduce((total, candidate) => total + candidate.entries.length, 0);
-      return {
-        schemaVersion: 1 as const,
-        policyVersion: searchPolicyVersion,
-        kind: "path" as const,
-        mode: snapshot.mode,
-        query: snapshot.query,
-        path: snapshot.path,
-        resultCount: page.entries.length,
-        snapshotResultCount: snapshot.resultCount,
-        pageIndex,
-        remainingResultCount: snapshot.resultCount - consumed,
-        ...(nextPageIndex < snapshot.pages.length
-          ? { nextCursor: encodeCursor(snapshot.id, nextPageIndex) }
-          : {}),
-        currentContentMustBeReread: true as const,
-        entries: page.entries,
-        omissions: page.omissions,
-      };
+      return validateSearchOutput(
+        pathPageOutput(snapshot, page, pageIndex, snapshot.resultCount - consumed, hasNext),
+      );
     }
     const page = snapshot.pages[pageIndex] ?? { matches: [], omissions: [] };
     const consumed = snapshot.pages
-      .slice(0, nextPageIndex)
+      .slice(0, pageIndex + 1)
       .reduce((total, candidate) => total + candidate.matches.length, 0);
-    const groups = new Map<string, ContentMatch[]>();
-    for (const { path, ...match } of page.matches) {
-      const grouped = groups.get(path) ?? [];
-      grouped.push(match);
-      groups.set(path, grouped);
-    }
-    return {
-      schemaVersion: 1 as const,
-      policyVersion: searchPolicyVersion,
-      kind: "content" as const,
-      mode: snapshot.mode,
-      case: snapshot.case,
-      context: snapshot.context,
-      query: snapshot.query,
-      path: snapshot.path,
-      resultCount: page.matches.length,
-      snapshotResultCount: snapshot.resultCount,
-      pageIndex,
-      remainingResultCount: snapshot.resultCount - consumed,
-      ...(nextPageIndex < snapshot.pages.length
-        ? { nextCursor: encodeCursor(snapshot.id, nextPageIndex) }
-        : {}),
-      currentContentMustBeReread: true as const,
-      groups: [...groups].map(([path, matches]) => ({ path, matches })),
-      omissions: page.omissions,
-    };
+    return validateSearchOutput(
+      contentPageOutput(snapshot, page, pageIndex, snapshot.resultCount - consumed, hasNext),
+    );
   }
 
   #admit(snapshot: SearchSnapshot) {
+    for (let pageIndex = 0; pageIndex < snapshot.pages.length; pageIndex += 1) {
+      if (
+        Buffer.byteLength(JSON.stringify(this.#output(snapshot, pageIndex)), "utf8") >
+        maximumPageBytes
+      ) {
+        throw new SearchCursorError(
+          "search_quota_exceeded",
+          "The repository search page metadata exceeded its UTF-8 byte limit.",
+        );
+      }
+    }
     while (
       this.#snapshots.size >= maximumSnapshots ||
       this.#aggregateBytes + snapshot.byteCount > maximumAggregateSnapshotBytes
@@ -497,17 +494,6 @@ class SearchSnapshotRegistry {
         "search_quota_exceeded",
         "The repository search snapshot registry is full.",
       );
-    }
-    for (let pageIndex = 0; pageIndex < snapshot.pages.length; pageIndex += 1) {
-      if (
-        Buffer.byteLength(JSON.stringify(this.#output(snapshot, pageIndex)), "utf8") >
-        maximumPageBytes
-      ) {
-        throw new SearchCursorError(
-          "search_quota_exceeded",
-          "The repository search page metadata exceeded its UTF-8 byte limit.",
-        );
-      }
     }
     this.#snapshots.set(snapshot.id, snapshot);
     this.#aggregateBytes += snapshot.byteCount;
@@ -763,6 +749,7 @@ export type RepositorySearchProcessObserver = {
   recorded?(): void;
   signalled?(signal: NodeJS.Signals): void;
   closed(): void;
+  gitClosed?(): void;
 };
 
 export type RepositorySearchBackend = {
@@ -793,7 +780,13 @@ function createProcessRepositorySearchBackend(options: {
 }): RepositorySearchBackend {
   return {
     readChangedPaths(input) {
-      return readGitChangedPaths(input.workspaceRoot, input.path, input.signal, input.budget);
+      return readGitChangedPaths(
+        input.workspaceRoot,
+        input.path,
+        input.signal,
+        input.budget,
+        options.processObserver,
+      );
     },
     runRecords(input) {
       return runRipgrepRecords({
@@ -868,12 +861,10 @@ async function runContentSearch(options: {
         : ["--ignore-case"]),
     "--color",
     "never",
-    ...options.include.flatMap((glob) => ["--glob", glob]),
     ...options.exclude.flatMap((glob) => ["--glob", `!${glob}`]),
     ...(options.context === 0 ? [] : ["--context", String(options.context)]),
     "--",
     options.query,
-    options.path,
   ];
   const changedPaths = await options.backend.readChangedPaths({
     workspaceRoot: options.workspaceRoot,
@@ -882,21 +873,60 @@ async function runContentSearch(options: {
     budget: options.budget,
   });
   try {
+    const discovery =
+      options.include.length > 0 || options.path !== "."
+        ? await discoverSearchPaths({
+            ...options,
+            positiveGlobs: options.include,
+            negativeGlobs: options.exclude.map((glob) => `!${glob}`),
+          })
+        : undefined;
+    const preflight =
+      discovery === undefined
+        ? undefined
+        : await probeCandidatePaths(
+            options.workspaceRoot,
+            discovery.paths,
+            options.budget,
+            options.probeFileSystem,
+            options.signal,
+            discovery.identities,
+          );
+    const admission =
+      discovery === undefined || preflight === undefined
+        ? undefined
+        : {
+            paths: new Set(preflight.paths),
+            identities: discovery.identities,
+          };
     const collector = new ContentMatchCollector(
       options.mode,
       options.context,
       changedPaths,
       options.budget,
       options.workspaceRoot,
+      admission,
     );
-    await options.backend.runRecords({
-      args,
-      workspaceRoot: options.workspaceRoot,
-      signal: options.signal,
-      separator: "\n",
-      accept: (record) => collector.accept(record),
-      budget: options.budget,
-    });
+    const batches =
+      preflight === undefined ? [[options.path]] : searchPathArgumentBatches(preflight.paths);
+    for (const batch of batches.length === 0 ? [[]] : batches) {
+      options.signal.throwIfAborted();
+      await options.backend.runRecords({
+        // Empty stdin still lets the native backend validate a regex when
+        // discovery admitted no files, without scanning excluded paths.
+        args: [
+          ...args,
+          ...(batch.length === 0
+            ? ["-"]
+            : batch.map((path) => (path === "." ? path : `./${path}`))),
+        ],
+        workspaceRoot: options.workspaceRoot,
+        signal: options.signal,
+        separator: "\n",
+        accept: (record) => collector.accept(record),
+        budget: options.budget,
+      });
+    }
     const parsed = collector.finish();
     const probed = await probeCandidatePaths(
       options.workspaceRoot,
@@ -910,6 +940,7 @@ async function runContentSearch(options: {
     return {
       matches: parsed.matches.filter((match) => accepted.has(match.path)),
       omissions: [
+        ...(preflight?.omissions ?? []),
         ...probed.omissions,
         ...(parsed.omittedCandidateCount > 0
           ? [
@@ -949,51 +980,31 @@ async function runPathSearch(options: {
     signal: options.signal,
     budget: options.budget,
   });
-  let rawRecordCount = 0;
+  const discovery = await discoverSearchPaths({
+    ...options,
+    positiveGlobs: options.mode === "glob" && !options.query.startsWith("!") ? [options.query] : [],
+    negativeGlobs: options.mode === "glob" && options.query.startsWith("!") ? [options.query] : [],
+  });
   let rankedCandidateCount = 0;
-  const initialFileIdentities = new Map<string, FileIdentity | undefined>();
   const candidates = new BoundedBestCandidates<{
     readonly path: string;
     readonly tier: number;
     readonly rankReason: PathRankReason;
-  }>(maximumRankedCandidates, (left, right) => {
-    return left.tier - right.tier || compareChangedThenPath(left.path, right.path, changedPaths);
-  });
-  await options.backend.runRecords({
-    args: [
-      "--no-config",
-      "--no-require-git",
-      "--files",
-      "--null",
-      ...(options.mode === "glob" ? ["--glob", options.query] : []),
-      "--",
-      options.path,
-    ],
-    workspaceRoot: options.workspaceRoot,
-    signal: options.signal,
-    separator: "\0",
-    budget: options.budget,
-    accept(record) {
-      options.budget.consumeWorkRecord();
-      rawRecordCount += 1;
-      if (rawRecordCount > maximumRawRecords || rawRecordCount > maximumWorkRecords) {
-        throw new SearchCursorError(
-          "search_quota_exceeded",
-          "Repository path search exceeded its record limit.",
-        );
-      }
-      const path = record.split(sep).join("/").replace(/^\.\//u, "");
-      initialFileIdentities.set(path, captureFileIdentity(options.workspaceRoot, path));
-      const rank =
-        options.mode === "glob"
-          ? { tier: 0, rankReason: "glob" as const }
-          : fuzzyPathRank(options.query, path);
-      if (rank !== undefined) {
-        rankedCandidateCount += 1;
-        candidates.add({ path, ...rank });
-      }
-    },
-  });
+  }>(
+    maximumRankedCandidates,
+    (left, right) =>
+      left.tier - right.tier || compareChangedThenPath(left.path, right.path, changedPaths),
+  );
+  for (const path of discovery.paths) {
+    const rank =
+      options.mode === "glob"
+        ? { tier: 0, rankReason: "glob" as const }
+        : fuzzyPathRank(options.query, path);
+    if (rank !== undefined) {
+      rankedCandidateCount += 1;
+      candidates.add({ path, ...rank });
+    }
+  }
   options.signal.throwIfAborted();
   const ranked = candidates.sorted();
   const probed = await probeCandidatePaths(
@@ -1002,7 +1013,7 @@ async function runPathSearch(options: {
     options.budget,
     options.probeFileSystem,
     options.signal,
-    initialFileIdentities,
+    discovery.identities,
   );
   const accepted = new Set(probed.paths);
   const candidateOmissions =
@@ -1021,6 +1032,125 @@ async function runPathSearch(options: {
   return { entries, omissions: [...probed.omissions, ...candidateOmissions] };
 }
 
+const maximumSearchPathArgumentBytes = 64 * 1024;
+
+function searchPathArgumentBatches(paths: readonly string[]): readonly string[][] {
+  const batches: string[][] = [];
+  let batch: string[] = [];
+  let bytes = 0;
+  for (const path of paths) {
+    const size = Buffer.byteLength(path, "utf8") + 3;
+    if (size > maximumSearchPathArgumentBytes)
+      throw new SearchCursorError(
+        "search_quota_exceeded",
+        "One repository path exceeded the process argument bound.",
+      );
+    if (batch.length > 0 && bytes + size > maximumSearchPathArgumentBytes) {
+      batches.push(batch);
+      batch = [];
+      bytes = 0;
+    }
+    batch.push(path);
+    bytes += size;
+  }
+  if (batch.length > 0) batches.push(batch);
+  return batches;
+}
+
+async function discoverSearchPaths(options: {
+  readonly workspaceRoot: string;
+  readonly path: string;
+  readonly signal: AbortSignal;
+  readonly budget: SearchRequestBudget;
+  readonly backend: RepositorySearchBackend;
+  readonly positiveGlobs: readonly string[];
+  readonly negativeGlobs: readonly string[];
+}): Promise<{
+  readonly paths: readonly string[];
+  readonly identities: ReadonlyMap<string, FileIdentity | undefined>;
+}> {
+  const identities = new Map<string, FileIdentity | undefined>();
+  let rawRecords = 0;
+  const args = [
+    "--no-config",
+    "--no-require-git",
+    "--no-follow",
+    "--files",
+    "--null",
+    ...options.negativeGlobs.flatMap((glob) => ["--glob", glob]),
+  ];
+  await options.backend.runRecords({
+    // An explicit ignored file or directory bypasses rg's ignore rules. Root
+    // metadata admission is filtered to the requested scope before any probe.
+    args: [...args, "--", "."],
+    workspaceRoot: options.workspaceRoot,
+    signal: options.signal,
+    separator: "\0",
+    budget: options.budget,
+    accept(record) {
+      options.budget.consumeWorkRecord();
+      rawRecords += 1;
+      if (rawRecords > maximumRawRecords)
+        throw new SearchCursorError(
+          "search_quota_exceeded",
+          "Repository path discovery exceeded its record limit.",
+        );
+      const path = normalizeSearchPath(record);
+      if (
+        path === undefined ||
+        (options.path !== "." && path !== options.path && !path.startsWith(`${options.path}/`))
+      )
+        return;
+      identities.set(path, captureFileIdentity(options.workspaceRoot, path));
+    },
+  });
+  // GitignoreBuilder treats raw comment and blank override lines as no-ops.
+  const positive = options.positiveGlobs.filter(
+    (glob) => !glob.startsWith("#") && !/^\p{White_Space}*$/u.test(glob),
+  );
+  if (positive.length === 0) return { paths: [...identities.keys()].sort(), identities };
+  const matching = new Set(identities.keys());
+  const parents = [...new Set([...matching].map((path) => dirname(path)))].sort();
+  for (const batch of searchPathArgumentBatches(parents.length === 0 ? ["."] : parents)) {
+    await options.backend.runRecords({
+      // A negative-only walk cannot override hidden or ignore exclusions. Its
+      // complement gives the exact native positive glob matches. Explicit
+      // admitted parents + depth one prevent directory pruning from making a
+      // directory-name match accidentally include all of its descendants.
+      args: [
+        ...args,
+        "--maxdepth",
+        parents.length === 0 ? "0" : "1",
+        ...positive.flatMap((glob) => ["--glob", `!${glob}`]),
+        "--",
+        ...batch.map((path) => (path === "." ? path : `./${path}`)),
+      ],
+      workspaceRoot: options.workspaceRoot,
+      signal: options.signal,
+      separator: "\0",
+      budget: options.budget,
+      accept(record) {
+        options.budget.consumeWorkRecord();
+        const path = normalizeSearchPath(record);
+        if (path !== undefined) matching.delete(path);
+      },
+    });
+  }
+  return { paths: [...matching].sort(), identities };
+}
+
+function normalizeSearchPath(value: string): string | undefined {
+  const path = value.split(sep).join("/").replace(/^\.\//u, "");
+  if (
+    path.length === 0 ||
+    isAbsolute(path) ||
+    hasHiddenPathComponent(path) ||
+    path.split("/").some((part) => part === "" || part === "." || part === "..")
+  )
+    return undefined;
+  return path;
+}
+
 function compareChangedThenPath(left: string, right: string, changedPaths: ReadonlySet<string>) {
   const changedDifference = Number(changedPaths.has(right)) - Number(changedPaths.has(left));
   return changedDifference || (left < right ? -1 : left > right ? 1 : 0);
@@ -1031,6 +1161,7 @@ function readGitChangedPaths(
   path: string,
   signal: AbortSignal,
   budget: RepositorySearchBackendBudget,
+  observer?: RepositorySearchProcessObserver,
 ): Promise<ReadonlySet<string>> {
   signal.throwIfAborted();
   return new Promise((resolvePromise, rejectPromise) => {
@@ -1068,77 +1199,61 @@ function readGitChangedPaths(
       return;
     }
     const chunks: Buffer[] = [];
-    let byteCount = 0;
     let settled = false;
-    let terminalError = false;
+    let unavailable = false;
+    let terminalError: unknown;
     const termination = createBoundedChildTermination(child);
     const abort = () => termination.start();
-    if (signal.aborted) {
-      abort();
-    } else {
-      signal.addEventListener("abort", abort, { once: true });
-    }
+    if (signal.aborted) abort();
+    else signal.addEventListener("abort", abort, { once: true });
     child.stdout.on("data", (chunk: Buffer) => {
+      if (terminalError !== undefined) return;
       try {
         budget.consumeRawBytes(chunk.length);
-      } catch {
-        byteCount = maximumRawParsedBytes + 1;
+        chunks.push(chunk);
+      } catch (error) {
+        terminalError = error;
         termination.start();
-        return;
       }
-      byteCount += chunk.length;
-      chunks.push(chunk);
     });
     child.stderr.resume();
     child.once("error", () => {
-      if (settled) {
-        return;
-      }
-      terminalError = true;
+      if (settled) return;
+      unavailable = true;
       termination.start();
     });
     child.once("close", (exitCode) => {
-      if (settled) {
-        return;
-      }
+      if (settled) return;
       settled = true;
       termination.closed();
       signal.removeEventListener("abort", abort);
-      if (signal.aborted) {
-        rejectPromise(signal.reason);
-        return;
-      }
-      if (byteCount > maximumRawParsedBytes) {
-        rejectPromise(
-          new SearchCursorError(
-            "search_quota_exceeded",
-            "Repository Git status exceeded the raw byte limit.",
-          ),
-        );
-        return;
-      }
-      if (terminalError || exitCode !== 0) {
-        resolvePromise(new Set());
-        return;
-      }
-      const fields = Buffer.concat(chunks).toString("utf8").split("\0");
-      const paths = new Set<string>();
-      for (let index = 0; index < fields.length; index += 1) {
-        const field = fields[index];
-        if (field === undefined || field.length < 4) {
-          continue;
+      try {
+        observer?.gitClosed?.();
+        if (signal.aborted) throw signal.reason;
+        if (terminalError !== undefined) throw terminalError;
+        if (unavailable || exitCode !== 0) {
+          resolvePromise(new Set());
+          return;
         }
-        budget.consumeWorkRecord();
-        paths.add(field.slice(3).split(sep).join("/"));
-        if (field[0] === "R" || field[1] === "R" || field[0] === "C" || field[1] === "C") {
-          const source = fields[index + 1];
-          if (source !== undefined) {
-            paths.add(source.split(sep).join("/"));
-            index += 1;
+        const fields = Buffer.concat(chunks).toString("utf8").split("\0");
+        const paths = new Set<string>();
+        for (let index = 0; index < fields.length; index += 1) {
+          const field = fields[index];
+          if (field === undefined || field.length < 4) continue;
+          budget.consumeWorkRecord();
+          paths.add(field.slice(3).split(sep).join("/"));
+          if (field[0] === "R" || field[1] === "R" || field[0] === "C" || field[1] === "C") {
+            const source = fields[index + 1];
+            if (source !== undefined) {
+              paths.add(source.split(sep).join("/"));
+              index += 1;
+            }
           }
         }
+        resolvePromise(paths);
+      } catch (error) {
+        rejectPromise(error);
       }
-      resolvePromise(paths);
     });
   });
 }
@@ -1207,7 +1322,11 @@ async function probeCandidatePath(
     signal.throwIfAborted();
     const before = await fileSystem.lstat(absolutePath);
     signal.throwIfAborted();
-    if (!before.isFile() || before.isSymbolicLink()) {
+    if (
+      !before.isFile() ||
+      before.isSymbolicLink() ||
+      realpathSync(absolutePath) !== absolutePath
+    ) {
       return "non_ordinary";
     }
     if (
@@ -1273,6 +1392,7 @@ function captureFileIdentity(workspaceRoot: string, path: string): FileIdentity 
   }
   try {
     const current = lstatSync(absolutePath);
+    if (realpathSync(absolutePath) !== absolutePath) return undefined;
     return {
       dev: current.dev,
       ino: current.ino,
@@ -1354,6 +1474,7 @@ function runRipgrepRecords(options: {
   readonly processObserver?: RepositorySearchProcessObserver;
   accept(record: string): void;
 }): Promise<void> {
+  options.signal.throwIfAborted();
   return new Promise((resolvePromise, rejectPromise) => {
     let child: ChildProcessWithoutNullStreams;
     try {
@@ -1512,6 +1633,10 @@ class ContentMatchCollector {
     readonly changedPaths: ReadonlySet<string>,
     readonly budget: SearchRequestBudget,
     readonly workspaceRoot: string,
+    readonly admission?: {
+      readonly paths: ReadonlySet<string>;
+      readonly identities: ReadonlyMap<string, FileIdentity | undefined>;
+    },
   ) {
     this.#candidates = new BoundedBestCandidates(maximumRankedCandidates, (left, right) => {
       return (
@@ -1533,22 +1658,25 @@ class ContentMatchCollector {
     }
     const event = ripgrepEventSchema.parse(JSON.parse(line));
     if (event.type === "begin") {
-      const path = event.data.path.text.split(sep).join("/").replace(/^\.\//u, "");
-      this.#initialFileIdentities.set(path, captureFileIdentity(this.workspaceRoot, path));
+      const path = normalizeSearchPath(event.data.path.text);
+      if (path !== undefined && this.admission === undefined)
+        this.#initialFileIdentities.set(path, captureFileIdentity(this.workspaceRoot, path));
       return;
     }
     if (event.type !== "match" && event.type !== "context") {
       return;
     }
-    const path = event.data.path.text.split(sep).join("/").replace(/^\.\//u, "");
+    const path = normalizeSearchPath(event.data.path.text);
+    if (path === undefined || (this.admission !== undefined && !this.admission.paths.has(path)))
+      return;
     const snippet = truncateDisplayedCharacters(event.data.lines.text.replace(/[\r\n]+$/u, ""));
-    if (event.type === "context") {
+    if (this.context > 0) {
       this.#contextLines.set(`${path}\0${event.data.line_number}`, {
         line: event.data.line_number,
         snippet,
       });
-      return;
     }
+    if (event.type === "context") return;
     this.#rawMatchCount += event.data.submatches.length;
     if (this.#rawMatchCount > maximumRawRecords) {
       throw new SearchCursorError(
@@ -1597,7 +1725,7 @@ class ContentMatchCollector {
     return {
       matches,
       omittedCandidateCount: Math.max(0, this.#rawMatchCount - matches.length),
-      initialFileIdentities: this.#initialFileIdentities,
+      initialFileIdentities: this.admission?.identities ?? this.#initialFileIdentities,
     };
   }
 }
@@ -1652,171 +1780,254 @@ function truncateDisplayedCharacters(value: string): string {
   return Array.from(value).slice(0, maximumSnippetCharacters).join("");
 }
 
+type Omission = z.infer<typeof omissionSchema>;
+type PageIdentity = Pick<SearchSnapshotBase, "id" | "query" | "path" | "resultCount">;
+type PathPageIdentity = PageIdentity & Pick<PathSearchSnapshot, "mode">;
+type ContentPageIdentity = PageIdentity & Pick<ContentSearchSnapshot, "mode" | "case" | "context">;
+
+function pageEnvelope(
+  identity: PageIdentity,
+  pageIndex: number,
+  resultCount: number,
+  remainingResultCount: number,
+  hasNext: boolean,
+) {
+  return {
+    schemaVersion: 1 as const,
+    policyVersion: searchPolicyVersion,
+    query: identity.query,
+    path: identity.path,
+    resultCount,
+    snapshotResultCount: identity.resultCount,
+    pageIndex,
+    remainingResultCount,
+    ...(hasNext ? { nextCursor: encodeCursor(identity.id, pageIndex + 1) } : {}),
+    currentContentMustBeReread: true as const,
+  };
+}
+
+function pathPageOutput(
+  identity: PathPageIdentity,
+  page: PathPage,
+  pageIndex: number,
+  remaining: number,
+  hasNext: boolean,
+) {
+  return {
+    ...pageEnvelope(identity, pageIndex, page.entries.length, remaining, hasNext),
+    kind: "path" as const,
+    mode: identity.mode,
+    entries: page.entries,
+    omissions: page.omissions,
+  };
+}
+
+function contentPageOutput(
+  identity: ContentPageIdentity,
+  page: ContentPage,
+  pageIndex: number,
+  remaining: number,
+  hasNext: boolean,
+) {
+  return {
+    ...pageEnvelope(identity, pageIndex, page.matches.length, remaining, hasNext),
+    kind: "content" as const,
+    mode: identity.mode,
+    case: identity.case,
+    context: identity.context,
+    groups: [...groupMatches(page.matches)].map(([path, matches]) => ({
+      path,
+      matches: matches.map(({ path: _path, ...match }) => match),
+    })),
+    omissions: page.omissions,
+  };
+}
+
+function validateSearchOutput<T>(output: T): T {
+  if (!repositorySearchOutputSchema.safeParse(output).success) {
+    throw new Error("The repository search produced an invalid result.");
+  }
+  return output;
+}
+
+function pageFits(output: unknown): boolean {
+  return Buffer.byteLength(JSON.stringify(output), "utf8") <= maximumPageBytes;
+}
+
+function summarizeOmissions(omissions: readonly Omission[]): readonly Omission[] {
+  const counts = new Map<Omission["reason"], number>();
+  for (const omission of omissions)
+    counts.set(omission.reason, (counts.get(omission.reason) ?? 0) + omission.count);
+  return [...counts].map(([reason, count]) => ({ reason, path: ".", count }));
+}
+
+function snapshotOmissions(
+  initial: readonly Omission[],
+  unboundedCount: number,
+  resultCount: number,
+): readonly Omission[] {
+  return [
+    ...initial,
+    ...(unboundedCount > resultCount
+      ? [
+          {
+            reason: "snapshot_result_limit" as const,
+            path: ".",
+            count: unboundedCount - resultCount,
+          },
+        ]
+      : []),
+  ];
+}
+
 function createPathPages(
   entries: readonly PathEntry[],
   limit: number,
   unboundedResultCount: number,
-  initialOmissions: readonly z.infer<typeof omissionSchema>[],
+  initialOmissions: readonly Omission[],
+  identity: PathPageIdentity,
 ): readonly PathPage[] {
   const pages: PathPage[] = [];
+  const initial = snapshotOmissions(initialOmissions, unboundedResultCount, entries.length);
   let offset = 0;
-  while (offset < entries.length) {
-    const accepted: PathEntry[] = [];
-    const omissions = pages.length === 0 ? [...initialOmissions] : [];
-    while (accepted.length < limit && offset + accepted.length < entries.length) {
-      const entry = entries[offset + accepted.length];
-      if (entry === undefined) {
-        break;
+  do {
+    let candidates: PathEntry[] = [];
+    let page: PathPage | undefined;
+    const fixed = pages.length === 0 ? initial : [];
+    const compact = summarizeOmissions(fixed);
+    const fit = (candidate: PathEntry[]): PathPage | undefined => {
+      const rest = entries.length - offset - candidate.length;
+      const remainder: Omission[] =
+        rest > 0
+          ? [
+              {
+                reason: candidate.length === limit ? "page_limit" : "page_byte_limit",
+                path: ".",
+                count: rest,
+              },
+            ]
+          : [];
+      for (const accounting of [fixed, compact]) {
+        const proposal = { entries: candidate, omissions: [...accounting, ...remainder] };
+        if (pageFits(pathPageOutput(identity, proposal, pages.length, rest, rest > 0)))
+          return proposal;
       }
-      const remaining = entries.length - offset - accepted.length - 1;
-      const candidateOmissions =
-        remaining > 0
-          ? [...omissions, { reason: "page_byte_limit" as const, path: ".", count: remaining }]
-          : omissions;
+      return undefined;
+    };
+    while (candidates.length < limit && offset + candidates.length < entries.length) {
+      const entry = entries[offset + candidates.length];
+      if (entry === undefined) break;
+      candidates = [...candidates, entry];
+      // Omissions and cursors can disappear in a longer prefix. Only the
+      // mandatory result body is monotonic, so use it as the stopping bound.
       if (
-        Buffer.byteLength(
-          JSON.stringify({ entries: [...accepted, entry], omissions: candidateOmissions }),
-          "utf8",
-        ) >
-        12 * 1_024
-      ) {
+        !pageFits(
+          pathPageOutput(identity, { entries: candidates, omissions: [] }, pages.length, 0, false),
+        )
+      )
         break;
-      }
-      accepted.push(entry);
+      page = fit(candidates) ?? page;
     }
-    if (accepted.length === 0) {
+    if (entries.length === 0) page = fit([]);
+    if (page === undefined)
       throw new SearchCursorError(
         "search_quota_exceeded",
-        "One normalized repository path result exceeded the page byte limit.",
+        "One normalized repository path result and its accounting exceeded the page byte limit.",
       );
-    }
-    offset += accepted.length;
-    if (offset < entries.length) {
-      omissions.push({
-        reason: accepted.length === limit ? "page_limit" : "page_byte_limit",
-        path: ".",
-        count: entries.length - offset,
-      });
-    }
-    if (pages.length === 0 && unboundedResultCount > entries.length) {
-      omissions.push({
-        reason: "snapshot_result_limit",
-        path: ".",
-        count: unboundedResultCount - entries.length,
-      });
-    }
-    pages.push({ entries: accepted, omissions });
-  }
-  return pages.length === 0 ? [{ entries: [], omissions: [...initialOmissions] }] : pages;
+    pages.push(page);
+    offset += page.entries.length;
+  } while (offset < entries.length);
+  return pages;
 }
 
 function createContentPages(
   matches: readonly RankedContentMatch[],
   limit: number,
   unboundedResultCount: number,
-  initialOmissions: readonly z.infer<typeof omissionSchema>[],
+  initialOmissions: readonly Omission[],
+  identity: ContentPageIdentity,
 ): readonly ContentPage[] {
-  let remaining = [...groupMatches(matches).entries()].map(([path, grouped]) => ({
-    path,
-    matches: grouped,
-  }));
+  let remaining = [...groupMatches(matches)].map(([path, grouped]) => ({ path, matches: grouped }));
   const pages: ContentPage[] = [];
-  while (remaining.length > 0) {
-    const accepted: RankedContentMatch[] = [];
-    const next: typeof remaining = [];
-    const omissions: z.infer<typeof omissionSchema>[] =
-      pages.length === 0 ? [...initialOmissions] : [];
-    let byteLimited = false;
-    for (let groupIndex = 0; groupIndex < remaining.length; groupIndex += 1) {
-      const group = remaining[groupIndex] as (typeof remaining)[number];
-      const available = limit - accepted.length;
-      const maximumAcceptedCount = Math.min(
-        group.matches.length,
-        maximumMatchesPerFilePerPage,
-        Math.max(0, available),
-      );
-      let acceptedCount = 0;
-      while (acceptedCount < maximumAcceptedCount) {
-        const match = group.matches[acceptedCount];
-        if (match === undefined) {
+  const initial = snapshotOmissions(initialOmissions, unboundedResultCount, matches.length);
+  let consumed = 0;
+  do {
+    let candidates: RankedContentMatch[] = [];
+    const candidateCounts = new Map<string, { total: number; count: number }>();
+    let page: ContentPage | undefined;
+    const fixed = pages.length === 0 ? initial : [];
+    const compact = summarizeOmissions(fixed);
+    const fit = (candidate: RankedContentMatch[]): ContentPage | undefined => {
+      const rest = matches.length - consumed - candidate.length;
+      const reason =
+        candidate.length === limit ? ("page_limit" as const) : ("page_byte_limit" as const);
+      const remainders: Omission[] = [];
+      let displayedRemainder = 0;
+      for (const [path, group] of candidateCounts) {
+        const count = group.total - group.count;
+        if (count > 0) {
+          displayedRemainder += count;
+          remainders.push({
+            reason: group.count === maximumMatchesPerFilePerPage ? "per_file_page_limit" : reason,
+            path,
+            count,
+          });
+        }
+      }
+      const undisplayed = rest - displayedRemainder;
+      if (undisplayed > 0) remainders.push({ reason, path: ".", count: undisplayed });
+      for (const accounting of [fixed, compact]) {
+        const proposal = { matches: candidate, omissions: [...accounting, ...remainders] };
+        if (pageFits(contentPageOutput(identity, proposal, pages.length, rest, rest > 0)))
+          return proposal;
+      }
+      return undefined;
+    };
+    let full = false;
+    for (const group of remaining) {
+      for (const match of group.matches.slice(0, maximumMatchesPerFilePerPage)) {
+        if (candidates.length === limit) {
+          full = true;
           break;
         }
-        const candidateMatches = [...accepted, match];
-        const remainingCount =
-          remaining
-            .slice(groupIndex)
-            .reduce((total, candidate) => total + candidate.matches.length, 0) -
-          acceptedCount -
-          1;
-        const candidateOmissions =
-          remainingCount > 0
-            ? [
-                ...omissions,
-                {
-                  reason: "page_byte_limit" as const,
-                  path: ".",
-                  count: remainingCount,
-                },
-              ]
-            : omissions;
-        if (contentPagePayloadBytes(candidateMatches, candidateOmissions) > 12 * 1_024) {
-          byteLimited = true;
+        const previousCount = candidateCounts.get(group.path)?.count ?? 0;
+        candidateCounts.set(group.path, { total: group.matches.length, count: previousCount + 1 });
+        candidates = [...candidates, match];
+        if (
+          !pageFits(
+            contentPageOutput(
+              identity,
+              { matches: candidates, omissions: [] },
+              pages.length,
+              0,
+              false,
+            ),
+          )
+        ) {
+          full = true;
           break;
         }
-        accepted.push(match);
-        acceptedCount += 1;
+        page = fit(candidates) ?? page;
       }
-      const rest = group.matches.slice(acceptedCount);
-      if (rest.length > 0) {
-        next.push({ path: group.path, matches: rest });
-        omissions.push({
-          reason: byteLimited
-            ? "page_byte_limit"
-            : acceptedCount >= maximumMatchesPerFilePerPage
-              ? "per_file_page_limit"
-              : "page_limit",
-          path: group.path,
-          count: rest.length,
-        });
-      }
-      if (byteLimited) {
-        next.push(...remaining.slice(groupIndex + 1));
-        break;
-      }
+      if (full) break;
     }
-    if (accepted.length === 0) {
+    if (matches.length === 0) page = fit([]);
+    if (page === undefined)
       throw new SearchCursorError(
         "search_quota_exceeded",
-        "The repository search page could not make bounded progress.",
+        "The repository search result and its accounting could not make bounded progress.",
       );
-    }
-    if (pages.length === 0 && unboundedResultCount > matches.length) {
-      omissions.push({
-        reason: "snapshot_result_limit",
-        path: ".",
-        count: unboundedResultCount - matches.length,
-      });
-    }
-    pages.push({ matches: accepted, omissions });
-    remaining = next;
-  }
-  return pages.length === 0 ? [{ matches: [], omissions: [...initialOmissions] }] : pages;
-}
-
-function contentPagePayloadBytes(
-  matches: readonly RankedContentMatch[],
-  omissions: readonly z.infer<typeof omissionSchema>[],
-): number {
-  return Buffer.byteLength(
-    JSON.stringify({
-      groups: [...groupMatches(matches)].map(([path, grouped]) => ({
-        path,
-        matches: grouped.map(({ path: _path, ...match }) => match),
-      })),
-      omissions,
-    }),
-    "utf8",
-  );
+    pages.push(page);
+    consumed += page.matches.length;
+    const consumedByPath = new Map<string, number>();
+    for (const match of page.matches)
+      consumedByPath.set(match.path, (consumedByPath.get(match.path) ?? 0) + 1);
+    remaining = remaining.flatMap((group) => {
+      const rest = group.matches.slice(consumedByPath.get(group.path) ?? 0);
+      return rest.length === 0 ? [] : [{ path: group.path, matches: rest }];
+    });
+  } while (remaining.length > 0);
+  return pages;
 }
 
 function groupMatches(

--- a/packages/testkit/src/agent-session.test.ts
+++ b/packages/testkit/src/agent-session.test.ts
@@ -1713,6 +1713,8 @@ describe("AgentSession", () => {
         tools: createCodingToolRegistryForTesting({
           workspaceRoot,
           repositorySearchBackend: createScriptedRepositorySearchBackend([
+            { records: ["src/selected.ts"] },
+            { records: [] },
             {
               records: scriptedContentRecords([
                 {
@@ -1743,12 +1745,10 @@ describe("AgentSession", () => {
         "--color",
         "never",
         "--glob",
-        "**/*.ts",
-        "--glob",
         "!tests/**",
         "--",
         "Needle[A-Z][a-z]+",
-        ".",
+        "./src/selected.ts",
       ]);
       expect(searchOutput).toMatchObject({
         kind: "content",
@@ -2173,8 +2173,9 @@ describe("AgentSession", () => {
         tools: createCodingToolRegistryForTesting({
           workspaceRoot,
           repositorySearchBackend: createScriptedRepositorySearchBackend([
+            { records: ["src/alpha.test.ts", "tests/beta.test.ts", "src/alpha.ts"] },
             {
-              records: ["src/alpha.test.ts", "tests/beta.test.ts"],
+              records: ["src/alpha.ts"],
               assertArguments(arguments_) {
                 observedArguments = arguments_;
               },
@@ -2199,12 +2200,16 @@ describe("AgentSession", () => {
       expect(observedArguments).toEqual([
         "--no-config",
         "--no-require-git",
+        "--no-follow",
         "--files",
         "--null",
+        "--maxdepth",
+        "1",
         "--glob",
-        "{src,tests}/**/*.test.ts",
+        "!{src,tests}/**/*.test.ts",
         "--",
-        ".",
+        "./src",
+        "./tests",
       ]);
     } finally {
       await rm(workspaceRoot, { recursive: true, force: true });

--- a/packages/testkit/src/managed-search.os.test.ts
+++ b/packages/testkit/src/managed-search.os.test.ts
@@ -1,0 +1,214 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createPermissionPolicy, type JsonValue, type ModelDriver } from "@adam-agent/agent";
+import {
+  createInMemoryManagedAgentControlStore,
+  createInMemorySessionStoreDirectory,
+  createManagedAgentControl,
+  createProjectExecutionDomain,
+  createProjectLifecycleOwner,
+  type SessionRecord,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+
+import { withManagedFailureGuard } from "./managed-agent-test-support.js";
+import { requireSessionEvent } from "./session-event.test-support.js";
+
+type ContentPage = {
+  readonly kind: "content";
+  readonly resultCount: number;
+  readonly snapshotResultCount: number;
+  readonly remainingResultCount: number;
+  readonly pageIndex: number;
+  readonly nextCursor?: string;
+  readonly groups: readonly {
+    readonly path: string;
+    readonly matches: readonly { readonly line: number; readonly snippet: string }[];
+  }[];
+};
+
+test("a real managed child pages the shared search and continues after a typed cursor failure", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-managed-search-"));
+  const workspaceRoot = join(root, "workspace");
+  const stateRoot = join(root, "state");
+  await mkdir(workspaceRoot);
+  await mkdir(join(workspaceRoot, "src"));
+  await mkdir(join(workspaceRoot, "ignored"));
+  const expectedPaths = Array.from(
+    { length: 300 },
+    (_, index) => `src/file-${String(index).padStart(3, "0")}.ts`,
+  );
+  await Promise.all([
+    writeFile(join(workspaceRoot, ".gitignore"), "ignored/\n"),
+    writeFile(join(workspaceRoot, "ignored/private.ts"), "extension must remain ignored\n"),
+    writeFile(join(workspaceRoot, ".hidden.ts"), "extension must remain hidden\n"),
+    writeFile(join(workspaceRoot, "binary.ts"), "extension\0binary bytes\n"),
+    writeFile(join(workspaceRoot, "src/AGENTS.md"), "HIT-SCOPE MUST REMAIN INACTIVE\n"),
+    symlink("src/file-000.ts", join(workspaceRoot, "linked.ts")),
+  ]);
+  await Promise.all(
+    expectedPaths.map((path, index) =>
+      writeFile(join(workspaceRoot, path), `export const extension${index} = true;\n`),
+    ),
+  );
+  const parentSessionId = "123e4567-e89b-42d3-a456-426614174010";
+  const pages: ContentPage[] = [];
+  const outputs: JsonValue[] = [];
+  const failures: string[] = [];
+  let invalidCursorTurn = false;
+  let providerRequests = 0;
+  const model: ModelDriver = {
+    async *stream(request) {
+      providerRequests += 1;
+      expect(JSON.stringify(request.messages)).not.toContain("HIT-SCOPE MUST REMAIN INACTIVE");
+      const last = request.messages.at(-1);
+      let cursor: string | undefined;
+      if (last?.role === "tool") {
+        if (last.result.status === "failed") {
+          failures.push(last.result.error.code);
+          yield { type: "text_delta", text: "Child cursor failure handled." };
+          yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+          yield { type: "finish", reason: "stop" };
+          return;
+        }
+        outputs.push(last.result.output);
+        const page = last.result.output as unknown as ContentPage;
+        expect(page.kind).toBe("content");
+        pages.push(page);
+        if (page.nextCursor === undefined) {
+          yield { type: "text_delta", text: "Child paged all 300 files." };
+          yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+          yield { type: "finish", reason: "stop" };
+          return;
+        }
+        cursor = page.nextCursor;
+      } else if (invalidCursorTurn) cursor = "not-a-cursor";
+      const callId = `child-search-${providerRequests}`;
+      yield { type: "tool_call_start", id: callId, name: "search_repository" };
+      yield {
+        type: "tool_call_delta",
+        id: callId,
+        json: JSON.stringify({
+          kind: "content",
+          query: "extension",
+          mode: "literal",
+          case: "insensitive",
+          include: ["*.ts"],
+          limit: 50,
+          ...(cursor === undefined ? {} : { cursor }),
+        }),
+      };
+      yield { type: "tool_call_end", id: callId };
+      yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+      yield { type: "finish", reason: "tool_calls" };
+    },
+  };
+  const domain = createProjectExecutionDomain({
+    lifecycleOwner: createProjectLifecycleOwner({ workspaceRoot, stateRoot }),
+  });
+  const claim = await domain.claimRoot({ rootId: "project-runtime" });
+  const childSessionStores = createInMemorySessionStoreDirectory<SessionRecord>();
+  const control = createManagedAgentControl({
+    parentSessionId,
+    projectId: `sha256:${createHash("sha256").update(workspaceRoot).digest("hex")}`,
+    workspaceRoot,
+    targetIdentity: {
+      targetId: "deepseek-v4-flash.direct",
+      vendor: "deepseek",
+      modelId: "deepseek-v4-flash",
+      route: "direct",
+      profileVersion: 1,
+      certification: "certified",
+    },
+    contextProfile: {
+      version: 1,
+      contextWindowTokens: 128_000,
+      maximumOutputTokens: 4096,
+      compactAtTokens: 96_000,
+      postCompactTargetTokens: 32_000,
+      retainedTargetTokens: 8000,
+      estimatorVersion: 1,
+    },
+    model,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    executionDomain: domain,
+    store: createInMemoryManagedAgentControlStore(),
+    childSessionStores,
+  });
+  const subscription = new AbortController();
+  const settledAfter = async (previousTurnId?: string) => {
+    for await (const frame of control.observe({ parentSessionId, signal: subscription.signal })) {
+      const thread = frame.snapshot.threads[0];
+      if (
+        thread?.turn.phase === "idle" &&
+        thread.turn.outcome !== undefined &&
+        thread.turn.turnId !== previousTurnId
+      )
+        return thread;
+    }
+    throw new Error("The managed search did not publish its settled outcome.");
+  };
+  try {
+    const firstSettlement = settledAfter();
+    await control.dispatch({
+      type: "start_thread",
+      parentSessionId,
+      role: "builtin:explore",
+      task: "Page through every matching extension file.",
+      description: "Search repository files",
+    });
+    const first = await withManagedFailureGuard(firstSettlement, "managed paginated search");
+    expect(first.turn.outcome).toMatchObject({
+      status: "completed",
+      summary: "Child paged all 300 files.",
+    });
+    expect(failures).toEqual([]);
+    expect(pages.map((page) => page.resultCount)).toEqual([50, 50, 50, 50, 50, 50]);
+    expect(pages.map((page) => page.remainingResultCount)).toEqual([250, 200, 150, 100, 50, 0]);
+    expect(pages.map((page) => page.pageIndex)).toEqual([0, 1, 2, 3, 4, 5]);
+    expect(pages.every((page) => page.snapshotResultCount === 300)).toBe(true);
+    expect(pages.flatMap((page) => page.groups.map((group) => group.path))).toEqual(expectedPaths);
+    for (const output of outputs)
+      expect(Buffer.byteLength(JSON.stringify(output))).toBeLessThanOrEqual(16 * 1024);
+
+    invalidCursorTurn = true;
+    const nextSettlement = settledAfter(first.turn.turnId);
+    await control.dispatch({
+      type: "next_turn",
+      parentSessionId,
+      threadId: first.threadId,
+      expectedTurnId: first.turn.turnId,
+      task: "Handle this invalid cursor and report completion.",
+    });
+    const next = await withManagedFailureGuard(nextSettlement, "managed typed search feedback");
+    expect(next.turn.outcome).toMatchObject({
+      status: "completed",
+      summary: "Child cursor failure handled.",
+    });
+    expect(failures).toEqual(["search_cursor_invalid"]);
+    const records = await (await childSessionStores.open(next.turn.childSessionId))?.read();
+    const events = records
+      ?.filter((record) => record.schemaVersion === 3 && record.record.type === "runtime_event")
+      .map((record) => requireSessionEvent(record).event);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "tool_failed",
+        name: "search_repository",
+        error: expect.objectContaining({ code: "search_cursor_invalid" }),
+      }),
+    );
+    expect(events).toContainEqual({
+      type: "session_settled",
+      result: { status: "completed", answer: "Child cursor failure handled." },
+    });
+  } finally {
+    subscription.abort();
+    await control.dispatch({ type: "close", parentSessionId });
+    await claim.release();
+    await domain.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/testkit/src/repository-search.os.test.ts
+++ b/packages/testkit/src/repository-search.os.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { writeFileSync } from "node:fs";
 import { chmod, lstat, mkdir, mkdtemp, open, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -27,8 +27,8 @@ import {
   sessionLifecycleTargetIdentity,
 } from "./session-lifecycle.test-support.js";
 
-test("wide search failure is durable model feedback and leaves Main ready after JSONL restart", async () => {
-  const root = await mkdtemp(join(tmpdir(), "adam-search-failure-feedback-"));
+test("wide search returns every bounded page and leaves Main ready after JSONL restart", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-search-page-feedback-"));
   const workspaceRoot = join(root, "workspace");
   const stateRoot = join(root, "state");
   await mkdir(workspaceRoot);
@@ -40,14 +40,34 @@ test("wide search failure is durable model feedback and leaves Main ready after 
       ),
     ),
   );
+  const pages: Array<{
+    resultCount: number;
+    snapshotResultCount: number;
+    remainingResultCount: number;
+    pageIndex: number;
+    groups: Array<{ path: string; matches: unknown[] }>;
+    omissions: Array<{ reason: string; path: string; count: number }>;
+    nextCursor?: string;
+  }> = [];
   let feedback: unknown;
   const driver = new FakeModelDriver((request) => {
-    if (request.messages.at(-1)?.role === "user")
+    const last = request.messages.at(-1);
+    if (last?.role === "tool") {
+      feedback ??= last.result;
+      if (last.result.status === "completed")
+        pages.push(last.result.output as (typeof pages)[number]);
+    }
+    const cursor = pages.at(-1)?.nextCursor;
+    if (
+      last?.role === "user" ||
+      (last?.role === "tool" && last.result.status === "completed" && cursor !== undefined)
+    ) {
+      const id = `wide-search-${pages.length}`;
       return [
-        { type: "tool_call_start", id: "wide-search", name: "search_repository" },
+        { type: "tool_call_start", id, name: "search_repository" },
         {
           type: "tool_call_delta",
-          id: "wide-search",
+          id,
           json: JSON.stringify({
             kind: "content",
             query: "extension",
@@ -55,15 +75,15 @@ test("wide search failure is durable model feedback and leaves Main ready after 
             case: "insensitive",
             include: ["*.ts"],
             limit: 50,
+            ...(cursor === undefined ? {} : { cursor }),
           }),
         },
-        { type: "tool_call_end", id: "wide-search" },
+        { type: "tool_call_end", id },
         { type: "finish", reason: "tool_calls" },
       ];
-    const last = request.messages.at(-1);
-    if (last?.role === "tool") feedback = last.result;
+    }
     return [
-      { type: "text_delta", text: "Search failure handled." },
+      { type: "text_delta", text: "Wide search completed." },
       { type: "finish", reason: "stop" },
     ];
   });
@@ -103,21 +123,37 @@ test("wide search failure is durable model feedback and leaves Main ready after 
       phase,
       lastRecord: lastRecord?.schemaVersion === 3 ? lastRecord.record : undefined,
     }).toMatchObject({
-      result: { status: "completed", answer: "Search failure handled." },
+      result: { status: "completed", answer: "Wide search completed." },
       snapshotStatus: "settled",
       phase: "ready",
       lastRecord: { type: "runtime_event", event: { type: "session_settled" } },
     });
-    expect(feedback).toMatchObject({ status: "failed", error: { code: "search_quota_exceeded" } });
+    expect(feedback).toMatchObject({
+      status: "completed",
+      output: { resultCount: 50, snapshotResultCount: 300 },
+    });
+    expect(pages).toHaveLength(6);
+    for (const [index, page] of pages.entries()) {
+      expect(Buffer.byteLength(JSON.stringify(page), "utf8")).toBeLessThanOrEqual(16 * 1024);
+      expect(page).toMatchObject({
+        pageIndex: index,
+        resultCount: 50,
+        snapshotResultCount: 300,
+        remainingResultCount: 250 - index * 50,
+      });
+      expect(page.groups.every((group) => group.matches.length === 1)).toBe(true);
+      expect(page.omissions).toEqual(
+        index === 5 ? [] : [{ reason: "page_limit", path: ".", count: 250 - index * 50 }],
+      );
+    }
+    expect(pages.flatMap((page) => page.groups.map((group) => group.path))).toEqual(
+      Array.from({ length: 300 }, (_, index) => `file-${String(index).padStart(3, "0")}.ts`),
+    );
     expect(records).toContainEqual(
       expect.objectContaining({
         record: expect.objectContaining({
           type: "runtime_event",
-          event: expect.objectContaining({
-            type: "tool_failed",
-            callId: "wide-search",
-            error: expect.objectContaining({ code: "search_quota_exceeded" }),
-          }),
+          event: expect.objectContaining({ type: "tool_completed", callId: "wide-search-0" }),
         }),
       }),
     );
@@ -890,3 +926,792 @@ async function executeSearch(
     toolProfileDigest: "sha256:repository-search-os-contract-profile",
   });
 }
+
+test.each(["path", "content"] as const)(
+  "%s pages budget long queries, paths, and context inside the complete envelope",
+  async (kind) => {
+    const root = await mkdtemp(join(tmpdir(), "adam-search-envelope-"));
+    const folder = "directory-".repeat(15);
+    await mkdir(join(root, folder));
+    const expected = Array.from(
+      { length: 60 },
+      (_, index) => `${folder}/file-${String(index).padStart(3, "0")}-${"name".repeat(25)}.ts`,
+    );
+    try {
+      await Promise.all(
+        expected.map((path) =>
+          writeFile(
+            join(root, path),
+            `${"before".repeat(70)}\nneedle match\n${"after".repeat(80)}\n`,
+          ),
+        ),
+      );
+      const adapter = createRepositorySearchToolAdapterForTesting({ workspaceRoot: root });
+      const input =
+        kind === "path"
+          ? {
+              kind,
+              mode: "glob",
+              query: `{${Array.from({ length: 1800 }, () => "*").join(",")}}`,
+              limit: 50,
+            }
+          : { kind, mode: "regex", query: `needle|${"界".repeat(3000)}`, context: 1, limit: 50 };
+      const paths: string[] = [];
+      let cursor: string | undefined;
+      do {
+        const result = await executeSearchPage(adapter, {
+          ...input,
+          ...(cursor === undefined ? {} : { cursor }),
+        });
+        expect(result).toMatchObject({ status: "completed" });
+        if (result.status !== "completed") throw new Error(result.error.message);
+        expect(adapter.outputSchema.safeParse(result.output).success).toBe(true);
+        expect(Buffer.byteLength(JSON.stringify(result.output), "utf8")).toBeLessThanOrEqual(
+          16 * 1024,
+        );
+        const page = result.output as {
+          entries?: Array<{ path: string }>;
+          groups?: Array<{ path: string }>;
+          nextCursor?: string;
+          remainingResultCount: number;
+        };
+        paths.push(...(page.entries ?? page.groups ?? []).map((entry) => entry.path));
+        expect(page.remainingResultCount).toBe(60 - paths.length);
+        cursor = page.nextCursor;
+      } while (cursor !== undefined);
+      expect(paths).toEqual(expected);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);
+
+test("dense content pages preserve per-file remainder and every normalized match", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-search-dense-pages-"));
+  try {
+    await writeFile(
+      join(root, "a.ts"),
+      Array.from({ length: 26 }, (_, index) => `needle a${index}\n`).join(""),
+    );
+    await writeFile(
+      join(root, "b.ts"),
+      Array.from({ length: 11 }, (_, index) => `needle b${index}\n`).join(""),
+    );
+    const adapter = createRepositorySearchToolAdapterForTesting({ workspaceRoot: root });
+    const seen: string[] = [];
+    const counts = new Map([
+      ["a.ts", 0],
+      ["b.ts", 0],
+    ]);
+    let cursor: string | undefined;
+    do {
+      const result = await executeSearchPage(adapter, {
+        kind: "content",
+        query: "needle",
+        limit: 7,
+        ...(cursor === undefined ? {} : { cursor }),
+      });
+      expect(result).toMatchObject({ status: "completed" });
+      if (result.status !== "completed") throw new Error(result.error.message);
+      const page = result.output as {
+        groups: Array<{ path: string; matches: Array<{ line: number }> }>;
+        omissions: Array<{ path: string; count: number }>;
+        nextCursor?: string;
+        remainingResultCount: number;
+      };
+      expect(Buffer.byteLength(JSON.stringify(page), "utf8")).toBeLessThanOrEqual(16 * 1024);
+      for (const group of page.groups) {
+        expect(group.matches.length).toBeLessThanOrEqual(5);
+        counts.set(group.path, (counts.get(group.path) ?? 0) + group.matches.length);
+        seen.push(...group.matches.map((match) => `${group.path}:${match.line}`));
+        const remaining = (group.path === "a.ts" ? 26 : 11) - (counts.get(group.path) ?? 0);
+        if (remaining > 0)
+          expect(page.omissions).toContainEqual(
+            expect.objectContaining({ path: group.path, count: remaining }),
+          );
+      }
+      expect(page.remainingResultCount).toBe(37 - seen.length);
+      expect(page.omissions.reduce((total, omission) => total + omission.count, 0)).toBe(
+        page.remainingResultCount,
+      );
+      cursor = page.nextCursor;
+    } while (cursor !== undefined);
+    expect(seen.length).toBe(37);
+    expect(new Set(seen)).toEqual(
+      new Set([
+        ...Array.from({ length: 26 }, (_, index) => `a.ts:${index + 1}`),
+        ...Array.from({ length: 11 }, (_, index) => `b.ts:${index + 1}`),
+      ]),
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("many binary probe omissions retain an exact bounded aggregate", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-search-probe-accounting-"));
+  try {
+    await Promise.all(
+      Array.from({ length: 300 }, (_, index) =>
+        writeFile(
+          join(root, `file-${String(index).padStart(3, "0")}-${"binary".repeat(20)}.ts`),
+          Buffer.from([0, 65, 66]),
+        ),
+      ),
+    );
+    await Promise.all(
+      Array.from({ length: 60 }, (_, index) =>
+        writeFile(join(root, `file-text-${String(index).padStart(3, "0")}.ts`), "ordinary text\n"),
+      ),
+    );
+    const adapter = createRepositorySearchToolAdapterForTesting({ workspaceRoot: root });
+    const result = await executeSearchPage(adapter, { kind: "path", query: "file", limit: 50 });
+    expect(result).toMatchObject({
+      status: "completed",
+      output: {
+        resultCount: 50,
+        snapshotResultCount: 60,
+        remainingResultCount: 10,
+        omissions: [
+          { reason: "binary", path: ".", count: 300 },
+          { reason: "page_limit", path: ".", count: 10 },
+        ],
+      },
+    });
+    if (result.status !== "completed") throw new Error(result.error.message);
+    expect(Buffer.byteLength(JSON.stringify(result.output), "utf8")).toBeLessThanOrEqual(16 * 1024);
+    const first = result.output as { nextCursor: string };
+    await writeFile(join(root, "file-extra.ts"), "created after snapshot\n");
+    const second = await executeSearchPage(adapter, {
+      kind: "path",
+      query: "file",
+      limit: 50,
+      cursor: first.nextCursor,
+    });
+    expect(second).toMatchObject({
+      status: "completed",
+      output: {
+        resultCount: 10,
+        remainingResultCount: 0,
+        omissions: [],
+        entries: Array.from({ length: 10 }, (_, index) => ({
+          path: `file-text-${String(index + 50).padStart(3, "0")}.ts`,
+        })),
+      },
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("an impossible complete search envelope remains durable typed quota feedback", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-search-impossible-envelope-"));
+  const workspaceRoot = join(root, "workspace");
+  await mkdir(workspaceRoot);
+  await writeFile(
+    join(workspaceRoot, "large-context.ts"),
+    [
+      ...Array.from({ length: 3 }, () => "前".repeat(500)),
+      "needle",
+      ...Array.from({ length: 3 }, () => "後".repeat(500)),
+    ].join("\n"),
+  );
+  const harness = createInMemorySessionLifecycleHarness();
+  const driver = new FakeModelDriver((request) => {
+    if (request.messages.at(-1)?.role === "user")
+      return [
+        { type: "tool_call_start", id: "quota-search", name: "search_repository" },
+        {
+          type: "tool_call_delta",
+          id: "quota-search",
+          json: JSON.stringify({
+            kind: "content",
+            mode: "regex",
+            query: `needle|${"界".repeat(4000)}`,
+            context: 3,
+          }),
+        },
+        { type: "tool_call_end", id: "quota-search" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    expect(request.messages.at(-1)).toMatchObject({
+      role: "tool",
+      result: { status: "failed", error: { code: "search_quota_exceeded" } },
+    });
+    return [
+      { type: "text_delta", text: "Narrow the context or query." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const lifecycle = harness.createLifecycle({
+    workspaceRoot,
+    stateRoot: join(root, "state"),
+    modelTargets: modelTargetsWithDriver(driver),
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+  });
+  try {
+    const created = await lifecycle.create({ targetIdentity: sessionLifecycleTargetIdentity });
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: "Use this large query and context." },
+      }),
+    ).resolves.toMatchObject({
+      result: { status: "completed", answer: "Narrow the context or query." },
+      snapshot: { status: "settled" },
+    });
+    const records = await (await harness.sessions.open(created.sessionId))?.read();
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        record: expect.objectContaining({
+          type: "runtime_event",
+          event: expect.objectContaining({
+            type: "tool_failed",
+            callId: "quota-search",
+            error: expect.objectContaining({ code: "search_quota_exceeded" }),
+          }),
+        }),
+      }),
+    );
+    expect(records?.at(-1)).toMatchObject({
+      record: {
+        type: "runtime_event",
+        event: { type: "session_settled", result: { status: "completed" } },
+      },
+    });
+  } finally {
+    await lifecycle.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+async function executeSearchPage(
+  adapter: ReturnType<typeof createRepositorySearchToolAdapterForTesting>,
+  input: Record<string, unknown>,
+) {
+  const prepared = adapter.prepare(JSON.stringify(input));
+  if (prepared.status !== "ready") return prepared;
+  return prepared.execute({
+    signal: new AbortController().signal,
+    callId: "search-page",
+    toolName: "search_repository",
+    sessionId: "search-page-session",
+    toolProfileDigest: "sha256:search-page-profile",
+  });
+}
+
+test.each(["界", "😀", "a😀"])(
+  "search output schema counts Unicode characters consistently for matches and context: %s",
+  async (unit) => {
+    const root = await mkdtemp(join(tmpdir(), "adam-search-unicode-schema-"));
+    try {
+      await writeFile(
+        join(root, "unicode.ts"),
+        `${unit.repeat(600)}\nneedle${unit.repeat(600)}\n${unit.repeat(600)}\n`,
+      );
+      const adapter = createRepositorySearchToolAdapterForTesting({ workspaceRoot: root });
+      const result = await executeSearchPage(adapter, {
+        kind: "content",
+        query: "needle",
+        context: 1,
+      });
+      expect(result).toMatchObject({ status: "completed" });
+      if (result.status !== "completed") throw new Error(result.error.message);
+      const parsed = adapter.outputSchema.safeParse(result.output);
+      expect(parsed.success, JSON.stringify(parsed.error)).toBe(true);
+      const output = result.output as {
+        groups: Array<{
+          matches: Array<{
+            snippet: string;
+            contextBefore: Array<{ snippet: string }>;
+            contextAfter: Array<{ snippet: string }>;
+          }>;
+        }>;
+      };
+      const match = output.groups[0]?.matches[0];
+      expect(match).toBeDefined();
+      if (match === undefined) throw new Error("Expected the Unicode match.");
+      for (const snippet of [
+        match.snippet,
+        ...match.contextBefore.map((line) => line.snippet),
+        ...match.contextAfter.map((line) => line.snippet),
+      ]) {
+        expect(Array.from(snippet)).toHaveLength(500);
+        expect(snippet.isWellFormed()).toBe(true);
+      }
+      expect(match.snippet.startsWith("needle")).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);
+
+test.each(["work", "raw"] as const)(
+  "Git %s-budget rejection stays in the search Promise after process close",
+  async (kind) => {
+    const root = await mkdtemp(join(tmpdir(), "adam-search-git-work-"));
+    const bin = join(root, "bin");
+    const workspaceRoot = join(root, "workspace");
+    await mkdir(bin);
+    await mkdir(workspaceRoot);
+    await writeFile(join(workspaceRoot, "needle.ts"), "needle\n");
+    const git = join(bin, "git");
+    const program =
+      kind === "work"
+        ? "process.stdout.write(' M needle.ts\\0'.repeat(200001));"
+        : "const chunk=Buffer.alloc(8*1024*1024,65); let writes=0; function send(){if(writes++<9)process.stdout.write(chunk,send);} send();";
+    await writeFile(git, `#!${process.execPath}\n${program}\n`);
+    await chmod(git, 0o700);
+    try {
+      const moduleUrl = new URL("../../agent/dist/internal-testing.js", import.meta.url).href;
+      const script = `import { createRepositorySearchToolAdapterForTesting } from ${JSON.stringify(moduleUrl)};
+      let gitClosed = false;
+      const adapter = createRepositorySearchToolAdapterForTesting({workspaceRoot: ${JSON.stringify(workspaceRoot)}, processObserver: {spawned(){},closed(){},gitClosed(){gitClosed=true;}}});
+      const prepared = adapter.prepare(JSON.stringify({kind:'path',query:'needle'}));
+      if(prepared.status !== 'ready') throw new Error('Not prepared');
+      try {
+        const result = await prepared.execute({signal:new AbortController().signal,callId:'git-work',toolName:'search_repository',sessionId:'git-work',toolProfileDigest:'sha256:git-work'});
+        process.stdout.write(JSON.stringify({settled: true, gitClosed, result}));
+      } catch (error) { process.stdout.write(JSON.stringify({caught: true, message: String(error)})); }
+    `;
+      const { PATH: inheritedPath } = process.env;
+      const result = spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+        env: { ...process.env, PATH: `${bin}:${inheritedPath ?? ""}` },
+        encoding: "utf8",
+        timeout: 20_000,
+      });
+      expect({
+        status: result.status,
+        signal: result.signal,
+        error: result.error,
+        stderr: result.stderr,
+      }).toEqual({ status: 0, signal: null, error: undefined, stderr: "" });
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        settled: true,
+        gitClosed: true,
+        result: { status: "failed", error: { code: "search_quota_exceeded" } },
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);
+
+test("positive globs and explicit paths preserve the ordinary discovery boundary", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-search-discovery-boundary-"));
+  const workspaceRoot = join(root, "workspace");
+  await mkdir(workspaceRoot);
+  try {
+    for (const directory of ["ignored", "localignored", "nested", "folder.ts", ".secret"])
+      await mkdir(join(workspaceRoot, directory));
+    await writeFile(join(workspaceRoot, ".gitignore"), "ignored/\n");
+    await writeFile(join(workspaceRoot, ".ignore"), "localignored/\n");
+    await writeFile(join(workspaceRoot, ".rgignore"), "extra.ts\n");
+    for (const path of [
+      "normal.ts",
+      "nested/keep.ts",
+      "folder.ts/keep.txt",
+      "text.txt",
+      "ignored/private.ts",
+      "localignored/private.ts",
+      "extra.ts",
+      ".hidden.ts",
+      ".secret/private.ts",
+    ])
+      await writeFile(join(workspaceRoot, path), "needle\n");
+    await writeFile(join(workspaceRoot, "binary.ts"), "needle\0binary");
+    await writeFile(join(root, "outside.ts"), "needle\n");
+    await symlink(join(root, "outside.ts"), join(workspaceRoot, "linked.ts"));
+    const adapter = createRepositorySearchToolAdapterForTesting({ workspaceRoot });
+    const all = ["folder.ts/keep.txt", "nested/keep.ts", "normal.ts", "text.txt"];
+    const cases = [
+      [{ kind: "path", mode: "glob", query: "*" }, all],
+      [{ kind: "path", mode: "glob", query: "*.ts" }, ["nested/keep.ts", "normal.ts"]],
+      [
+        { kind: "path", mode: "fuzzy", query: "ts" },
+        ["folder.ts/keep.txt", "nested/keep.ts", "normal.ts"],
+      ],
+      [{ kind: "content", query: "needle", include: ["*.ts"] }, ["nested/keep.ts", "normal.ts"]],
+      [
+        {
+          kind: "content",
+          mode: "regex",
+          query: "need(le)",
+          include: ["*.ts"],
+          exclude: ["nested/**"],
+        },
+        ["normal.ts"],
+      ],
+      [{ kind: "content", query: "needle", path: "ignored" }, []],
+      [{ kind: "content", query: "needle", path: "ignored/private.ts" }, []],
+      [{ kind: "path", mode: "glob", query: "*", path: "ignored/private.ts" }, []],
+      [{ kind: "content", query: "needle", path: "nested/keep.ts" }, ["nested/keep.ts"]],
+    ] as const;
+    for (const [input, expected] of cases) {
+      const result = await executeSearchPage(adapter, input);
+      expect(result, JSON.stringify(input)).toMatchObject({ status: "completed" });
+      if (result.status !== "completed") throw new Error(result.error.message);
+      const output = result.output as {
+        entries?: Array<{ path: string }>;
+        groups?: Array<{ path: string }>;
+      };
+      expect(
+        (output.entries ?? output.groups ?? []).map((entry) => entry.path).sort(),
+        JSON.stringify(input),
+      ).toEqual(expected);
+    }
+    await expect(
+      executeSearchPage(adapter, {
+        kind: "content",
+        mode: "regex",
+        query: "[",
+        include: ["*.missing"],
+      }),
+    ).resolves.toMatchObject({ status: "failed", error: { code: "tool_io_failed" } });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("ranked and snapshot result ceilings retain exact independent omission counts", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-search-result-ceilings-"));
+  try {
+    await writeFile(
+      join(root, "many.ts"),
+      Array.from({ length: 20_000 }, (_, index) => `needle ${index + 1}\n`).join(""),
+    );
+    const adapter = createRepositorySearchToolAdapterForTesting({ workspaceRoot: root });
+    const first = await executeSearchPage(adapter, { kind: "content", query: "needle", limit: 50 });
+    expect(first).toMatchObject({
+      status: "completed",
+      output: {
+        resultCount: 5,
+        snapshotResultCount: 4096,
+        remainingResultCount: 4091,
+        omissions: [
+          { reason: "ranked_candidate_limit", path: ".", count: 3616 },
+          { reason: "snapshot_result_limit", path: ".", count: 12288 },
+          { reason: "per_file_page_limit", path: "many.ts", count: 4091 },
+        ],
+      },
+    });
+    if (first.status !== "completed") throw new Error(first.error.message);
+    const output = first.output as { nextCursor?: string };
+    expect(output.nextCursor).toEqual(expect.any(String));
+    const second = await executeSearchPage(adapter, {
+      kind: "content",
+      query: "needle",
+      limit: 50,
+      cursor: output.nextCursor,
+    });
+    expect(second).toMatchObject({
+      status: "completed",
+      output: {
+        pageIndex: 1,
+        groups: [
+          {
+            path: "many.ts",
+            matches: [{ line: 6 }, { line: 7 }, { line: 8 }, { line: 9 }, { line: 10 }],
+          },
+        ],
+        omissions: [{ reason: "per_file_page_limit", path: "many.ts", count: 4086 }],
+      },
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("snapshot byte pressure evicts old cursors and oversized replacement leaves recent snapshots immutable", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-search-snapshot-bytes-"));
+  const file = join(root, "context.ts");
+  const beforeContext = `${"前".repeat(500)}\n`.repeat(3);
+  const afterContext = `${"後".repeat(500)}\n`.repeat(3);
+  const block = `${beforeContext}needle\n${afterContext}`;
+  try {
+    await writeFile(file, block.repeat(350));
+    const adapter = createRepositorySearchToolAdapterForTesting({ workspaceRoot: root });
+    const cursors: string[] = [];
+    for (let index = 0; index < 6; index += 1) {
+      const result = await executeSearchPage(adapter, {
+        kind: "content",
+        mode: "regex",
+        query: `needle|unused${index}`,
+        context: 3,
+      });
+      expect(result, `snapshot ${index}`).toMatchObject({
+        status: "completed",
+        output: { snapshotResultCount: 350 },
+      });
+      if (result.status !== "completed") throw new Error(result.error.message);
+      const output = result.output as { nextCursor: string };
+      cursors.push(output.nextCursor);
+    }
+    await expect(
+      executeSearchPage(adapter, {
+        kind: "content",
+        mode: "regex",
+        query: "needle|unused0",
+        context: 3,
+        cursor: cursors[0],
+      }),
+    ).resolves.toMatchObject({ status: "failed", error: { code: "search_cursor_stale" } });
+    const recentInput = {
+      kind: "content",
+      mode: "regex",
+      query: "needle|unused5",
+      context: 3,
+      cursor: cursors[5],
+    };
+    const before = await executeSearchPage(adapter, recentInput);
+    expect(before).toMatchObject({
+      status: "completed",
+      output: { pageIndex: 1, groups: [{ matches: [{ snippet: "needle" }] }] },
+    });
+    await writeFile(file, block.replace("needle", "changed needle").repeat(600));
+    await expect(
+      executeSearchPage(adapter, { kind: "content", query: "needle", context: 3 }),
+    ).resolves.toMatchObject({ status: "failed", error: { code: "search_quota_exceeded" } });
+    expect(await executeSearchPage(adapter, recentInput)).toEqual(before);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("Main search hits keep instructions inactive until an explicit search path selects their scope", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-search-instruction-scope-"));
+  const workspaceRoot = join(root, "workspace");
+  await mkdir(join(workspaceRoot, "nested"), { recursive: true });
+  await writeFile(
+    join(workspaceRoot, "nested", "AGENTS.md"),
+    "Use two-space indentation. NESTED_SCOPE_SENTINEL\n",
+  );
+  await writeFile(join(workspaceRoot, "nested", "match.ts"), "needle\n");
+  let explicit = false;
+  const driver = new FakeModelDriver((request) => {
+    const last = request.messages.at(-1);
+    if (last?.role === "user")
+      return [
+        {
+          type: "tool_call_start",
+          id: explicit ? "scoped-search" : "root-search",
+          name: "search_repository",
+        },
+        {
+          type: "tool_call_delta",
+          id: explicit ? "scoped-search" : "root-search",
+          json: JSON.stringify({
+            kind: "content",
+            query: "needle",
+            include: ["*.ts"],
+            ...(explicit ? { path: "nested" } : {}),
+          }),
+        },
+        { type: "tool_call_end", id: explicit ? "scoped-search" : "root-search" },
+        { type: "finish", reason: "tool_calls" },
+      ];
+    expect(last).toMatchObject({
+      role: "tool",
+      result: { status: "completed", output: { groups: [{ path: "nested/match.ts" }] } },
+    });
+    expect(JSON.stringify(request.messages).includes("NESTED_SCOPE_SENTINEL")).toBe(explicit);
+    return [
+      { type: "text_delta", text: "Search scope respected." },
+      { type: "finish", reason: "stop" },
+    ];
+  });
+  const lifecycle = createSessionLifecycleForTests({
+    workspaceRoot,
+    stateRoot: join(root, "state"),
+    modelTargets: modelTargetsWithDriver(driver),
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+  });
+  try {
+    const created = await lifecycle.create({ targetIdentity: sessionLifecycleTargetIdentity });
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: "Discover a matching file." },
+      }),
+    ).resolves.toMatchObject({ result: { status: "completed" } });
+    explicit = true;
+    await expect(
+      lifecycle.continue({
+        sessionId: created.sessionId,
+        input: { text: "Search the nested directory explicitly." },
+      }),
+    ).resolves.toMatchObject({ result: { status: "completed" } });
+  } finally {
+    await lifecycle.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("adjacent matching Unicode lines remain present in requested context", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-search-adjacent-context-"));
+  try {
+    await writeFile(join(root, "adjacent.ts"), "needle 😀 one\nneedle 😀 two\nneedle 😀 three\n");
+    const adapter = createRepositorySearchToolAdapterForTesting({ workspaceRoot: root });
+    const result = await executeSearchPage(adapter, {
+      kind: "content",
+      query: "needle",
+      context: 1,
+    });
+    expect(result).toMatchObject({
+      status: "completed",
+      output: {
+        groups: [
+          {
+            path: "adjacent.ts",
+            matches: [
+              {
+                line: 1,
+                snippet: "needle 😀 one",
+                contextBefore: [],
+                contextAfter: [{ line: 2, snippet: "needle 😀 two" }],
+              },
+              {
+                line: 2,
+                snippet: "needle 😀 two",
+                contextBefore: [{ line: 1, snippet: "needle 😀 one" }],
+                contextAfter: [{ line: 3, snippet: "needle 😀 three" }],
+              },
+              {
+                line: 3,
+                snippet: "needle 😀 three",
+                contextBefore: [{ line: 2, snippet: "needle 😀 two" }],
+                contextAfter: [],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    if (result.status !== "completed") throw new Error(result.error.message);
+    expect(adapter.outputSchema.safeParse(result.output).success).toBe(true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test.each(["content", "path"] as const)(
+  "%s pagination admits a complete page whose first prefix cannot fit",
+  async (kind) => {
+    const root = await mkdtemp(join(tmpdir(), "adam-search-nonmonotonic-page-"));
+    const folder = Array.from(
+      { length: kind === "content" ? 10 : 18 },
+      (_, index) => `${String(index).padStart(2, "0")}${"d".repeat(217)}`,
+    ).join("/");
+    const path = `${folder}/hit.ts`;
+    try {
+      await mkdir(join(root, folder), { recursive: true });
+      await writeFile(join(root, path), "needle\nneedle\n");
+      if (kind === "path") await writeFile(join(root, "z.ts"), "needle\n");
+      const adapter = createRepositorySearchToolAdapterForTesting({ workspaceRoot: root });
+      const input =
+        kind === "content"
+          ? { kind, mode: "regex", query: `needle|${"界".repeat(4000)}`, limit: 50 }
+          : { kind, mode: "glob", query: `{**/hit.ts,z.ts,${"界".repeat(4000)}}`, limit: 50 };
+      const result = await executeSearchPage(adapter, input);
+      expect(result).toMatchObject({
+        status: "completed",
+        output: {
+          resultCount: 2,
+          snapshotResultCount: 2,
+          remainingResultCount: 0,
+          omissions: [],
+          ...(kind === "content"
+            ? { groups: [{ path, matches: [{ line: 1 }, { line: 2 }] }] }
+            : { entries: [{ path }, { path: "z.ts" }] }),
+        },
+      });
+      if (result.status !== "completed") throw new Error(result.error.message);
+      expect(Buffer.byteLength(JSON.stringify(result.output), "utf8")).toBeLessThanOrEqual(
+        16 * 1024,
+      );
+      expect(adapter.outputSchema.safeParse(result.output).success).toBe(true);
+      expect(result.output).not.toHaveProperty("nextCursor");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);
+
+test("native glob blank handling preserves a literal BOM and Unicode whitespace no-ops", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-search-glob-blank-"));
+  try {
+    await writeFile(join(root, "a.ts"), "needle\n");
+    await writeFile(join(root, "\ufeff"), "needle\n");
+    const adapter = createRepositorySearchToolAdapterForTesting({ workspaceRoot: root });
+    for (const [query, expected] of [
+      ["\ufeff", ["\ufeff"]],
+      ["\u0085", ["a.ts", "\ufeff"]],
+      [" ", ["a.ts", "\ufeff"]],
+    ] as const) {
+      const result = await executeSearchPage(adapter, { kind: "path", mode: "glob", query });
+      expect(result).toMatchObject({
+        status: "completed",
+        output: { entries: expected.map((path) => ({ path, rankReason: "glob" })) },
+      });
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("long admitted parent and file arguments keep every result across native batches", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-search-argument-batches-"));
+  const expected = Array.from(
+    { length: 300 },
+    (_, index) => `${String(index).padStart(3, "0")}-${"d".repeat(215)}/hit.ts`,
+  );
+  let started = 0;
+  let closed = 0;
+  try {
+    await Promise.all(
+      expected.map(async (path) => {
+        await mkdir(join(root, path.slice(0, path.lastIndexOf("/"))));
+        await writeFile(join(root, path), "needle\n");
+      }),
+    );
+    const adapter = createRepositorySearchToolAdapterForTesting({
+      workspaceRoot: root,
+      processObserver: {
+        spawned() {
+          started += 1;
+        },
+        closed() {
+          closed += 1;
+        },
+      },
+    });
+    const paths: string[] = [];
+    let cursor: string | undefined;
+    do {
+      const result = await executeSearchPage(adapter, {
+        kind: "content",
+        query: "needle",
+        include: ["*.ts"],
+        limit: 50,
+        ...(cursor === undefined ? {} : { cursor }),
+      });
+      expect(result).toMatchObject({ status: "completed" });
+      if (result.status !== "completed") throw new Error(result.error.message);
+      expect(closed).toBe(started);
+      expect(Buffer.byteLength(JSON.stringify(result.output), "utf8")).toBeLessThanOrEqual(
+        16 * 1024,
+      );
+      const page = result.output as {
+        groups: Array<{ path: string }>;
+        nextCursor?: string;
+        remainingResultCount: number;
+      };
+      paths.push(...page.groups.map((group) => group.path));
+      expect(page.remainingResultCount).toBe(300 - paths.length);
+      cursor = page.nextCursor;
+    } while (cursor !== undefined);
+    expect(paths).toEqual(expected);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/testkit/src/search-glob-grammar.os.test.ts
+++ b/packages/testkit/src/search-glob-grammar.os.test.ts
@@ -1,0 +1,213 @@
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { createReadToolRegistry } from "@adam-agent/agent";
+import { createRepositorySearchToolAdapterForTesting } from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+
+const legalPaths = [
+  "#file.ts",
+  "*.ts",
+  "@(a).ts",
+  "a.ts",
+  "a[.ts",
+  "b.txt",
+  "file-1.ts",
+  "file-{1..3}.ts",
+  "foo/bar.ts",
+  "space .ts",
+  "src/a.ts",
+  "src/b.txt",
+  "src/foo",
+  "src/sub/a.ts",
+  "é.ts",
+  "😀.ts",
+] as const;
+const typescriptPaths = [
+  "#file.ts",
+  "*.ts",
+  "@(a).ts",
+  "a.ts",
+  "a[.ts",
+  "file-1.ts",
+  "file-{1..3}.ts",
+  "foo/bar.ts",
+  "space .ts",
+  "src/a.ts",
+  "src/sub/a.ts",
+  "é.ts",
+  "😀.ts",
+] as const;
+const cases: readonly { readonly query: string; readonly expected: readonly string[] }[] = [
+  { query: "*", expected: legalPaths },
+  { query: "*.ts", expected: typescriptPaths },
+  { query: "/a.ts", expected: ["a.ts"] },
+  { query: "src/*.ts", expected: ["src/a.ts"] },
+  { query: "src/**", expected: ["src/a.ts", "src/b.txt", "src/foo", "src/sub/a.ts"] },
+  { query: "foo/", expected: [] },
+  { query: "foo", expected: ["src/foo"] },
+  { query: "*.{ts,txt}", expected: [...typescriptPaths, "b.txt", "src/b.txt"].sort() },
+  { query: "{a,{b,c}}.ts", expected: ["a.ts", "src/a.ts", "src/sub/a.ts"] },
+  { query: "\\*.ts", expected: ["*.ts"] },
+  { query: "@(a).ts", expected: ["@(a).ts"] },
+  { query: "file-{1..3}.ts", expected: [] },
+  { query: "?.ts", expected: ["*.ts", "a.ts", "src/a.ts", "src/sub/a.ts"] },
+  { query: "??.ts", expected: ["a[.ts", "é.ts"] },
+  { query: "[é].ts", expected: [] },
+  {
+    query: "[!a]*.ts",
+    expected: [
+      "#file.ts",
+      "*.ts",
+      "@(a).ts",
+      "file-1.ts",
+      "file-{1..3}.ts",
+      "foo/bar.ts",
+      "space .ts",
+      "é.ts",
+      "😀.ts",
+    ],
+  },
+  { query: "[*].ts", expected: ["*.ts"] },
+  { query: "\\#file.ts", expected: ["#file.ts"] },
+  { query: "#file.ts", expected: legalPaths },
+  { query: " ", expected: legalPaths },
+  {
+    query: "!a.ts",
+    expected: [
+      "#file.ts",
+      "*.ts",
+      "@(a).ts",
+      "a[.ts",
+      "b.txt",
+      "file-1.ts",
+      "file-{1..3}.ts",
+      "foo/bar.ts",
+      "space .ts",
+      "src/b.txt",
+      "src/foo",
+      "é.ts",
+      "😀.ts",
+    ],
+  },
+  {
+    query: "!foo",
+    expected: [
+      "#file.ts",
+      "*.ts",
+      "@(a).ts",
+      "a.ts",
+      "a[.ts",
+      "b.txt",
+      "file-1.ts",
+      "file-{1..3}.ts",
+      "space .ts",
+      "src/a.ts",
+      "src/b.txt",
+      "src/sub/a.ts",
+      "é.ts",
+      "😀.ts",
+    ],
+  },
+];
+
+test("repository path matching preserves native glob syntax over its admitted discovery set", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-search-native-globs-"));
+  try {
+    for (const path of [...legalPaths, ".hidden.ts", "ignored/private.ts"]) {
+      await mkdir(join(workspaceRoot, dirname(path)), { recursive: true });
+      await writeFile(join(workspaceRoot, path), "needle\n");
+    }
+    await writeFile(join(workspaceRoot, ".gitignore"), "ignored/\n");
+    const adapter = createReadToolRegistry({ workspaceRoot }).resolve("search_repository");
+    if (adapter === undefined) throw new Error("The public search tool was unavailable.");
+    for (const { query, expected } of cases) {
+      const result = await executeSearch(adapter, query);
+      expect(result, query).toMatchObject({
+        status: "completed",
+        output: { resultCount: expected.length },
+      });
+      if (result.status !== "completed") throw new Error(`Search failed for ${query}.`);
+      expect(adapter.outputSchema.safeParse(result.output).success, query).toBe(true);
+      const output = result.output as { readonly entries: readonly { readonly path: string }[] };
+      expect(
+        output.entries.map((entry) => entry.path),
+        query,
+      ).toEqual(expected);
+    }
+    await expect(executeSearch(adapter, "a[.ts")).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "tool_io_failed" },
+    });
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("an excluded-tree record flood cannot consume the admitted search budget", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-search-excluded-budget-"));
+  const workspaceRoot = join(root, "workspace");
+  const executable = join(root, "external-rg.mjs");
+  await mkdir(workspaceRoot);
+  await writeFile(join(workspaceRoot, "normal.ts"), "needle\n");
+  await writeFile(join(workspaceRoot, ".gitignore"), "ignored/\n");
+  // External process input models ripgrep's override precedence without creating
+  // 100,001 real files just to demonstrate a raw-record budget failure.
+  await writeFile(
+    executable,
+    `#!${process.execPath}
+const args = process.argv.slice(2);
+const globs = [];
+const nul = String.fromCharCode(0);
+for (let index = 0; index < args.length; index += 1) {
+  if (args[index] === '--glob' || args[index] === '-g') globs.push(args[++index]);
+  else if (args[index].startsWith('--glob=')) globs.push(args[index].slice(7));
+}
+if (globs.some(glob => !glob.startsWith('!'))) {
+  let output = '';
+  for (let index = 0; index < 100001; index += 1) output += 'ignored/file-' + index + '.ts' + nul;
+  process.stdout.write(output);
+} else if (globs.includes('!*')) {
+  process.exitCode = 1;
+} else {
+  process.stdout.write('normal.ts' + nul);
+}
+`,
+  );
+  await chmod(executable, 0o700);
+  try {
+    const adapter = createRepositorySearchToolAdapterForTesting({
+      workspaceRoot,
+      rgPathOverrideForTesting: executable,
+    });
+    await expect(executeSearch(adapter, "*")).resolves.toMatchObject({
+      status: "completed",
+      output: {
+        resultCount: 1,
+        snapshotResultCount: 1,
+        entries: [{ path: "normal.ts", rankReason: "glob" }],
+        omissions: [],
+      },
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+async function executeSearch(
+  adapter: ReturnType<typeof createRepositorySearchToolAdapterForTesting>,
+  query: string,
+) {
+  const prepared = adapter.prepare(
+    JSON.stringify({ kind: "path", mode: "glob", query, limit: 50 }),
+  );
+  if (prepared.status !== "ready") return prepared;
+  return prepared.execute({
+    signal: new AbortController().signal,
+    callId: "glob-contract",
+    toolName: "search_repository",
+    sessionId: "glob-contract-session",
+    toolProfileDigest: "sha256:glob-contract-profile",
+  });
+}


### PR DESCRIPTION
Broad repository searches could fail the page quota because omitted-result metadata grew beyond the byte budget. Pages now measure the complete output, including paths, query, context, omissions and the actual cursor, while retaining exact per-file and aggregate accounting. Bounded prefix selection also handles a complete page becoming smaller when remainder and cursor metadata disappear.

Discovery honors hidden, ignore, binary, symlink and requested-path rules before positive glob matching. Filtering retains the pinned ripgrep grammar without adding a dependency. Match and context snippets use the same 500-codepoint contract, adjacent matching lines remain available as context, and actual outputs pass the declared schema. Git parsing and budget errors now settle through their owning Promise after process close.

Validation covers all pages of 300-file searches through Main and a real managed child, production TUI success/failure followed by another durable Main input, native glob syntax and excluded-tree budgets, dense and long-path pages, snapshot eviction/cursor preservation, and real Git/ripgrep cancellation and failure contracts. Independent specification and engineering reviews have no remaining findings.

Final `pnpm quality:check` passed: 2,262 tests, with 18 existing opt-in skips; code, Markdown, TypeScript and browser checks all passed.
