### PR TITLE
Streamline agent views, handle navigation and draft receipts

### DIFF
--- a/apps/tui/src/agent-admission-card.test.ts
+++ b/apps/tui/src/agent-admission-card.test.ts
@@ -1,0 +1,37 @@
+import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
+import { expect, test } from "vitest";
+import { AgentAdmissionCard } from "./agent-admission-card.js";
+import { createAdamTuiTheme } from "./theme.js";
+
+test.each([40, 80, 120])(
+  "admission cards use the available %i columns while keeping the exact receipt separate",
+  (width) => {
+    for (const noColor of [false, true]) {
+      const card = new AgentAdmissionCard(
+        {
+          status: "queued",
+          lane: "background",
+          threadId: "thread",
+          turnId: "turn",
+          handle: "@explore-9",
+          displayName: "Explore",
+          description: "核查 e\u0301 schema compatibility and runtime ownership evidence",
+        },
+        createAdamTuiTheme(noColor),
+      );
+      const lines = card.render(width);
+      expect(lines).toHaveLength(2);
+      expect(stripTerminalSequences(lines[1] ?? "")).toBe("Queued @explore-9");
+      expect(stripTerminalSequences(lines[0] ?? "")).toContain("Explore · 核查 e\u0301");
+      if (width >= 80)
+        expect(stripTerminalSequences(lines[0] ?? "")).toBe(
+          "Explore · 核查 e\u0301 schema compatibility and runtime ownership evidence",
+        );
+      expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+      if (noColor)
+        expect(lines.join("\n").replaceAll("\u001b[0m", "")).toBe(
+          stripTerminalSequences(lines.join("\n")),
+        );
+    }
+  },
+);

--- a/apps/tui/src/agent-admission-card.ts
+++ b/apps/tui/src/agent-admission-card.ts
@@ -1,0 +1,28 @@
+import type { ManagedAdmissionDisplay } from "@adam-agent/presentation";
+import { type Component, truncateToWidth } from "@earendil-works/pi-tui";
+import { safeTerminalText } from "./safe-terminal-text.js";
+import type { AdamTuiTheme } from "./theme.js";
+
+/** A recorded admission acknowledges startup or queueing, never task completion. */
+export class AgentAdmissionCard implements Component {
+  constructor(
+    private readonly admission: ManagedAdmissionDisplay,
+    private readonly theme: AdamTuiTheme,
+    private readonly showExpandHint = false,
+  ) {}
+
+  invalidate(): void {}
+
+  render(width: number): string[] {
+    return [
+      this.theme.toolTitle(
+        safeTerminalText(`${this.admission.displayName} · ${this.admission.description}`),
+      ),
+      this.theme.toolOutput(
+        safeTerminalText(
+          `${this.admission.status === "started" ? "Started" : "Queued"} ${this.admission.handle}${this.showExpandHint ? " · Ctrl+O expand" : ""}`,
+        ),
+      ),
+    ].map((line) => truncateToWidth(line, width));
+  }
+}

