### PR TITLE
Make agent capacity configurable per session

### DIFF
--- a/apps/tui/src/agent-fleet.os.test.ts
+++ b/apps/tui/src/agent-fleet.os.test.ts
@@ -271,11 +271,11 @@ test.each([{}, { columns: 40, rows: 12 }])(
   async (viewport) => {
     let stopping = false;
     let calls = 0;
-    const four = Promise.withResolvers<void>();
+    const eight = Promise.withResolvers<void>();
     const driver: ModelDriver = {
       async *stream(request) {
         calls += 1;
-        if (calls === 4) four.resolve();
+        if (calls === 8) eight.resolve();
         if (!stopping)
           await new Promise<void>((resolve) =>
             request.signal.addEventListener("abort", () => resolve(), { once: true }),
@@ -294,25 +294,25 @@ test.each([{}, { columns: 40, rows: 12 }])(
         command: {
           type: "spawn_agents",
           parentSessionId: h.parent.sessionId,
-          entries: Array.from({ length: 7 }, (_, index) => ({
+          entries: Array.from({ length: 11 }, (_, index) => ({
             role: "builtin:explore" as const,
             task: `Inspect item ${index}`,
             description: `Cold item ${index}`,
           })),
         },
       });
-      await four.promise;
+      await eight.promise;
       stopping = true;
       await h.stop();
       cold = await startManagedTui(driver, { restore: h.storage, ...viewport });
       expect(cold.terminal.lines().join("\n")).not.toContain("3 running");
       await cold.press("/agents\r", "Agents workspace");
-      expect(calls).toBe(4);
-      await cold.press("\u001b[F", "@explore-7");
-      await cold.press("u", "@explore-7");
+      expect(calls).toBe(8);
+      await cold.press("\u001b[F", "@explore-11");
+      await cold.press("u", "@explore-11");
       expect(cold.terminal.lines().join("\n")).toContain("u again to resume 1");
       await cold.press("u", "Completed");
-      expect(calls).toBe(5);
+      expect(calls).toBe(9);
       await cold.press("U", "u again to resume 2");
       await cold.press("u", "Resumed 2");
       const restarted = cold;
@@ -332,7 +332,7 @@ test.each([{}, { columns: 40, rows: 12 }])(
         const unsubscribe = restarted.presentation.subscribe(check);
         check();
       });
-      expect(calls).toBe(7);
+      expect(calls).toBe(11);
       expect(
         cold.presentation
           .getState()

--- a/apps/tui/src/agent-fleet.test.ts
+++ b/apps/tui/src/agent-fleet.test.ts
@@ -105,13 +105,13 @@ test("background spawn cards settle to Started and Queued with frozen identities
   let childCalls = 0;
   const prepared = Promise.withResolvers<void>();
   const releaseStart = Promise.withResolvers<void>();
-  const fourStarted = Promise.withResolvers<void>();
+  const eightStarted = Promise.withResolvers<void>();
   const h = await startManagedTui(
     {
       async *stream(request) {
         if (!request.tools.some((tool) => tool.name === "spawn_agents")) {
           yield { type: "text_delta", text: "Reading batch evidence." };
-          if (++childCalls === 4) fourStarted.resolve();
+          if (++childCalls === 8) eightStarted.resolve();
           await new Promise<void>((resolve) => {
             if (request.signal.aborted) resolve();
             else request.signal.addEventListener("abort", () => resolve(), { once: true });
@@ -122,7 +122,7 @@ test("background spawn cards settle to Started and Queued with frozen identities
             type: "tool_call_delta",
             id: "batch",
             json: JSON.stringify({
-              entries: Array.from({ length: 5 }, (_, index) => ({
+              entries: Array.from({ length: 9 }, (_, index) => ({
                 role: "builtin:explore",
                 task: `Read evidence ${index + 1}`,
                 description: `Inspect item ${index + 1}`,
@@ -139,42 +139,42 @@ test("background spawn cards settle to Started and Queued with frozen identities
       },
     },
     {
-      rows: 48,
+      rows: 64,
       childRecordBarrier: async (record) => {
         if (record.schemaVersion === 3 && record.record.type === "session_genesis") {
-          if (++preparedCount === 4) prepared.resolve();
+          if (++preparedCount === 8) prepared.resolve();
           await releaseStart.promise;
         }
       },
     },
   );
   try {
-    await h.press("Inspect these five items.\r", "Confirm delegation");
+    await h.press("Inspect these nine items.\r", "Confirm delegation");
     await h.press("\r", "Batch admitted; Main ready.");
     await prepared.promise;
     await h.terminal.waitForScreen("Starting · 0 used");
     const screen = h.terminal.lines().join("\n");
     expect(screen).toContain("Started @explore-1 · Explore · Inspect item 1");
-    expect(screen).toContain("Queued @explore-5 · Explore · Inspect item 5");
+    expect(screen).toContain("Queued @explore-9 · Explore · Inspect item 9");
     expect(
       h.presentation
         .getState()
         .authoritative.managedControl?.threads.filter((thread) => thread.turn.phase === "starting"),
-    ).toHaveLength(4);
+    ).toHaveLength(8);
     expect(
       h.presentation
         .getState()
         .authoritative.managedControl?.threads.filter((thread) => thread.turn.phase === "queued"),
     ).toHaveLength(1);
     releaseStart.resolve();
-    await fourStarted.promise;
-    await h.terminal.waitForScreen("@explore-4 · Explore · Running");
+    await eightStarted.promise;
+    await h.terminal.waitForScreen("● Agents · 8 running · 1 queued");
     const state = h.presentation.getState();
     expect(
       state.authoritative.managedControl?.threads.filter(
         (thread) => thread.turn.phase === "executing",
       ),
-    ).toHaveLength(4);
+    ).toHaveLength(8);
     expect(
       state.authoritative.managedControl?.threads.filter(
         (thread) => thread.turn.phase === "queued",
@@ -185,7 +185,7 @@ test("background spawn cards settle to Started and Queued with frozen identities
         (item) => item.type === "tool_call" && item.qualifiedName === "spawn_agents",
       ),
     ).toMatchObject({ status: "completed" });
-    expect(screen.slice(screen.indexOf("Fleet ·"))).not.toContain("@explore-5");
+    expect(screen.slice(screen.indexOf("Fleet ·"))).not.toContain("@explore-9");
     expect(mainCalls).toBe(2);
   } finally {
     releaseStart.resolve();
@@ -193,14 +193,14 @@ test("background spawn cards settle to Started and Queued with frozen identities
   }
 });
 
-test("Widget projects live child activity and individually frozen queued configuration and budget", async () => {
-  const fourStarted = Promise.withResolvers<void>();
+test("Widget projects live child activity and queued details expose frozen configuration and budget", async () => {
+  const eightStarted = Promise.withResolvers<void>();
   let calls = 0;
   const h = await startManagedTui(
     {
       async *stream(request) {
         yield { type: "text_delta", text: "Inspecting exact repository evidence." };
-        if (++calls === 4) fourStarted.resolve();
+        if (++calls === 8) eightStarted.resolve();
         await new Promise<void>((resolve) => {
           if (request.signal.aborted) resolve();
           else request.signal.addEventListener("abort", () => resolve(), { once: true });
@@ -215,11 +215,11 @@ test("Widget projects live child activity and individually frozen queued configu
     expect(
       await h.presentation.dispatch({
         type: "managed_control",
-        commandId: "visible-five",
+        commandId: "visible-nine",
         command: {
           type: "spawn_agents",
           parentSessionId: h.parent.sessionId,
-          entries: Array.from({ length: 5 }, (_, index) => ({
+          entries: Array.from({ length: 9 }, (_, index) => ({
             role: "builtin:explore",
             task: `Read item ${index + 1}`,
             description: `Evidence ${index + 1}`,
@@ -227,14 +227,21 @@ test("Widget projects live child activity and individually frozen queued configu
         },
       }),
     ).toMatchObject({ status: "admitted" });
-    await fourStarted.promise;
+    await eightStarted.promise;
     await h.press("Independent Main draft", "Independent Main draft");
     const screen = h.terminal.lines().join("\n");
     expect(screen).toContain("Inspecting exact repository evidence.");
-    expect(screen).toContain("Queued @explore-5 · Explore · Evidence 5");
-    expect(screen).toContain("deepseek-v4-flash.direct · thinking default");
-    expect(screen).toContain("0 used · 0 reserved");
-    const queued = h.presentation.getState().authoritative.managedControl?.threads[4];
+    expect(screen).toContain("● Agents · 8 running · 1 queued");
+    await h.press("\u0001\u000b/agents\r", "Agents workspace");
+    await h.press("\u001b[F", "@explore-9");
+    await h.press("\r", "Queued tasks are immutable.");
+    const detail = h.terminal.lines().join("\n");
+    expect(detail).toContain("Evidence 9");
+    expect(detail).toContain("deepseek-v4-flash.direct");
+    expect(detail).toContain("thinking default");
+    expect(detail).toContain("0 used");
+    expect(detail).toContain("0 reserved");
+    const queued = h.presentation.getState().authoritative.managedControl?.threads[8];
     expect(queued?.turn.configuration).toMatchObject({
       targetId: "deepseek-v4-flash.direct",
       thinking: "default",
@@ -247,23 +254,27 @@ test("Widget projects live child activity and individually frozen queued configu
       ceiling: null,
       available: null,
     });
-    expect(calls).toBe(4);
+    expect(calls).toBe(8);
   } finally {
     await h.close();
   }
 });
 
 test("thirty-two admitted agents compress truthfully without hiding the Main editor", async () => {
-  const fourStarted = Promise.withResolvers<void>();
+  const eightStarted = Promise.withResolvers<void>();
   const firstFinish = Promise.withResolvers<void>();
-  const fifthStarted = Promise.withResolvers<void>();
+  const ninthStarted = Promise.withResolvers<void>();
   let calls = 0;
+  let ninthRequest = "";
   const h = await startManagedTui(
     {
       async *stream(request) {
         const call = ++calls;
-        if (call === 4) fourStarted.resolve();
-        if (call === 5) fifthStarted.resolve();
+        if (call === 8) eightStarted.resolve();
+        if (call === 9) {
+          ninthRequest = JSON.stringify(request.messages);
+          ninthStarted.resolve();
+        }
         await Promise.race([
           call === 1 ? firstFinish.promise : new Promise<void>(() => {}),
           new Promise<void>((resolve) => {
@@ -302,18 +313,27 @@ test("thirty-two admitted agents compress truthfully without hiding the Main edi
         },
       }),
     ).toMatchObject({ status: "admitted" });
-    await fourStarted.promise;
+    await eightStarted.promise;
     await h.press("Main draft", "Main draft");
     const screen = h.terminal.lines().join("\n");
     expect(screen).toContain("Main draft");
-    expect(screen).toContain("28 queued");
-    expect(screen).toContain("… hidden 3 run/28 queued/1 line");
+    expect(screen).toContain("● Agents · 8 running · 24 queued");
+    expect(screen).toContain("… hidden 7 run/24 queued/1 line");
     expect(screen).toContain("Fleet");
-    expect(h.presentation.getState().authoritative.managedControl?.threads).toHaveLength(32);
+    const admitted = h.presentation.getState().authoritative.managedControl?.threads ?? [];
+    expect(admitted).toHaveLength(32);
+    expect(admitted.filter((thread) => thread.turn.phase === "executing")).toHaveLength(8);
+    expect(admitted.filter((thread) => thread.turn.phase === "queued")).toHaveLength(24);
+    expect(calls).toBe(8);
     const beforeFinish = h.terminal.output().length;
     firstFinish.resolve();
-    await fifthStarted.promise;
-    await h.terminal.waitForFrameAfter("… hidden 3 run/27 queued/1 done/1 line", beforeFinish);
+    await ninthStarted.promise;
+    await h.terminal.waitForFrameAfter("… hidden 7 run/23 queued/1 done/1 line", beforeFinish);
+    expect(calls).toBe(9);
+    expect(ninthRequest).toContain("Read item 9");
+    const advanced = h.presentation.getState().authoritative.managedControl?.threads ?? [];
+    expect(advanced[8]?.turn.phase).toBe("executing");
+    expect(advanced.filter((thread) => thread.turn.phase === "queued")).toHaveLength(23);
     const mixed = h.terminal.lines().join("\n");
     expect(mixed).toContain("Main draft");
     expect(mixed).toContain("Fleet");
@@ -324,11 +344,11 @@ test("thirty-two admitted agents compress truthfully without hiding the Main edi
 });
 
 test("queued agents stay individually inspectable and exact cancellation never opens a dead Fleet row", async () => {
-  const fourStarted = Promise.withResolvers<void>();
+  const eightStarted = Promise.withResolvers<void>();
   let calls = 0;
   const h = await startManagedTui({
     async *stream(request) {
-      if (++calls === 4) fourStarted.resolve();
+      if (++calls === 8) eightStarted.resolve();
       await new Promise<void>((resolve) => {
         if (request.signal.aborted) resolve();
         else request.signal.addEventListener("abort", () => resolve(), { once: true });
@@ -344,7 +364,7 @@ test("queued agents stay individually inspectable and exact cancellation never o
         command: {
           type: "spawn_agents",
           parentSessionId: h.parent.sessionId,
-          entries: Array.from({ length: 5 }, (_, index) => ({
+          entries: Array.from({ length: 9 }, (_, index) => ({
             role: "builtin:explore",
             task: `Private task ${index + 1}`,
             description: `Queued evidence ${index + 1}`,
@@ -352,27 +372,27 @@ test("queued agents stay individually inspectable and exact cancellation never o
         },
       }),
     ).toMatchObject({ status: "admitted" });
-    await fourStarted.promise;
+    await eightStarted.promise;
     await h.press("/agents\r", "Agents workspace");
-    await h.press("\u001b[F", "@explore-5");
+    await h.press("\u001b[F", "@explore-9");
     await h.press("\r", "Queued tasks are immutable.");
     const detail = h.terminal.lines().join("\n");
     expect(detail).toContain("deepseek-v4-flash.direct");
     expect(detail).toContain("thinking default");
     expect(detail).toContain("no cumulative budget");
-    expect(detail).not.toContain("Private task 5");
+    expect(detail).not.toContain("Private task 9");
     await h.press("x", "x again to cancel");
     await h.press("x", "Cancelled");
-    expect(h.presentation.getState().authoritative.managedControl?.threads[4]?.turn).toMatchObject({
+    expect(h.presentation.getState().authoritative.managedControl?.threads[8]?.turn).toMatchObject({
       phase: "idle",
       lastOutcome: "cancelled",
     });
-    expect(calls).toBe(4);
+    expect(calls).toBe(8);
     await h.press("\u001b[27;1;27~", "Agents workspace", "Esc list");
     await h.press("\u001b[27;1;27~", "Fleet", "Agents workspace");
     expect(
       h.terminal.lines().join("\n").slice(h.terminal.lines().join("\n").indexOf("Fleet ·")),
-    ).not.toContain("@explore-5");
+    ).not.toContain("@explore-9");
   } finally {
     await h.close();
   }
@@ -1732,11 +1752,11 @@ test("cold Seen and Suppress reconcile an already durable wait tool result befor
 
 test("a queued cancellation keeps per-thread export available without creating a child session or continuation action", async () => {
   let calls = 0;
-  const fourStarted = Promise.withResolvers<void>();
+  const eightStarted = Promise.withResolvers<void>();
   const h = await startManagedTui({
     async *stream(request) {
       calls += 1;
-      if (calls === 4) fourStarted.resolve();
+      if (calls === 8) eightStarted.resolve();
       await new Promise<void>((resolve) =>
         request.signal.addEventListener("abort", () => resolve(), { once: true }),
       );
@@ -1751,7 +1771,7 @@ test("a queued cancellation keeps per-thread export available without creating a
         command: {
           type: "spawn_agents",
           parentSessionId: h.parent.sessionId,
-          entries: Array.from({ length: 5 }, (_, index) => ({
+          entries: Array.from({ length: 9 }, (_, index) => ({
             role: "builtin:explore" as const,
             task: "Inspect",
             description: `Export queue ${index}`,
@@ -1759,9 +1779,9 @@ test("a queued cancellation keeps per-thread export available without creating a
         },
       }),
     ).toMatchObject({ status: "admitted" });
-    await fourStarted.promise;
+    await eightStarted.promise;
     await h.press("/agents\r", "Agents workspace");
-    await h.press("\u001b[F", "@explore-5");
+    await h.press("\u001b[F", "@explore-9");
     await h.press("x", "x again to cancel");
     await h.press("x", "Cancelled");
     await h.press("\r", "e export");
@@ -1769,14 +1789,14 @@ test("a queued cancellation keeps per-thread export available without creating a
     await h.press("e", "Export agent");
     await h.press("\r", "Confirm export");
     await h.press("\r", "Export ready");
-    const thread = h.presentation.getState().authoritative.managedControl?.threads[4];
+    const thread = h.presentation.getState().authoritative.managedControl?.threads[8];
     if (thread === undefined) throw new Error("Missing cancelled queue entry");
     expect(thread.actions).not.toContain("new_turn");
     expect(await h.children.open(thread.turn.childSessionId)).toBeUndefined();
     expect(h.presentation.getState().authoritative.managedControl?.exports?.[0]?.turnId).toBe(
       thread.turn.turnId,
     );
-    expect(calls).toBe(4);
+    expect(calls).toBe(8);
   } finally {
     await h.close();
   }

--- a/apps/tui/src/agent-input.test.ts
+++ b/apps/tui/src/agent-input.test.ts
@@ -289,7 +289,7 @@ test("a retained child draft rejects after another turn starts without rebinding
 test.each(["wait", "suspend"] as const)(
   "Session picker offers Stay and %s before switching and preserves child draft scope",
   async (decision) => {
-    const fourStarted = Promise.withResolvers<void>();
+    const eightStarted = Promise.withResolvers<void>();
     const finish = Promise.withResolvers<void>();
     let calls = 0;
     const h = await startManagedTui(
@@ -301,7 +301,7 @@ test.each(["wait", "suspend"] as const)(
             yield { type: "finish", reason: "stop" };
             return;
           }
-          if (++calls === 4) fourStarted.resolve();
+          if (++calls === 8) eightStarted.resolve();
           await Promise.race([
             finish.promise,
             new Promise<void>((resolve) => {
@@ -329,7 +329,7 @@ test.each(["wait", "suspend"] as const)(
           command: {
             type: "spawn_agents",
             parentSessionId: h.parent.sessionId,
-            entries: Array.from({ length: 5 }, (_, index) => ({
+            entries: Array.from({ length: 9 }, (_, index) => ({
               role: "builtin:explore",
               task: `Source ${index + 1}.`,
               description: `Source item ${index + 1}`,
@@ -337,7 +337,10 @@ test.each(["wait", "suspend"] as const)(
           },
         }),
       ).toMatchObject({ status: "admitted" });
-      await fourStarted.promise;
+      await eightStarted.promise;
+      expect(h.presentation.getState().authoritative.managedControl?.threads[8]?.turn.phase).toBe(
+        "queued",
+      );
       await h.terminal.waitForScreen("@explore-1 · Explore · Running");
       await h.openFirstAgent();
       await h.press("\r", "Cooperative");
@@ -370,7 +373,7 @@ test.each(["wait", "suspend"] as const)(
       );
       expect(h.presentation.getState().managedDrafts).toHaveLength(0);
       expect(h.presentation.getState().authoritative.managedControl?.threads).toHaveLength(0);
-      expect(calls).toBe(decision === "wait" ? 5 : 4);
+      expect(calls).toBe(decision === "wait" ? 9 : 8);
       await h.press("/resume\r", "Select a project session");
       await h.press("Fleet fixture", "Search: Fleet fixture");
       await h.press("\r", "Adam · Fleet fixture");

--- a/apps/tui/src/delegation-selector.ts
+++ b/apps/tui/src/delegation-selector.ts
@@ -77,7 +77,7 @@ export class DelegationSelector implements Component {
   }
   #createList(): SelectList {
     const envelope = this.#envelope;
-    const lane = envelope.policy[envelope.mode === "background" ? "background" : "reserved"];
+    const lane = delegationLaneBounds(envelope, envelope.mode);
     const items =
       this.#page === "review"
         ? [
@@ -138,7 +138,7 @@ export class DelegationSelector implements Component {
               },
             ]
           : this.#page === "custom"
-            ? (envelope.version === 2
+            ? (envelope.version !== 1
                 ? this.options.canChangeMode === false
                   ? (["running", "queued"] as const)
                   : (["budgetTokens", "running", "queued"] as const)
@@ -177,7 +177,7 @@ export class DelegationSelector implements Component {
                         },
                       ]
                     : []),
-                  ...(envelope.version === 2
+                  ...(envelope.version !== 1
                     ? this.options.canChangeMode === false
                       ? []
                       : [
@@ -205,7 +205,7 @@ export class DelegationSelector implements Component {
                       label: `Running ${running}`,
                       description: `Range 1–${lane.running}; queued ${Math.max(0, envelope.threads - running)} (0–${lane.queued})`,
                     })),
-                  ...(envelope.version === 2
+                  ...(envelope.version !== 1
                     ? []
                     : [0.25, 0.5, 1].map((n) => ({
                         value: `thread:${Math.max(1, Math.floor(n * (envelope.policy.threadTokens ?? 0)))}`,
@@ -349,14 +349,7 @@ export class DelegationSelector implements Component {
           this.#list = this.#createList();
           return;
         }
-        const limits: ManagedDelegationLimits = {
-          mode: envelope.mode,
-          running: envelope.running,
-          queued: envelope.queued,
-          aggregateTokens: envelope.aggregateTokens,
-          threadTokens: envelope.threadTokens,
-          sessionTokens: envelope.sessionTokens,
-        };
+        const limits = this.#limits();
         const [field, raw] = item.value.split(":");
         const update: ManagedDelegationLimits =
           item.value === "unbudgeted"
@@ -369,16 +362,17 @@ export class DelegationSelector implements Component {
                   ? { running: Number(raw), queued: Math.max(0, envelope.threads - Number(raw)) }
                   : {
                       mode: item.value === "foreground" ? "foreground" : "background",
-                      running: Math.min(
-                        envelope.threads,
-                        envelope.policy[item.value === "foreground" ? "reserved" : "background"]
-                          .running,
-                      ),
+                      running: delegationLaneBounds(
+                        envelope,
+                        item.value === "foreground" ? "foreground" : "background",
+                      ).running,
                       queued: Math.max(
                         0,
                         envelope.threads -
-                          envelope.policy[item.value === "foreground" ? "reserved" : "background"]
-                            .running,
+                          delegationLaneBounds(
+                            envelope,
+                            item.value === "foreground" ? "foreground" : "background",
+                          ).running,
                       ),
                     };
         if (this.options.onLimits !== undefined)
@@ -456,12 +450,14 @@ export class DelegationSelector implements Component {
     const { mode, running, queued, aggregateTokens, threadTokens, sessionTokens } = this.#envelope;
     return {
       mode,
-      running,
+      ...(this.#envelope.version === 3 && this.#envelope.concurrency?.mode === "owner"
+        ? {}
+        : { running }),
       queued,
       aggregateTokens,
       threadTokens,
       sessionTokens,
-      ...(this.#envelope.version === 2 && this.options.canChangeMode !== false
+      ...(this.#envelope.version !== 1 && this.options.canChangeMode !== false
         ? {
             budgetTokens:
               this.#envelope.taskBudget?.mode === "limited"
@@ -473,7 +469,7 @@ export class DelegationSelector implements Component {
   }
   #numericBound(field: NumericLimit): { label: string; min: number; max: number } {
     const envelope = this.#envelope;
-    const lane = envelope.policy[envelope.mode === "background" ? "background" : "reserved"];
+    const lane = delegationLaneBounds(envelope, envelope.mode);
     switch (field) {
       case "budgetTokens":
         return { label: "Task budget tokens", min: 1, max: Number.MAX_SAFE_INTEGER };
@@ -615,4 +611,16 @@ export class DelegationSelector implements Component {
       truncateToWidth(theme.muted("Enter choose · Esc cancel"), width),
     ];
   }
+}
+
+function delegationLaneBounds(
+  envelope: ManagedDelegationEnvelope,
+  mode: "background" | "foreground",
+) {
+  const lane = envelope.policy[mode === "background" ? "background" : "reserved"];
+  return {
+    running:
+      lane.running === "unlimited" ? envelope.threads : Math.min(lane.running, envelope.threads),
+    queued: lane.queued === "unlimited" ? 32 : lane.queued,
+  };
 }

--- a/packages/agent/src/fleet-ledger.ts
+++ b/packages/agent/src/fleet-ledger.ts
@@ -3,6 +3,7 @@ import { isDeepStrictEqual } from "node:util";
 import type { ManagedDelegationContext, ManagedDelegationLimits } from "@adam-agent/presentation";
 import { z } from "zod";
 import type { ContextProfile } from "./context-profile.js";
+import { backgroundCapacitySchema } from "./managed-agent-capacity.js";
 import type { ManagedControlRecord } from "./managed-agent-folds.js";
 import { agentRoleIdSchema } from "./role-catalog.js";
 import {
@@ -43,7 +44,7 @@ export function requestedDelegationContext(
       ? "task"
       : "current_request";
 }
-export const fleetPolicySchema = z
+const historicalFleetPolicySchema = z
   .strictObject({
     version: z.union([z.literal(1), z.literal(2)]),
     background: z.strictObject({
@@ -68,14 +69,40 @@ export const fleetPolicySchema = z
           policy.sessionTokens === null,
     "Token policy fields must match their frozen version.",
   );
+export const fleetPolicySchema = z.union([
+  historicalFleetPolicySchema,
+  z.strictObject({
+    version: z.literal(3),
+    background: z.strictObject({
+      running: backgroundCapacitySchema,
+      queued: z.literal("unlimited"),
+    }),
+    reserved: z.strictObject({ running: z.literal(1), queued: z.number().int().min(0).max(4) }),
+    maximumAttempts: z.literal("unlimited"),
+    threadTokens: z.null(),
+    batchTokens: z.null(),
+    sessionTokens: z.null(),
+    storageBytes: positive.max(32 * 1024 * 1024),
+  }),
+]);
 export type FleetPolicy = z.infer<typeof fleetPolicySchema>;
+/** Unlimited is serialized explicitly; Infinity is only an arithmetic comparison bound. */
+export function fleetLimit(value: number | "unlimited"): number {
+  return value === "unlimited" ? Infinity : value;
+}
 export const delegationOriginSchema = z.strictObject({
   kind: z.enum(["main_run", "direct_request"]),
   id: z.uuid(),
   callId: z.string().min(1).max(512).optional(),
 });
 const delegationEnvelopeFields = z.strictObject({
-  version: z.union([z.literal(1), z.literal(2)]),
+  version: z.union([z.literal(1), z.literal(2), z.literal(3)]),
+  concurrency: z
+    .discriminatedUnion("mode", [
+      z.strictObject({ mode: z.literal("owner") }),
+      z.strictObject({ mode: z.literal("limited"), running: positive.max(32) }),
+    ])
+    .optional(),
   taskBudget: taskBudgetSchema.optional(),
   id: z.uuid(),
   digest: z
@@ -88,7 +115,7 @@ const delegationEnvelopeFields = z.strictObject({
     .max(32),
   mode: z.enum(["background", "foreground"]),
   threads: positive.max(32),
-  running: positive.max(4),
+  running: positive.max(32),
   queued: z.number().int().min(0).max(32),
   aggregateTokens: positive.nullable(),
   threadTokens: positive.nullable(),
@@ -103,6 +130,15 @@ const delegationEnvelopeFields = z.strictObject({
 export const delegationEnvelopeSchema = delegationEnvelopeFields.refine(
   (envelope) =>
     envelope.version === envelope.policy.version &&
+    (envelope.version === 3
+      ? envelope.concurrency !== undefined &&
+        envelope.running <= envelope.threads &&
+        (envelope.concurrency.mode === "limited"
+          ? envelope.concurrency.running === envelope.running
+          : envelope.mode === "background" &&
+            envelope.running ===
+              Math.min(fleetLimit(envelope.policy.background.running), envelope.threads))
+      : envelope.concurrency === undefined && envelope.running <= 4) &&
     (envelope.version === 1
       ? envelope.taskBudget === undefined &&
         envelope.aggregateTokens !== null &&
@@ -133,10 +169,10 @@ export type FleetUsage = Omit<Extract<FleetProviderEvent, { type: "provider_usag
 export function resolveFleetPolicy(profile: ContextProfile, input?: FleetPolicy): FleetPolicy {
   const policy = fleetPolicySchema.parse(
     input ?? {
-      version: 2,
-      background: { running: 4, queued: 32 },
+      version: 3,
+      background: { running: 8, queued: "unlimited" },
       reserved: { running: 1, queued: 4 },
-      maximumAttempts: 4,
+      maximumAttempts: "unlimited",
       threadTokens: null,
       batchTokens: null,
       sessionTokens: null,
@@ -180,14 +216,28 @@ export function createDelegationEnvelope(
         : { version: 1, mode: "limited", taskId, grants: [{ id: taskId, tokens: budgetTokens }] };
   const value = {
     version: policy.version,
-    ...(policy.version === 2 ? { taskBudget } : {}),
+    ...(policy.version === 3
+      ? {
+          concurrency:
+            limits.running === undefined && input.mode === "background"
+              ? { mode: "owner" as const }
+              : { mode: "limited" as const, running: limits.running ?? 1 },
+        }
+      : {}),
+    ...(policy.version !== 1 ? { taskBudget } : {}),
     id: randomUUID(),
     origin: input.origin,
     roles: input.roles ?? ["builtin:explore"],
     mode: input.mode,
     threads: input.count,
-    running: Math.min(lane.running, input.count),
-    queued: Math.max(0, input.count - lane.running),
+    running: Math.min(fleetLimit(lane.running), input.count),
+    queued: Math.max(
+      0,
+      input.count -
+        (policy.version === 3 && limits.running !== undefined
+          ? limits.running
+          : fleetLimit(lane.running)),
+    ),
     aggregateTokens: minimumTokenCeiling(
       policy.batchTokens,
       input.sessionTokens,
@@ -254,9 +304,13 @@ export function delegationEnvelopeMatches(
     envelope.mode === expected.mode &&
     (expected.origin === undefined || isDeepStrictEqual(envelope.origin, expected.origin)) &&
     envelope.running <=
-      expected.policy[envelope.mode === "background" ? "background" : "reserved"].running &&
+      fleetLimit(
+        expected.policy[envelope.mode === "background" ? "background" : "reserved"].running,
+      ) &&
     envelope.queued <=
-      expected.policy[envelope.mode === "background" ? "background" : "reserved"].queued &&
+      fleetLimit(
+        expected.policy[envelope.mode === "background" ? "background" : "reserved"].queued,
+      ) &&
     (envelope.mode !== "foreground" || envelope.threads === 1) &&
     withinTokenCeiling(envelope.aggregateTokens, expected.policy.batchTokens) &&
     withinTokenCeiling(envelope.aggregateTokens, envelope.sessionTokens) &&
@@ -316,7 +370,7 @@ export function fleetSessionCeiling(
   records: readonly ManagedControlRecord[],
   policy: FleetPolicy,
 ): number | null {
-  if (policy.version === 2) return null;
+  if (policy.version !== 1) return null;
   const first = records.find(
     (entry) => entry.event.type === "admitted" && entry.event.envelope !== undefined,
   );
@@ -344,7 +398,7 @@ export function assertFleetReservation(
 ): void {
   if (admission.event.type !== "admitted" || admission.event.envelope === undefined) return;
   const envelope = admission.event.envelope;
-  if (envelope.version === 2 && envelope.taskBudget !== undefined) {
+  if (envelope.version !== 1 && envelope.taskBudget !== undefined) {
     const budget = taskBudgetUsage(
       fleetTaskBudget(records, envelope.taskBudget),
       taskFleetEvents(records, admission),

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -25,6 +25,7 @@ export {
   ManagedAgentStoreError,
   recoverInterruptedManagedAgents,
 } from "./managed-agent.js";
+export { createManagedAgentCapacityConfiguration } from "./managed-agent-capacity.js";
 export {
   createManagedAgentControl,
   createManagedAgentControlToolRegistry,

--- a/packages/agent/src/managed-agent-capacity.ts
+++ b/packages/agent/src/managed-agent-capacity.ts
@@ -1,0 +1,85 @@
+import { createHash } from "node:crypto";
+import { realpath } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { z } from "zod";
+import {
+  createOwnerConfigurationFileStorage,
+  hasDuplicateJsonObjectKey,
+} from "./secure-user-configuration.js";
+
+export const backgroundCapacitySchema = z.union([
+  z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+  z.literal("unlimited"),
+]);
+export type BackgroundCapacity = z.infer<typeof backgroundCapacitySchema>;
+
+const configurationSchema = z.strictObject({
+  version: z.literal(1),
+  backgroundRunning: backgroundCapacitySchema,
+});
+
+export class ManagedAgentCapacityConfigurationError extends Error {
+  constructor(
+    readonly code:
+      | "managed_agent_capacity_configuration_invalid"
+      | "managed_agent_capacity_configuration_unsafe"
+      | "managed_agent_capacity_configuration_unavailable",
+  ) {
+    super(
+      code === "managed_agent_capacity_configuration_invalid"
+        ? "The Main session's background capacity configuration is invalid."
+        : code === "managed_agent_capacity_configuration_unsafe"
+          ? "The Main session's background capacity configuration is unsafe."
+          : "The Main session's background capacity configuration could not be saved.",
+    );
+    this.name = "ManagedAgentCapacityConfigurationError";
+  }
+}
+
+export async function createManagedAgentCapacityConfiguration(options: {
+  readonly workspaceRoot: string;
+  readonly stateRoot: string;
+  readonly parentSessionId: string;
+}): Promise<{
+  load(): Promise<BackgroundCapacity | undefined>;
+  save(running: BackgroundCapacity): Promise<void>;
+}> {
+  const parentSessionId = z.uuid().parse(options.parentSessionId);
+  const workspace = await realpath(options.workspaceRoot);
+  const projectKey = createHash("sha256").update(workspace).digest("hex");
+  const directoryPath = join(resolve(options.stateRoot), "projects", projectKey, "managed-agents");
+  const storage = createOwnerConfigurationFileStorage({
+    directoryPath,
+    configurationPath: join(directoryPath, `capacity-${parentSessionId}.json`),
+    maximumBytes: 1024,
+    temporaryPrefix: `.capacity-${parentSessionId}`,
+  });
+  return {
+    async load() {
+      const stored = await storage.read();
+      if (stored.status === "missing") return undefined;
+      if (stored.status === "unsafe")
+        throw new ManagedAgentCapacityConfigurationError(
+          "managed_agent_capacity_configuration_unsafe",
+        );
+      try {
+        if (hasDuplicateJsonObjectKey(stored.text)) throw new TypeError("Duplicate field.");
+        return configurationSchema.parse(JSON.parse(stored.text)).backgroundRunning;
+      } catch {
+        throw new ManagedAgentCapacityConfigurationError(
+          "managed_agent_capacity_configuration_invalid",
+        );
+      }
+    },
+    async save(running) {
+      const configuration = configurationSchema.parse({ version: 1, backgroundRunning: running });
+      try {
+        await storage.write(`${JSON.stringify(configuration)}\n`);
+      } catch {
+        throw new ManagedAgentCapacityConfigurationError(
+          "managed_agent_capacity_configuration_unavailable",
+        );
+      }
+    },
+  };
+}

--- a/packages/agent/src/managed-agent-control.ts
+++ b/packages/agent/src/managed-agent-control.ts
@@ -56,6 +56,7 @@ import {
   type FleetPolicy,
   type FleetUsage,
   fleetBudget,
+  fleetLimit,
   fleetSessionCeiling,
   fleetStorage,
   fleetTaskBudget,
@@ -73,6 +74,7 @@ import {
   ManagedAgentStoreError,
   nodeManagedAgentDeadlineScheduler,
 } from "./managed-agent.js";
+import { type BackgroundCapacity, backgroundCapacitySchema } from "./managed-agent-capacity.js";
 import {
   foldManagedControl,
   type ManagedControlEvent,
@@ -186,6 +188,11 @@ export type ManagedWorkspaceFrame = {
 };
 
 export type ManagedAgentControl = AgentRoleAdministration & {
+  /** Owner-only execution policy update; never exposed in the model tool registry. */
+  configureBackgroundCapacity(input: {
+    readonly parentSessionId: string;
+    readonly running: BackgroundCapacity;
+  }): Promise<ManagedWorkspaceSnapshot>;
   [managedReviewAdmission](input: ReviewAdmissionInput): Promise<ManagedControlRecord>;
   [managedReviewRecovery](input: {
     readonly reviewRunId: string;
@@ -446,6 +453,7 @@ export function createManagedAgentControl(options: {
     }[]
   >;
   readonly policy?: FleetPolicy;
+  readonly persistBackgroundCapacity?: (running: BackgroundCapacity) => Promise<void>;
   readonly readPlan?: () => Promise<PlanCycleSnapshot | undefined>;
   readonly webTools?: ToolRegistry;
   readonly resolveRoleTarget?: (input: {
@@ -510,7 +518,9 @@ export function createManagedAgentControl(options: {
       return false;
     }
   };
-  const policy = resolveFleetPolicy(options.contextProfile, options.policy);
+  let policy = resolveFleetPolicy(options.contextProfile, options.policy);
+  const continuationPolicyFor = (original: DelegationEnvelope): FleetPolicy =>
+    original.version === 3 && policy.version === 3 ? policy : original.policy;
   const controlStore = options.store.forParent(options.parentSessionId);
   let serial = Promise.resolve();
   let closing = false;
@@ -770,8 +780,11 @@ export function createManagedAgentControl(options: {
               origin.event.frozen !== undefined &&
               origin.event.envelope !== undefined &&
               attempts <
-                Math.min(policy.maximumAttempts, origin.event.envelope.policy.maximumAttempts) &&
-              (origin.event.envelope.version === 2 ||
+                Math.min(
+                  fleetLimit(policy.maximumAttempts),
+                  fleetLimit(origin.event.envelope.policy.maximumAttempts),
+                ) &&
+              (origin.event.envelope.version !== 1 ||
                 inspected.budget?.available === null ||
                 (inspected.budget?.available ?? 0) > 0)
             )
@@ -874,6 +887,7 @@ export function createManagedAgentControl(options: {
     );
     return {
       ...snapshot,
+      policy: structuredClone(policy),
       threads,
       storage: await storageUsage(records, undefined, true),
       budget: fleetBudget(
@@ -1927,7 +1941,8 @@ export function createManagedAgentControl(options: {
         });
         const runTokenLimit =
           admission?.event.type === "admitted" &&
-          admission.event.envelope?.version === 2 &&
+          admission.event.envelope !== undefined &&
+          admission.event.envelope.version !== 1 &&
           frozen?.review === undefined
             ? frozen?.roleDefinition?.limits?.maxTokens
             : Math.min(
@@ -2152,6 +2167,25 @@ export function createManagedAgentControl(options: {
     message: string,
   ): ManagedControlReceipt => ({ status: "rejected", code, message });
   const control: ManagedAgentControl = {
+    async configureBackgroundCapacity(input) {
+      const running = backgroundCapacitySchema.parse(input.running);
+      if (input.parentSessionId !== options.parentSessionId)
+        throw new TypeError("This control belongs to another parent Session.");
+      const configure = () =>
+        authorized(async () => {
+          if (closing || policy.version !== 3)
+            throw new TypeError("Only an open current-policy Main can change background capacity.");
+          if (options.persistBackgroundCapacity === undefined)
+            throw new TypeError("Owner capacity configuration is unavailable.");
+          await options.persistBackgroundCapacity(running);
+          policy = { ...policy, background: { ...policy.background, running } };
+          await startReady();
+          const snapshot = await project(await controlStore.read(), options.parentSessionId);
+          for (const subscriber of subscribers) subscriber({ type: "reset", snapshot });
+          return snapshot;
+        });
+      return options.admissionGuard === undefined ? configure() : options.admissionGuard(configure);
+    },
     async [managedReviewRecovery](input) {
       await serial;
       const records = await controlStore.read();
@@ -2493,11 +2527,12 @@ export function createManagedAgentControl(options: {
                 command.additionalBudgetTokens,
                 managedControlDigest(origin),
               );
-      const sessionTokens = fleetSessionCeiling(records, first.event.envelope.policy);
+      const continuationPolicy = continuationPolicyFor(first.event.envelope);
+      const sessionTokens = fleetSessionCeiling(records, continuationPolicy);
       const available = fleetBudget(records, sessionTokens).available;
       if (available !== null && available <= 0)
         throw new FleetBudgetError("fleet_budget_exhausted");
-      return createDelegationEnvelope(first.event.envelope.policy, {
+      return createDelegationEnvelope(continuationPolicy, {
         mode: first.event.lane === "reserved" ? "foreground" : "background",
         count: 1,
         roles: [first.event.role],
@@ -3639,7 +3674,7 @@ export function createManagedAgentControl(options: {
                 (thread.turn.lane ?? "background") === lane && thread.turn.phase !== "idle",
             ).length +
               command.entries.length >
-            policy[lane].running + policy[lane].queued
+            fleetLimit(policy[lane].running) + fleetLimit(policy[lane].queued)
           )
             return rejected(
               "capacity_exhausted",
@@ -3851,7 +3886,7 @@ export function createManagedAgentControl(options: {
           )
             return rejected(
               "storage_quota_exceeded",
-              "There is not enough logical storage for the complete batch and its terminal receipts.",
+              "This Main's retained control history and child transcripts leave insufficient storage for this batch and its terminal receipts.",
             );
           const records = await controlStore.appendBatchNext(inputs);
           const lastAdmission = records.at(-1);
@@ -4248,7 +4283,8 @@ export function createManagedAgentControl(options: {
           if (
             (await controlStore.read()).filter(
               (record) => record.threadId === previous.threadId && record.event.type === "admitted",
-            ).length >= Math.min(policy.maximumAttempts, initialMaximumAttempts)
+            ).length >=
+            Math.min(fleetLimit(policy.maximumAttempts), fleetLimit(initialMaximumAttempts))
           )
             return rejected("attempt_limit", "This thread has reached its four-attempt limit.");
           if (previous.turn.phase !== "idle")
@@ -4340,6 +4376,7 @@ export function createManagedAgentControl(options: {
               ))) ||
           digest !== managedControlDigest(fields) ||
           envelope.policyDigest !== managedControlDigest(envelope.policy) ||
+          !isDeepStrictEqual(envelope.policy, continuationPolicyFor(inherited.envelope)) ||
           !isDeepStrictEqual(envelope.roles, [inherited.role]) ||
           envelope.threads !== 1 ||
           envelope.running !== 1 ||
@@ -4368,7 +4405,7 @@ export function createManagedAgentControl(options: {
           snapshot.threads.filter(
             (thread) => thread.turn.phase !== "idle" && (thread.turn.lane ?? "background") === lane,
           ).length >=
-          policy[lane].running + policy[lane].queued
+          fleetLimit(policy[lane].running) + fleetLimit(policy[lane].queued)
         )
           return rejected("capacity_exhausted", "This lane has no remaining admission capacity.");
         let continuationFrozen = inherited.frozen;
@@ -4459,7 +4496,7 @@ export function createManagedAgentControl(options: {
         )
           return rejected(
             "storage_quota_exceeded",
-            "There is no exact admission and terminal storage reservation for another turn.",
+            "This Main's retained control history and child transcripts leave insufficient storage for another turn and its terminal receipts.",
           );
         await append(identity, event);
         ready.add(identity.turnId);

--- a/packages/agent/src/managed-agent-folds.ts
+++ b/packages/agent/src/managed-agent-folds.ts
@@ -394,6 +394,17 @@ export function validateManagedControlRecord(
     )
       return invalid();
     const priorAdmission = threadRecords.findLast((entry) => entry.event.type === "admitted");
+    const priorEnvelope =
+      priorAdmission?.event.type === "admitted" ? priorAdmission.event.envelope : undefined;
+    const envelope = record.event.envelope;
+    // v3 scheduling semantics cannot be attached to a historical thread on replay.
+    if (
+      priorEnvelope !== undefined &&
+      envelope !== undefined &&
+      (priorEnvelope.version === 3 || envelope.version === 3) &&
+      priorEnvelope.version !== envelope.version
+    )
+      return invalid();
     const taskBudget = record.event.envelope?.taskBudget;
     if (taskBudget !== undefined) {
       const priorBudget =

--- a/packages/agent/src/managed-agent-recovery.ts
+++ b/packages/agent/src/managed-agent-recovery.ts
@@ -370,7 +370,12 @@ export function validateFleetTaskProviderReceipts(
   controlRecords: readonly ManagedControlRecord[],
   allowPendingSource = false,
 ): void {
-  if (admission.event.type !== "admitted" || admission.event.envelope?.version !== 2) return;
+  if (
+    admission.event.type !== "admitted" ||
+    admission.event.envelope === undefined ||
+    admission.event.envelope.version === 1
+  )
+    return;
   const receipts = controlRecords.flatMap((record) =>
     record.turnId !== admission.turnId
       ? []

--- a/packages/agent/src/managed-agent-scheduler.ts
+++ b/packages/agent/src/managed-agent-scheduler.ts
@@ -1,4 +1,5 @@
 import type { ManagedWorkspaceSnapshot } from "@adam-agent/presentation";
+import { fleetLimit } from "./fleet-ledger.js";
 
 /** Scheduling selects from durable order. Control owns admission and execution. */
 export function selectManagedStarts(
@@ -6,18 +7,33 @@ export function selectManagedStarts(
   active: ReadonlySet<string>,
   ready: ReadonlySet<string>,
   policy: {
-    readonly background: { readonly running: number };
+    readonly background: { readonly running: number | "unlimited" };
     readonly reserved: { readonly running: number };
   },
 ): readonly string[] {
-  const remaining = { background: policy.background.running, reserved: policy.reserved.running };
+  const remaining = {
+    background: fleetLimit(policy.background.running),
+    reserved: policy.reserved.running,
+  };
+  const legacyActive = { background: 0, reserved: 0 };
   for (const thread of snapshot.threads)
-    if (active.has(thread.turn.turnId)) remaining[thread.turn.lane ?? "background"] -= 1;
+    if (active.has(thread.turn.turnId)) {
+      const lane = thread.turn.lane ?? "background";
+      remaining[lane] -= 1;
+      if (thread.turn.envelope?.version !== 3) legacyActive[lane] += 1;
+    }
   const envelopes = new Map<string, number>();
   for (const thread of snapshot.threads) {
     const envelope = thread.turn.envelope;
     if (envelope !== undefined && !envelopes.has(envelope.id))
-      envelopes.set(envelope.id, envelope.running);
+      envelopes.set(
+        envelope.id,
+        envelope.version === 3 && envelope.concurrency?.mode === "owner"
+          ? Infinity
+          : envelope.version === 3 && envelope.concurrency?.mode === "limited"
+            ? envelope.concurrency.running
+            : envelope.running,
+      );
   }
   for (const thread of snapshot.threads) {
     const envelope = thread.turn.envelope;
@@ -31,11 +47,19 @@ export function selectManagedStarts(
       (a.turn.admissionSequence ?? 0) - (b.turn.admissionSequence ?? 0),
   )) {
     const lane = thread.turn.lane ?? "background";
+    const envelope = thread.turn.envelope;
+    if (
+      envelope?.version !== 3 &&
+      legacyActive[lane] >=
+        fleetLimit(envelope?.policy[lane].running ?? (lane === "background" ? 4 : 1))
+    )
+      continue;
     if (thread.turn.envelope !== undefined && (envelopes.get(thread.turn.envelope.id) ?? 0) <= 0)
       continue;
     if (!ready.has(thread.turn.turnId) || active.has(thread.turn.turnId) || remaining[lane] <= 0)
       continue;
     remaining[lane] -= 1;
+    if (envelope?.version !== 3) legacyActive[lane] += 1;
     if (thread.turn.envelope !== undefined)
       envelopes.set(thread.turn.envelope.id, (envelopes.get(thread.turn.envelope.id) ?? 0) - 1);
     selected.push(thread.turn.turnId);

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -72,6 +72,7 @@ import {
   managedAgentSnapshotWithChildHistories,
   recoverInterruptedManagedAgents,
 } from "./managed-agent.js";
+import { createManagedAgentCapacityConfiguration } from "./managed-agent-capacity.js";
 import {
   createManagedAgentControl,
   createManagedAgentControlToolRegistry,
@@ -1577,6 +1578,18 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
         )
           throw new SessionLifecycleError("session_model_target_incompatible");
         const webTools = await toolsForWebProfile(genesis.record.webEvidence);
+        let policy = resolveFleetPolicy(contextProfile, composition.policy);
+        const capacityConfiguration =
+          policy.version === 3
+            ? await createManagedAgentCapacityConfiguration({
+                workspaceRoot: options.workspaceRoot,
+                stateRoot: effectiveStateRoot,
+                parentSessionId: sessionId,
+              })
+            : undefined;
+        const backgroundRunning = await capacityConfiguration?.load();
+        if (policy.version === 3 && backgroundRunning !== undefined)
+          policy = { ...policy, background: { ...policy.background, running: backgroundRunning } };
         return createManagedAgentControl({
           roleCatalog: agentRoleCatalog,
           roleTargets,
@@ -1588,7 +1601,10 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           workspaceRoot: options.workspaceRoot,
           targetIdentity: snapshot.targetIdentity,
           contextProfile,
-          ...(composition.policy === undefined ? {} : { policy: composition.policy }),
+          policy,
+          ...(capacityConfiguration === undefined
+            ? {}
+            : { persistBackgroundCapacity: capacityConfiguration.save }),
           admissionGuard: (operation, constraints) =>
             serializeFamily(async () => {
               if (

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -2144,6 +2144,7 @@ export type ManagedAgentExport = {
 };
 
 export type ManagedWorkspaceSnapshot = {
+  readonly policy?: ManagedFleetPolicy;
   readonly reviewers?: {
     readonly running: number;
     readonly queued: number;
@@ -2184,16 +2185,31 @@ export type ManagedWorkspaceSnapshot = {
   readonly threads: readonly ManagedControlThread[];
 };
 
+export type ManagedBackgroundCapacity = number | "unlimited";
 export type ManagedFleetPolicy = {
-  readonly version: 1 | 2;
-  readonly background: { readonly running: number; readonly queued: number };
   readonly reserved: { readonly running: 1; readonly queued: number };
-  readonly maximumAttempts: number;
-  readonly threadTokens: number | null;
-  readonly batchTokens: number | null;
-  readonly sessionTokens: number | null;
   readonly storageBytes: number;
-};
+} & (
+  | {
+      readonly version: 1 | 2;
+      readonly background: { readonly running: number; readonly queued: number };
+      readonly maximumAttempts: number;
+      readonly threadTokens: number | null;
+      readonly batchTokens: number | null;
+      readonly sessionTokens: number | null;
+    }
+  | {
+      readonly version: 3;
+      readonly background: {
+        readonly running: ManagedBackgroundCapacity;
+        readonly queued: "unlimited";
+      };
+      readonly maximumAttempts: "unlimited";
+      readonly threadTokens: null;
+      readonly batchTokens: null;
+      readonly sessionTokens: null;
+    }
+);
 export type ManagedDelegationMessage = ManagedControlLink & {
   readonly role: "user" | "assistant";
   readonly text: string;
@@ -2225,7 +2241,11 @@ export type ManagedDelegationEnvelope = {
         readonly grants: { readonly id: string; readonly tokens: number }[];
       }
     | undefined;
-  readonly version: 1 | 2;
+  readonly version: 1 | 2 | 3;
+  readonly concurrency?:
+    | { readonly mode: "owner" }
+    | { readonly mode: "limited"; readonly running: number }
+    | undefined;
   readonly id: string;
   readonly digest: `sha256:${string}`;
   readonly origin: {

--- a/packages/testkit/src/managed-agent-capacity.os.test.ts
+++ b/packages/testkit/src/managed-agent-capacity.os.test.ts
@@ -1,0 +1,272 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createPermissionPolicy, type ModelDriver } from "@adam-agent/agent";
+import {
+  createJsonlManagedAgentControlStore,
+  createJsonlSessionStoreDirectory,
+  createManagedAgentCapacityConfiguration,
+  type SessionRecord,
+  sessionManagedControl,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+import { createInMemorySessionLifecycleHarness } from "./index.js";
+import { withManagedFailureGuard } from "./managed-agent-test-support.js";
+import {
+  modelTargetsWithDriver,
+  sessionLifecycleTargetIdentity as targetIdentity,
+} from "./session-lifecycle.test-support.js";
+
+const parentSessionId = "00000000-0000-4000-8000-000000000001";
+const secondParentSessionId = "00000000-0000-4000-8000-000000000002";
+
+async function configurationPath(workspaceRoot: string, stateRoot: string, parent: string) {
+  const canonicalRoot = await realpath(workspaceRoot);
+  const project = createHash("sha256").update(canonicalRoot).digest("hex");
+  return join(stateRoot, "projects", project, "managed-agents", `capacity-${parent}.json`);
+}
+
+test("background capacity is durable per Main, including explicit unlimited", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-capacity-configuration-"));
+  const stateRoot = join(workspaceRoot, "state");
+  const options = { workspaceRoot, stateRoot, parentSessionId };
+  try {
+    const first = await createManagedAgentCapacityConfiguration(options);
+    const second = await createManagedAgentCapacityConfiguration({
+      ...options,
+      parentSessionId: secondParentSessionId,
+    });
+    expect(await first.load()).toBeUndefined();
+    await first.save(17);
+    await second.save("unlimited");
+    expect(await (await createManagedAgentCapacityConfiguration(options)).load()).toBe(17);
+    expect(await second.load()).toBe("unlimited");
+    expect(
+      JSON.parse(
+        await readFile(await configurationPath(workspaceRoot, stateRoot, parentSessionId), "utf8"),
+      ),
+    ).toEqual({ version: 1, backgroundRunning: 17 });
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test.each([
+  '{"version":1,"backgroundRunning":0}',
+  '{"version":1,"backgroundRunning":1.5}',
+  '{"version":1,"backgroundRunning":9007199254740992}',
+  '{"version":1,"backgroundRunning":"8"}',
+  '{"version":1,"backgroundRunning":8,"backgroundRunning":"unlimited"}',
+  '{"version":1,"backgroundRunning":8,"queued":32}',
+])("invalid persisted background capacity is refused: %s", async (text) => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-capacity-invalid-"));
+  const stateRoot = join(workspaceRoot, "state");
+  try {
+    const path = await configurationPath(workspaceRoot, stateRoot, parentSessionId);
+    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+    await writeFile(path, text, { mode: 0o600 });
+    const configuration = await createManagedAgentCapacityConfiguration({
+      workspaceRoot,
+      stateRoot,
+      parentSessionId,
+    });
+    await expect(configuration.load()).rejects.toMatchObject({
+      code: "managed_agent_capacity_configuration_invalid",
+    });
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("capacity configuration refuses an unsafe symlink without changing its target", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-capacity-unsafe-"));
+  const stateRoot = join(workspaceRoot, "state");
+  try {
+    const path = await configurationPath(workspaceRoot, stateRoot, parentSessionId);
+    const target = join(workspaceRoot, "other.json");
+    const original = '{"version":1,"backgroundRunning":2}\n';
+    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+    await writeFile(target, original, { mode: 0o600 });
+    await symlink(target, path);
+    const configuration = await createManagedAgentCapacityConfiguration({
+      workspaceRoot,
+      stateRoot,
+      parentSessionId,
+    });
+    await expect(configuration.load()).rejects.toMatchObject({
+      code: "managed_agent_capacity_configuration_unsafe",
+    });
+    await expect(configuration.save(9)).rejects.toMatchObject({
+      code: "managed_agent_capacity_configuration_unavailable",
+    });
+    expect(await readFile(target, "utf8")).toBe(original);
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test.each([1, 2] as const)(
+  "Lifecycle retains an explicitly configured v%s fleet policy",
+  async (version) => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-capacity-historical-"));
+    const stateRoot = join(workspaceRoot, "state");
+    const h = createInMemorySessionLifecycleHarness();
+    const policy = {
+      version,
+      background: { running: 2, queued: 4 },
+      reserved: { running: 1 as const, queued: 4 },
+      maximumAttempts: 2,
+      threadTokens: version === 1 ? 128_000 : null,
+      batchTokens: version === 1 ? 256_000 : null,
+      sessionTokens: version === 1 ? 512_000 : null,
+      storageBytes: 32 * 1024 * 1024,
+    };
+    const lifecycle = h.createLifecycle({
+      workspaceRoot,
+      stateRoot,
+      permissions: createPermissionPolicy({ allowedEffects: ["read", "delegate"] }),
+      modelTargets: modelTargetsWithDriver({
+        async *stream() {
+          yield { type: "finish", reason: "stop" };
+        },
+      }),
+      [sessionManagedControl]: {
+        policy,
+        store: await createJsonlManagedAgentControlStore({ workspaceRoot, stateRoot }),
+        childSessionStores: createJsonlSessionStoreDirectory<SessionRecord>({
+          workspaceRoot,
+          stateRoot: join(stateRoot, "children"),
+        }),
+      },
+    });
+    try {
+      const parent = await lifecycle.create({ targetIdentity });
+      const configuration = await createManagedAgentCapacityConfiguration({
+        workspaceRoot,
+        stateRoot,
+        parentSessionId: parent.sessionId,
+      });
+      await configuration.save("unlimited");
+      const control = await lifecycle[sessionManagedControl](parent.sessionId);
+      if (control === undefined) throw new Error("Missing historical policy Control");
+      expect((await control.inspect({ parentSessionId: parent.sessionId })).policy).toEqual(policy);
+    } finally {
+      await lifecycle.close();
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test("candidate Lifecycle persists Owner capacity before applying it and cold loading never starts its queue", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-capacity-lifecycle-"));
+  const stateRoot = join(workspaceRoot, "state");
+  const h = createInMemorySessionLifecycleHarness();
+  const started = Promise.withResolvers<void>();
+  let calls = 0;
+  const driver: ModelDriver = {
+    async *stream(request) {
+      calls += 1;
+      started.resolve();
+      await new Promise<void>((resolve) => {
+        if (request.signal.aborted) resolve();
+        else request.signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      yield { type: "finish", reason: "stop" };
+    },
+  };
+  const options = {
+    workspaceRoot,
+    stateRoot,
+    permissions: createPermissionPolicy({ allowedEffects: ["read", "delegate"] }),
+    modelTargets: modelTargetsWithDriver(driver),
+    [sessionManagedControl]: {
+      store: await createJsonlManagedAgentControlStore({ workspaceRoot, stateRoot }),
+      childSessionStores: createJsonlSessionStoreDirectory<SessionRecord>({
+        workspaceRoot,
+        stateRoot: join(stateRoot, "children"),
+      }),
+    },
+  };
+  const warm = h.createLifecycle(options);
+  let cold: ReturnType<typeof h.createLifecycle> | undefined;
+  try {
+    const parent = await warm.create({ targetIdentity });
+    const control = await warm[sessionManagedControl](parent.sessionId);
+    if (control === undefined) throw new Error("Missing candidate Control");
+    expect(
+      await control.configureBackgroundCapacity({ parentSessionId: parent.sessionId, running: 1 }),
+    ).toMatchObject({ policy: { version: 3, background: { running: 1 } } });
+    const path = await configurationPath(workspaceRoot, stateRoot, parent.sessionId);
+    await chmod(path, 0o644);
+    await expect(
+      control.configureBackgroundCapacity({ parentSessionId: parent.sessionId, running: 3 }),
+    ).rejects.toMatchObject({ code: "managed_agent_capacity_configuration_unavailable" });
+    expect(await control.inspect({ parentSessionId: parent.sessionId })).toMatchObject({
+      policy: { background: { running: 1 } },
+    });
+    await chmod(path, 0o600);
+    const admission = await control.dispatch({
+      type: "spawn_agents",
+      parentSessionId: parent.sessionId,
+      mode: "background",
+      origin: { kind: "direct_request", id: randomUUID() },
+      entries: [
+        { role: "builtin:explore", task: "First durable task", description: "First task" },
+        { role: "builtin:explore", task: "Second durable task", description: "Queued task" },
+      ],
+    });
+    if (admission.status !== "admitted") throw new Error(JSON.stringify(admission));
+    await withManagedFailureGuard(started.promise, "first configured-capacity child start");
+    const queued = admission.turns[1];
+    if (queued === undefined) throw new Error("Missing queued task");
+    expect(
+      (await control.inspect({ parentSessionId: parent.sessionId })).threads[1]?.turn.phase,
+    ).toBe("queued");
+    expect(await warm.close()).toMatchObject({ status: "closed" });
+    cold = h.createLifecycle(options);
+    const recovered = await cold[sessionManagedControl](parent.sessionId);
+    if (recovered === undefined) throw new Error("Missing reopened candidate Control");
+    const snapshot = await recovered.inspect({ parentSessionId: parent.sessionId });
+    expect(snapshot).toMatchObject({ policy: { version: 3, background: { running: 1 } } });
+    expect(
+      snapshot.threads.find((thread) => thread.threadId === queued.threadId)?.turn,
+    ).toMatchObject({
+      turnId: queued.turnId,
+      recovery: "required",
+    });
+    expect(
+      await options[sessionManagedControl].childSessionStores.open(queued.childSessionId),
+    ).toBeUndefined();
+    expect(calls).toBe(1);
+    expect(
+      await recovered.configureBackgroundCapacity({
+        parentSessionId: parent.sessionId,
+        running: "unlimited",
+      }),
+    ).toMatchObject({ policy: { background: { running: "unlimited" } } });
+    expect(calls).toBe(1);
+    expect(
+      await (
+        await createManagedAgentCapacityConfiguration({
+          workspaceRoot,
+          stateRoot,
+          parentSessionId: parent.sessionId,
+        })
+      ).load(),
+    ).toBe("unlimited");
+  } finally {
+    await cold?.close();
+    await warm.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/testkit/src/managed-agent-capacity.test.ts
+++ b/packages/testkit/src/managed-agent-capacity.test.ts
@@ -1,0 +1,656 @@
+import { createPermissionPolicy, type ModelDriver } from "@adam-agent/agent";
+import {
+  createInMemoryManagedAgentControlStore,
+  createInMemorySessionStoreDirectory,
+  createManagedAgentControl,
+  createProjectExecutionDomain,
+  type SessionRecord,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+import { withManagedFailureGuard } from "./managed-agent-test-support.js";
+
+const parentSessionId = "00000000-0000-4000-8000-000000000001";
+const secondParentSessionId = "00000000-0000-4000-8000-000000000002";
+const targetIdentity = {
+  targetId: "deepseek-v4-flash.direct",
+  vendor: "deepseek",
+  modelId: "deepseek-v4-flash",
+  route: "direct",
+  profileVersion: 1,
+  certification: "certified",
+} as const;
+const contextProfile = {
+  version: 1,
+  contextWindowTokens: 128_000,
+  maximumOutputTokens: 4096,
+  compactAtTokens: 96_000,
+  postCompactTargetTokens: 32_000,
+  retainedTargetTokens: 8000,
+  estimatorVersion: 1,
+} as const;
+type Control = ReturnType<typeof createManagedAgentControl>;
+type Snapshot = Awaited<ReturnType<Control["inspect"]>>;
+
+function batch(count: number, prefix = "Work", parentId = parentSessionId) {
+  return {
+    type: "spawn_agents" as const,
+    parentSessionId: parentId,
+    entries: Array.from({ length: count }, (_, index) => ({
+      role: "builtin:explore" as const,
+      task: `${prefix} ${index}`,
+      description: `${prefix} ${index}`,
+    })),
+  };
+}
+
+function gatedProvider() {
+  const started: string[] = [];
+  const gates = new Map<string, ReturnType<typeof Promise.withResolvers<void>>>();
+  let changed = Promise.withResolvers<void>();
+  const model: ModelDriver = {
+    async *stream(request) {
+      const message = request.messages.findLast((entry) => entry.role === "user");
+      if (message?.role !== "user" || typeof message.content !== "string")
+        throw new Error("Missing external provider task.");
+      const gate = Promise.withResolvers<void>();
+      const abort = () => gate.resolve();
+      gates.set(message.content, gate);
+      started.push(message.content);
+      changed.resolve();
+      changed = Promise.withResolvers<void>();
+      request.signal.addEventListener("abort", abort, { once: true });
+      if (request.signal.aborted) abort();
+      try {
+        await gate.promise;
+        yield { type: "text_delta", text: `Completed ${message.content}.` };
+        yield { type: "usage", inputTokens: 10, outputTokens: 5 };
+        yield { type: "finish", reason: "stop" };
+      } finally {
+        request.signal.removeEventListener("abort", abort);
+      }
+    },
+  };
+  return {
+    model,
+    started,
+    release(task: string) {
+      const gate = gates.get(task);
+      if (gate === undefined) throw new Error(`Provider has not started ${task}.`);
+      gate.resolve();
+    },
+    async waitFor(count: number) {
+      await withManagedFailureGuard(
+        (async () => {
+          while (started.length < count) await changed.promise;
+        })(),
+        `${count} actual provider starts`,
+      );
+    },
+  };
+}
+
+async function fixture(model: ModelDriver) {
+  const domain = createProjectExecutionDomain({
+    lifecycleOwner: {
+      async acquire() {
+        return { async release() {} };
+      },
+      async run(operation) {
+        return operation();
+      },
+    },
+  });
+  const root = await domain.claimRoot({ rootId: "project-runtime" });
+  const store = createInMemoryManagedAgentControlStore();
+  const childSessionStores = createInMemorySessionStoreDirectory<SessionRecord>();
+  const options = {
+    parentSessionId,
+    projectId: `sha256:${"d".repeat(64)}` as const,
+    workspaceRoot: process.cwd(),
+    targetIdentity,
+    contextProfile,
+    model,
+    permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    executionDomain: domain,
+    store,
+    childSessionStores,
+    async persistBackgroundCapacity() {},
+  };
+  const control = createManagedAgentControl(options);
+  return {
+    control,
+    store,
+    options,
+    async close() {
+      await control.dispatch({ type: "close", parentSessionId });
+      await root.release();
+      await domain.close();
+    },
+  };
+}
+
+async function observeUntil(
+  control: Control,
+  predicate: (snapshot: Snapshot) => boolean,
+  parentId = parentSessionId,
+): Promise<Snapshot> {
+  const observer = new AbortController();
+  try {
+    return await withManagedFailureGuard(
+      (async () => {
+        for await (const frame of control.observe({
+          parentSessionId: parentId,
+          signal: observer.signal,
+        })) {
+          if (predicate(frame.snapshot)) return frame.snapshot;
+        }
+        throw new Error("Managed observation ended before its expected snapshot.");
+      })(),
+      "managed capacity snapshot",
+    );
+  } finally {
+    observer.abort();
+  }
+}
+
+function phases(snapshot: Snapshot) {
+  return {
+    executing: snapshot.threads.filter((thread) => thread.turn.phase === "executing").length,
+    queued: snapshot.threads.filter((thread) => thread.turn.phase === "queued").length,
+    idle: snapshot.threads.filter((thread) => thread.turn.phase === "idle").length,
+  };
+}
+
+test("successive batches admit 65 identities with eight running, 57 queued, FIFO release and queued cancellation", async () => {
+  const provider = gatedProvider();
+  const f = await fixture(provider.model);
+  try {
+    for (const command of [batch(32), batch(32, "Tail"), batch(1, "Last")])
+      expect(await f.control.dispatch(command)).toMatchObject({ status: "admitted" });
+    await provider.waitFor(8);
+    expect(phases(await f.control.inspect({ parentSessionId }))).toEqual({
+      executing: 8,
+      queued: 57,
+      idle: 0,
+    });
+    expect(provider.started).toEqual(Array.from({ length: 8 }, (_, index) => `Work ${index}`));
+    provider.release("Work 0");
+    await provider.waitFor(9);
+    expect(provider.started.at(-1)).toBe("Work 8");
+    const cancelled = (await f.control.inspect({ parentSessionId })).threads[9];
+    if (cancelled === undefined) throw new Error("Missing queued identity.");
+    expect(
+      await f.control.dispatch({
+        type: "cancel_turn",
+        parentSessionId,
+        threadId: cancelled.threadId,
+        expectedTurnId: cancelled.turn.turnId,
+      }),
+    ).toMatchObject({ status: "cancelled" });
+    provider.release("Work 1");
+    await provider.waitFor(10);
+    expect(provider.started.at(-1)).toBe("Work 10");
+    expect(provider.started).not.toContain("Work 9");
+    const settled = await observeUntil(f.control, (snapshot) => phases(snapshot).idle === 3);
+    expect(phases(settled)).toEqual({ executing: 8, queued: 54, idle: 3 });
+    expect(settled.threads[9]?.turn.outcome).toMatchObject({ status: "cancelled" });
+  } finally {
+    await f.close();
+  }
+});
+
+test("Owner capacity updates release admitted work and decreasing capacity preserves running tasks until slots free", async () => {
+  const provider = gatedProvider();
+  const f = await fixture(provider.model);
+  try {
+    const command = batch(20);
+    const envelope = await f.control.prepareDelegation(command);
+    expect(envelope).toMatchObject({ version: 3, concurrency: { mode: "owner" } });
+    expect(await f.control.dispatch({ ...command, envelope })).toMatchObject({
+      status: "admitted",
+    });
+    await provider.waitFor(8);
+    await f.control.configureBackgroundCapacity({ parentSessionId, running: 12 });
+    await provider.waitFor(12);
+    expect(phases(await f.control.inspect({ parentSessionId }))).toEqual({
+      executing: 12,
+      queued: 8,
+      idle: 0,
+    });
+    const lowered = await f.control.configureBackgroundCapacity({ parentSessionId, running: 2 });
+    expect(lowered.policy?.background.running).toBe(2);
+    expect(phases(lowered)).toEqual({ executing: 12, queued: 8, idle: 0 });
+    for (let index = 0; index < 10; index += 1) provider.release(`Work ${index}`);
+    const drained = await observeUntil(f.control, (snapshot) => phases(snapshot).idle === 10);
+    expect(phases(drained)).toEqual({ executing: 2, queued: 8, idle: 10 });
+    expect(provider.started).toHaveLength(12);
+    provider.release("Work 10");
+    await provider.waitFor(13);
+    expect(provider.started.at(-1)).toBe("Work 12");
+    const unlimited = await f.control.configureBackgroundCapacity({
+      parentSessionId,
+      running: "unlimited",
+    });
+    expect(unlimited.policy?.background.running).toBe("unlimited");
+    await provider.waitFor(20);
+    expect(phases(await f.control.inspect({ parentSessionId }))).toEqual({
+      executing: 9,
+      queued: 0,
+      idle: 11,
+    });
+    const admission = (await f.store.read()).find((record) => record.event.type === "admitted");
+    expect(admission?.event).toMatchObject({ envelope });
+  } finally {
+    await f.close();
+  }
+});
+
+test("an explicit two-running batch grant remains bounded after Owner capacity becomes unlimited", async () => {
+  const provider = gatedProvider();
+  const f = await fixture(provider.model);
+  try {
+    const command = batch(5);
+    const envelope = await f.control.prepareDelegation(command, { running: 2 });
+    expect(envelope).toMatchObject({ concurrency: { mode: "limited", running: 2 } });
+    expect(await f.control.dispatch({ ...command, envelope })).toMatchObject({
+      status: "admitted",
+    });
+    await provider.waitFor(2);
+    await f.control.configureBackgroundCapacity({ parentSessionId, running: "unlimited" });
+    expect(await f.control.dispatch(batch(1, "Independent"))).toMatchObject({ status: "admitted" });
+    await provider.waitFor(3);
+    expect(provider.started).toEqual(["Work 0", "Work 1", "Independent 0"]);
+    expect(phases(await f.control.inspect({ parentSessionId }))).toEqual({
+      executing: 3,
+      queued: 3,
+      idle: 0,
+    });
+    provider.release("Work 0");
+    await provider.waitFor(4);
+    expect(provider.started.at(-1)).toBe("Work 2");
+    expect(phases(await f.control.inspect({ parentSessionId }))).toEqual({
+      executing: 3,
+      queued: 2,
+      idle: 1,
+    });
+  } finally {
+    await f.close();
+  }
+});
+
+test("ordinary task history exceeds 16 attempts and sixth same-thread turn retains its original grant and cumulative usage", async () => {
+  let calls = 0;
+  const f = await fixture({
+    async *stream() {
+      calls += 1;
+      yield { type: "text_delta", text: "Evidence retained." };
+      yield { type: "usage", inputTokens: 10, outputTokens: 5 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    expect(await f.control.dispatch(batch(18))).toMatchObject({ status: "admitted" });
+    const history = await observeUntil(f.control, (snapshot) => snapshot.completions.length === 18);
+    expect(history.threads).toHaveLength(18);
+    expect(history.threads.every((thread) => thread.turn.outcome?.status === "completed")).toBe(
+      true,
+    );
+    expect(calls).toBe(18);
+    const command = batch(1, "Continued");
+    const envelope = await f.control.prepareDelegation(command, { budgetTokens: 20_000 });
+    expect(await f.control.dispatch({ ...command, envelope })).toMatchObject({
+      status: "admitted",
+    });
+    let snapshot = await observeUntil(f.control, (current) => current.completions.length === 19);
+    const original = snapshot.threads.at(-1);
+    if (original === undefined) throw new Error("Missing funded thread.");
+    for (let turn = 2; turn <= 6; turn += 1) {
+      const thread = snapshot.threads.find((entry) => entry.threadId === original.threadId);
+      if (thread === undefined) throw new Error("Lost continued identity.");
+      expect(
+        await f.control.dispatch({
+          type: "next_turn",
+          parentSessionId,
+          threadId: thread.threadId,
+          expectedTurnId: thread.turn.turnId,
+          task: `Ordinary user continuation ${turn}`,
+        }),
+      ).toMatchObject({ status: "accepted" });
+      snapshot = await observeUntil(
+        f.control,
+        (current) => current.completions.length === 18 + turn,
+      );
+      const continued = snapshot.threads.find((entry) => entry.threadId === original.threadId);
+      expect(continued?.turn.outcome).toMatchObject({ status: "completed" });
+      expect(continued?.turn.configuration).toEqual(original.turn.configuration);
+      expect(continued?.budget).toMatchObject({ ceiling: 20_000, knownUsed: turn * 15 });
+    }
+    const admissions = (await f.store.read()).filter(
+      (record) => record.threadId === original.threadId && record.event.type === "admitted",
+    );
+    expect(admissions).toHaveLength(6);
+    for (const admission of admissions)
+      expect(admission.event).toMatchObject({ envelope: { taskBudget: envelope.taskBudget } });
+    expect(calls).toBe(24);
+    expect(snapshot.budget?.knownUsed).toBe(360);
+  } finally {
+    await f.close();
+  }
+});
+
+test("an exhausted explicit task grant still blocks new provider work on an ordinary continuation", async () => {
+  let calls = 0;
+  const f = await fixture({
+    async *stream() {
+      calls += 1;
+      yield { type: "text_delta", text: "Budget consumed." };
+      yield { type: "usage", inputTokens: 7000, outputTokens: 0 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    const command = batch(1);
+    const envelope = await f.control.prepareDelegation(command, { budgetTokens: 7000 });
+    expect(await f.control.dispatch({ ...command, envelope })).toMatchObject({
+      status: "admitted",
+    });
+    const first = await observeUntil(f.control, (snapshot) => snapshot.completions.length === 1);
+    const thread = first.threads[0];
+    if (thread === undefined) throw new Error("Missing budgeted thread.");
+    expect(thread.budget).toMatchObject({ ceiling: 7000, knownUsed: 7000, available: 0 });
+    expect(
+      await f.control.dispatch({
+        type: "next_turn",
+        parentSessionId,
+        threadId: thread.threadId,
+        expectedTurnId: thread.turn.turnId,
+        task: "Continue without a new grant.",
+      }),
+    ).toMatchObject({ status: "accepted" });
+    const stopped = await observeUntil(f.control, (snapshot) => snapshot.completions.length === 2);
+    expect(stopped.threads[0]?.turn.outcome).toMatchObject({ status: "failed" });
+    expect(stopped.threads[0]?.budget).toMatchObject({
+      ceiling: 7000,
+      knownUsed: 7000,
+      available: 0,
+    });
+    expect(calls).toBe(1);
+  } finally {
+    await f.close();
+  }
+});
+
+test("two Main sessions sharing one project domain and stores each retain eight independent background slots", async () => {
+  const provider = gatedProvider();
+  const f = await fixture(provider.model);
+  const second = createManagedAgentControl({
+    ...f.options,
+    parentSessionId: secondParentSessionId,
+  });
+  try {
+    expect(await f.control.dispatch(batch(9, "First"))).toMatchObject({ status: "admitted" });
+    expect(await second.dispatch(batch(9, "Second", secondParentSessionId))).toMatchObject({
+      status: "admitted",
+    });
+    await provider.waitFor(16);
+    const before = await second.inspect({ parentSessionId: secondParentSessionId });
+    expect(phases(before)).toEqual({ executing: 8, queued: 1, idle: 0 });
+    expect(phases(await f.control.inspect({ parentSessionId }))).toEqual({
+      executing: 8,
+      queued: 1,
+      idle: 0,
+    });
+    const first = (await f.control.inspect({ parentSessionId })).threads[0];
+    if (first === undefined) throw new Error("Missing first Main child.");
+    expect(
+      await f.control.dispatch({
+        type: "cancel_turn",
+        parentSessionId,
+        threadId: first.threadId,
+        expectedTurnId: first.turn.turnId,
+      }),
+    ).toMatchObject({ status: "cancelled" });
+    await provider.waitFor(17);
+    expect(provider.started.at(-1)).toBe("First 8");
+    expect((await second.inspect({ parentSessionId: secondParentSessionId })).threads).toEqual(
+      before.threads,
+    );
+    expect(provider.started).not.toContain("Second 8");
+    provider.release("Second 0");
+    await provider.waitFor(18);
+    expect(provider.started.at(-1)).toBe("Second 8");
+  } finally {
+    await second.dispatch({ type: "close", parentSessionId: secondParentSessionId });
+    await f.close();
+  }
+});
+
+test("the reserved foreground lane retains one running and four queued while all eight background slots are occupied", async () => {
+  const provider = gatedProvider();
+  const f = await fixture(provider.model);
+  const foreground: ReturnType<Control["dispatch"]>[] = [];
+  try {
+    expect(await f.control.dispatch(batch(9))).toMatchObject({ status: "admitted" });
+    await provider.waitFor(8);
+    for (let index = 0; index < 5; index += 1)
+      foreground.push(
+        f.control.dispatch({ ...batch(1, `Foreground ${index}`), mode: "foreground" }),
+      );
+    const full = await observeUntil(
+      f.control,
+      (snapshot) => snapshot.threads.length === 14 && phases(snapshot).executing === 9,
+    );
+    await provider.waitFor(9);
+    expect(full.threads.filter((thread) => thread.turn.lane === "reserved")).toHaveLength(5);
+    expect(
+      full.threads.filter(
+        (thread) => thread.turn.lane === "reserved" && thread.turn.phase === "queued",
+      ),
+    ).toHaveLength(4);
+    expect(phases(full)).toEqual({ executing: 9, queued: 5, idle: 0 });
+    expect(
+      await f.control.dispatch({ ...batch(1, "Reserved overflow"), mode: "foreground" }),
+    ).toMatchObject({ status: "rejected", code: "capacity_exhausted" });
+    provider.release("Foreground 0 0");
+    expect(await foreground[0]).toMatchObject({
+      status: "completed",
+      results: [{ outcome: { status: "completed" } }],
+    });
+    await provider.waitFor(10);
+    expect(provider.started.at(-1)).toBe("Foreground 1 0");
+    expect(provider.started).not.toContain("Work 8");
+    expect(
+      (await f.control.inspect({ parentSessionId })).threads.filter(
+        (thread) => thread.turn.lane === "background" && thread.turn.phase === "executing",
+      ),
+    ).toHaveLength(8);
+  } finally {
+    await f.close();
+    await Promise.all(foreground);
+  }
+});
+
+test("retained child transcripts consume storage independently of ordinary task counts and reject new admission atomically", async () => {
+  let calls = 0;
+  const f = await fixture({
+    async *stream() {
+      calls += 1;
+      yield { type: "text_delta", text: "e".repeat(16 * 1024) };
+      yield { type: "usage", inputTokens: 20, outputTokens: 4096 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  let restored: Control | undefined;
+  try {
+    expect(await f.control.dispatch(batch(1))).toMatchObject({ status: "admitted" });
+    let snapshot = await observeUntil(f.control, (current) => current.completions.length === 1);
+    for (let turn = 2; turn <= 3; turn += 1) {
+      const thread = snapshot.threads[0];
+      if (thread === undefined) throw new Error("Missing retained transcript identity.");
+      expect(
+        await f.control.dispatch({
+          type: "next_turn",
+          parentSessionId,
+          threadId: thread.threadId,
+          expectedTurnId: thread.turn.turnId,
+          task: `Continue retained evidence ${turn}`,
+        }),
+      ).toMatchObject({ status: "accepted" });
+      snapshot = await observeUntil(f.control, (current) => current.completions.length === turn);
+      expect(snapshot.threads[0]?.turn.outcome).toMatchObject({ status: "completed" });
+    }
+    await f.control.dispatch({ type: "close", parentSessionId });
+    if (snapshot.policy === undefined) throw new Error("Missing current execution policy.");
+    const records = await f.store.read();
+    const journalBytes = Buffer.byteLength(
+      records.map((record) => `${JSON.stringify(record)}\n`).join(""),
+    );
+    const transcripts = await Promise.all(
+      [...new Set(records.map((record) => record.childSessionId))].map(async (id) => {
+        const store = await f.options.childSessionStores.open(id);
+        if (store === undefined) throw new Error("Missing historical child transcript.");
+        return store.read();
+      }),
+    );
+    const childBytes = Buffer.byteLength(
+      transcripts
+        .flat()
+        .map((record) => `${JSON.stringify(record)}\n`)
+        .join(""),
+    );
+    expect(childBytes).toBeGreaterThan(48 * 1024);
+    // The journal alone fits beside a fresh 320 KiB terminal reservation.
+    expect(journalBytes + 320 * 1024).toBeLessThan(450_000);
+    expect(journalBytes + childBytes + 320 * 1024).toBeGreaterThan(450_000);
+    restored = createManagedAgentControl({
+      ...f.options,
+      policy: { ...snapshot.policy, storageBytes: 450_000 },
+    });
+    const retained = await restored.inspect({ parentSessionId });
+    expect(retained.storage).toMatchObject({
+      ceiling: 450_000,
+      usedBytes: journalBytes + childBytes,
+      reservedTerminalBytes: 0,
+    });
+    expect(retained.threads).toHaveLength(1);
+    expect(await restored.dispatch(batch(1, "New task"))).toMatchObject({
+      status: "rejected",
+      code: "storage_quota_exceeded",
+    });
+    expect(await f.store.read()).toEqual(records);
+    expect(calls).toBe(3);
+    expect((await restored.inspect({ parentSessionId })).storage).toEqual(retained.storage);
+  } finally {
+    await restored?.dispatch({ type: "close", parentSessionId });
+    await f.close();
+  }
+});
+
+test("mutating a policy projection cannot change the Owner's execution capacity", async () => {
+  const provider = gatedProvider();
+  const f = await fixture(provider.model);
+  try {
+    const snapshot = await f.control.inspect({ parentSessionId });
+    if (snapshot.policy === undefined) throw new Error("Missing policy projection.");
+    Object.assign(snapshot.policy.background, { running: "unlimited" });
+    const command = batch(9);
+    const envelope = await f.control.prepareDelegation(command);
+    expect(envelope.policy.background.running).toBe(8);
+    expect(await f.control.dispatch({ ...command, envelope })).toMatchObject({
+      status: "admitted",
+    });
+    await provider.waitFor(8);
+    expect(phases(await f.control.inspect({ parentSessionId }))).toEqual({
+      executing: 8,
+      queued: 1,
+      idle: 0,
+    });
+  } finally {
+    await f.close();
+  }
+});
+
+test("supplied current envelopes cannot upgrade historical threads and valid continuations retain four slots", async () => {
+  const f = await fixture({
+    async *stream() {
+      yield { type: "text_delta", text: "Historical evidence." };
+      yield { type: "usage", inputTokens: 10, outputTokens: 5 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  const legacy = createManagedAgentControl({
+    ...f.options,
+    policy: {
+      version: 2,
+      background: { running: 4, queued: 32 },
+      reserved: { running: 1, queued: 4 },
+      maximumAttempts: 4,
+      threadTokens: null,
+      batchTokens: null,
+      sessionTokens: null,
+      storageBytes: 32 * 1024 * 1024,
+    },
+  });
+  const provider = gatedProvider();
+  let current: Control | undefined;
+  try {
+    expect(await legacy.dispatch(batch(5))).toMatchObject({ status: "admitted" });
+    const original = await observeUntil(legacy, (snapshot) => snapshot.completions.length === 5);
+    await legacy.dispatch({ type: "close", parentSessionId });
+    current = createManagedAgentControl({ ...f.options, model: provider.model });
+    const before = await f.store.read();
+    for (const [index, thread] of original.threads.entries()) {
+      const upgraded = await current.prepareDelegation(batch(1, `Upgrade ${index}`));
+      expect(
+        await current.dispatch({
+          type: "next_turn",
+          parentSessionId,
+          threadId: thread.threadId,
+          expectedTurnId: thread.turn.turnId,
+          task: `Upgrade ${index}`,
+          envelope: upgraded,
+        }),
+      ).toMatchObject({ status: "rejected", code: "action_unavailable" });
+    }
+    expect(await f.store.read()).toEqual(before);
+    for (const [index, thread] of original.threads.entries()) {
+      const command = {
+        type: "next_turn" as const,
+        parentSessionId,
+        threadId: thread.threadId,
+        expectedTurnId: thread.turn.turnId,
+        task: `Historical continuation ${index}`,
+      };
+      const envelope = await current.prepareContinuation(command);
+      expect(envelope.version).toBe(2);
+      expect(await current.dispatch({ ...command, envelope })).toMatchObject({
+        status: "accepted",
+      });
+    }
+    await provider.waitFor(4);
+    const snapshot = await current.inspect({ parentSessionId });
+    expect(phases(snapshot)).toEqual({ executing: 4, queued: 1, idle: 0 });
+    expect(snapshot.threads.every((thread) => thread.turn.envelope?.version === 2)).toBe(true);
+    const records = await f.store.read();
+    const initialTurns = new Set(original.threads.map((thread) => thread.turn.turnId));
+    const nextIndex = records.findIndex(
+      (record) => record.event.type === "admitted" && !initialTurns.has(record.turnId),
+    );
+    const nextAdmission = records[nextIndex];
+    if (nextAdmission?.event.type !== "admitted")
+      throw new Error("Missing historical continuation receipt.");
+    const upgraded = await current.prepareDelegation(batch(1, "Invalid restored upgrade"));
+    const restored = createInMemoryManagedAgentControlStore();
+    for (const record of records.slice(0, nextIndex)) await restored.append(record);
+    await expect(
+      restored.append({
+        ...nextAdmission,
+        event: { ...nextAdmission.event, batchId: upgraded.id, envelope: upgraded },
+      }),
+    ).rejects.toMatchObject({ code: "managed_agent_log_invalid" });
+  } finally {
+    await current?.dispatch({ type: "close", parentSessionId });
+    await legacy.dispatch({ type: "close", parentSessionId });
+    await f.close();
+  }
+});

--- a/packages/testkit/src/managed-agent-scheduler.test.ts
+++ b/packages/testkit/src/managed-agent-scheduler.test.ts
@@ -72,13 +72,24 @@ const contextProfile = {
   estimatorVersion: 1,
 } as const;
 
-test("AgentSession atomically spawns four running and twenty-eight queued children while Main completes", async () => {
-  const fourStarted = Promise.withResolvers<void>();
+const currentFleetPolicy = {
+  version: 3,
+  background: { running: 8, queued: "unlimited" },
+  reserved: { running: 1, queued: 4 },
+  maximumAttempts: "unlimited",
+  threadTokens: null,
+  batchTokens: null,
+  sessionTokens: null,
+  storageBytes: 32 * 1024 * 1024,
+} as const;
+
+test("AgentSession atomically spawns eight running and twenty-four queued children while Main completes", async () => {
+  const eightStarted = Promise.withResolvers<void>();
   let childCalls = 0;
   const childModel: ModelDriver = {
     async *stream(request) {
       childCalls += 1;
-      if (childCalls === 4) fourStarted.resolve();
+      if (childCalls === 8) eightStarted.resolve();
       await new Promise<void>((resolve) => {
         if (request.signal.aborted) resolve();
         else request.signal.addEventListener("abort", () => resolve(), { once: true });
@@ -157,15 +168,15 @@ test("AgentSession atomically spawns four running and twenty-eight queued childr
       name: "spawn_agents",
       result: { status: "completed", output: { status: "admitted" } },
     });
-    await withManagedFailureGuard(fourStarted.promise, "four actual child provider starts");
+    await withManagedFailureGuard(eightStarted.promise, "eight actual child provider starts");
     const snapshot = await control.inspect({ parentSessionId });
     expect(snapshot.threads).toHaveLength(32);
-    expect(snapshot.threads.filter((thread) => thread.turn.phase === "executing")).toHaveLength(4);
-    expect(snapshot.threads.filter((thread) => thread.turn.phase === "queued")).toHaveLength(28);
+    expect(snapshot.threads.filter((thread) => thread.turn.phase === "executing")).toHaveLength(8);
+    expect(snapshot.threads.filter((thread) => thread.turn.phase === "queued")).toHaveLength(24);
     expect(snapshot.threads.map((thread) => thread.description)).toEqual(
       entries.map((entry) => entry.description),
     );
-    expect(childCalls).toBe(4);
+    expect(childCalls).toBe(8);
   } finally {
     confirmation();
     await control.dispatch({ type: "close", parentSessionId });
@@ -305,14 +316,14 @@ test("cold queued admission resumes exact protected context without adopting lat
     const admitted = await first.dispatch({
       type: "spawn_agents",
       parentSessionId,
-      entries: Array.from({ length: 5 }, (_, i) => ({
+      entries: Array.from({ length: 9 }, (_, i) => ({
         role: "builtin:explore",
         task: `Exact bytes ${i}\n中文`,
         description: `Evidence ${i}`,
       })),
     });
     if (admitted.status !== "admitted") throw new Error("Expected batch admission");
-    const queued = admitted.turns[4];
+    const queued = admitted.turns[8];
     if (queued === undefined) throw new Error("Missing queued identity");
     await first.dispatch({ type: "close", parentSessionId });
     expect(await children.open(queued.childSessionId)).toBeUndefined();
@@ -331,7 +342,7 @@ test("cold queued admission resumes exact protected context without adopting lat
         },
       },
     });
-    expect((await cold.inspect({ parentSessionId })).threads[4]?.turn).toMatchObject({
+    expect((await cold.inspect({ parentSessionId })).threads[8]?.turn).toMatchObject({
       phase: "waiting",
       waitReason: "suspended",
     });
@@ -351,7 +362,7 @@ test("cold queued admission resumes exact protected context without adopting lat
     } finally {
       observer.abort();
     }
-    expect(restarted?.messages).toContainEqual({ role: "user", content: "Exact bytes 4\n中文" });
+    expect(restarted?.messages).toContainEqual({ role: "user", content: "Exact bytes 8\n中文" });
     expect(JSON.stringify(restarted?.messages)).toContain("Original selected parent request.");
     expect(JSON.stringify(restarted?.messages)).not.toContain("Later private text");
   } finally {
@@ -389,6 +400,17 @@ async function schedulerFixture(
     executionDomain: domain,
     store,
     childSessionStores: createInMemorySessionStoreDirectory<SessionRecord>(),
+    // These original scheduler tracers retain their persisted v2 limits.
+    policy: {
+      version: 2,
+      background: { running: 4, queued: 32 },
+      reserved: { running: 1, queued: 4 },
+      maximumAttempts: 4,
+      threadTokens: null,
+      batchTokens: null,
+      sessionTokens: null,
+      storageBytes: 32 * 1024 * 1024,
+    },
     ...additions,
   });
   return {
@@ -501,73 +523,83 @@ test("lane reservations cap nonterminal admission and preserve FIFO without borr
   }
 });
 
-test("permission waits retain admission, release running capacity and reacquire before the effect with resumption priority", async () => {
-  const release = Promise.withResolvers<void>();
-  const f = await schedulerFixture(
-    {
-      async *stream(request) {
-        const task = request.messages.find((message) => message.role === "user");
-        if (task?.role !== "user" || typeof task.content !== "string")
-          throw new Error("Missing task");
-        if (
-          task.content === "Ask 0" &&
-          !request.messages.some((message) => message.role === "tool")
-        ) {
-          yield { type: "tool_call_start", id: "read-evidence", name: "read_file" };
-          yield { type: "tool_call_delta", id: "read-evidence", json: '{"path":"package.json"}' };
-          yield { type: "tool_call_end", id: "read-evidence" };
+test.each([4, 8])(
+  "permission waits release %s-slot capacity and reacquire with resumption priority",
+  async (capacity) => {
+    const release = Promise.withResolvers<void>();
+    const f = await schedulerFixture(
+      {
+        async *stream(request) {
+          const task = request.messages.find((message) => message.role === "user");
+          if (task?.role !== "user" || typeof task.content !== "string")
+            throw new Error("Missing task");
+          if (
+            task.content === "Ask 0" &&
+            !request.messages.some((message) => message.role === "tool")
+          ) {
+            yield { type: "tool_call_start", id: "read-evidence", name: "read_file" };
+            yield { type: "tool_call_delta", id: "read-evidence", json: '{"path":"package.json"}' };
+            yield { type: "tool_call_end", id: "read-evidence" };
+            yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+            yield { type: "finish", reason: "tool_calls" };
+            return;
+          }
+          if (task.content !== "Ask 0") {
+            const abort = Promise.withResolvers<void>();
+            if (request.signal.aborted) abort.resolve();
+            else request.signal.addEventListener("abort", () => abort.resolve(), { once: true });
+            await Promise.race([release.promise, abort.promise]);
+          }
+          yield { type: "text_delta", text: task.content };
           yield { type: "usage", inputTokens: 20, outputTokens: 10 };
-          yield { type: "finish", reason: "tool_calls" };
-          return;
-        }
-        if (task.content !== "Ask 0") {
-          const abort = Promise.withResolvers<void>();
-          if (request.signal.aborted) abort.resolve();
-          else request.signal.addEventListener("abort", () => abort.resolve(), { once: true });
-          await Promise.race([release.promise, abort.promise]);
-        }
-        yield { type: "text_delta", text: task.content };
-        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
-        yield { type: "finish", reason: "stop" };
+          yield { type: "finish", reason: "stop" };
+        },
       },
-    },
-    { permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["read"] }) },
-  );
-  try {
-    const result = await f.control.dispatch(batch(6, "Ask"));
-    expect(result.status).toBe("admitted");
-    await observeUntil(
-      f.control,
-      (snapshot) =>
-        snapshot.threads[0]?.turn.waitReason === "permission" &&
-        snapshot.threads[4]?.turn.phase === "executing",
+      {
+        permissions: createPermissionPolicy({ allowedEffects: [], askedEffects: ["read"] }),
+        ...(capacity === 8 ? { policy: currentFleetPolicy } : {}),
+      },
     );
-    const snapshot = await f.control.inspect({ parentSessionId });
-    const thread = snapshot.threads[0];
-    if (thread?.turn.attention === undefined) throw new Error("Missing exact permission request");
-    expect(snapshot.threads.filter((entry) => entry.turn.phase === "executing")).toHaveLength(4);
-    const decision = await f.control.dispatch({
-      type: "decide_permission",
-      parentSessionId,
-      threadId: thread.threadId,
-      expectedTurnId: thread.turn.turnId,
-      requestId: thread.turn.attention.id,
-      decision: "allow",
-    });
-    expect(decision).toMatchObject({ status: "accepted" });
-    await observeUntil(f.control, (state) => state.threads[0]?.turn.waitReason === "capacity");
-    expect((await f.control.inspect({ parentSessionId })).threads[5]?.turn.phase).toBe("queued");
-    release.resolve();
-    await observeUntil(f.control, (state) => state.completions.length === 6);
-    const resumed = (await f.store.read()).filter(
-      (record) => record.event.type === "capacity_acquired",
-    );
-    expect(resumed[0]?.threadId).toBe(thread.threadId);
-  } finally {
-    release.resolve();
-    await f.close();
-  }
-});
+    try {
+      const result = await f.control.dispatch(batch(capacity + 2, "Ask"));
+      expect(result.status).toBe("admitted");
+      await observeUntil(
+        f.control,
+        (snapshot) =>
+          snapshot.threads[0]?.turn.waitReason === "permission" &&
+          snapshot.threads[capacity]?.turn.phase === "executing",
+      );
+      const snapshot = await f.control.inspect({ parentSessionId });
+      const thread = snapshot.threads[0];
+      if (thread?.turn.attention === undefined) throw new Error("Missing exact permission request");
+      expect(snapshot.threads.filter((entry) => entry.turn.phase === "executing")).toHaveLength(
+        capacity,
+      );
+      const decision = await f.control.dispatch({
+        type: "decide_permission",
+        parentSessionId,
+        threadId: thread.threadId,
+        expectedTurnId: thread.turn.turnId,
+        requestId: thread.turn.attention.id,
+        decision: "allow",
+      });
+      expect(decision).toMatchObject({ status: "accepted" });
+      await observeUntil(f.control, (state) => state.threads[0]?.turn.waitReason === "capacity");
+      expect((await f.control.inspect({ parentSessionId })).threads[capacity + 1]?.turn.phase).toBe(
+        "queued",
+      );
+      release.resolve();
+      await observeUntil(f.control, (state) => state.completions.length === capacity + 2);
+      const resumed = (await f.store.read()).filter(
+        (record) => record.event.type === "capacity_acquired",
+      );
+      expect(resumed[0]?.threadId).toBe(thread.threadId);
+    } finally {
+      release.resolve();
+      await f.close();
+    }
+  },
+);
 
 test("immutable grants share one Session ceiling and unknown provider usage retains capacity until exact settlement", async () => {
   let calls = 0;
@@ -1506,6 +1538,16 @@ test.each([1, 4])(
     const cold = await schedulerFixture(model, {
       store: first.store,
       childSessionStores: children,
+      policy: {
+        version: 3,
+        background: { running: 8, queued: "unlimited" },
+        reserved: { running: 1, queued: 4 },
+        maximumAttempts: "unlimited",
+        threadTokens: null,
+        batchTokens: null,
+        sessionTokens: null,
+        storageBytes: 32 * 1024 * 1024,
+      },
     });
     try {
       const continuation = await cold.control.dispatch({
@@ -2110,7 +2152,7 @@ test.each(["wait", "suspend"] as const)(
   async (choice) => {
     const h = createInMemorySessionLifecycleHarness();
     const store = createInMemoryManagedAgentControlStore();
-    const fourStarted = Promise.withResolvers<void>();
+    const eightStarted = Promise.withResolvers<void>();
     const finish = Promise.withResolvers<void>();
     let calls = 0;
     const driver: ModelDriver = {
@@ -2126,7 +2168,7 @@ test.each(["wait", "suspend"] as const)(
           yield { type: "finish", reason: "stop" };
           return;
         }
-        if (++calls === 4) fourStarted.resolve();
+        if (++calls === 8) eightStarted.resolve();
         await Promise.race([
           finish.promise,
           new Promise<void>((resolve) => {
@@ -2178,8 +2220,8 @@ test.each(["wait", "suspend"] as const)(
     try {
       const control = await lifecycle[sessionManagedControl](a.sessionId);
       if (control === undefined) throw new Error("No source Control");
-      await control.dispatch({ ...batch(5), parentSessionId: a.sessionId });
-      await fourStarted.promise;
+      await control.dispatch({ ...batch(9), parentSessionId: a.sessionId });
+      await eightStarted.promise;
       expect(
         await presentation.dispatch({ type: "select_session", sessionId: b.sessionId }),
       ).toMatchObject({ status: "rejected", code: "transition_required" });
@@ -2222,14 +2264,14 @@ test.each(["wait", "suspend"] as const)(
       expect(await switching).toMatchObject({ status: "admitted" });
       expect(presentation.getState().authoritative.active?.session.id).toBe(b.sessionId);
       expect(presentation.getState().authoritative.managedControl?.threads).toEqual([]);
-      expect((await control.inspect({ parentSessionId: a.sessionId })).threads[4]?.turn.phase).toBe(
+      expect((await control.inspect({ parentSessionId: a.sessionId })).threads[8]?.turn.phase).toBe(
         choice === "suspend" ? "waiting" : "idle",
       );
       expect(
         await control.dispatch({ ...batch(1, "Stale source"), parentSessionId: a.sessionId }),
       ).toMatchObject({ status: "rejected", code: "authority_busy" });
       const sourceSnapshot = await control.inspect({ parentSessionId: a.sessionId });
-      const last = sourceSnapshot.threads[4];
+      const last = sourceSnapshot.threads[8];
       if (last === undefined) throw new Error("Missing original target");
       expect(
         await control.dispatch({
@@ -2241,7 +2283,7 @@ test.each(["wait", "suspend"] as const)(
         status: "resumed",
         results: [{ status: "rejected", code: "authority_busy" }],
       });
-      expect(calls).toBe(choice === "suspend" ? 4 : 5);
+      expect(calls).toBe(choice === "suspend" ? 8 : 9);
       const source = await lifecycle.inspect({ sessionId: a.sessionId });
       if (source.schemaVersion !== 3) throw new Error("Missing source");
       const branch = await lifecycle.branch({


### PR DESCRIPTION
The candidate managed-control path now defaults to eight background agents per Main session and durably queues excess work. Owner configuration accepts a positive integer or `unlimited`, persists per session, and applies increases to existing queues; decreases leave running work intact. Explicitly narrowed batch concurrency remains frozen.

The v3 policy accepts ordinary continuations and additional batches without lifetime attempt or queue-count quotas. Explicit task budgets, retained-history storage accounting, permission/context limits and the reserved foreground/reviewer lane remain enforced. Historical v1/v2 envelopes retain their original authority, including during continuation and recovery. Cold activation loads capacity without automatically starting queued work.

Validation covers a 32-item batch at 8 running/24 queued, 65 cumulative admissions, live capacity changes, six same-thread turns, separate Main counters, budget/storage refusals, durable configuration and cold recovery. Regression tests also prevent supplied envelopes from upgrading historical policy and prevent mutable snapshot data from changing Owner capacity. Independent specification and engineering reviews passed.

The ordinary production entry remains on its existing composition; this change completes the candidate policy and scheduler behavior.

Final `pnpm quality:check` passed 2,377 tests with 18 existing opt-in skips, including code, Markdown, TypeScript and browser-boundary checks.
