### PR TITLE
Arm filesystem observers before probing fixture state

### DIFF
--- a/apps/tui/src/tui-filesystem.os.test.ts
+++ b/apps/tui/src/tui-filesystem.os.test.ts
@@ -1,0 +1,43 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { waitForFilesystemEffect } from "./tui-filesystem.test-support.js";
+
+test("a filesystem effect published during the initial probe is observed without another write", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-file-observation-"));
+  const path = join(root, "receipt");
+  let initial = true;
+  const observed = waitForFilesystemEffect(
+    path,
+    async () => {
+      const snapshot = await readFile(path, "utf8").catch((error: NodeJS.ErrnoException) => {
+        if (error.code !== "ENOENT") throw error;
+        return undefined;
+      });
+      if (initial) {
+        initial = false;
+        // The real effect arrives after the probe's snapshot, before it returns.
+        await writeFile(path, "ready\n");
+      }
+      return snapshot;
+    },
+    "publish",
+  );
+  let guard: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const missing = new Promise<never>((_resolve, reject) => {
+      guard = setTimeout(
+        () => reject(new Error("The initial-probe filesystem notification was lost.")),
+        10000,
+      );
+    });
+    await expect(Promise.race([observed, missing])).resolves.toBe("ready\n");
+  } finally {
+    clearTimeout(guard);
+    // Release the old lazy watcher after failure, without changing that verdict.
+    await writeFile(path, "ready\n");
+    await observed.catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/apps/tui/src/tui-filesystem.test-support.ts
+++ b/apps/tui/src/tui-filesystem.test-support.ts
@@ -1,4 +1,5 @@
-import { access, readdir, readFile, rm, watch } from "node:fs/promises";
+import { watch } from "node:fs";
+import { access, readdir, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 
 import { cleanupActiveTuiFixtures } from "./tui-fixture.test-support.js";
@@ -43,42 +44,34 @@ export async function waitForFileContents(path: string, expected: string): Promi
   );
 }
 
-async function waitForFilesystemEffect<T>(
+export async function waitForFilesystemEffect<T>(
   path: string,
   observe: () => Promise<T | undefined>,
   action: string,
 ): Promise<T> {
   const directory = join(path, "..");
   const filename = path.slice(directory.length + 1);
-  const watcher = watch(directory);
+  let change = Promise.withResolvers<void>();
   const failure = Promise.withResolvers<never>();
+  // fs.watch subscribes immediately; the promise-based iterator is lazy.
+  const watcher = watch(directory, () => change.resolve());
+  watcher.on("error", failure.reject);
   const guard = setTimeout(
     () => failure.reject(new Error(`The fixture did not ${action} ${filename}.`)),
     missingFilesystemEffectFailureMilliseconds,
   );
   guard.unref();
   try {
-    const initial = await observe();
-    if (initial !== undefined) {
-      return initial;
+    while (true) {
+      const changed = change.promise;
+      const observed = await Promise.race([observe(), failure.promise]);
+      if (observed !== undefined) return observed;
+      await Promise.race([changed, failure.promise]);
+      change = Promise.withResolvers<void>();
     }
-    return await Promise.race([
-      (async () => {
-        for await (const _event of watcher) {
-          const observed = await observe();
-          if (observed !== undefined) {
-            return observed;
-          }
-        }
-        throw new Error(
-          `The filesystem watcher closed before the fixture could ${action} ${filename}.`,
-        );
-      })(),
-      failure.promise,
-    ]);
   } finally {
     clearTimeout(guard);
-    await watcher.return?.();
+    watcher.close();
   }
 }
 


### PR DESCRIPTION
A file created while a TUI fixture's initial state probe was pending could be missed: `fs.promises.watch()` did not subscribe until the later iterator read. The waiter could then hang even though the expected file was already present, and iterator cleanup could also remain pending.

Install `fs.watch` before the initial probe, preserve its change notification across each probe, and close it directly during cleanup. Success still requires observing the actual filesystem state. The existing 30-second failure guard and reasoning pagination assertions remain unchanged.

Validation:

- A real filesystem regression deterministically fails with the old waiter and passes with the eager observer.
- The original adjacent-range and late-range reasoning tests pass.
- Independent Astra Medium review passed on `e0a25b36421546ed67e351e8ecda9f1db1a77906`.
- `pnpm quality:check`: 2,345 passed, 18 existing opt-in skips; code, Markdown, TypeScript, browser, and OS gates passed.

This corrects the shared fixture race found while closing the merged delegation changes in #154.