--- a/apps/tui/src/agent-conversation-viewer.ts
+++ b/apps/tui/src/agent-conversation-viewer.ts
@@ -37,15 +37,21 @@ import {
   wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import { agentElapsedLabel } from "./agent-widget.js";
+import { focusedWheelDirection } from "./focused-wheel-input.js";
 import { safeTerminalText } from "./safe-terminal-text.js";
 import { parseTaskBudgetFollowUp } from "./task-budget-input.js";
 import type { AdamTuiTheme } from "./theme.js";
 import { ToolPreview } from "./tool-preview.js";
 
 const viewerKeys = {
-  up: (data: string) => getKeybindings().matches(data, "tui.select.up") || matchesKey(data, "k"),
+  up: (data: string) =>
+    focusedWheelDirection(data) === -1 ||
+    getKeybindings().matches(data, "tui.select.up") ||
+    matchesKey(data, "k"),
   down: (data: string) =>
-    getKeybindings().matches(data, "tui.select.down") || matchesKey(data, "j"),
+    focusedWheelDirection(data) === 1 ||
+    getKeybindings().matches(data, "tui.select.down") ||
+    matchesKey(data, "j"),
   pageUp: (data: string) =>
     getKeybindings().matches(data, "tui.select.pageUp") || matchesKey(data, "shift+up"),
   pageDown: (data: string) =>
@@ -118,6 +124,9 @@ export class AgentConversationViewer implements Component {
   #readGeneration = 0;
   #closed = false;
   #details = false;
+  #help = false;
+  #helpScroll = 0;
+  #helpMaximumScroll = 0;
   #detailScroll = 0;
   #detailMaximumScroll = 0;
   #notice = "";
@@ -179,6 +188,7 @@ export class AgentConversationViewer implements Component {
         cursor: string | null,
       ) => Promise<ManagedAgentTranscriptPageResource>;
       readonly onSend: (command: ManagedControlCommand) => Promise<CommandReceipt>;
+      readonly isMainCommand?: (text: string) => boolean;
       readonly onSaveDraft: (draft: ManagedComposerDraft) => Promise<void>;
       readonly onClearDraft: (draft: ManagedComposerDraft) => Promise<boolean>;
       readonly onReadResource: (
@@ -396,6 +406,11 @@ export class AgentConversationViewer implements Component {
       this.back();
       return;
     }
+    if (this.options.isMainCommand?.(text)) {
+      this.#inputNotice = "Run this command in Main. Child draft retained.";
+      this.options.onChange();
+      return;
+    }
     const target = this.#composeTarget;
     if (target === undefined) return;
     if (
@@ -528,7 +543,9 @@ export class AgentConversationViewer implements Component {
     });
   }
   back(): void {
-    if (this.#exportView !== undefined) {
+    if (this.#help) {
+      this.#help = false;
+    } else if (this.#exportView !== undefined) {
       if (this.#exportView.phase === "confirm") this.#exportView.phase = "fields";
       else this.#exportView = undefined;
     } else if (this.#suppressTarget !== undefined) {
@@ -550,15 +567,42 @@ export class AgentConversationViewer implements Component {
   }
   handleInput(data: string): void {
     if (isKeyRelease(data)) return;
+    const wheel = focusedWheelDirection(data);
     if (!isKeyRepeat(data) && !matchesKey(data, "x")) this.#cancelTarget = undefined;
     if (matchesKey(data, "enter") && isKeyRepeat(data)) return;
+    if (this.#help) {
+      if ((matchesKey(data, "escape") || matchesKey(data, "?")) && !isKeyRepeat(data))
+        this.#help = false;
+      else if (matchesKey(data, "home")) this.#helpScroll = 0;
+      else if (matchesKey(data, "end")) this.#helpScroll = this.#helpMaximumScroll;
+      else if (viewerKeys.up(data) || viewerKeys.pageUp(data))
+        this.#helpScroll = Math.max(
+          0,
+          this.#helpScroll -
+            (viewerKeys.up(data) ? 1 : Math.max(1, this.options.maximumLines() - 2)),
+        );
+      else if (viewerKeys.down(data) || viewerKeys.pageDown(data))
+        this.#helpScroll = Math.min(
+          this.#helpMaximumScroll,
+          this.#helpScroll +
+            (viewerKeys.down(data) ? 1 : Math.max(1, this.options.maximumLines() - 2)),
+        );
+      this.options.onChange();
+      return;
+    }
     if (this.#exportView !== undefined) {
       this.handleExportInput(data, this.#exportView);
       this.options.onChange();
       return;
     }
+    if (this.#resources !== undefined) {
+      this.handleResourceInput(data);
+      this.options.onChange();
+      return;
+    }
     if (this.#details) {
-      if ((matchesKey(data, "escape") || data === "?") && !isKeyRepeat(data)) this.#details = false;
+      if ((matchesKey(data, "escape") || matchesKey(data, "d")) && !isKeyRepeat(data))
+        this.#details = false;
       else if (matchesKey(data, "home")) this.#detailScroll = 0;
       else if (matchesKey(data, "end")) this.#detailScroll = this.#detailMaximumScroll;
       else if (viewerKeys.up(data) || viewerKeys.pageUp(data))
@@ -576,14 +620,15 @@ export class AgentConversationViewer implements Component {
       this.options.onChange();
       return;
     }
-    if (!this.#composing && data === "?" && !isKeyRepeat(data)) {
-      this.#details = true;
-      this.#detailScroll = 0;
+    if (!this.#composing && matchesKey(data, "?") && !isKeyRepeat(data)) {
+      this.#help = true;
+      this.#helpScroll = 0;
       this.options.onChange();
       return;
     }
-    if (this.#resources !== undefined) {
-      this.handleResourceInput(data);
+    if (!this.#composing && matchesKey(data, "d") && !isKeyRepeat(data)) {
+      this.#details = true;
+      this.#detailScroll = 0;
       this.options.onChange();
       return;
     }
@@ -693,6 +738,11 @@ export class AgentConversationViewer implements Component {
       if (!isKeyRepeat(data)) this.back();
       return;
     }
+    if (wheel !== null) {
+      this.scrollConversation(wheel, false);
+      this.options.onChange();
+      return;
+    }
     if (this.#composing) {
       if (this.#sending) return;
       if (
@@ -725,7 +775,12 @@ export class AgentConversationViewer implements Component {
       }
       this.#composing = true;
       this.#composer.focused = this.#focused;
-    } else if (matchesKey(data, "d") && !isKeyRepeat(data) && this.#composer.getValue()) {
+    } else if (
+      matchesKey(data, "ctrl+d") &&
+      !isKeyRepeat(data) &&
+      !this.#sending &&
+      this.#composer.getValue()
+    ) {
       this.#composer.setValue("");
       void this.saveLocalDraft().catch(() => undefined);
       this.#composeTarget = undefined;
@@ -769,27 +824,30 @@ export class AgentConversationViewer implements Component {
     } else if (matchesKey(data, "end")) {
       this.followTail();
     } else if (viewerKeys.up(data) || viewerKeys.pageUp(data)) {
-      this.freezePage();
-      if (viewerKeys.pageUp(data) && this.#scrollOffset === 0 && this.#manualPage?.olderCursor)
-        this.loadPage(this.#manualPage.olderCursor, "older");
-      else
-        this.#scrollOffset = Math.max(
-          0,
-          this.#scrollOffset - (viewerKeys.pageUp(data) ? this.#bodyHeight : 1),
-        );
+      this.scrollConversation(-1, viewerKeys.pageUp(data));
     } else if (viewerKeys.down(data) || viewerKeys.pageDown(data)) {
+      this.scrollConversation(1, viewerKeys.pageDown(data));
+    }
+    this.options.onChange();
+  }
+  private scrollConversation(direction: -1 | 1, page: boolean): void {
+    if (direction < 0) {
+      this.freezePage();
+      if (page && this.#scrollOffset === 0 && this.#manualPage?.olderCursor)
+        this.loadPage(this.#manualPage.olderCursor, "older");
+      else this.#scrollOffset = Math.max(0, this.#scrollOffset - (page ? this.#bodyHeight : 1));
+    } else {
       if (this.#scrollOffset >= this.#maximumScroll && this.#newerCursors.length > 0)
         this.loadPage(this.#newerCursors.at(-1) ?? null, "newer");
       else {
         this.#scrollOffset = Math.min(
           this.#maximumScroll,
-          this.#scrollOffset + (viewerKeys.pageDown(data) ? this.#bodyHeight : 1),
+          this.#scrollOffset + (page ? this.#bodyHeight : 1),
         );
         if (this.#scrollOffset >= this.#maximumScroll && this.#newerCursors.length === 0)
           this.followTail();
       }
     }
-    this.options.onChange();
   }
   invalidate(): void {}
   private canCompose(): boolean {
@@ -1165,6 +1223,30 @@ export class AgentConversationViewer implements Component {
     ].map((line) => truncateToWidth(line, width));
   }
   render(width: number): string[] {
+    if (this.#help) {
+      const lines = [
+        "Enter: focus the independent child editor",
+        "Enter in editor: send · Tab: cooperative/interrupt delivery",
+        "Esc: editor to viewer to Fleet to Main",
+        "d: exact agent details · Ctrl+D: discard retained draft",
+        "t: confirm retarget to the current turn",
+        "x x: cancel the exact turn",
+        "v: bounded resources · i: exact input receipts",
+        "m: raw/assistant/full Markdown",
+        "Home/End: scroll start/follow tail",
+        "j/k, arrows or wheel: scroll current viewport",
+        "PgUp/PgDown or Shift+arrows: page and bounded transcript",
+        "Run built-in commands in Main; child drafts stay private.",
+      ].flatMap((line) => wrapTextWithAnsi(line, width));
+      const height = Math.max(1, this.options.maximumLines() - 2);
+      this.#helpMaximumScroll = Math.max(0, lines.length - height);
+      this.#helpScroll = Math.min(this.#helpScroll, this.#helpMaximumScroll);
+      return [
+        this.options.theme.primary("Conversation help"),
+        ...lines.slice(this.#helpScroll, this.#helpScroll + height),
+        "↑↓ / wheel scroll · Esc conversation",
+      ].map((line) => truncateToWidth(line, width));
+    }
     const completion = this.#completion;
     if (
       this.#focused &&
@@ -1195,9 +1277,7 @@ export class AgentConversationViewer implements Component {
       this.#manualPage === undefined ? this.#olderCursor : this.#manualPage.olderCursor;
     const liveOmittedBytes =
       this.#manualPage === undefined ? this.#liveOmittedBytes : this.#manualPage.liveOmittedBytes;
-    const header = [
-      this.options.theme.primary(`Conversation · ${thread.handle} · ${thread.displayName}`),
-      safeTerminalText(thread.description),
+    const configurationDetails = [
       config === undefined
         ? "Recorded target unavailable"
         : `${safeTerminalText(config.targetId)} · thinking ${safeTerminalText(config.thinking)}`,
@@ -1210,6 +1290,10 @@ export class AgentConversationViewer implements Component {
               ? [`Provider usage exceeded request estimates by ${thread.budget.overrun} tokens.`]
               : []),
           ]),
+    ];
+    const header = [
+      this.options.theme.primary(`Conversation · ${thread.handle} · ${thread.displayName}`),
+      safeTerminalText(thread.description),
       `${thread.turn.label}${agentElapsedLabel(thread)}`,
       ...(this.#activity?.tool?.status === "generating_arguments"
         ? [`Generating arguments · ${safeTerminalText(this.#activity.tool.name)}`]
@@ -1247,7 +1331,7 @@ export class AgentConversationViewer implements Component {
       ...(this.#composeTarget !== undefined &&
       this.#composer.getValue() &&
       this.#composeTarget.expectedTurnId !== thread.turn.turnId
-        ? ["Draft targets an earlier turn · d discard · t retarget"]
+        ? ["Draft targets an earlier turn · Ctrl+D discard · t retarget"]
         : []),
       `${this.#followTail ? "Following tail" : "Manual scroll · End tail"} · m ${this.#renderMode === "raw" ? "raw" : `${this.#renderMode} Markdown`}`,
       ...(olderCursor === null ? [] : ["PgUp at top: older transcript page"]),
@@ -1278,12 +1362,12 @@ export class AgentConversationViewer implements Component {
               : "Enter send · Esc viewer",
           ]
         : [
-            ...(this.#composer.getValue() ? [`Draft to ${thread.handle}`] : []),
+            ...(this.#composer.getValue() ? [`Draft to ${thread.handle} · Ctrl+D discard`] : []),
             this.canCompose()
-              ? "Enter compose · Esc back"
+              ? "Enter compose · Esc back · d details · ? help"
               : this.#thread.turn.phase === "settling"
-                ? "Settling · input available after cleanup · Esc back"
-                : "Input unavailable · Esc back",
+                ? "Settling · input available after cleanup · Esc back · d details · ? help"
+                : "Input unavailable · Esc back · d details · ? help",
           ]),
     ];
     const body = (this.#manualPage?.items ?? this.#items).flatMap((item) => {
@@ -1332,15 +1416,12 @@ export class AgentConversationViewer implements Component {
     if (this.#details) {
       const details = [
         ...header.slice(1),
-        `Rendering: ${this.#renderMode} · m cycles raw/assistant/full`,
-        "Enter: focus the independent child editor",
-        "Esc: editor to viewer to Fleet to Main",
-        "x x: cancel the exact turn",
-        "v: bounded resources · i: exact input receipts",
-        "d: discard retained draft · t: confirm retarget",
-        "Home/End: scroll start/follow tail",
-        "j/k or configured arrows: scroll",
-        "PgUp/PgDown or Shift+arrows: page and bounded transcript",
+        ...configurationDetails,
+        `Role: ${thread.role}`,
+        `Thread: ${thread.threadId}`,
+        `Turn: ${thread.turn.turnId}`,
+        `Attempt: ${thread.turn.attemptId}`,
+        ...(config === undefined ? [] : [`Configuration: ${config.digest}`]),
       ].flatMap((line) => wrapTextWithAnsi(safeTerminalText(line), width));
       const height = Math.max(1, maximum - 2);
       this.#detailMaximumScroll = Math.max(0, details.length - height);
@@ -1383,7 +1464,9 @@ export class AgentConversationViewer implements Component {
             `Enter send${this.#mode === "cooperative" || this.#mode === "interrupt" ? " · Tab" : ""} · Esc viewer`,
           ]
         : [
-            ...(this.#composer.getValue() ? [`Draft to ${thread.handle} · d/t`] : []),
+            ...(this.#composer.getValue()
+              ? [`Draft to ${thread.handle} · Ctrl+D discard · t retarget`]
+              : []),
             ...(this.#suppressTarget !== undefined
               ? ["Suppress from Main? s confirm", "Esc cancel · skip automatic delivery"]
               : this.#retargetPending
@@ -1407,7 +1490,7 @@ export class AgentConversationViewer implements Component {
         Math.max(0, compactBody.length - this.#bodyHeight);
       return [
         this.options.theme.primary(`Conversation · ${thread.handle}`),
-        `${hidden} lines hidden · m ${this.#renderMode} · ?`,
+        `${this.#followTail ? "Tail" : "Manual · End tail"} · d details · ? help · ${hidden} lines hidden · m ${this.#renderMode}`,
         ...compactBody.slice(this.#scrollOffset, this.#scrollOffset + this.#bodyHeight),
         ...essential,
       ].map((line) => truncateToWidth(line, width));

--- a/apps/tui/src/agent-draft-cleanup-overlap.os.test.ts
+++ b/apps/tui/src/agent-draft-cleanup-overlap.os.test.ts
@@ -1,0 +1,113 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test, vi } from "vitest";
+import { startManagedTui } from "./agent-fleet.test-support.js";
+import { terminalObservationTimeoutMilliseconds } from "./virtual-terminal.test-support.js";
+
+const filesystem = vi.hoisted(() => ({
+  beforeUnlink: undefined as ((path: string) => Promise<void>) | undefined,
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    async unlink(path: Parameters<typeof actual.unlink>[0]) {
+      await filesystem.beforeUnlink?.(String(path));
+      return actual.unlink(path);
+    },
+  };
+});
+
+test.each(["success", "failure"] as const)(
+  "a newer Main draft survives accepted-input cleanup %s while filesystem deletion is pending",
+  async (outcome) => {
+    const started = Promise.withResolvers<void>();
+    const deleting = Promise.withResolvers<void>();
+    const releaseDelete = Promise.withResolvers<void>();
+    const failure = Promise.withResolvers<never>();
+    let calls = 0;
+    const h = await startManagedTui(
+      {
+        async *stream(request) {
+          calls += 1;
+          started.resolve();
+          await new Promise<void>((resolve) => {
+            if (request.signal.aborted) resolve();
+            else request.signal.addEventListener("abort", () => resolve(), { once: true });
+          });
+          yield { type: "finish", reason: "stop" };
+        },
+      },
+      { draftPersistencePolicy: "recoverable" },
+    );
+    let guard: ReturnType<typeof setTimeout> | undefined;
+    let edit: ReturnType<typeof h.presentation.dispatch> | undefined;
+    try {
+      expect(
+        await h.presentation.dispatch({
+          type: "managed_control",
+          commandId: "cleanup-overlap-fixture",
+          command: {
+            type: "spawn_agents",
+            parentSessionId: h.parent.sessionId,
+            entries: [
+              { role: "builtin:explore", task: "Original work.", description: "Original work" },
+            ],
+          },
+        }),
+      ).toMatchObject({ status: "admitted" });
+      await started.promise;
+      await h.press("@explore-1", "> [Agent] @explore-1");
+      await h.press("\t", "@explore-1");
+      await h.press(" Accepted original input.", "Accepted original input.");
+      await h.press("\r", "Send to @explore-1");
+      const projects = await readdir(join(h.storage.stateRoot, "drafts"));
+      expect(projects).toHaveLength(1);
+      const draftsRoot = join(h.storage.stateRoot, "drafts", projects[0] as string);
+      const manifest = join(draftsRoot, `session-${h.parent.sessionId}.json`);
+      filesystem.beforeUnlink = async (path) => {
+        if (path !== manifest) return;
+        filesystem.beforeUnlink = undefined;
+        deleting.resolve();
+        await releaseDelete.promise;
+        if (outcome === "failure")
+          throw Object.assign(new Error("The held draft deletion failed."), { code: "EACCES" });
+      };
+      guard = setTimeout(
+        () => failure.reject(new Error("Accepted-input draft cleanup did not reach unlink.")),
+        terminalObservationTimeoutMilliseconds,
+      );
+      h.terminal.input("\r");
+      await Promise.race([deleting.promise, failure.promise]);
+      const beforeEdit = h.terminal.output().length;
+      edit = h.presentation.dispatch({ type: "update_draft_text", text: " Newer Main draft." });
+      // The public read proves the newer mutation reached the composer before deletion resumes.
+      expect(await h.presentation.dispatch({ type: "read_expanded_draft" })).toMatchObject({
+        status: "admitted",
+        draftText: expect.stringContaining("Newer Main draft."),
+      });
+      releaseDelete.resolve();
+      expect(await edit).toMatchObject({ status: "admitted" });
+      await h.terminal.waitForFrameAfter("Input accepted for @explore-1", beforeEdit);
+      expect(h.presentation.getState().composer.renderedText).toBe("@explore-1 Newer Main draft.");
+      await h.terminal.waitForFrameAfter("Newer Main draft.", beforeEdit);
+      expect(h.terminal.lines().join("\n")).not.toContain("Accepted original input.");
+      expect(await readFile(manifest, "utf8")).toContain("Newer Main draft.");
+      expect(
+        (await h.store.read()).filter((record) => record.event.type === "input_accepted"),
+      ).toEqual([
+        expect.objectContaining({
+          event: expect.objectContaining({ mode: "cooperative", text: "Accepted original input." }),
+        }),
+      ]);
+      expect(calls).toBe(1);
+    } finally {
+      clearTimeout(guard);
+      filesystem.beforeUnlink = undefined;
+      releaseDelete.resolve();
+      await edit?.catch(() => undefined);
+      await h.close();
+    }
+  },
+);

--- a/apps/tui/src/agent-draft-cleanup.os.test.ts
+++ b/apps/tui/src/agent-draft-cleanup.os.test.ts
@@ -1,0 +1,82 @@
+import { chmod, readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { startManagedTui } from "./agent-fleet.test-support.js";
+
+test.each(["message", "role"] as const)(
+  "accepted %s survives a draft cleanup failure without losing its draft or receipt",
+  async (kind) => {
+    let draftsRoot: string | undefined;
+    let armed = false;
+    const started = Promise.withResolvers<void>();
+    const h = await startManagedTui(
+      {
+        async *stream(request) {
+          started.resolve();
+          await new Promise<void>((resolve) => {
+            if (request.signal.aborted) resolve();
+            else request.signal.addEventListener("abort", () => resolve(), { once: true });
+          });
+          yield { type: "finish", reason: "stop" };
+        },
+      },
+      {
+        draftPersistencePolicy: "recoverable",
+        controlRecordBarrier: async (record) => {
+          if (armed && record.event.type === (kind === "message" ? "input_accepted" : "admitted")) {
+            if (draftsRoot === undefined) throw new Error("Missing owned draft directory.");
+            await chmod(draftsRoot, 0o500);
+          }
+        },
+      },
+    );
+    try {
+      if (kind === "message") {
+        expect(
+          await h.presentation.dispatch({
+            type: "managed_control",
+            commandId: "cleanup-fixture",
+            command: {
+              type: "spawn_agents",
+              parentSessionId: h.parent.sessionId,
+              entries: [
+                { role: "builtin:explore", task: "Original work.", description: "Original work" },
+              ],
+            },
+          }),
+        ).toMatchObject({ status: "admitted" });
+        await started.promise;
+      }
+      const recipient = kind === "message" ? "@explore-1" : "@Explore";
+      await h.press(recipient, kind === "message" ? "> [Agent] @explore-1" : "New agent · Explore");
+      await h.press("\t", recipient);
+      await h.press(" Keep this draft.", "Keep this draft.");
+      await h.press("\r", kind === "message" ? "Send to @explore-1" : "Delegation");
+      const projects = await readdir(join(h.storage.stateRoot, "drafts"));
+      expect(projects).toHaveLength(1);
+      draftsRoot = join(h.storage.stateRoot, "drafts", projects[0] as string);
+      const files = await readdir(draftsRoot);
+      const before = await Promise.all(
+        files.map((name) => readFile(join(draftsRoot as string, name), "utf8")),
+      );
+      expect(before.join("\n")).toContain("Keep this draft.");
+      armed = true;
+      await h.press("\r", "Draft cleanup failed");
+      expect(h.presentation.getState().composer.renderedText).toBe(`${recipient} Keep this draft.`);
+      expect(h.terminal.lines().join("\n")).toContain("Keep this draft.");
+      expect(h.terminal.lines().join("\n")).not.toContain("could not be accepted");
+      expect(
+        (await h.store.read()).filter(
+          (record) => record.event.type === (kind === "message" ? "input_accepted" : "admitted"),
+        ),
+      ).toHaveLength(1);
+      expect(
+        await Promise.all(files.map((name) => readFile(join(draftsRoot as string, name), "utf8"))),
+      ).toEqual(before);
+    } finally {
+      armed = false;
+      if (draftsRoot !== undefined) await chmod(draftsRoot, 0o700);
+      await h.close();
+    }
+  },
+);

--- a/apps/tui/src/agent-fleet.os.test.ts
+++ b/apps/tui/src/agent-fleet.os.test.ts
@@ -400,7 +400,7 @@ test("cold undelivered input remains private and can be explicitly inspected and
     await cold.press("\r", "New turn");
     expect(cold.conversationText()).toContain("PRIVATE_UNDELIVERED_MESSAGE");
     await cold.press("\u001b", "Enter compose · Esc back", "To @explore-1");
-    await cold.press("d", "Enter compose · Esc back");
+    await cold.press("\u0004", "Enter compose · Esc back");
     expect(cold.conversationText()).not.toContain("Draft to @explore-1");
     expect(calls).toBe(1);
     expect(

--- a/apps/tui/src/agent-fleet.test.ts
+++ b/apps/tui/src/agent-fleet.test.ts
@@ -99,99 +99,117 @@ test("running Explore has Widget and Fleet, layered Enter and Esc preserve indep
   }
 });
 
-test("background spawn cards settle to Started and Queued with frozen identities while Main returns", async () => {
-  let mainCalls = 0;
-  let preparedCount = 0;
-  let childCalls = 0;
-  const prepared = Promise.withResolvers<void>();
-  const releaseStart = Promise.withResolvers<void>();
-  const eightStarted = Promise.withResolvers<void>();
-  const h = await startManagedTui(
-    {
-      async *stream(request) {
-        if (!request.tools.some((tool) => tool.name === "spawn_agents")) {
-          yield { type: "text_delta", text: "Reading batch evidence." };
-          if (++childCalls === 8) eightStarted.resolve();
-          await new Promise<void>((resolve) => {
-            if (request.signal.aborted) resolve();
-            else request.signal.addEventListener("abort", () => resolve(), { once: true });
-          });
-        } else if (++mainCalls === 1) {
-          yield { type: "tool_call_start", id: "batch", name: "spawn_agents" };
-          yield {
-            type: "tool_call_delta",
-            id: "batch",
-            json: JSON.stringify({
-              entries: Array.from({ length: 9 }, (_, index) => ({
-                role: "builtin:explore",
-                task: `Read evidence ${index + 1}`,
-                description: `Inspect item ${index + 1}`,
-              })),
-            }),
-          };
-          yield { type: "tool_call_end", id: "batch" };
+test.each([40, 80, 120])(
+  "%i-column background cards retain exact Started and Queued identities while Main returns",
+  async (columns) => {
+    let mainCalls = 0;
+    let preparedCount = 0;
+    let childCalls = 0;
+    const prepared = Promise.withResolvers<void>();
+    const releaseStart = Promise.withResolvers<void>();
+    const eightStarted = Promise.withResolvers<void>();
+    const h = await startManagedTui(
+      {
+        async *stream(request) {
+          if (!request.tools.some((tool) => tool.name === "spawn_agents")) {
+            yield { type: "text_delta", text: "Reading batch evidence." };
+            if (++childCalls === 8) eightStarted.resolve();
+            await new Promise<void>((resolve) => {
+              if (request.signal.aborted) resolve();
+              else request.signal.addEventListener("abort", () => resolve(), { once: true });
+            });
+          } else if (++mainCalls === 1) {
+            yield { type: "tool_call_start", id: "batch", name: "spawn_agents" };
+            yield {
+              type: "tool_call_delta",
+              id: "batch",
+              json: JSON.stringify({
+                entries: Array.from({ length: 9 }, (_, index) => ({
+                  role: "builtin:explore",
+                  task: `Read evidence ${index + 1}`,
+                  description: `核查 e\u0301 证据 ${index + 1}`,
+                })),
+              }),
+            };
+            yield { type: "tool_call_end", id: "batch" };
+            yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+            yield { type: "finish", reason: "tool_calls" };
+            return;
+          } else yield { type: "text_delta", text: "Batch admitted; Main ready." };
           yield { type: "usage", inputTokens: 20, outputTokens: 10 };
-          yield { type: "finish", reason: "tool_calls" };
-          return;
-        } else yield { type: "text_delta", text: "Batch admitted; Main ready." };
-        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
-        yield { type: "finish", reason: "stop" };
+          yield { type: "finish", reason: "stop" };
+        },
       },
-    },
-    {
-      rows: 64,
-      childRecordBarrier: async (record) => {
-        if (record.schemaVersion === 3 && record.record.type === "session_genesis") {
-          if (++preparedCount === 8) prepared.resolve();
-          await releaseStart.promise;
-        }
+      {
+        columns,
+        rows: 64,
+        childRecordBarrier: async (record) => {
+          if (record.schemaVersion === 3 && record.record.type === "session_genesis") {
+            if (++preparedCount === 8) prepared.resolve();
+            await releaseStart.promise;
+          }
+        },
       },
-    },
-  );
-  try {
-    await h.press("Inspect these nine items.\r", "Confirm delegation");
-    await h.press("\r", "Batch admitted; Main ready.");
-    await prepared.promise;
-    await h.terminal.waitForScreen("Starting · 0 used");
-    const screen = h.terminal.lines().join("\n");
-    expect(screen).toContain("Started @explore-1 · Explore · Inspect item 1");
-    expect(screen).toContain("Queued @explore-9 · Explore · Inspect item 9");
-    expect(
-      h.presentation
-        .getState()
-        .authoritative.managedControl?.threads.filter((thread) => thread.turn.phase === "starting"),
-    ).toHaveLength(8);
-    expect(
-      h.presentation
-        .getState()
-        .authoritative.managedControl?.threads.filter((thread) => thread.turn.phase === "queued"),
-    ).toHaveLength(1);
-    releaseStart.resolve();
-    await eightStarted.promise;
-    await h.terminal.waitForScreen("● Agents · 8 running · 1 queued");
-    const state = h.presentation.getState();
-    expect(
-      state.authoritative.managedControl?.threads.filter(
-        (thread) => thread.turn.phase === "executing",
-      ),
-    ).toHaveLength(8);
-    expect(
-      state.authoritative.managedControl?.threads.filter(
-        (thread) => thread.turn.phase === "queued",
-      ),
-    ).toHaveLength(1);
-    expect(
-      state.authoritative.active?.transcript.items.find(
-        (item) => item.type === "tool_call" && item.qualifiedName === "spawn_agents",
-      ),
-    ).toMatchObject({ status: "completed" });
-    expect(screen.slice(screen.indexOf("Fleet ·"))).not.toContain("@explore-9");
-    expect(mainCalls).toBe(2);
-  } finally {
-    releaseStart.resolve();
-    await h.close();
-  }
-});
+    );
+    try {
+      await h.press("Inspect these nine items.\r", "Confirm delegation");
+      expect(h.terminal.lines().join("\n")).not.toMatch(/Started @|Queued @/u);
+      expect(childCalls).toBe(0);
+      await h.press("\r", "Batch admitted; Main ready.");
+      await prepared.promise;
+      await h.terminal.waitForScreen("⎿ Starting");
+      const screen = h.terminal.lines().join("\n");
+      const lines = h.terminal.lines().map((line) => line.trim());
+      // The physical terminal exposes the continuation cell after each wide character.
+      const cardStart = lines.indexOf("Explore · 核 查  e\u0301 证 据  1");
+      expect(cardStart).toBeGreaterThanOrEqual(0);
+      expect(lines.slice(cardStart, cardStart + 18)).toEqual(
+        Array.from({ length: 9 }, (_, index) => [
+          `Explore · 核 查  e\u0301 证 据  ${index + 1}`,
+          index === 8 ? "Queued @explore-9 · Ctrl+O expand" : `Started @explore-${index + 1}`,
+        ]).flat(),
+      );
+      expect(lines).not.toContain("Completed");
+      expect(screen).not.toContain("managed_agent_batch");
+      expect(
+        h.presentation
+          .getState()
+          .authoritative.managedControl?.threads.filter(
+            (thread) => thread.turn.phase === "starting",
+          ),
+      ).toHaveLength(8);
+      expect(
+        h.presentation
+          .getState()
+          .authoritative.managedControl?.threads.filter((thread) => thread.turn.phase === "queued"),
+      ).toHaveLength(1);
+      releaseStart.resolve();
+      await eightStarted.promise;
+      await h.terminal.waitForScreen("● Agents · 8 running · 1 queued");
+      const state = h.presentation.getState();
+      expect(
+        state.authoritative.managedControl?.threads.filter(
+          (thread) => thread.turn.phase === "executing",
+        ),
+      ).toHaveLength(8);
+      expect(
+        state.authoritative.managedControl?.threads.filter(
+          (thread) => thread.turn.phase === "queued",
+        ),
+      ).toHaveLength(1);
+      expect(
+        state.authoritative.active?.transcript.items.find(
+          (item) => item.type === "tool_call" && item.qualifiedName === "spawn_agents",
+        ),
+      ).toMatchObject({ status: "completed" });
+      expect(screen.slice(screen.indexOf("Fleet ·"))).not.toContain("@explore-9");
+      expect(mainCalls).toBe(2);
+    } finally {
+      releaseStart.resolve();
+      await h.close();
+    }
+  },
+);
 
 test("Widget projects live child activity and queued details expose frozen configuration and budget", async () => {
   const eightStarted = Promise.withResolvers<void>();
@@ -506,8 +524,10 @@ test("ConversationViewer follows live output, preserves manual scroll, and survi
     await h.terminal.waitForScreen("@explore-1 · Explore · Running");
     await h.openFirstAgent();
     expect(h.conversationText()).toContain("First live line.");
-    expect(h.conversationText()).toContain("deepseek-v4-flash.direct · thinking default");
-    expect(h.conversationText()).toContain("128000 context");
+    await h.press("d", "Conversation details");
+    expect(h.terminal.lines().join("\n")).toContain("deepseek-v4-flash.direct · thinking default");
+    expect(h.terminal.lines().join("\n")).toContain("128000 context");
+    await h.press("\u001b", "First live line.", "Conversation details");
     const beforeLines = h.terminal.output().length;
     releaseLines.resolve();
     await h.terminal.waitForFrameAfter("Live line 50", beforeLines);
@@ -879,7 +899,8 @@ test("viewer x x cancels the exact turn only on two presses and retains unknown 
     expect(
       h.presentation.getState().authoritative.managedControl?.threads[0]?.budget?.unknownReserved,
     ).toBeGreaterThan(0);
-    expect(h.conversationText()).toContain("unknown reserved");
+    await h.press("d", "Conversation details");
+    expect(h.terminal.lines().join("\n")).toContain("unknown reserved");
   } finally {
     await h.close();
   }
@@ -1183,7 +1204,7 @@ test.each([
       ).toMatchObject({ managedDraft: { text: "界é👩‍💻" } });
       expect(h.terminal.lines().join("\n")).not.toContain("�");
       await h.press("\u001b[27u", "Draft");
-      await h.press("?", "Conversation details");
+      await h.press("d", "Conversation details");
       expect(h.terminal.lines().join("\n")).toContain("deepseek-v4-flash.direct");
       await h.press("\u001b[27u", "Draft");
       await h.press("\u001b[27u", "Fleet");
@@ -1197,7 +1218,7 @@ test.each([
   },
 );
 
-test("Widget and viewer expose owner-timed elapsed duration and actual compact model and usage preferences", async () => {
+test("Widget retains elapsed and optional model while details expose current usage", async () => {
   const started = Promise.withResolvers<void>();
   const finish = Promise.withResolvers<void>();
   const usageRendered = Promise.withResolvers<void>();
@@ -1230,6 +1251,10 @@ test("Widget and viewer expose owner-timed elapsed duration and actual compact m
     await h.press("/agents settings\r", "Agent settings");
     await h.press("\u001b[B\u001b[B\r", "Model/thinking · shown");
     await h.press("\u001b", "thinking default");
+    expect(h.terminal.lines().join("\n")).not.toMatch(/\d+ used|\d+ reserved/u);
+    await h.press("/agents\r", "Agents workspace");
+    await h.press("\r", "Conversation ·");
+    await h.press("d", "Conversation details");
     expect(h.terminal.lines().join("\n")).toContain("0 used");
     const offset = h.terminal.output().length;
     finish.resolve();
@@ -1241,9 +1266,7 @@ test("Widget and viewer expose owner-timed elapsed duration and actual compact m
     expect(thread?.turn.outcome?.atUnixMilliseconds).toBeGreaterThanOrEqual(
       thread?.turn.startedAtUnixMilliseconds ?? Infinity,
     );
-    await h.press("/agents\r", "Agents workspace");
-    await h.press("\r", "elapsed");
-    expect(h.conversationText()).toContain("40 used");
+    expect(h.terminal.lines().join("\n")).toContain("40 used");
   } finally {
     finish.resolve();
     usageRendered.resolve();
@@ -1784,6 +1807,7 @@ test("a queued cancellation keeps per-thread export available without creating a
     await h.press("\u001b[F", "@explore-9");
     await h.press("x", "x again to cancel");
     await h.press("x", "Cancelled");
+    await h.press("\r", "Enter result / export");
     await h.press("\r", "e export");
     expect(h.terminal.lines().join("\n")).toContain("e export");
     await h.press("e", "Export agent");
@@ -1837,7 +1861,7 @@ test("viewer Help disarms an earlier x-x cancellation before returning to the sa
     await h.press("/agents\r", "Agents workspace");
     await h.press("\r", "Conversation");
     await h.press("x", "x again to cancel");
-    await h.press("?", "Conversation details");
+    await h.press("?", "Conversation help");
     await h.press("\u001b", "Following tail");
     await h.press("x", "x again to cancel");
     expect(h.conversationText()).toContain("x again to cancel");
@@ -2085,6 +2109,55 @@ test("workspace Attention navigation disarms an earlier exact cancellation", asy
     );
     await h.press("x", "Cancelled");
     expect(aborts).toBe(1);
+  } finally {
+    await h.close();
+  }
+});
+
+test("declined admission keeps its reason visible without reporting a child start", async () => {
+  let calls = 0;
+  const h = await startManagedTui({
+    async *stream() {
+      if (++calls === 1) {
+        yield { type: "tool_call_start", id: "declined-spawn", name: "spawn_agents" };
+        yield {
+          type: "tool_call_delta",
+          id: "declined-spawn",
+          json: JSON.stringify({
+            entries: [
+              {
+                role: "builtin:explore",
+                task: "Inspect requested evidence",
+                description: "Requested evidence",
+              },
+            ],
+          }),
+        };
+        yield { type: "tool_call_end", id: "declined-spawn" };
+        yield { type: "finish", reason: "tool_calls" };
+      } else {
+        yield { type: "text_delta", text: "Delegation declined; Main ready." };
+        yield { type: "finish", reason: "stop" };
+      }
+    },
+  });
+  try {
+    await h.press("Consider delegation.\r", "Confirm delegation");
+    expect(h.terminal.lines().join("\n")).not.toMatch(/Started @|Queued @/u);
+    await h.press("\u001b", "Delegation declined; Main ready.");
+    const screen = h.terminal.lines().join("\n");
+    expect(screen).toContain("permission_denied");
+    expect(screen).not.toMatch(/Started @|Queued @|managed_agent_batch/u);
+    expect(h.presentation.getState().authoritative.managedControl?.threads).toHaveLength(0);
+    const admission = h.presentation
+      .getState()
+      .authoritative.active?.transcript.items.find(
+        (item) => item.type === "tool_call" && item.callId === "declined-spawn",
+      );
+    expect(admission).toMatchObject({
+      status: "denied",
+      outcome: { status: "failed", code: "permission_denied" },
+    });
   } finally {
     await h.close();
   }

--- a/apps/tui/src/agent-fleet.ts
+++ b/apps/tui/src/agent-fleet.ts
@@ -22,6 +22,8 @@ import {
   truncateToWidth,
   wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
+import { agentElapsedLabel } from "./agent-widget.js";
+import { focusedWheelDirection } from "./focused-wheel-input.js";
 import { safeTerminalText } from "./safe-terminal-text.js";
 import type { AdamTuiTheme } from "./theme.js";
 
@@ -63,6 +65,11 @@ export class AgentFleet implements Component {
   handleMainInput(data: string, empty: boolean): boolean {
     if (this.#snapshot === undefined || this.rows().length === 0) return false;
     if (isKeyRelease(data)) return this.#active;
+    const wheel = focusedWheelDirection(data);
+    if (wheel !== null) {
+      if (!this.#active || !empty) return false;
+      data = wheel < 0 ? "\u001b[A" : "\u001b[B";
+    }
     if (!empty) {
       this.#active = false;
       return false;
@@ -104,7 +111,7 @@ export class AgentFleet implements Component {
       { id: null, text: "Main" },
       ...rows.map((thread) => ({
         id: thread.threadId,
-        text: `${thread.handle} · ${thread.displayName} · ${thread.turn.label}${this.drafts.get(thread.threadId)?.text || this.options.hasDraft?.(thread) ? ` · Draft to ${thread.handle}` : ""}`,
+        text: `${thread.handle} · ${safeTerminalText(thread.displayName)} · ${thread.turn.label}${agentElapsedLabel(thread)} · ${safeTerminalText(thread.description)}${this.drafts.get(thread.threadId)?.text || this.options.hasDraft?.(thread) ? ` · Draft to ${thread.handle}` : ""}`,
       })),
     ];
     const selectedIndex = Math.max(
@@ -146,6 +153,9 @@ export class AgentWorkspace implements Component {
   #visibleSettings = new Set<number>();
   #selected: string | undefined;
   #detail = false;
+  #help = false;
+  #helpScroll = 0;
+  #helpMaximumScroll = 0;
   #detailScroll = 0;
   #detailMaximumScroll = 0;
   #history = false;
@@ -203,16 +213,36 @@ export class AgentWorkspace implements Component {
     if (!this.rows().some((thread) => this.key(thread) === this.#selected))
       this.select(this.rows()[0]);
   }
+  openDetails(thread: ManagedControlThread): boolean {
+    const selected = this.rows().find(
+      (entry) => entry.threadId === thread.threadId && entry.turn.turnId === thread.turn.turnId,
+    );
+    if (selected === undefined) return false;
+    this.select(selected);
+    this.#detail = true;
+    this.#detailScroll = 0;
+    this.#help = false;
+    this.#settingsOpen = false;
+    this.#armed = undefined;
+    this.#closeTarget = undefined;
+    this.#resumeTargets = undefined;
+    this.options.onChange();
+    return true;
+  }
   back(): void {
     this.#armed = undefined;
     this.#closeTarget = undefined;
-    if (this.#settingsOpen && this.options.initialView !== "settings") this.#settingsOpen = false;
+    if (this.#help) this.#help = false;
+    else if (this.#settingsOpen && this.options.initialView !== "settings")
+      this.#settingsOpen = false;
     else if (this.#detail) this.#detail = false;
     else this.options.onClose();
     this.options.onChange();
   }
   handleInput(data: string): void {
     if (isKeyRelease(data)) return;
+    const wheel = focusedWheelDirection(data);
+    if (wheel !== null) data = wheel < 0 ? "\u001b[A" : "\u001b[B";
     if (!isKeyRepeat(data)) {
       if (!matchesKey(data, "x")) this.#armed = undefined;
       if (!matchesKey(data, "c")) this.#closeTarget = undefined;
@@ -220,6 +250,31 @@ export class AgentWorkspace implements Component {
     }
     if (matchesKey(data, "escape")) {
       if (!isKeyRepeat(data)) this.back();
+      return;
+    }
+    if (this.#help) {
+      if (matchesKey(data, "?") && !isKeyRepeat(data)) this.#help = false;
+      else if (matchesKey(data, "home")) this.#helpScroll = 0;
+      else if (matchesKey(data, "end")) this.#helpScroll = this.#helpMaximumScroll;
+      else if (matchesKey(data, "up") || matchesKey(data, "pageUp"))
+        this.#helpScroll = Math.max(
+          0,
+          this.#helpScroll -
+            (matchesKey(data, "up") ? 1 : Math.max(1, this.options.maximumLines() - 2)),
+        );
+      else if (matchesKey(data, "down") || matchesKey(data, "pageDown"))
+        this.#helpScroll = Math.min(
+          this.#helpMaximumScroll,
+          this.#helpScroll +
+            (matchesKey(data, "down") ? 1 : Math.max(1, this.options.maximumLines() - 2)),
+        );
+      this.options.onChange();
+      return;
+    }
+    if (matchesKey(data, "?") && !isKeyRepeat(data)) {
+      this.#help = true;
+      this.#helpScroll = 0;
+      this.options.onChange();
       return;
     }
     if (this.#settingsOpen) {
@@ -311,6 +366,11 @@ export class AgentWorkspace implements Component {
     const threads = this.rows();
     const index = threads.findIndex((thread) => this.key(thread) === this.#selected);
     const selected = threads[index];
+    if (matchesKey(data, "d") && !isKeyRepeat(data)) {
+      if (selected !== undefined && (this.#detail || this.#visibleIds.has(this.key(selected))))
+        this.openDetails(selected);
+      return;
+    }
     if (!matchesKey(data, "u") && !matchesKey(data, "shift+u")) this.#resumeTargets = undefined;
     if (
       (matchesKey(data, "u") || matchesKey(data, "shift+u")) &&
@@ -464,7 +524,17 @@ export class AgentWorkspace implements Component {
     }
     this.#armed = undefined;
     if (this.#detail) {
-      if (matchesKey(data, "home")) this.#detailScroll = 0;
+      if (
+        matchesKey(data, "enter") &&
+        !isKeyRepeat(data) &&
+        selected !== undefined &&
+        (selected.turn.hasStarted || selected.turn.outcome !== undefined)
+      )
+        this.options.onOpen(
+          selected,
+          this.#history || selected.lifecycle === "closed" || !selected.turn.hasStarted,
+        );
+      else if (matchesKey(data, "home")) this.#detailScroll = 0;
       else if (matchesKey(data, "end")) this.#detailScroll = this.#detailMaximumScroll;
       else if (matchesKey(data, "up") || matchesKey(data, "pageUp"))
         this.#detailScroll = Math.max(
@@ -489,11 +559,8 @@ export class AgentWorkspace implements Component {
         selected !== undefined &&
         this.#visibleIds.has(this.key(selected))
       ) {
-        if (selected.turn.hasStarted || selected.turn.outcome !== undefined)
-          this.options.onOpen(
-            selected,
-            this.#history || selected.lifecycle === "closed" || !selected.turn.hasStarted,
-          );
+        if (selected.turn.hasStarted)
+          this.options.onOpen(selected, this.#history || selected.lifecycle === "closed");
         else {
           this.#detail = true;
           this.#detailScroll = 0;
@@ -504,6 +571,22 @@ export class AgentWorkspace implements Component {
   }
   invalidate(): void {}
   render(width: number): string[] {
+    if (this.#help) {
+      const lines = [
+        "↑↓ / wheel select · Enter conversation or queued overview",
+        "d details · h history · t types · s settings · a attention",
+        "x x cancel · c c close · u u resume · U then u resume all",
+        "Esc returns to the previous view",
+      ].flatMap((line) => wrapTextWithAnsi(line, width));
+      const height = Math.max(1, this.options.maximumLines() - 2);
+      this.#helpMaximumScroll = Math.max(0, lines.length - height);
+      this.#helpScroll = Math.min(this.#helpScroll, this.#helpMaximumScroll);
+      return [
+        this.options.theme.primary("Agents help"),
+        ...lines.slice(this.#helpScroll, this.#helpScroll + height),
+        "↑↓ / wheel scroll · Esc back",
+      ].map((line) => truncateToWidth(line, width));
+    }
     if (this.#settingsOpen) {
       const settings = this.#settings;
       const entries = [
@@ -534,8 +617,9 @@ export class AgentWorkspace implements Component {
       const config = thread.turn.configuration;
       const budget = thread.budget;
       lines.push(
-        this.options.theme.primary(`${thread.turn.label} ${thread.handle} · ${thread.displayName}`),
+        this.options.theme.primary(`Agent details · ${thread.handle} · ${thread.displayName}`),
         safeTerminalText(thread.description),
+        `${thread.turn.label}${agentElapsedLabel(thread)}`,
       );
       if (config !== undefined)
         lines.push(
@@ -547,6 +631,21 @@ export class AgentWorkspace implements Component {
           `${budget.knownUsed} used · ${budget.outstandingReserved} reserved`,
           `${budget.unknownReserved} unknown · ${budget.available === null ? "no cumulative budget" : `${budget.available} available`}`,
         );
+      if (thread.turn.diagnostic !== undefined)
+        lines.push(safeTerminalText(thread.turn.diagnostic));
+      if (thread.turn.attention?.question !== undefined)
+        lines.push(safeTerminalText(thread.turn.attention.question));
+      if (thread.turn.outcome !== undefined) {
+        if (!thread.turn.hasStarted) lines.push("No agent session was started.");
+        lines.push(safeTerminalText(thread.turn.outcome.summary));
+      }
+      lines.push(
+        `Role: ${thread.role}`,
+        `Turn: ${thread.turn.turnId}`,
+        `Attempt: ${thread.turn.attemptId}`,
+        ...(config === undefined ? [] : [`Configuration: ${config.digest}`]),
+        `Thread: ${thread.threadId}`,
+      );
       if (!thread.turn.hasStarted && thread.turn.outcome === undefined)
         lines.push(
           ...wrapTextWithAnsi(
@@ -570,7 +669,7 @@ export class AgentWorkspace implements Component {
         title,
         `↑↓ detail · ${Math.max(0, details.length - height)} lines hidden`,
         ...details.slice(this.#detailScroll, this.#detailScroll + height),
-        `${thread.actions?.includes("cancel") ? "x x cancel · " : ""}Esc list`,
+        `${thread.turn.hasStarted ? "Enter conversation · " : thread.turn.outcome !== undefined ? "Enter result / export · " : ""}${thread.actions?.includes("cancel") ? "x x cancel · " : ""}Esc list`,
       );
     } else {
       const threads = this.rows();
@@ -592,8 +691,8 @@ export class AgentWorkspace implements Component {
       ].join(" · ");
       const hints = [
         width < 72
-          ? "Enter inspect · t types · h/s/a · Esc"
-          : "Enter inspect · t types · h history · s settings · a attention · Esc back",
+          ? "Enter open · d details · ? help · Esc"
+          : "Enter open · d details · h history · t types · s settings · ? help · Esc back",
         ...(controls ? [controls] : []),
       ];
       const maximum = Math.max(
@@ -619,7 +718,7 @@ export class AgentWorkspace implements Component {
       lines.push(
         ...visible.map(
           (entry) =>
-            `${this.key(entry) === this.#selected ? "●" : "○"} ${entry.handle} · ${width < 48 ? `${entry.turn.label.split(" · ")[0]} · ${safeTerminalText(entry.description)}` : `${safeTerminalText(entry.displayName)} · ${safeTerminalText(entry.description)} · ${entry.turn.label}`}${entry.lifecycle === "closed" ? " · Closed" : ""}${this.#history ? ` · ${entry.turn.turnId.slice(0, 8)}` : ""}${this.options.hasDraft?.(entry) ? ` · Draft to ${entry.handle}` : ""}`,
+            `${this.key(entry) === this.#selected ? "●" : "○"} ${entry.handle} · ${width < 48 ? `${entry.turn.label.split(" · ")[0]} · ${safeTerminalText(entry.description)}` : `${safeTerminalText(entry.displayName)} · ${safeTerminalText(entry.description)} · ${entry.turn.label}`}${agentElapsedLabel(entry)}${entry.lifecycle === "closed" ? " · Closed" : ""}${this.options.hasDraft?.(entry) ? ` · Draft to ${entry.handle}` : ""}`,
         ),
       );
       if (start > 0 || start + visible.length < threads.length)

--- a/apps/tui/src/agent-handle-navigation.test.ts
+++ b/apps/tui/src/agent-handle-navigation.test.ts
@@ -1,0 +1,318 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ModelDriver } from "@adam-agent/agent";
+import { expect, test } from "vitest";
+import { type ManagedTuiFixture, startManagedTui } from "./agent-fleet.test-support.js";
+
+async function startThreads(h: ManagedTuiFixture, count: number) {
+  expect(
+    await h.presentation.dispatch({
+      type: "managed_control",
+      commandId: "handle-navigation-admission",
+      command: {
+        type: "spawn_agents",
+        parentSessionId: h.parent.sessionId,
+        entries: Array.from({ length: count }, (_, index) => ({
+          role: "builtin:explore" as const,
+          task: `Inspect evidence ${index + 1} · 中文 e\u0301 🧭`,
+          description: `Evidence ${index + 1}`,
+        })),
+      },
+    }),
+  ).toMatchObject({ status: "admitted" });
+}
+
+async function selectHandle(h: ManagedTuiFixture, handle: string) {
+  await h.press(handle, `> [Agent] ${handle}`);
+  await h.press("\t", handle);
+}
+
+test.each([
+  { state: "running", columns: 80, rows: 24 },
+  { state: "completed", columns: 40, rows: 18 },
+  { state: "completed", columns: 120, rows: 32 },
+  { state: "queued", columns: 80, rows: 24 },
+  { state: "queued", columns: 40, rows: 12 },
+])(
+  "a bare selected handle opens its exact $state view at $columns columns without a task",
+  async ({ state, columns, rows }) => {
+    let calls = 0;
+    const started = Promise.withResolvers<void>();
+    const count = state === "queued" ? 9 : 1;
+    const driver: ModelDriver = {
+      async *stream(request) {
+        calls += 1;
+        yield { type: "text_delta", text: "Visible child evidence." };
+        if (calls === (state === "queued" ? 8 : 1)) started.resolve();
+        if (state !== "completed")
+          await new Promise<void>((resolve) => {
+            if (request.signal.aborted) resolve();
+            else request.signal.addEventListener("abort", () => resolve(), { once: true });
+          });
+        yield { type: "usage", inputTokens: 10, outputTokens: 5 };
+        yield { type: "finish", reason: "stop" };
+      },
+    };
+    const h = await startManagedTui(driver, { columns, rows });
+    try {
+      await startThreads(h, count);
+      await started.promise;
+      if (state === "completed") await h.terminal.waitForScreen("Completed");
+      const thread = h.presentation.getState().authoritative.managedControl?.threads.at(-1);
+      if (thread === undefined) throw new Error("Missing exact child identity.");
+      const beforeAdmissions = (await h.store.read()).filter(
+        (record) => record.event.type === "admitted",
+      );
+      const mainBefore = await (await h.sessions.open(h.parent.sessionId))?.read();
+      await selectHandle(h, thread.handle);
+      await h.press(
+        "\r",
+        state === "queued" ? `Agent details · ${thread.handle}` : `Conversation · ${thread.handle}`,
+      );
+      expect(h.presentation.getState().composer.renderedText).toBe(thread.handle);
+      expect((await h.store.read()).filter((record) => record.event.type === "admitted")).toEqual(
+        beforeAdmissions,
+      );
+      expect(
+        (await h.store.read()).filter((record) => record.event.type === "input_accepted"),
+      ).toEqual([]);
+      expect(await (await h.sessions.open(h.parent.sessionId))?.read()).toEqual(mainBefore);
+      expect(calls).toBe(state === "queued" ? 8 : 1);
+      if (state === "queued") {
+        expect(await h.children.open(thread.turn.childSessionId)).toBeUndefined();
+        await h.press("\x1b", "Agents workspace");
+        await h.press("\x1b", thread.handle, "Agents workspace");
+      } else await h.press("\x1b", thread.handle, "Conversation ·");
+      expect(h.presentation.getState().composer.elements).toEqual([
+        expect.objectContaining({
+          type: "mention",
+          kind: "agent",
+          threadId: thread.threadId,
+          handle: thread.handle,
+        }),
+      ]);
+      await h.press("\x7f", "deepseek-v4-flash.direct");
+      await h.press("Main draft restored.", "Main draft restored.");
+      expect(h.presentation.getState().composer.renderedText).toBe("Main draft restored.");
+    } finally {
+      await h.close();
+    }
+  },
+);
+
+test("a Main command after an exact handle remains a draft and never becomes a child input", async () => {
+  let calls = 0;
+  const h = await startManagedTui({
+    async *stream() {
+      calls += 1;
+      yield { type: "text_delta", text: "Child completed." };
+      yield { type: "usage", inputTokens: 10, outputTokens: 5 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    await startThreads(h, 1);
+    await h.terminal.waitForScreen("Completed");
+    await selectHandle(h, "@explore-1");
+    await h.press(" /help xyz", "/help xyz");
+    await h.press("\r", "Run this command in Main.");
+    expect(h.presentation.getState().composer.renderedText).toBe("@explore-1 /help xyz");
+    expect(
+      (await h.store.read()).filter((record) => record.event.type === "admitted"),
+    ).toHaveLength(1);
+    expect(
+      (await h.store.read()).filter((record) => record.event.type === "input_accepted"),
+    ).toEqual([]);
+    expect(calls).toBe(1);
+  } finally {
+    await h.close();
+  }
+});
+
+test("late handle-message acceptance preserves a newer Main draft", async () => {
+  const started = Promise.withResolvers<void>();
+  const accepted = Promise.withResolvers<void>();
+  const releaseReceipt = Promise.withResolvers<void>();
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        started.resolve();
+        await new Promise<void>((resolve) => {
+          if (request.signal.aborted) resolve();
+          else request.signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    {
+      controlRecordBarrier: async (record) => {
+        if (record.event.type === "input_accepted") {
+          accepted.resolve();
+          await releaseReceipt.promise;
+        }
+      },
+    },
+  );
+  try {
+    await startThreads(h, 1);
+    await started.promise;
+    await selectHandle(h, "@explore-1");
+    await h.press(" Original input.", "Original input.");
+    await h.press("\r", "Send to @explore-1");
+    h.terminal.input("\r");
+    await accepted.promise;
+    await h.press(" New draft.", "New draft.");
+    expect(h.presentation.getState().composer.renderedText).toBe(
+      "@explore-1 Original input. New draft.",
+    );
+    const beforeReceipt = h.terminal.output().length;
+    releaseReceipt.resolve();
+    await h.terminal.waitForFrameAfter("Input accepted for @explore-1", beforeReceipt);
+    expect(h.terminal.lines().join("\n")).toContain("Original input. New draft.");
+    expect(h.presentation.getState().composer.renderedText).toBe(
+      "@explore-1 Original input. New draft.",
+    );
+    expect(
+      (await h.store.read()).filter((record) => record.event.type === "input_accepted"),
+    ).toEqual([
+      expect.objectContaining({
+        event: expect.objectContaining({ mode: "cooperative", text: "Original input." }),
+      }),
+    ]);
+  } finally {
+    releaseReceipt.resolve();
+    await h.close();
+  }
+});
+
+test("a selected file sharing an agent handle stays a Main file reference", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-handle-file-"));
+  await writeFile(join(workspaceRoot, "explore-1"), "File evidence.\n");
+  let calls = 0;
+  const h = await startManagedTui(
+    {
+      async *stream() {
+        calls += 1;
+        yield {
+          type: "text_delta",
+          text: calls === 1 ? "Child completed." : "Main file reference received.",
+        };
+        yield { type: "usage", inputTokens: 10, outputTokens: 5 };
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    { workspaceRoot },
+  );
+  try {
+    await startThreads(h, 1);
+    await h.terminal.waitForScreen("Completed");
+    await h.press("@explore-1", "> [Agent] @explore-1");
+    await h.press("\x1b[B", "> [File] @explore-1");
+    await h.press("\t", "@explore-1");
+    await h.press("\r", "The prompt does not target the active session or is blank.");
+    expect(calls).toBe(1);
+    expect(h.presentation.getState().composer.elements).toEqual([
+      expect.objectContaining({ type: "mention", kind: "path", path: "explore-1" }),
+    ]);
+    await h.press(" Inspect this file.", "Inspect this file.");
+    await h.press("\r", "Main file reference received.");
+    expect(calls).toBe(2);
+    expect(
+      (await h.store.read()).filter((record) => record.event.type === "admitted"),
+    ).toHaveLength(1);
+    const records = await (await h.sessions.open(h.parent.sessionId))?.read();
+    const completion = h.presentation.getState().authoritative.managedControl?.completions[0];
+    if (completion === undefined) throw new Error("Missing retained child completion.");
+    expect(
+      records?.flatMap((record) =>
+        record.schemaVersion === 3 &&
+        record.record.type === "runtime_event" &&
+        record.record.event.type === "user_message"
+          ? [record.record.event.text]
+          : [],
+      ),
+    ).toEqual([
+      "@explore-1 Inspect this file.",
+      `Parent message (${completion.id}): Managed agent ${completion.threadId}, turn ${completion.turnId}: completed\nChild completed.`,
+    ]);
+  } finally {
+    await h.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("a bare handle that closes after selection stays unavailable without rebinding", async () => {
+  let calls = 0;
+  const h = await startManagedTui({
+    async *stream() {
+      calls += 1;
+      yield { type: "text_delta", text: "Child completed." };
+      yield { type: "usage", inputTokens: 10, outputTokens: 5 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    await startThreads(h, 1);
+    await h.terminal.waitForScreen("Completed");
+    const thread = h.presentation.getState().authoritative.managedControl?.threads[0];
+    if (thread === undefined) throw new Error("Missing exact thread.");
+    await selectHandle(h, thread.handle);
+    expect(
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: "close-selected",
+        command: {
+          type: "close_thread",
+          parentSessionId: h.parent.sessionId,
+          threadId: thread.threadId,
+          expectedTurnId: thread.turn.turnId,
+        },
+      }),
+    ).toMatchObject({ status: "admitted" });
+    await h.press("\r", "Recipient unavailable");
+    expect(h.presentation.getState().composer.elements).toEqual([
+      expect.objectContaining({ kind: "agent", threadId: thread.threadId }),
+    ]);
+    expect(
+      (await h.store.read()).filter((record) => record.event.type === "admitted"),
+    ).toHaveLength(1);
+    expect(calls).toBe(1);
+  } finally {
+    await h.close();
+  }
+});
+
+test("the real viewer keeps a Main command in its private draft without child dispatch", async () => {
+  let calls = 0;
+  const h = await startManagedTui({
+    async *stream() {
+      calls += 1;
+      yield { type: "text_delta", text: "Child completed." };
+      yield { type: "usage", inputTokens: 10, outputTokens: 5 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    await startThreads(h, 1);
+    await h.terminal.waitForScreen("Completed");
+    await selectHandle(h, "@explore-1");
+    await h.press("\r", "Conversation · @explore-1");
+    await h.press("\r", "New turn");
+    await h.press("/help xyz", "/help xyz");
+    await h.press("\r", "Run this command in Main. Child draft retained.");
+    expect(h.conversationText()).toContain("/help xyz");
+    expect(
+      (await h.store.read()).filter((record) => record.event.type === "admitted"),
+    ).toHaveLength(1);
+    expect(
+      (await h.store.read()).filter((record) => record.event.type === "input_accepted"),
+    ).toEqual([]);
+    expect(calls).toBe(1);
+    await h.press("\x1b", "Enter compose");
+    await h.press("\x1b", "@explore-1", "Conversation ·");
+    expect(h.presentation.getState().composer.renderedText).toBe("@explore-1");
+  } finally {
+    await h.close();
+  }
+});

--- a/apps/tui/src/agent-uxr-navigation.test.ts
+++ b/apps/tui/src/agent-uxr-navigation.test.ts
@@ -1,0 +1,257 @@
+import type {
+  ManagedComposerDraft,
+  ManagedControlThread,
+  ManagedWorkspaceSnapshot,
+} from "@adam-agent/presentation";
+import { expect, test } from "vitest";
+import { AgentConversationViewer } from "./agent-conversation-viewer.js";
+import { AgentWorkspace } from "./agent-fleet.js";
+import { agentViewThread } from "./agent-view.test-support.js";
+import { createAdamTuiTheme } from "./theme.js";
+
+const unexpected = async (): Promise<never> => {
+  throw new Error("Navigation must not dispatch an action.");
+};
+
+function workspace(threads: readonly ManagedControlThread[], maximumLines = 12) {
+  const opened: { thread: ManagedControlThread; readOnly?: boolean }[] = [];
+  const snapshot: ManagedWorkspaceSnapshot = {
+    parentSessionId: "parent",
+    threads,
+    completions: [],
+    status: "ready",
+    revision: 1,
+  };
+  const view = new AgentWorkspace({
+    snapshot,
+    theme: createAdamTuiTheme(false),
+    maximumLines: () => maximumLines,
+    onChange() {},
+    onClose() {},
+    onOpen(thread, readOnly) {
+      opened.push({ thread, ...(readOnly === undefined ? {} : { readOnly }) });
+    },
+    onAttention() {},
+    onSettings: unexpected,
+    onDispatch: unexpected,
+  });
+  return { view, opened };
+}
+
+test("d opens exact details without changing list selection; focused wheel and Esc restore the list", () => {
+  const threads = Array.from({ length: 12 }, (_, index) => agentViewThread(index + 1));
+  const { view, opened } = workspace(threads);
+  view.render(80);
+  view.handleInput("\u001b[<65;10;8M");
+  const selected = view.render(80).join("\n");
+  expect(selected).toContain("● @explore-2");
+  view.handleInput("d");
+  expect(view.render(80).join("\n")).toContain("Agent details · @explore-2");
+  view.handleInput("\u001b[F");
+  expect(view.render(80).join("\n")).toContain("thread-2");
+  view.handleInput("\u001b");
+  expect(view.render(80).join("\n")).toBe(selected);
+  expect(opened).toEqual([]);
+});
+
+test("never-started cancelled turns open an overview and historical started turns remain read only", () => {
+  const original = agentViewThread();
+  const { hasStarted: _started, ...turn } = original.turn;
+  const thread: ManagedControlThread = {
+    ...original,
+    turn: {
+      ...turn,
+      phase: "idle",
+      label: "Cancelled",
+      outcome: {
+        type: "outcome",
+        status: "cancelled",
+        summary: "Cancelled before start",
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          reasoningTokens: 0,
+          providerCalls: 0,
+          unknownCalls: 0,
+        },
+        transcript: { sequence: 0, digest: `sha256:${"b".repeat(64)}` },
+      },
+    },
+    previousTurns: [{ ...original.turn, turnId: "previous-turn" }],
+  };
+  const { view, opened } = workspace([thread]);
+  view.render(80);
+  view.handleInput("\r");
+  expect(view.render(80).join("\n")).toContain("Agent details · @explore-1");
+  expect(opened).toEqual([]);
+  view.handleInput("\u001b");
+  view.handleInput("h");
+  view.render(80);
+  view.handleInput("d");
+  expect(view.render(80).join("\n")).toContain("Agent details · @explore-1");
+  view.handleInput("\u001b");
+  view.render(80);
+  view.handleInput("\r");
+  expect(opened).toMatchObject([
+    { thread: { turn: { turnId: "previous-turn" }, actions: [] }, readOnly: true },
+  ]);
+});
+
+async function conversation(text = "Retained child draft") {
+  const thread = agentViewThread();
+  const drafts = new Map<string, ManagedComposerDraft>([
+    [
+      thread.threadId,
+      {
+        parentSessionId: thread.parentSessionId,
+        threadId: thread.threadId,
+        expectedTurnId: thread.turn.turnId,
+        mode: "cooperative",
+        text,
+      },
+    ],
+  ]);
+  const read = Promise.withResolvers<void>();
+  const resourceRead = Promise.withResolvers<void>();
+  let resourceRequested = false;
+  const sent: unknown[] = [];
+  const viewer = new AgentConversationViewer({
+    thread,
+    drafts,
+    theme: createAdamTuiTheme(false),
+    maximumLines: () => 16,
+    renderMode: "raw",
+    isMainCommand: (input) => input === "/agents",
+    onChange: () => {
+      read.resolve();
+      if (resourceRequested && viewer.render(80).join("\n").includes("Artifact page"))
+        resourceRead.resolve();
+    },
+    onClose() {},
+    onExport: unexpected,
+    onSeen: unexpected,
+    onSuppress: unexpected,
+    async onSend(command) {
+      sent.push(command);
+      return unexpected();
+    },
+    async onSaveDraft() {},
+    async onClearDraft() {
+      return true;
+    },
+    async onReadResource() {
+      resourceRequested = true;
+      return {
+        mediaType: "text/plain",
+        offset: 0,
+        byteCount: 400,
+        totalByteCount: 400,
+        eof: true,
+        nextRange: null,
+        text: Array.from({ length: 30 }, (_, index) => `Resource line ${index + 1}`).join("\n"),
+      };
+    },
+    async onRead() {
+      return {
+        type: "managed_agent_transcript_page",
+        agentId: thread.threadId,
+        turnId: thread.turn.turnId,
+        attemptId: thread.turn.attemptId,
+        childSessionId: thread.turn.childSessionId,
+        throughSequence: 1,
+        olderCursor: null,
+        items: [
+          {
+            type: "assistant_message",
+            id: "answer",
+            sequence: 1,
+            sourceSessionId: thread.turn.childSessionId,
+            branchBoundary: null,
+            artifact: {
+              id: "result",
+              mediaType: "text/plain",
+              byteCount: 400,
+              source: "model_response",
+            },
+            text: Array.from({ length: 30 }, (_, index) => `Transcript line ${index + 1}`).join(
+              "\n",
+            ),
+          },
+        ],
+      };
+    },
+  });
+  await read.promise;
+  return { viewer, drafts, sent, resourceRead: resourceRead.promise };
+}
+
+test("viewer details retain drafts and wheel pauses tail across details and help", async () => {
+  const { viewer, drafts } = await conversation();
+  try {
+    const tail = viewer.render(80).join("\n");
+    expect(tail).toContain("Transcript line 30");
+    viewer.handleInput("\u001b[<64;8;9M");
+    const scrolled = viewer.render(80).join("\n");
+    expect(scrolled).not.toContain("Transcript line 30");
+    viewer.handleInput("d");
+    expect(viewer.render(80).join("\n")).toContain("Conversation details");
+    expect(drafts.get("thread-1")?.text).toBe("Retained child draft");
+    viewer.handleInput("\u001b");
+    expect(viewer.render(80).join("\n")).toBe(scrolled);
+    viewer.handleInput("?");
+    expect(viewer.render(80).join("\n")).toContain("Conversation help");
+    viewer.handleInput("\u001b");
+    expect(viewer.render(80).join("\n")).toBe(scrolled);
+    viewer.handleInput("\u001b[<65;8;9M");
+    expect(viewer.render(80).join("\n")).toBe(tail);
+    viewer.handleInput("\u0004");
+    expect(viewer.render(80).join("\n")).not.toContain("Draft to");
+    expect(drafts.has("thread-1")).toBe(false);
+  } finally {
+    viewer.dispose();
+  }
+});
+
+test("viewer Enter rejects a Main command before creating an input receipt and retains its private draft", async () => {
+  const { viewer, drafts, sent } = await conversation("/agents");
+  try {
+    viewer.handleInput("\r");
+    viewer.handleInput("\r");
+    expect(viewer.render(80).join("\n")).toContain(
+      "Run this command in Main. Child draft retained.",
+    );
+    expect(sent).toEqual([]);
+    expect(drafts.get("thread-1")).toMatchObject({ text: "/agents" });
+    expect(drafts.get("thread-1")).not.toHaveProperty("inputId");
+    viewer.handleInput("\u001b");
+    expect(viewer.render(80).join("\n")).toContain("Draft to @explore-1");
+  } finally {
+    viewer.dispose();
+  }
+});
+
+test("resource focus consumes details/help keys and wheel without changing the conversation viewport", async () => {
+  const { viewer, resourceRead } = await conversation();
+  try {
+    viewer.render(80);
+    viewer.handleInput("\u001b[<64;8;9M");
+    const conversationFrame = viewer.render(80).join("\n");
+    viewer.handleInput("v");
+    expect(viewer.render(80).join("\n")).toContain("Conversation resources");
+    viewer.handleInput("\r");
+    await resourceRead;
+    const resourceFrame = viewer.render(80).join("\n");
+    expect(resourceFrame).toContain("Resource line 1\n");
+    viewer.handleInput("d");
+    viewer.handleInput("?");
+    expect(viewer.render(80).join("\n")).toBe(resourceFrame);
+    viewer.handleInput("\u001b[<65;8;9M");
+    expect(viewer.render(80).join("\n")).not.toContain("Resource line 1\n");
+    viewer.handleInput("\u001b");
+    expect(viewer.render(80).join("\n")).toContain("Conversation resources");
+    viewer.handleInput("\u001b");
+    expect(viewer.render(80).join("\n")).toBe(conversationFrame);
+  } finally {
+    viewer.dispose();
+  }
+});

--- a/apps/tui/src/agent-widget.test.ts
+++ b/apps/tui/src/agent-widget.test.ts
@@ -1,4 +1,5 @@
 import { defaultAgentUiSettings, type ManagedWorkspaceSnapshot } from "@adam-agent/presentation";
+import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
 import { expect, test } from "vitest";
 import { agentViewThread } from "./agent-view.test-support.js";
 import { AgentWidget } from "./agent-widget.js";
@@ -49,6 +50,210 @@ test.each([3, 4])(
         maximum === 3 ? "2 detail lines hidden" : "2 finished hidden",
       );
       expect(lines.join("\n")).not.toContain("…  hidden");
+    } finally {
+      widget.dispose();
+    }
+  },
+);
+
+test.each([40, 80, 120])(
+  "compact Widget keeps readable Unicode status at %i columns in both color modes",
+  (width) => {
+    for (const noColor of [false, true]) {
+      const running = agentViewThread();
+      const queued = agentViewThread(2);
+      const queuedTurn = { ...queued.turn };
+      delete queuedTurn.hasStarted;
+      const widget = new AgentWidget(createAdamTuiTheme(noColor), () => 12, {
+        scheduler: {
+          schedule() {
+            return { cancel() {} };
+          },
+        },
+      });
+      try {
+        widget.setSnapshot({
+          parentSessionId: "parent",
+          revision: 1,
+          status: "ready",
+          completions: [],
+          threads: [
+            {
+              ...running,
+              displayName: "审查",
+              description: "核查 e\u0301 证据",
+              budget: {
+                ceiling: 1000,
+                knownUsed: 20,
+                outstandingReserved: 40,
+                unknownReserved: 1,
+                available: 939,
+                overrun: 0,
+              },
+              turn: { ...running.turn, phase: "waiting", label: "Permission required" },
+            },
+            {
+              ...queued,
+              displayName: "探索",
+              description: "读取 e\u0301 文件",
+              turn: { ...queuedTurn, phase: "queued", label: "Queued" },
+            },
+          ],
+        });
+        widget.setActivity([
+          {
+            agentId: running.threadId,
+            attemptId: running.turn.attemptId,
+            childSessionId: running.turn.childSessionId,
+            activity: "replying",
+            assistant: { itemId: "live", text: "Older activity" },
+          },
+        ]);
+        const lines = widget.render(width);
+        const text = stripTerminalSequences(lines.join("\n"));
+        expect(text).toContain("审查 · 核查 e\u0301 证据");
+        expect(text).toContain("Permission required");
+        expect(text).toContain("Queued @explore-2");
+        expect(text).not.toMatch(/used|reserved|fixture-target|sha256:/u);
+        expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+        if (noColor) expect(lines.join("\n").replaceAll("\u001b[0m", "")).toBe(text);
+      } finally {
+        widget.dispose();
+      }
+    }
+  },
+);
+
+test.each([
+  {
+    phase: "waiting" as const,
+    waitReason: "parent_input" as const,
+    label: "Waiting for you",
+    expected: "1 waiting",
+    attention: true,
+  },
+  {
+    phase: "waiting" as const,
+    waitReason: "permission" as const,
+    label: "Permission required",
+    expected: "1 waiting",
+    attention: true,
+  },
+  {
+    phase: "settling" as const,
+    waitReason: "none" as const,
+    label: "Settling",
+    expected: "1 settling",
+    attention: false,
+  },
+  {
+    phase: "idle" as const,
+    waitReason: "none" as const,
+    label: "Failed",
+    expected: "1 error",
+    attention: false,
+  },
+])(
+  "two-line Widget reports $label instead of counting it as running",
+  ({ phase, waitReason, label, expected, attention }) => {
+    const thread = agentViewThread();
+    const widget = new AgentWidget(createAdamTuiTheme(true), () => 2, {
+      scheduler: {
+        schedule() {
+          return { cancel() {} };
+        },
+      },
+    });
+    const snapshot: ManagedWorkspaceSnapshot = {
+      parentSessionId: "parent",
+      revision: 1,
+      status: "ready",
+      completions: [],
+      threads: [thread],
+    };
+    try {
+      widget.setSnapshot(snapshot);
+      widget.setActivity([
+        {
+          agentId: thread.threadId,
+          attemptId: thread.turn.attemptId,
+          childSessionId: thread.turn.childSessionId,
+          activity: "replying",
+          assistant: { itemId: "stale", text: "Old running output" },
+        },
+      ]);
+      widget.setSnapshot({
+        ...snapshot,
+        revision: 2,
+        threads: [
+          {
+            ...thread,
+            turn: {
+              ...thread.turn,
+              phase,
+              waitReason,
+              label,
+              ...(phase === "idle" ? { lastOutcome: "failed" as const } : {}),
+            },
+          },
+        ],
+      });
+      const lines = widget.render(40);
+      expect(lines).toHaveLength(2);
+      expect(lines.join("\n")).toContain(expected);
+      if (attention) expect(lines.join("\n")).toContain("1 attention");
+      expect(lines.join("\n")).not.toMatch(/running|\d+ run(?:\/|\b)|Old running output/u);
+      expect(lines.every((line) => visibleWidth(line) <= 40)).toBe(true);
+    } finally {
+      widget.dispose();
+    }
+  },
+);
+
+test.each([2, 3])(
+  "%i-line Widget preserves mixed attention, settling and error counts",
+  (maximum) => {
+    const threads = Array.from({ length: 4 }, (_, index) => agentViewThread(index + 1));
+    const snapshot: ManagedWorkspaceSnapshot = {
+      parentSessionId: "parent",
+      revision: 1,
+      status: "ready",
+      completions: [],
+      threads,
+    };
+    const widget = new AgentWidget(createAdamTuiTheme(true), () => maximum, {
+      scheduler: {
+        schedule() {
+          return { cancel() {} };
+        },
+      },
+    });
+    try {
+      widget.setSnapshot(snapshot);
+      widget.setSnapshot({
+        ...snapshot,
+        revision: 2,
+        threads: threads.map((thread, index) => ({
+          ...thread,
+          turn: {
+            ...thread.turn,
+            phase: index < 2 ? "waiting" : index === 2 ? "settling" : "idle",
+            waitReason: index === 0 ? "parent_input" : index === 1 ? "permission" : "none",
+            label: index < 2 ? "Waiting for you" : index === 2 ? "Settling" : "Failed",
+            lastOutcome: index === 3 ? "failed" : "none",
+          },
+        })),
+      });
+      const lines = widget.render(40);
+      expect(lines).toHaveLength(maximum);
+      expect(lines.join("\n")).toContain("2 waiting");
+      expect(lines.join("\n")).toContain("1 settling");
+      expect(lines.join("\n")).toContain("2 attention");
+      expect(lines.join("\n")).toContain("1 error");
+      expect(lines.join("\n")).not.toContain("running");
+      if (maximum === 2) expect(lines[0]).toBe("● Agents 4 · 2 attention · 1 error");
+      else expect(lines[1]).toBe("└─ Failed · Explore · Evidence 4");
+      expect(lines.every((line) => visibleWidth(line) <= 40)).toBe(true);
     } finally {
       widget.dispose();
     }

--- a/apps/tui/src/agent-widget.ts
+++ b/apps/tui/src/agent-widget.ts
@@ -9,7 +9,7 @@ import type {
   ManagedWorkspaceSnapshot,
   PresentationDisplayState,
 } from "@adam-agent/presentation";
-import { type Component, truncateToWidth } from "@earendil-works/pi-tui";
+import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import {
   type DeadlineHandle,
   type DeadlineScheduler,
@@ -126,18 +126,62 @@ export class AgentWidget implements Component {
     const finished = threads.filter((thread) => thread.turn.phase === "idle");
     const isQueuedThread = (thread: (typeof threads)[number]) =>
       thread.turn.phase === "queued" ||
-      (!thread.turn.hasStarted && thread.turn.phase === "waiting");
-    const running = threads.filter(
+      (!thread.turn.hasStarted &&
+        thread.turn.phase === "waiting" &&
+        (thread.turn.waitReason === "capacity" || thread.turn.waitReason === "suspended"));
+    const active = threads.filter(
       (thread) => thread.turn.phase !== "idle" && !isQueuedThread(thread),
     );
+    const running = active.filter(
+      (thread) => thread.turn.phase === "starting" || thread.turn.phase === "executing",
+    );
+    const waiting = active.filter((thread) => thread.turn.phase === "waiting");
+    const settling = active.filter((thread) => thread.turn.phase === "settling");
     const queued = threads.filter(isQueuedThread);
-    const renderThread = (thread: (typeof threads)[number]): string[] => {
+    const needsAttention = (thread: (typeof threads)[number]) =>
+      thread.turn.attention !== undefined ||
+      thread.turn.waitReason === "permission" ||
+      thread.turn.waitReason === "parent_input" ||
+      thread.turn.recovery === "required" ||
+      thread.turn.health === "stalled";
+    const hasError = (thread: (typeof threads)[number]) =>
+      thread.turn.lastOutcome === "failed" || thread.turn.outcome?.error !== undefined;
+    const attentionCount = threads.filter(needsAttention).length;
+    const errorCount = threads.filter(hasError).length;
+    const urgentCounts = [
+      ...(attentionCount ? [`${attentionCount} attention`] : []),
+      ...(errorCount ? [`${errorCount} error${errorCount === 1 ? "" : "s"}`] : []),
+    ];
+    const maximum = Math.max(2, this.maximumLines());
+    if (maximum === 2 && (waiting.length || settling.length || attentionCount || errorCount)) {
+      return [
+        this.theme.primary(
+          `● Agents ${threads.length}${urgentCounts.length ? ` · ${urgentCounts.join(" · ")}` : ""}`,
+        ),
+        boundedCountSummary(
+          [
+            ...(waiting.length ? [`${waiting.length} waiting`] : []),
+            ...(queued.length ? [`${queued.length} queued`] : []),
+            ...(settling.length ? [`${settling.length} settling`] : []),
+            ...(running.length ? [`${running.length} running`] : []),
+            ...(finished.length ? [`${finished.length} finished`] : []),
+          ],
+          width,
+        ),
+      ].map((line) => truncateToWidth(line, width));
+    }
+    const renderThread = (thread: (typeof threads)[number], compressed = false): string[] => {
       const activity = this.#activity.find(
         (item) => item.agentId === thread.threadId && item.attemptId === thread.turn.attemptId,
       );
       const config = thread.turn.configuration;
-      const budget = thread.budget;
       const isQueued = isQueuedThread(thread);
+      const priorityStatus =
+        compressed &&
+        (needsAttention(thread) ||
+          hasError(thread) ||
+          thread.turn.phase === "waiting" ||
+          thread.turn.phase === "settling");
       const elapsed = agentElapsedLabel(thread);
       const content =
         (activity?.tool?.status === "generating_arguments"
@@ -145,30 +189,38 @@ export class AgentWidget implements Component {
           : activity?.tool?.name) ??
         activity?.assistant?.text.split("\n").find((line) => line.trim().length > 0) ??
         (activity?.reasoning ? "Thinking…" : thread.turn.label);
+      const visibleContent =
+        (thread.turn.phase !== "executing" || thread.turn.health === "stalled") &&
+        content !== thread.turn.label
+          ? `${thread.turn.label} · ${content}`
+          : content;
       return [
-        `├─ ${isQueued ? `${thread.turn.label.split(" · ")[0]} ${thread.handle} · ` : thread.turn.phase === "executing" ? `${["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"][this.#frame]} ` : ""}${this.theme.reference(safeTerminalText(thread.displayName))} · ${thread.turn.phase === "idle" ? `${thread.turn.label} · ` : ""}${safeTerminalText(thread.description)}${elapsed}${thread.turn.phase === "idle" ? `${budget === undefined ? "" : ` · ${budget.knownUsed} used${budget.unknownReserved > 0 ? ` · ${budget.unknownReserved} unknown reserved` : ""}`}` : ""}`,
+        `├─ ${isQueued ? `${safeTerminalText(thread.turn.label.split(" · ")[0] ?? thread.turn.label)} ${safeTerminalText(thread.handle)} · ` : priorityStatus ? `${safeTerminalText(thread.turn.label)} · ` : thread.turn.phase === "executing" ? `${["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"][this.#frame]} ` : ""}${this.theme.reference(safeTerminalText(thread.displayName))} · ${thread.turn.phase === "idle" && !priorityStatus ? `${safeTerminalText(thread.turn.label)} · ` : ""}${safeTerminalText(thread.description)}${elapsed}`,
         ...(!isQueued && thread.turn.phase !== "idle"
-          ? [
-              `   ⎿ ${safeTerminalText(content)}${budget === undefined ? "" : ` · ${budget.knownUsed} used · ${budget.outstandingReserved} reserved${budget.unknownReserved ? ` · ${budget.unknownReserved} unknown` : ""}`}`,
-            ]
+          ? [`   ⎿ ${safeTerminalText(visibleContent)}`]
           : []),
-        ...((isQueued || settings?.showModel) && config !== undefined
+        ...(thread.turn.outcome?.error === undefined
+          ? []
+          : [
+              `   ⎿ ${safeTerminalText(`${thread.turn.outcome.error.code}: ${thread.turn.outcome.error.message}`)}`,
+            ]),
+        ...(settings?.showModel && config !== undefined
           ? [
               `   ${safeTerminalText(config.targetId)} · thinking ${safeTerminalText(config.thinking)}`,
             ]
           : []),
-        ...(isQueued && budget !== undefined
-          ? [
-              `   ${budget.knownUsed} used · ${budget.outstandingReserved} reserved · ${budget.unknownReserved} unknown · ${budget.available === null ? "no cumulative budget" : `${budget.available} available`}`,
-            ]
-          : []),
       ];
     };
-    const maximum = Math.max(2, this.maximumLines());
-    const normal = [...finished, ...running, ...queued].flatMap(renderThread);
+    const normal = [...finished, ...active, ...queued].flatMap((thread) => renderThread(thread));
+    const statusCounts = [
+      `${running.length} running`,
+      ...(waiting.length ? [`${waiting.length} waiting`] : []),
+      ...(settling.length ? [`${settling.length} settling`] : []),
+      `${queued.length} queued`,
+    ];
     const lines = [
       this.theme.primary(
-        `● Agents${normal.length + 1 > maximum ? ` · ${running.length} running · ${queued.length} queued` : ""}`,
+        `● Agents${normal.length + 1 > maximum ? ` · ${(urgentCounts.length ? urgentCounts : statusCounts).join(" · ")}` : ""}`,
       ),
     ];
     if (normal.length + 1 <= maximum) lines.push(...normal);
@@ -176,34 +228,35 @@ export class AgentWidget implements Component {
       const showQueueSummary = queued.length > 0 && maximum > 2;
       let budget = maximum - 2 - Number(showQueueSummary);
       let hiddenRunning = 0;
+      let hiddenWaiting = 0;
+      let hiddenSettling = 0;
       let hiddenFinished = 0;
       let hiddenDetails = 0;
-      for (const thread of running) {
+      const priority = (thread: (typeof threads)[number]) =>
+        hasError(thread) ? 2 : needsAttention(thread) ? 1 : 0;
+      const ordered = [...active, ...finished].sort(
+        (left, right) => priority(right) - priority(left),
+      );
+      for (const thread of ordered) {
         if (budget === 0) {
-          hiddenRunning += 1;
+          if (thread.turn.phase === "waiting") hiddenWaiting += 1;
+          else if (thread.turn.phase === "settling") hiddenSettling += 1;
+          else if (thread.turn.phase === "idle") hiddenFinished += 1;
+          else hiddenRunning += 1;
           continue;
         }
-        const full = renderThread(thread);
+        const full = renderThread(thread, true);
         const rendered = full.slice(0, budget);
         lines.push(...rendered);
         budget -= rendered.length;
         hiddenDetails += full.length - rendered.length;
       }
       if (showQueueSummary) lines.push(`├─ ${queued.length} queued · /agents`);
-      for (const thread of finished) {
-        if (budget === 0) {
-          hiddenFinished += 1;
-          continue;
-        }
-        const full = renderThread(thread);
-        const rendered = full.slice(0, budget);
-        lines.push(...rendered);
-        budget -= rendered.length;
-        hiddenDetails += full.length - rendered.length;
-      }
       const compact = width < 60;
       const hidden = [
         ...(hiddenRunning ? [`${hiddenRunning} ${compact ? "run" : "running"}`] : []),
+        ...(hiddenWaiting ? [`${hiddenWaiting} waiting`] : []),
+        ...(hiddenSettling ? [`${hiddenSettling} settling`] : []),
         ...(queued.length ? [`${queued.length} queued`] : []),
         ...(hiddenFinished ? [`${hiddenFinished} ${compact ? "done" : "finished"}`] : []),
         ...(hiddenDetails ? [`${hiddenDetails} ${compact ? "line" : "detail lines"}`] : []),
@@ -214,4 +267,13 @@ export class AgentWidget implements Component {
     if (lastBranch >= 0) lines[lastBranch] = (lines[lastBranch] ?? "").replace("├─", "└─");
     return lines.map((line) => truncateToWidth(line, width));
   }
+}
+
+/** Keep whole status counts; the header's total still covers any omitted categories. */
+function boundedCountSummary(parts: readonly string[], width: number): string {
+  for (let count = parts.length; count > 0; count -= 1) {
+    const text = `${parts.slice(0, count).join(" · ")}${count < parts.length ? " · …" : ""}`;
+    if (visibleWidth(text) <= width) return text;
+  }
+  return truncateToWidth(parts[0] ?? "", width);
 }

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -1871,6 +1871,7 @@ test("candidate ProjectRuntime runs real JSONL child Enter, Main response, layer
     workspaceRoot,
     stateRoot,
     controlRoot,
+    terminalProcessMarker: join(testRoot, "terminal-process"),
   });
   let completed = false;
   let waiting = "New session";
@@ -1897,6 +1898,43 @@ test("candidate ProjectRuntime runs real JSONL child Enter, Main response, layer
     waiting = "Conversation";
     fixture.write("\r");
     await fixture.waitForCompleteFrameAfter("Conversation", offset);
+    offset = fixture.output().length;
+    waiting = "Conversation help";
+    fixture.write("?");
+    await fixture.waitForCompleteFrameAfter("Conversation help", offset);
+    expect(fixture.screen()?.join("\n")).toContain("Ctrl+D: discard retained draft");
+    offset = fixture.output().length;
+    fixture.write("\u001b[27;1:1u\u001b[27;1:2u\u001b[27;1:3u");
+    await fixture.waitForCompleteFrameAfter("Enter compose", offset, "Conversation help");
+    offset = fixture.output().length;
+    await fixture.resize(80, 16);
+    await fixture.waitForCompleteFrameAfter("Conversation", offset);
+    offset = fixture.output().length;
+    waiting = "Conversation details";
+    fixture.write("d");
+    await fixture.waitForCompleteFrameAfter("Conversation details", offset);
+    const detailBody = () => {
+      const lines = fixture.screen() ?? [];
+      const title = lines.findIndex((line) => line.includes("Conversation details"));
+      expect(title).toBeGreaterThanOrEqual(0);
+      return lines[title + 1];
+    };
+    expect(detailBody()).toContain("PTY child");
+    offset = fixture.output().length;
+    waiting = "scrolled Conversation details";
+    fixture.write("\u001b[<65;8;9M");
+    await fixture.waitForCompleteFrameAfter("Conversation details", offset);
+    expect(detailBody()).not.toContain("PTY child");
+    offset = fixture.output().length;
+    fixture.write("\u001b[<64;8;9M");
+    await fixture.waitForCompleteFrameAfter("Conversation details", offset);
+    expect(detailBody()).toContain("PTY child");
+    offset = fixture.output().length;
+    fixture.write("\u001b[27;1:1u\u001b[27;1:2u\u001b[27;1:3u");
+    await fixture.waitForCompleteFrameAfter("Enter compose", offset, "Conversation details");
+    offset = fixture.output().length;
+    await fixture.resize(80, 24);
+    await fixture.waitForCompleteFrameAfter("Enter compose", offset);
     offset = fixture.output().length;
     waiting = "Cooperative";
     fixture.write("\r");

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -1672,11 +1672,12 @@ test("Kitty Ctrl+O repeat and release phases expand one tool card only once", as
     await fixture.waitForRecordedOutput("Read complete.");
     const beforeToolView = fixture.output().length;
     fixture.write("\u001b[5~");
-    await fixture.waitForRecordedOutput("\u001b[?2026l", beforeToolView);
-    expect(fixture.screen()?.join("\n") ?? "").toContain("read README.md · Ctrl+O expand");
+    await fixture.waitForCompleteFrameAfter("read README.md · Ctrl+O expand", beforeToolView);
     const beforeToggle = fixture.output().length;
-    fixture.write("\u001b[111;5:1u\u001b[111;5:2u\u001b[111;5:2u\u001b[111;5:3ux");
-    await fixture.waitForRecordedOutput("x", beforeToggle);
+    fixture.write(
+      "\u001b[111;5:1u\u001b[111;5:2u\u001b[111;5:2u\u001b[111;5:3uKITTY_PHASES_PROCESSED",
+    );
+    await fixture.waitForCompleteFrameAfter("KITTY_PHASES_PROCESSED", beforeToggle);
     const screen = fixture.screen()?.join("\n") ?? "";
     expect(screen).toContain("read README.md · Ctrl+O fold");
     fixture.write("\u0015\u0011");

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -43,6 +43,7 @@ import {
   VStack,
 } from "@earendil-works/pi-tui";
 import PQueue from "p-queue";
+import { AgentAdmissionCard } from "./agent-admission-card.js";
 import { AgentConversationViewer } from "./agent-conversation-viewer.js";
 import { AgentFleet, AgentSessionTransition, AgentWorkspace } from "./agent-fleet.js";
 import { AgentNavigator, ManagedAgentRoster } from "./agent-navigator.js";
@@ -384,7 +385,10 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   });
   const agentWidget = new AgentWidget(
     theme,
-    () => Math.max(2, Math.min(12, Math.floor((physicalTerminal.rows - 8) / 2))),
+    () =>
+      editor.isShowingAutocomplete()
+        ? 2
+        : Math.max(2, Math.min(12, Math.floor((physicalTerminal.rows - 8) / 2))),
     {
       scheduler: deadlineScheduler,
       onChange: () => renderState(),
@@ -403,7 +407,12 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
             draft.threadId === thread.threadId && draft.parentSessionId === thread.parentSessionId,
         ) ?? false,
     maximumLines: () =>
-      Math.max(1, Math.min(7, physicalTerminal.rows - (physicalTerminal.columns < 80 ? 15 : 12))),
+      editor.isShowingAutocomplete()
+        ? 1
+        : Math.max(
+            1,
+            Math.min(7, physicalTerminal.rows - (physicalTerminal.columns < 80 ? 15 : 12)),
+          ),
   });
   const todoCompactViewModel = new TodoCompactViewModel();
   const todoCompactOverlay = new TodoCompactOverlay(todoCompactViewModel, theme);
@@ -697,6 +706,10 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   let workspaceTrustMutationPending = false;
   let webSearchConfigurationPending = false;
   editorSlot.addChild(editor);
+  const compactCompletionFooter = () =>
+    options.presentation.getState().authoritative.managedControl !== undefined &&
+    editor.isShowingAutocomplete() &&
+    physicalTerminal.rows < 18;
   const supportedRoot = new VStack([
     header,
     {
@@ -763,7 +776,11 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
             options.presentation.getState().authoritative.managedControl !== undefined &&
             options.presentation.getState().agentUiSettings?.fleetEnabled !== false,
         },
-        footer,
+        { component: footer, visible: () => !compactCompletionFooter() },
+        {
+          component: new ResponsiveLine(theme.muted("Tab select · ↑↓ choose · Esc close")),
+          visible: compactCompletionFooter,
+        },
       ]),
       basis: "auto",
       minSize: 1,
@@ -2219,17 +2236,21 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         const key = JSON.stringify([item, expanded]);
         let cachedTool = toolComponents.get(item.id);
         if (cachedTool?.key !== key) {
-          const tool = new Box(1, 1, theme.toolBackground);
+          const admissionCard = item.qualifiedName === "spawn_agents";
+          const admissions = item.managedAdmissions ?? [];
+          const tool = new Box(admissionCard ? 0 : 1, admissionCard ? 0 : 1, theme.toolBackground);
           const subject = item.subject?.value;
           const label = safeTerminalText(item.label);
           const baseTitle =
-            item.kind === "shell"
-              ? subject === undefined
-                ? "$"
-                : `$ ${safeTerminalText(subject)}`
-              : subject === undefined
-                ? label
-                : `${label} ${safeTerminalText(subject)}`;
+            admissionCard && !expanded
+              ? "Agents"
+              : item.kind === "shell"
+                ? subject === undefined
+                  ? "$"
+                  : `$ ${safeTerminalText(subject)}`
+                : subject === undefined
+                  ? label
+                  : `${label} ${safeTerminalText(subject)}`;
           const action = `Ctrl+O ${expanded ? "fold" : "expand"}`;
           const firstTitleLine = baseTitle.split("\n", 1)[0] ?? "";
           const singleLineTitle = firstTitleLine === baseTitle ? baseTitle : `${firstTitleLine} …`;
@@ -2241,22 +2262,25 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
             standard: titleWithAction(32),
             wide: titleWithAction(90),
           });
-          tool.addChild(toolTitle);
-          for (const admission of item.managedAdmissions ?? []) {
+          if (admissions.length === 0 || expanded) {
+            tool.addChild(admissionCard ? new ResponsiveLine(titleWithAction(90)) : toolTitle);
+          }
+          for (const [index, admission] of admissions.entries()) {
             tool.addChild(
-              new ResponsiveLine(
-                theme.toolOutput(
-                  safeTerminalText(
-                    `${admission.status === "started" ? "Started" : "Queued"} ${admission.handle} · ${admission.displayName} · ${admission.description}`,
-                  ),
-                ),
+              new AgentAdmissionCard(
+                admission,
+                theme,
+                index === admissions.length - 1 && !expanded,
               ),
             );
           }
           if (item.preview !== null) {
             tool.addChild(new ToolPreview(item.preview, expanded, theme));
           }
-          const detail = item.resultSummary ?? toolStatusText(item.status, item.outcome?.status);
+          const detail =
+            admissions.length > 0 && item.status === "completed"
+              ? null
+              : (item.resultSummary ?? toolStatusText(item.status, item.outcome?.status));
           if (detail !== null) {
             tool.addChild(new ResponsiveLine(theme.toolOutput(safeTerminalText(detail))));
           }
@@ -3684,6 +3708,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           commandId: randomUUID(),
           command,
         }),
+      isMainCommand: (text) => commandRegistry.parse(text.trimStart()).kind === "known",
       onSaveDraft: async (draft) => {
         const receipt = await options.presentation.dispatch({ type: "save_agent_draft", draft });
         if (receipt.status === "rejected") {
@@ -5082,6 +5107,35 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       return;
     }
     if (first?.type === "mention" && first.kind === "agent") {
+      if (commandRegistry.parse(text.trimStart()).kind === "known") {
+        editor.disableSubmit = false;
+        showNotice("warning", "Run this command in Main. The draft is retained.", "until_edit");
+        renderState();
+        return;
+      }
+      if (
+        state.composer.elements.every(
+          (element) =>
+            element === first || (element.type === "text" && element.text.trim().length === 0),
+        )
+      ) {
+        const thread = state.authoritative.managedControl?.threads.find(
+          (entry) =>
+            entry.parentSessionId === first.parentSessionId &&
+            entry.threadId === first.threadId &&
+            entry.handle === first.handle,
+        );
+        editor.disableSubmit = false;
+        clearNotice();
+        if (thread === undefined) showUnavailableRecipient(first, state.composer.draftRevision);
+        else if (!thread.turn.hasStarted) {
+          showAgentNavigator(thread.parentSessionId);
+          if (!agentWorkspace?.workspace.openDetails(thread))
+            showUnavailableRecipient(first, state.composer.draftRevision);
+        } else showManagedConversation(thread);
+        renderState();
+        return;
+      }
       const draftRevision = state.composer.draftRevision;
       void options.presentation
         .dispatch({ type: "direct_agent_input", draftRevision })
@@ -5101,6 +5155,13 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
           };
           const send = (mode: "cooperative" | "interrupt" | "new_turn" | "reply") => {
             handle?.hide();
+            const actionId = showNotice(
+              "progress",
+              `Sending to ${first.handle}…`,
+              "until_replaced",
+              first.parentSessionId,
+            );
+            renderState();
             void options.presentation
               .dispatch({
                 type: "direct_agent_input",
@@ -5112,19 +5173,35 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
               })
               .then((result) => {
                 editor.disableSubmit = false;
-                if (result.status === "rejected") showNotice("error", result.message, "until_edit");
+                if (result.status === "rejected")
+                  settleNotice(
+                    actionId,
+                    "error",
+                    result.message,
+                    "until_edit",
+                    first.parentSessionId,
+                  );
                 else {
-                  editor.setText("");
-                  showNotice("success", `Input accepted for ${first.handle}.`, "until_edit");
+                  settleNotice(
+                    actionId,
+                    result.draftCleanupFailed ? "warning" : "success",
+                    result.draftCleanupFailed
+                      ? `Input accepted for ${first.handle}. Draft cleanup failed; do not resend.`
+                      : `Input accepted for ${first.handle}.`,
+                    "until_edit",
+                    first.parentSessionId,
+                  );
                 }
                 renderState();
               })
               .catch(() => {
                 editor.disableSubmit = false;
-                showNotice(
+                settleNotice(
+                  actionId,
                   "error",
                   "The exact input could not be accepted. The draft is retained.",
                   "until_edit",
+                  first.parentSessionId,
                 );
                 renderState();
               });
@@ -5321,7 +5398,12 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
                 .then((result) => {
                   if (result.status === "rejected")
                     showNotice("error", result.message, "until_edit");
-                  else editor.setText("");
+                  else if (result.draftCleanupFailed)
+                    showNotice(
+                      "warning",
+                      "Agent admitted. Draft cleanup failed; do not resend.",
+                      "until_edit",
+                    );
                   editor.disableSubmit = false;
                   renderState();
                 })
@@ -5351,11 +5433,10 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         });
       return;
     }
-    if (
-      text.trim().length === 0 &&
-      state.composer.pastedTexts.length === 0 &&
-      !state.composer.elements.some((element) => element.type === "skill")
-    ) {
+    if (text.trim().length === 0 && state.composer.renderedText.trim().length === 0) {
+      editor.disableSubmit = false;
+      clearNotice();
+      renderState();
       return;
     }
     const earlyParsed = commandRegistry.parse(text);

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -1088,6 +1088,31 @@ export async function createPresentationSession(
         await persistCurrentTurnDraft();
       }
     };
+    const clearAcceptedTurnDraft = async (
+      draftRevision: number,
+      expectedScope: TurnDraftScopeV1,
+      submittedScope?: TurnDraftScopeV1 | null,
+    ): Promise<boolean> => {
+      const stillCurrent = () =>
+        turnComposer.snapshot().revision === draftRevision &&
+        isDeepStrictEqual(expectedScope, currentDraftScope());
+      if (!stillCurrent()) return false;
+      try {
+        if (recoverableDrafts !== null) {
+          // Queue captured scopes together before edits can enqueue newer saves.
+          const deletions = [recoverableDrafts.delete(expectedScope)];
+          if (submittedScope != null && !isDeepStrictEqual(submittedScope, expectedScope))
+            deletions.push(recoverableDrafts.delete(submittedScope));
+          await Promise.all(deletions);
+        }
+        // Disk I/O never mutates the composer; a newer edit wins this comparison.
+        if (!stillCurrent()) return false;
+        return !(await turnComposer.reset(draftRevision));
+      } catch {
+        // Control acceptance is already durable; draft cleanup cannot revoke it.
+        return true;
+      }
+    };
     const loadTurnDraft = async (scope: TurnDraftScopeV1, targetId?: string) => {
       const recovered = await recoverableDrafts?.load(scope);
       if (
@@ -3117,17 +3142,17 @@ export async function createPresentationSession(
           { directThinkingSelection: command.thinkingSelection ?? null, directResources },
         );
         if (receipt.status === "rejected") return receipt;
-        if (turnComposer.snapshot().revision === command.draftRevision) {
-          await turnComposer.clear();
-          await persistCurrentTurnDraft();
-          if (recoverableDrafts !== null && submittedScope !== null)
-            await recoverableDrafts.delete(submittedScope);
-        }
+        const draftCleanupFailed = await clearAcceptedTurnDraft(
+          command.draftRevision,
+          { type: "session", sessionId: parentSessionId },
+          submittedScope,
+        );
         return {
           status: "admitted",
           commandId: command.confirmedEnvelope.id,
           resource: null,
           control: receipt,
+          ...(draftCleanupFailed ? { draftCleanupFailed: true as const } : {}),
         };
       }
       if (command.type === "direct_agent_input") {
@@ -3271,11 +3296,17 @@ export async function createPresentationSession(
           { directResources },
         );
         if (receipt.status === "rejected") return receipt;
-        if (turnComposer.snapshot().revision === command.draftRevision) {
-          await turnComposer.clear();
-          await persistCurrentTurnDraft();
-        }
-        return { status: "admitted", commandId: input.inputId, resource: null, control: receipt };
+        const draftCleanupFailed = await clearAcceptedTurnDraft(command.draftRevision, {
+          type: "session",
+          sessionId: parentSessionId,
+        });
+        return {
+          status: "admitted",
+          commandId: input.inputId,
+          resource: null,
+          control: receipt,
+          ...(draftCleanupFailed ? { draftCleanupFailed: true as const } : {}),
+        };
       }
       if (command.type === "managed_control") {
         const parentSessionId = command.command.parentSessionId;

--- a/packages/agent/src/turn-composer.ts
+++ b/packages/agent/src/turn-composer.ts
@@ -230,7 +230,7 @@ export type TurnComposer = {
     }[];
   }>;
   unseal(): void;
-  reset(baseRevision: number, commit: () => Promise<void>): Promise<boolean>;
+  reset(baseRevision: number, commit?: () => Promise<void>): Promise<boolean>;
   clear(options?: { readonly preserveRetained?: boolean }): Promise<void>;
   readExpandedText(): string;
   close(): Promise<void>;
@@ -1379,7 +1379,7 @@ export async function createTurnComposer(options: {
       }
       revision += 1;
       try {
-        await commit();
+        if (commit !== undefined) await commit();
       } catch (error) {
         elements = previousElements;
         nextOrdinal = previousNextOrdinal;

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -1383,6 +1383,7 @@ export type CommandReceipt =
       readonly commandId: string;
       readonly resource: ArtifactChunk | null;
       readonly draftText?: string;
+      readonly draftCleanupFailed?: true;
       readonly roleTarget?: {
         readonly qualifiedId: string;
         readonly definitionDigest: string;


### PR DESCRIPTION
Agent admission now uses compact role/task and Started/Queued cards, and the candidate Agent widget preserves attention and accurate phase counts in limited space. Agent views share `d` for details, `?` for Help and focused wheel scrolling. Submitting a selected handle alone opens its exact conversation or queued overview; handle messages keep the existing Control acceptance and delivery semantics.

The change also preserves newer drafts across late acceptance receipts and disk cleanup, keeps Main commands out of child messages, and leaves file references distinct from agent handles. Ordinary production composition remains unchanged.

Validation: independent specification and standards review; focused rendering and real-owner navigation/message regressions; real PTY resize, wheel, durable Enter and cleanup; representative responsiveness workload; final `pnpm quality:check`: 2,411 passed, 18 existing opt-in skips.
