### PR TITLE
fix(ui): preserve session state and submission lifecycle

### DIFF
--- a/apps/tui/src/agent-conversation-viewer.ts
+++ b/apps/tui/src/agent-conversation-viewer.ts
@@ -41,6 +41,7 @@ import { focusedWheelDirection } from "./focused-wheel-input.js";
 import { safeTerminalText } from "./safe-terminal-text.js";
 import { parseTaskBudgetFollowUp } from "./task-budget-input.js";
 import type { AdamTuiTheme } from "./theme.js";
+import { toolArgumentPhaseLabel } from "./tool-argument-phase.js";
 import { ToolPreview } from "./tool-preview.js";
 
 const viewerKeys = {
@@ -1291,12 +1292,16 @@ export class AgentConversationViewer implements Component {
               : []),
           ]),
     ];
+    const argumentPhase =
+      this.#activity?.tool === undefined
+        ? undefined
+        : toolArgumentPhaseLabel(this.#activity.tool.status);
     const header = [
       this.options.theme.primary(`Conversation · ${thread.handle} · ${thread.displayName}`),
       safeTerminalText(thread.description),
       `${thread.turn.label}${agentElapsedLabel(thread)}`,
-      ...(this.#activity?.tool?.status === "generating_arguments"
-        ? [`Generating arguments · ${safeTerminalText(this.#activity.tool.name)}`]
+      ...(argumentPhase !== undefined && this.#activity?.tool !== undefined
+        ? [`${argumentPhase} · ${safeTerminalText(this.#activity.tool.name)}`]
         : []),
       ...(thread.turn.diagnostic === undefined
         ? []

--- a/apps/tui/src/agent-role-input.test.ts
+++ b/apps/tui/src/agent-role-input.test.ts
@@ -235,6 +235,7 @@ test("direct role and exact-thread messages preserve folded pasted evidence", as
       await h.press("\r", "Delegation");
       await h.press("\r", mention === "@Explore" ? "Completed" : "Input accepted for @explore-1");
       await h.terminal.waitForScreen("○ @explore-1 · Explore · Completed");
+      expect(h.terminal.lines().join("\n")).not.toContain("Submitting prompt…");
       expect(JSON.stringify(requests.at(-1)?.messages)).toContain(marker);
       expect(h.presentation.getState().composer.renderedText).toBe("");
     }
@@ -683,6 +684,8 @@ test("a direct handle confirmation rejects a changed turn and retains the draft"
     ).toMatchObject({ status: "accepted" });
     await started.promise;
     await h.press("\r", "The exact turn or input action changed.");
+    expect(h.terminal.lines().join("\n")).not.toContain("Sending to @explore-1…");
+    expect(h.terminal.lines().join("\n")).not.toContain("Submitting prompt…");
     expect(h.presentation.getState().composer.renderedText).toBe(
       "@explore-1 Send only to the reviewed turn.",
     );
@@ -960,6 +963,7 @@ test("ordinary Enter seals manual recipients as one Main request without child r
     const text = "Inspect @探索🧭 @Explore @main";
     await h.press(text, "Inspect");
     await h.press("\r", "Main received literal mentions.");
+    expect(h.terminal.lines().join("\n")).not.toContain("Submitting prompt…");
     expect(requests).toHaveLength(1);
     expect(JSON.stringify(requests[0]?.messages)).toContain(text);
     expect(await h.store.read()).toEqual([]);
@@ -1307,5 +1311,67 @@ test("an Explore continuation retains its activated Skill and resources across a
   } finally {
     await h.close();
     await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("cancelling direct role and exact handle confirmation ends submission and retains the draft", async () => {
+  const h = await startManagedTui({
+    async *stream() {
+      yield { type: "text_delta", text: "Evidence complete." };
+      yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+      yield { type: "finish", reason: "stop" };
+    },
+  });
+  try {
+    await h.press("@Explore", "New agent · Explore");
+    await h.press("\t", "@Explore");
+    await h.press(" Inspect evidence.", "Inspect evidence.");
+    await h.press("\r", "Delegation");
+    await h.press("\x1b", "Inspect evidence.", "Delegation");
+    expect(h.terminal.lines().join("\n")).not.toContain("Submitting prompt…");
+    expect(h.presentation.getState().composer.renderedText).toBe("@Explore Inspect evidence.");
+    expect(h.presentation.getState().authoritative.managedControl?.threads).toHaveLength(0);
+    await h.press("\r", "Delegation");
+    await h.press("\r", "Completed");
+    await h.press("@explore-1", "[Agent] @explore-1 · Inspect evidence.");
+    await h.press("\t", "@explore-1");
+    await h.press(" Continue evidence.", "Continue evidence.");
+    await h.press("\r", "Delegation");
+    await h.press("\x1b", "Continue evidence.", "Delegation");
+    expect(h.terminal.lines().join("\n")).not.toContain("Submitting prompt…");
+    expect(h.presentation.getState().composer.renderedText).toBe("@explore-1 Continue evidence.");
+    expect(
+      (await h.store.read()).filter((record) => record.event.type === "admitted"),
+    ).toHaveLength(1);
+  } finally {
+    await h.close();
+  }
+});
+
+test("a rejected role confirmation ends admission progress and keeps its changed draft", async () => {
+  const h = await startManagedTui({
+    stream() {
+      throw new Error("Rejected delegation must not dispatch.");
+    },
+  });
+  try {
+    await h.press("@Explore", "New agent · Explore");
+    await h.press("\t", "@Explore");
+    await h.press(" Inspect evidence.", "Inspect evidence.");
+    await h.press("\r", "Delegation");
+    expect(
+      await h.presentation.dispatch({
+        type: "stage_pasted_text",
+        text: "Later evidence\n".repeat(50),
+      }),
+    ).toMatchObject({ status: "admitted" });
+    const changedDraft = h.presentation.getState().composer.elements;
+    await h.press("\r", "Select a current role and retry this exact draft.");
+    expect(h.terminal.lines().join("\n")).not.toContain("Admitting agent…");
+    expect(h.terminal.lines().join("\n")).not.toContain("Submitting prompt…");
+    expect(h.presentation.getState().composer.elements).toEqual(changedDraft);
+    expect(h.presentation.getState().authoritative.managedControl?.threads).toHaveLength(0);
+  } finally {
+    await h.close();
   }
 });

--- a/apps/tui/src/agent-widget.test.ts
+++ b/apps/tui/src/agent-widget.test.ts
@@ -259,3 +259,39 @@ test.each([2, 3])(
     }
   },
 );
+
+test.each([
+  ["generating_arguments", "Generating arguments"],
+  ["awaiting_model_completion", "Arguments received · waiting for model completion"],
+  ["processing_response", "Processing model response"],
+] as const)("Widget distinguishes %s from tool execution", (status, label) => {
+  const thread = agentViewThread();
+  const widget = new AgentWidget(createAdamTuiTheme(true), () => 12, {
+    scheduler: {
+      schedule() {
+        return { cancel() {} };
+      },
+    },
+  });
+  try {
+    widget.setSnapshot({
+      parentSessionId: "parent",
+      revision: 1,
+      status: "ready",
+      completions: [],
+      threads: [thread],
+    });
+    widget.setActivity([
+      {
+        agentId: thread.threadId,
+        attemptId: thread.turn.attemptId,
+        childSessionId: thread.turn.childSessionId,
+        activity: "using_tool",
+        tool: { callId: "call-1", name: "read_file", status },
+      },
+    ]);
+    expect(widget.render(120).join("\n")).toContain(`${label} · read_file`);
+  } finally {
+    widget.dispose();
+  }
+});

--- a/apps/tui/src/agent-widget.ts
+++ b/apps/tui/src/agent-widget.ts
@@ -17,6 +17,7 @@ import {
 } from "./exit-policy.js";
 import { safeTerminalText } from "./safe-terminal-text.js";
 import type { AdamTuiTheme } from "./theme.js";
+import { toolArgumentPhaseLabel } from "./tool-argument-phase.js";
 
 export function agentElapsedLabel(thread: ManagedControlThread): string {
   const start = thread.turn.startedAtUnixMilliseconds;
@@ -183,9 +184,11 @@ export class AgentWidget implements Component {
           thread.turn.phase === "waiting" ||
           thread.turn.phase === "settling");
       const elapsed = agentElapsedLabel(thread);
+      const argumentPhase =
+        activity?.tool === undefined ? undefined : toolArgumentPhaseLabel(activity.tool.status);
       const content =
-        (activity?.tool?.status === "generating_arguments"
-          ? `Generating arguments · ${activity.tool.name}`
+        (argumentPhase !== undefined
+          ? `${argumentPhase} · ${activity?.tool?.name}`
           : activity?.tool?.name) ??
         activity?.assistant?.text.split("\n").find((line) => line.trim().length > 0) ??
         (activity?.reasoning ? "Thinking…" : thread.turn.label);

--- a/apps/tui/src/argument-lifecycle.test.ts
+++ b/apps/tui/src/argument-lifecycle.test.ts
@@ -1,0 +1,194 @@
+import { ModelDriverError } from "@adam-agent/agent";
+import { expect, test } from "vitest";
+import { startManagedTui } from "./agent-fleet.test-support.js";
+
+test.each([
+  ["Main", "cancel"],
+  ["Child", "cancel"],
+  ["Main", "failure"],
+  ["Child", "failure"],
+] as const)(
+  "%s tracks each argument call across commentary, SDK end and %s",
+  async (surface, outcome) => {
+    const endFirst = Promise.withResolvers<void>();
+    const endSecond = Promise.withResolvers<void>();
+    const finish = Promise.withResolvers<void>();
+    const h = await startManagedTui({
+      async *stream(request) {
+        yield { type: "tool_call_start", id: "a", name: "read_file" };
+        yield { type: "tool_call_delta", id: "a", json: '{"path":"AGENTS.md"}' };
+        yield { type: "tool_call_start", id: "b", name: "list_directory" };
+        yield { type: "text_delta", text: "Both arguments are in progress." };
+        await endFirst.promise;
+        yield { type: "tool_call_end", id: "a" };
+        yield {
+          type: "reasoning_start",
+          id: "provider-reasoning-0",
+          artifactType: "provider_reasoning",
+        };
+        yield {
+          type: "reasoning_delta",
+          id: "provider-reasoning-0",
+          text: "Checking the remaining arguments.",
+        };
+        yield { type: "reasoning_end", id: "provider-reasoning-0" };
+        yield { type: "text_delta", text: "First call complete." };
+        await endSecond.promise;
+        yield { type: "tool_call_delta", id: "b", json: '{"path":"."}' };
+        yield { type: "tool_call_end", id: "b" };
+        yield { type: "text_delta", text: "Arguments complete; provider still open." };
+        await Promise.race([
+          finish.promise,
+          new Promise<void>((resolve) =>
+            request.signal.addEventListener("abort", () => resolve(), { once: true }),
+          ),
+        ]);
+        if (outcome === "failure")
+          throw new ModelDriverError("transport", "Provider interrupted", { cause: undefined });
+        yield { type: "finish", reason: "tool_calls" };
+      },
+    });
+    try {
+      if (surface === "Main")
+        await h.press("Inspect arguments\r", "Generating arguments · read_file");
+      else {
+        await h.press("@Explore", "New agent · Explore");
+        await h.press("\t", "@Explore");
+        await h.press(" Inspect arguments\r", "Delegation");
+        await h.press("\r", "Generating arguments · read_file");
+      }
+      const calls = () =>
+        surface === "Main"
+          ? h.presentation.getState().transient?.argumentCalls
+          : h.presentation.getState().managedAgentActivity?.[0]?.argumentCalls;
+      expect(calls()).toEqual([
+        { callId: "a", name: "read_file", status: "generating_arguments" },
+        { callId: "b", name: "list_directory", status: "generating_arguments" },
+      ]);
+      let checkpoint = h.terminal.output().length;
+      endFirst.resolve();
+      await h.terminal.waitForFrameAfter("Generating arguments · list_directory", checkpoint);
+      expect(calls()).toEqual([
+        { callId: "a", name: "read_file", status: "awaiting_model_completion" },
+        { callId: "b", name: "list_directory", status: "generating_arguments" },
+      ]);
+      checkpoint = h.terminal.output().length;
+      endSecond.resolve();
+      await h.terminal.waitForFrameAfter(
+        "waiting for model completion",
+        checkpoint,
+        "Generating arguments",
+      );
+      expect(calls()?.map((call) => call.status)).toEqual([
+        "awaiting_model_completion",
+        "awaiting_model_completion",
+      ]);
+      const records =
+        surface === "Main"
+          ? await (await h.sessions.open(h.parent.sessionId))?.read()
+          : await (
+              await h.children.open(
+                h.presentation.getState().managedAgentActivity?.[0]?.childSessionId ?? "",
+              )
+            )?.read();
+      expect(
+        records?.some(
+          (record) =>
+            record.schemaVersion === 3 &&
+            record.record.type === "runtime_event" &&
+            record.record.event.type === "tool_requested",
+        ),
+      ).toBe(false);
+      if (outcome === "failure") {
+        checkpoint = h.terminal.output().length;
+        finish.resolve();
+        await h.terminal.waitForFrameAfter(
+          surface === "Main" ? "model_request_failed" : "Failed",
+          checkpoint,
+          "waiting for model completion",
+        );
+        expect(calls() ?? []).toEqual([]);
+      } else if (surface === "Main") {
+        await h.press("\u0003", "cancelled");
+        expect(h.presentation.getState().transient?.argumentCalls ?? []).toEqual([]);
+      } else {
+        await h.openFirstAgent();
+        await h.press("x", "x again to cancel");
+        await h.press("x", "Cancelled");
+        expect(
+          h.presentation
+            .getState()
+            .managedAgentActivity?.flatMap((activity) => activity.argumentCalls ?? []) ?? [],
+        ).toEqual([]);
+      }
+    } finally {
+      endFirst.resolve();
+      endSecond.resolve();
+      finish.resolve();
+      await h.close();
+    }
+  },
+);
+
+test("Child processing response remains distinct from completed arguments and tool request", async () => {
+  const responseCommitted = Promise.withResolvers<void>();
+  const releaseResponse = Promise.withResolvers<void>();
+  let blocked = false;
+  const h = await startManagedTui(
+    {
+      async *stream(request) {
+        if (request.messages.at(-1)?.role === "tool") {
+          yield { type: "text_delta", text: "Inspection complete." };
+          yield { type: "usage", inputTokens: 100, outputTokens: 10 };
+          yield { type: "finish", reason: "stop" };
+          return;
+        }
+        yield { type: "tool_call_start", id: "read", name: "read_file" };
+        yield { type: "tool_call_delta", id: "read", json: '{"path":"AGENTS.md"}' };
+        yield { type: "tool_call_end", id: "read" };
+        yield { type: "usage", inputTokens: 100, outputTokens: 10 };
+        yield { type: "finish", reason: "tool_calls" };
+      },
+    },
+    {
+      async childRecordBarrier(record) {
+        if (
+          !blocked &&
+          record.schemaVersion === 3 &&
+          record.record.type === "model_response_completed"
+        ) {
+          blocked = true;
+          responseCommitted.resolve();
+          await releaseResponse.promise;
+        }
+      },
+    },
+  );
+  try {
+    await h.press("@Explore", "New agent · Explore");
+    await h.press("\t", "@Explore");
+    await h.press(" Inspect instructions\r", "Delegation");
+    await h.press("\r", "Processing model response");
+    await responseCommitted.promise;
+    expect(h.presentation.getState().managedAgentActivity?.[0]?.argumentCalls).toEqual([
+      { callId: "read", name: "read_file", status: "processing_response" },
+    ]);
+    const sessionId = h.presentation.getState().managedAgentActivity?.[0]?.childSessionId;
+    expect(sessionId).toBeDefined();
+    const records = await (await h.children.open(sessionId ?? ""))?.read();
+    expect(
+      records?.some(
+        (record) =>
+          record.schemaVersion === 3 &&
+          record.record.type === "runtime_event" &&
+          record.record.event.type === "tool_requested",
+      ),
+    ).toBe(false);
+    const checkpoint = h.terminal.output().length;
+    releaseResponse.resolve();
+    await h.terminal.waitForFrameAfter("Completed", checkpoint, "Processing model response");
+  } finally {
+    releaseResponse.resolve();
+    await h.close();
+  }
+});

--- a/apps/tui/src/tool-argument-phase.ts
+++ b/apps/tui/src/tool-argument-phase.ts
@@ -1,0 +1,13 @@
+/** Display the shared Main/Child argument lifecycle without inferring tool admission. */
+export function toolArgumentPhaseLabel(status: string): string | undefined {
+  switch (status) {
+    case "generating_arguments":
+      return "Generating arguments";
+    case "awaiting_model_completion":
+      return "Arguments received · waiting for model completion";
+    case "processing_response":
+      return "Processing model response";
+    default:
+      return undefined;
+  }
+}

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -113,6 +113,7 @@ import { ThinkingPicker } from "./thinking-picker.js";
 import { TodoCompactOverlay } from "./todo-compact-overlay.js";
 import { TodoCompactViewModel } from "./todo-compact-view-model.js";
 import { TodoNavigator } from "./todo-navigator.js";
+import { toolArgumentPhaseLabel } from "./tool-argument-phase.js";
 import { ToolPreview } from "./tool-preview.js";
 import { TranscriptViewport } from "./transcript-viewport.js";
 import { isTuiRunActive } from "./tui-run-state.js";
@@ -2501,7 +2502,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       transcript.addChild(
         new ResponsiveLine(
           theme.toolTitle(
-            `Generating arguments · ${safeTerminalText(state.transient.toolArguments.name)}`,
+            `${toolArgumentPhaseLabel(state.transient.toolArguments.status)} · ${safeTerminalText(state.transient.toolArguments.name)}`,
           ),
         ),
       );
@@ -5076,10 +5077,17 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         return;
       }
       const draftRevision = state.composer.draftRevision;
+      const prepareActionId = showNotice(
+        "progress",
+        `Preparing input for ${first.handle}…`,
+        "until_replaced",
+      );
       void options.presentation
         .dispatch({ type: "direct_agent_input", draftRevision })
         .then((receipt) => {
+          settleNoticeClear(prepareActionId);
           if (receipt.status === "rejected") {
+            editor.disableSubmit = false;
             showNotice("error", receipt.message, "until_edit");
             renderState();
             return;
@@ -5198,9 +5206,11 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         directTarget,
         selectedThinkingLevel(directTarget),
       );
+      const prepareActionId = showNotice("progress", "Preparing delegation…", "until_replaced");
       void options.presentation
         .dispatch({ type: "direct_delegation", draftRevision, thinkingSelection })
         .then((receipt) => {
+          settleNoticeClear(prepareActionId);
           if (receipt.status === "rejected") {
             if (receipt.code === "stale_interaction") {
               showUnavailableRecipient(first, draftRevision);
@@ -5324,6 +5334,8 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
             },
             onConfirm(selectedEnvelope, context, skills) {
               handle?.hide();
+              const actionId = showNotice("progress", "Admitting agent…", "until_replaced");
+              renderState();
               void options.presentation
                 .dispatch({
                   type: "direct_delegation",
@@ -5335,6 +5347,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
                   skills,
                 })
                 .then((result) => {
+                  settleNoticeClear(actionId);
                   if (result.status === "rejected")
                     showNotice("error", result.message, "until_edit");
                   else if (result.draftCleanupFailed)
@@ -6719,11 +6732,12 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       }
     }
     editor.disableSubmit = true;
-    showNotice("progress", "Submitting prompt…", "until_replaced");
+    const draftActionId = showNotice("progress", "Submitting prompt…", "until_replaced");
     renderState();
     void draftMutationQueue
       .onIdle()
       .then(() => {
+        settleNoticeClear(draftActionId);
         if (structuredEditorActive) {
           const composer = options.presentation.getState().composer;
           const literalText = composer.elements

--- a/apps/tui/src/uir-state-lifecycle.test.ts
+++ b/apps/tui/src/uir-state-lifecycle.test.ts
@@ -1,0 +1,216 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { startManagedTui } from "./agent-fleet.test-support.js";
+
+test.each(["Explore", "Research"] as const)(
+  "%s remains selectable and admits a child after Main reasoning, tool, text and naming updates",
+  async (role) => {
+    let requests = 0;
+    const generated = Promise.withResolvers<void>();
+    const h = await startManagedTui(
+      {
+        async *stream(request) {
+          if (request.purpose === "title") {
+            yield { type: "text_delta", text: "Generated Main title" };
+            yield { type: "finish", reason: "stop" };
+            return;
+          }
+          requests += 1;
+          if (requests === 1) {
+            yield {
+              type: "reasoning_start",
+              id: "provider-reasoning-0",
+              artifactType: "provider_reasoning",
+            };
+            yield {
+              type: "reasoning_delta",
+              id: "provider-reasoning-0",
+              text: "Inspect the instructions.",
+            };
+            yield { type: "reasoning_end", id: "provider-reasoning-0" };
+            yield { type: "tool_call_start", id: "read-1", name: "read_file" };
+            yield { type: "tool_call_delta", id: "read-1", json: '{"path":"AGENTS.md"}' };
+            yield { type: "tool_call_end", id: "read-1" };
+            yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+            yield { type: "finish", reason: "tool_calls" };
+            return;
+          }
+          yield {
+            type: "text_delta",
+            text: requests === 2 ? "Main inspection complete." : "Role child completed.",
+          };
+          yield { type: "usage", inputTokens: 100, outputTokens: 20 };
+          yield { type: "finish", reason: "stop" };
+        },
+      },
+      {},
+    );
+    h.lifecycle.enableAutomaticTitles();
+    const droppedRoles: number[] = [];
+    const unsubscribe = h.presentation.subscribe(() => {
+      const state = h.presentation.getState();
+      if (state.authoritative.active?.session.naming.generatedTitle === "Generated Main title")
+        generated.resolve();
+      if (!state.agentRoles?.some((item) => item.name === role)) droppedRoles.push(state.revision);
+    });
+    try {
+      await h.presentation.dispatch({
+        type: "clear_session_manual_name",
+        sessionId: h.parent.sessionId,
+      });
+      await h.press("Inspect instructions.\r", "Main inspection complete.");
+      await generated.promise;
+      expect(h.presentation.getState().agentRoles?.map((item) => item.name)).toEqual(
+        expect.arrayContaining(["Explore", "Research"]),
+      );
+      await h.presentation.dispatch({
+        type: "set_session_manual_name",
+        sessionId: h.parent.sessionId,
+        name: "Renamed Main",
+      });
+      await h.press(`@${role}`, `New agent · ${role}`);
+      await h.press("\t", `@${role}`);
+      await h.press(" Inspect the evidence.\r", "Delegation");
+      await h.press("\r", "Completed");
+      expect(droppedRoles).toEqual([]);
+      expect(
+        (await h.store.read()).filter((record) => record.event.type === "admitted"),
+      ).toHaveLength(1);
+      expect(h.presentation.getState().authoritative.managedControl?.threads[0]?.role).toBe(
+        `builtin:${role.toLowerCase()}`,
+      );
+    } finally {
+      unsubscribe();
+      await h.close();
+    }
+  },
+);
+
+test("selecting another session clears the old role catalog and reloads the destination", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-uir-roles-"));
+  const directory = join(workspaceRoot, ".agents", "agents");
+  await mkdir(directory, { recursive: true });
+  const roleFile = join(directory, "custom.md");
+  const definition = (name: string) =>
+    `---\nname: ${name}\ndescription: ${name} evidence.\nbase: explore\n---\nInspect evidence.\n`;
+  await writeFile(roleFile, definition("Original"));
+  const h = await startManagedTui(
+    {
+      async *stream() {
+        yield { type: "text_delta", text: "Destination role completed." };
+        yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+        yield { type: "finish", reason: "stop" };
+      },
+    },
+    { workspaceRoot },
+  );
+  const leaked: string[] = [];
+  const unsubscribe = h.presentation.subscribe(() => {
+    const state = h.presentation.getState();
+    if (
+      state.authoritative.active?.session.id !== h.parent.sessionId &&
+      state.agentRoles?.some((role) => role.name === "Original")
+    )
+      leaked.push("Original");
+  });
+  try {
+    expect(h.presentation.getState().agentRoles?.map((role) => role.name)).toContain("Original");
+    await writeFile(roleFile, definition("Destination"));
+    expect(
+      await h.presentation.dispatch({
+        type: "create_session",
+        targetId: "deepseek-v4-flash.direct",
+      }),
+    ).toMatchObject({ status: "admitted" });
+    expect(h.presentation.getState().agentRoles?.map((role) => role.name)).not.toContain(
+      "Original",
+    );
+    await h.press("\x1b", "New session draft");
+    await h.press("@Destination", "New agent · Destination evidence.");
+    await h.press("\t", "@Destination");
+    await h.press(" Inspect evidence.\r", "Delegation");
+    await h.press("\r", "Completed");
+    expect(h.presentation.getState().authoritative.managedControl?.threads[0]?.role).toBe(
+      "project:Destination",
+    );
+    expect(leaked).toEqual([]);
+  } finally {
+    unsubscribe();
+    await h.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test("every complete Main frame consumes the durable response once and preserves a later equal response", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "adam-uir-frames-"));
+  await writeFile(join(workspaceRoot, "evidence.txt"), "Small evidence file.");
+  const finishFirst = Promise.withResolvers<void>();
+  const secondEntered = Promise.withResolvers<void>();
+  const finishSecond = Promise.withResolvers<void>();
+  let calls = 0;
+  const h = await startManagedTui(
+    {
+      async *stream() {
+        if (++calls === 1) {
+          yield { type: "text_delta", text: "Equal response marker." };
+          await finishFirst.promise;
+          yield { type: "tool_call_start", id: "read", name: "read_file" };
+          yield { type: "tool_call_delta", id: "read", json: '{"path":"evidence.txt"}' };
+          yield { type: "tool_call_end", id: "read" };
+          yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+          yield { type: "finish", reason: "tool_calls" };
+        } else {
+          secondEntered.resolve();
+          await finishSecond.promise;
+          yield { type: "text_delta", text: "Equal response marker." };
+          yield { type: "usage", inputTokens: 20, outputTokens: 10 };
+          yield { type: "finish", reason: "stop" };
+        }
+      },
+    },
+    { workspaceRoot, rows: 50 },
+  );
+  const finalSettled = Promise.withResolvers<number>();
+  const unsubscribe = h.presentation.subscribe(() => {
+    const state = h.presentation.getState();
+    if (
+      calls === 2 &&
+      state.authoritative.active?.session.status === "settled" &&
+      state.transient === null
+    )
+      finalSettled.resolve(h.terminal.output().length);
+  });
+  try {
+    const offset = h.terminal.output().length;
+    await h.press("Inspect evidence.\r", "Equal response marker.");
+    finishFirst.resolve();
+    await h.terminal.waitForFrameAfter("Small evidence file.", offset);
+    await secondEntered.promise;
+    const firstFrames = h.terminal.completeFramesAfter(offset);
+    expect(firstFrames.length).toBeGreaterThan(0);
+    expect(firstFrames.map((frame) => frame.split("Equal response marker.").length - 1)).toEqual(
+      expect.arrayContaining([1]),
+    );
+    expect(
+      firstFrames.every((frame) => frame.split("Equal response marker.").length - 1 <= 1),
+    ).toBe(true);
+    const secondOffset = h.terminal.output().length;
+    finishSecond.resolve();
+    const settledOffset = await finalSettled.promise;
+    await h.terminal.waitForFrameAfter("idle", settledOffset);
+    expect(h.terminal.lines().join("\n").split("Equal response marker.").length - 1).toBe(2);
+    expect(
+      h.terminal
+        .completeFramesAfter(secondOffset)
+        .every((frame) => frame.split("Equal response marker.").length - 1 <= 2),
+    ).toBe(true);
+  } finally {
+    unsubscribe();
+    finishFirst.resolve();
+    finishSecond.resolve();
+    await h.close();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});

--- a/apps/tui/src/virtual-terminal.test-support.ts
+++ b/apps/tui/src/virtual-terminal.test-support.ts
@@ -177,6 +177,10 @@ export class VirtualTerminal implements Terminal {
     return this.#output;
   }
 
+  completeFramesAfter(offset: number): readonly string[] {
+    return this.#frames.filter((frame) => frame.endOffset > offset).map((frame) => frame.text);
+  }
+
   lines(): readonly string[] {
     return this.#viewport.lines();
   }

--- a/packages/agent/src/agent-session-contracts.ts
+++ b/packages/agent/src/agent-session-contracts.ts
@@ -245,6 +245,14 @@ export type ActiveContextUsage =
 
 export type RuntimeEvent =
   | { readonly type: "model_tool_arguments_started"; readonly id: string; readonly name: string }
+  | { readonly type: "model_tool_arguments_completed"; readonly id: string; readonly name: string }
+  | { readonly type: "model_response_processing"; readonly callIds: readonly string[] }
+  | {
+      readonly type: "model_tool_arguments_settled";
+      readonly id: string;
+      readonly name: string;
+      readonly status: "failed" | "cancelled";
+    }
   | { readonly type: "user_message"; readonly text: string }
   | { readonly type: "model_message_started" }
   | {

--- a/packages/agent/src/agent-session.ts
+++ b/packages/agent/src/agent-session.ts
@@ -270,6 +270,7 @@ export class AgentSession {
   #promptContext: PromptContextRecord | undefined;
   #skillContext: SkillContextRecordV1 | undefined;
   readonly #activeSkillContents = new Map<string, string>();
+  readonly #pendingToolArguments = new Map<string, string>();
   #pendingReasoningBlock: { readonly id: string } | undefined;
   readonly #repositoryWorkspaceRoot: string | undefined;
   readonly #durableContext: AgentSessionDurableContext | undefined;
@@ -688,6 +689,7 @@ export class AgentSession {
         throw error;
       }
     } catch (error) {
+      this.#settleToolArguments("failed");
       return executionFailureResult(error, this.#durableContext?.sessionId, this.#activeRunId);
     } finally {
       options.signal?.removeEventListener("abort", abortFromCaller);
@@ -1172,6 +1174,7 @@ export class AgentSession {
                   name: event.name,
                   argumentsJson: "",
                 });
+                this.#pendingToolArguments.set(event.id, event.name);
                 await this.#emit({
                   type: "model_tool_arguments_started",
                   id: event.id,
@@ -1207,6 +1210,11 @@ export class AgentSession {
               } else {
                 completedCalls.push(call);
                 assemblingCalls.delete(event.id);
+                this.#publish({
+                  type: "model_tool_arguments_completed",
+                  id: event.id,
+                  name: call.name,
+                });
               }
               break;
             }
@@ -1273,6 +1281,11 @@ export class AgentSession {
             case "finish":
               finishReason = event.reason;
               rawFinishReason = event.rawReason;
+              if (this.#pendingToolArguments.size > 0)
+                this.#publish({
+                  type: "model_response_processing",
+                  callIds: [...this.#pendingToolArguments.keys()],
+                });
               break;
           }
           if (
@@ -4185,6 +4198,7 @@ export class AgentSession {
       return this.#terminalResult;
     }
     this.#terminalResult = result;
+    this.#settleToolArguments(result.status === "cancelled" ? "cancelled" : "failed");
     await this.#settlePendingReasoningBlock(
       result.status === "cancelled" ? "interrupted" : "failed",
     );
@@ -4240,6 +4254,13 @@ export class AgentSession {
       },
     });
     this.#activeProviderAttempt = undefined;
+  }
+
+  #settleToolArguments(status: "failed" | "cancelled"): void {
+    for (const [id, name] of this.#pendingToolArguments) {
+      this.#publish({ type: "model_tool_arguments_settled", id, name, status });
+    }
+    this.#pendingToolArguments.clear();
   }
 
   async #settlePendingReasoningBlock(status: "interrupted" | "failed"): Promise<void> {
@@ -4392,7 +4413,10 @@ export class AgentSession {
     if (
       event.type !== "model_message_delta" &&
       event.type !== "model_reasoning_updated" &&
-      event.type !== "model_tool_arguments_started"
+      event.type !== "model_tool_arguments_started" &&
+      event.type !== "model_tool_arguments_completed" &&
+      event.type !== "model_response_processing" &&
+      event.type !== "model_tool_arguments_settled"
     ) {
       const canonicalEvent: CanonicalRuntimeEvent = event;
       const runId = this.#activeRunId;
@@ -4414,6 +4438,7 @@ export class AgentSession {
   }
 
   #publish(event: RuntimeEvent): void {
+    if (event.type === "tool_requested") this.#pendingToolArguments.delete(event.callId);
     for (const listener of this.#listeners) {
       notifyObserver(() => listener(event));
     }

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -20,6 +20,7 @@ import type {
   SessionNaming,
   SessionSummary,
   SkillCatalogDisplay,
+  ToolArgumentsDisplay,
   ToolPreviewDisplay,
   TranscriptItem,
 } from "@adam-agent/presentation";
@@ -940,6 +941,7 @@ export async function createPresentationSession(
         return false;
       }
       state = {
+        ...state,
         revision: state.revision + 1,
         authoritative: {
           ...state.authoritative,
@@ -1207,6 +1209,7 @@ export async function createPresentationSession(
       }
       advanceOperationCursor(next.display.operationId, next.throughSequence);
       state = {
+        ...state,
         revision: state.revision + 1,
         authoritative: {
           ...state.authoritative,
@@ -1252,6 +1255,7 @@ export async function createPresentationSession(
       }
       if (active.linkedOperations.length >= 256) {
         state = {
+          ...state,
           revision: state.revision + 1,
           authoritative: {
             ...state.authoritative,
@@ -1294,6 +1298,7 @@ export async function createPresentationSession(
       );
       items.splice(insertionIndex < 0 ? items.length : insertionIndex, 0, link);
       state = {
+        ...state,
         revision: state.revision + 1,
         authoritative: {
           ...state.authoritative,
@@ -1380,6 +1385,7 @@ export async function createPresentationSession(
         const sessionId = active.session.id;
         if (continuity.status === "current") {
           state = {
+            ...state,
             revision: state.revision + 1,
             authoritative: {
               ...state.authoritative,
@@ -1412,6 +1418,7 @@ export async function createPresentationSession(
           operationRepairs.delete(projected.display.operationId);
           const latestContinuity = state.authoritative.continuity;
           state = {
+            ...state,
             revision: state.revision + 1,
             authoritative: {
               ...state.authoritative,
@@ -1444,6 +1451,7 @@ export async function createPresentationSession(
             return;
           }
           state = {
+            ...state,
             revision: state.revision + 1,
             authoritative: {
               ...state.authoritative,
@@ -1488,6 +1496,7 @@ export async function createPresentationSession(
           return;
         }
         state = {
+          ...state,
           revision: state.revision + 1,
           authoritative: {
             ...state.authoritative,
@@ -1600,6 +1609,49 @@ export async function createPresentationSession(
         return { status: "rejected", code: "authority_rejected", message: result.message };
       return undefined;
     };
+    // The canonical message-start sequence distinguishes responses within one Run.
+    // Content is never used as identity during the live-to-durable handoff.
+    let activeModelMessage:
+      | { sessionId: string; runId: string; startedAtSequence: number }
+      | undefined;
+    const durableModelMessageThrough = new Map<string, number>();
+    const consumeDurableModelMessage = (
+      records: readonly SourcedSessionRecord[],
+      items: readonly TranscriptItem[],
+      transient: PresentationDisplayState["transient"],
+    ): PresentationDisplayState["transient"] => {
+      const visibleResponses = new Set(
+        items.flatMap((item) =>
+          item.type === "assistant_message" || item.type === "reasoning_block"
+            ? [`${item.sourceSessionId}:${item.sequence}`]
+            : [],
+        ),
+      );
+      // A durable read can precede queued model_message_started notifications.
+      // Retire its published responses even before a live identity has arrived.
+      for (const { sessionId, entry } of records) {
+        if (
+          entry.schemaVersion !== 3 ||
+          entry.record.type !== "model_response_completed" ||
+          !visibleResponses.has(`${sessionId}:${entry.sequence}`)
+        )
+          continue;
+        const key = `${sessionId}:${entry.record.runId}`;
+        durableModelMessageThrough.set(
+          key,
+          Math.max(durableModelMessageThrough.get(key) ?? 0, entry.sequence),
+        );
+      }
+      const message = activeModelMessage;
+      if (
+        message === undefined ||
+        transient === null ||
+        (durableModelMessageThrough.get(`${message.sessionId}:${message.runId}`) ?? 0) <
+          message.startedAtSequence
+      )
+        return transient;
+      return { ...transient, assistant: null, reasoning: null };
+    };
     let snapshotActivationQueue = Promise.resolve();
     let lastSnapshotActivation =
       created === undefined
@@ -1692,7 +1744,7 @@ export async function createPresentationSession(
       operationRepairs.clear();
       resetOperationCursors(activatedOperations);
       activeSessionThroughSequence = activeSequence;
-      if (snapshot.status === "settled") {
+      if (snapshot.status === "settled" || snapshot.status === "interrupted") {
         settledRuntimeBoundary = {
           sessionId: snapshot.sessionId,
           throughSequence: snapshot.lastSequence,
@@ -1718,6 +1770,16 @@ export async function createPresentationSession(
       ) {
         planRevisionIntent = null;
       }
+      const sameSession = state.authoritative.active?.session.id === snapshot.sessionId;
+      if (!sameSession) {
+        activeModelMessage = undefined;
+        durableModelMessageThrough.clear();
+      }
+      const activatedTransient = consumeDurableModelMessage(
+        activatedRecords,
+        activatedTranscript,
+        sameSession ? state.transient : null,
+      );
       const activatedControl = await options.lifecycle[sessionManagedControl](snapshot.sessionId);
       const activatedControlSnapshot = await activatedControl?.inspect({
         parentSessionId: snapshot.sessionId,
@@ -1727,7 +1789,10 @@ export async function createPresentationSession(
         revision: state.revision + 1,
         ...(activatedControlSnapshot === undefined
           ? {}
-          : { agentRoles: (await activatedControl?.inspectRoles())?.roles ?? [] }),
+          : {
+              agentRoles:
+                (await activatedControl?.inspectRoles({ reload: !sameSession }))?.roles ?? [],
+            }),
         authoritative: {
           ...previousAuthority,
           ...(activatedControlSnapshot === undefined
@@ -1780,7 +1845,7 @@ export async function createPresentationSession(
         transient:
           activeRun === undefined
             ? null
-            : (state.transient ?? { activity: "working", assistant: null, reasoning: null }),
+            : (activatedTransient ?? { activity: "working", assistant: null, reasoning: null }),
       };
       draftTargetIdentity = null;
       await observeManagedControl(snapshot.sessionId);
@@ -1817,6 +1882,7 @@ export async function createPresentationSession(
           return;
         }
         state = {
+          ...state,
           revision: state.revision + 1,
           authoritative: {
             ...state.authoritative,
@@ -1857,6 +1923,7 @@ export async function createPresentationSession(
       advanceSessionCursor(throughSequence);
       const continuity = state.authoritative.continuity;
       state = {
+        ...state,
         revision: state.revision + 1,
         authoritative: {
           ...state.authoritative,
@@ -1898,6 +1965,7 @@ export async function createPresentationSession(
       advanceSessionCursor(Math.max(throughSequence, inspected.lastSequence));
       const continuity = state.authoritative.continuity;
       state = {
+        ...state,
         revision: state.revision + 1,
         authoritative: {
           ...state.authoritative,
@@ -1993,8 +2061,8 @@ export async function createPresentationSession(
         const current = managedAgentActivity.find(
           (activity) => activity.agentId === agentId && activity.attemptId === attemptId,
         );
-        const generatingTool =
-          current?.tool?.status === "generating_arguments" ? current.tool : undefined;
+        const argumentCalls = projectArgumentCalls(current?.argumentCalls ?? [], event);
+        const generatingTool = selectedArgumentCall(argumentCalls);
         let projected = current;
         if (event.type === "model_message_started") {
           projected = {
@@ -2060,35 +2128,62 @@ export async function createPresentationSession(
                   activity: "using_tool",
                   tool: generatingTool,
                 };
-        } else if (
-          event.type === "tool_requested" ||
-          event.type === "tool_started" ||
-          event.type === "model_tool_arguments_started"
-        ) {
+        } else if (isArgumentLifecycleEvent(event)) {
+          const { tool: _previousTool, ...priorActivity } = current ?? {};
           projected = {
+            ...priorActivity,
+            agentId,
+            attemptId,
+            childSessionId,
+            activity: generatingTool === undefined ? "replying" : "using_tool",
+            ...(generatingTool === undefined ? {} : { tool: generatingTool }),
+          };
+        } else if (event.type === "tool_requested" || event.type === "tool_started") {
+          projected = {
+            ...current,
             agentId,
             attemptId,
             childSessionId,
             activity: "using_tool",
             tool: {
-              callId: event.type === "model_tool_arguments_started" ? event.id : event.callId,
+              callId: event.callId,
               name: event.name,
-              status:
-                event.type === "model_tool_arguments_started"
-                  ? "generating_arguments"
-                  : event.type === "tool_started"
-                    ? "running"
-                    : "requested",
+              status: event.type === "tool_started" ? "running" : "requested",
             },
           };
+        } else if (event.type === "model_message_completed") {
+          projected =
+            generatingTool === undefined
+              ? undefined
+              : {
+                  agentId,
+                  attemptId,
+                  childSessionId,
+                  activity: "using_tool",
+                  tool: generatingTool,
+                };
         } else if (
-          event.type === "model_message_completed" ||
           event.type === "tool_completed" ||
           event.type === "tool_failed" ||
-          event.type === "session_settled"
+          event.type === "session_settled" ||
+          event.type === "session_interrupted"
         ) {
-          projected = undefined;
+          projected =
+            generatingTool === undefined
+              ? undefined
+              : {
+                  agentId,
+                  attemptId,
+                  childSessionId,
+                  activity: "using_tool",
+                  tool: generatingTool,
+                };
         }
+        if (
+          projected !== undefined &&
+          (argumentCalls.length > 0 || current?.argumentCalls !== undefined)
+        )
+          projected = { ...projected, argumentCalls };
         if (projected !== current) {
           managedAgentActivity = [
             ...managedAgentActivity.filter(
@@ -2202,15 +2297,42 @@ export async function createPresentationSession(
             )
               return;
             const event = notification.event;
-            if (event.type === "model_tool_arguments_started") {
+            if (
+              notification.throughSequence <=
+                (durableModelMessageThrough.get(
+                  `${notification.sessionId}:${notification.runId}`,
+                ) ?? -1) &&
+              (event.type === "model_message_started" ||
+                event.type === "model_message_delta" ||
+                event.type === "model_reasoning_started" ||
+                event.type === "model_reasoning_updated" ||
+                event.type === "model_reasoning_settled")
+            )
+              return;
+            if (event.type === "model_message_started") {
+              activeModelMessage = {
+                sessionId: notification.sessionId,
+                runId: notification.runId,
+                startedAtSequence: notification.throughSequence,
+              };
+            }
+            if (isArgumentLifecycleEvent(event)) {
+              const argumentCalls = projectArgumentCalls(
+                state.transient?.argumentCalls ?? [],
+                event,
+              );
+              const toolArguments = selectedArgumentCall(argumentCalls);
+              const { toolArguments: _previousTool, ...transient } = state.transient ?? {};
               state = {
                 ...state,
                 revision: state.revision + 1,
                 transient: {
+                  ...transient,
                   activity: "working",
                   assistant: state.transient?.assistant ?? null,
                   reasoning: state.transient?.reasoning ?? null,
-                  toolArguments: { callId: event.id, name: event.name },
+                  argumentCalls,
+                  ...(toolArguments === undefined ? {} : { toolArguments }),
                 },
               };
               publishStateChange();
@@ -2233,6 +2355,7 @@ export async function createPresentationSession(
               | undefined;
             if (event.type === "user_message" || event.type === "model_message_started") {
               state = {
+                ...state,
                 revision: state.revision + 1,
                 authoritative: state.authoritative,
                 draft: state.draft,
@@ -2241,17 +2364,30 @@ export async function createPresentationSession(
               };
               publishStateChange();
             } else if (event.type === "tool_requested" || event.type === "tool_started") {
+              const argumentCalls = projectArgumentCalls(
+                state.transient?.argumentCalls ?? [],
+                event,
+              );
+              const toolArguments = selectedArgumentCall(argumentCalls);
               state = {
+                ...state,
                 revision: state.revision + 1,
                 authoritative: state.authoritative,
                 draft: state.draft,
                 composer: state.composer,
-                transient: { activity: "using_tool", assistant: null, reasoning: null },
+                transient: {
+                  activity: "using_tool",
+                  assistant: null,
+                  reasoning: null,
+                  argumentCalls,
+                  ...(toolArguments === undefined ? {} : { toolArguments }),
+                },
               };
               publishStateChange();
             } else if (event.type === "model_reasoning_started") {
               const target = knownTargets.get(active.session.targetId);
               state = {
+                ...state,
                 revision: state.revision + 1,
                 authoritative: state.authoritative,
                 draft: state.draft,
@@ -2281,6 +2417,7 @@ export async function createPresentationSession(
               );
               if (reasoning?.id === expectedId) {
                 state = {
+                  ...state,
                   revision: state.revision + 1,
                   authoritative: state.authoritative,
                   draft: state.draft,
@@ -2321,7 +2458,7 @@ export async function createPresentationSession(
               }
             }
             if (isModelMessageDelta(event)) {
-              const streamId = `${notification.sessionId}:${notification.runId}`;
+              const streamId = `${notification.sessionId}:${notification.runId}:${activeModelMessage?.startedAtSequence ?? notification.throughSequence}`;
               const existingText =
                 state.transient?.assistant?.streamId === streamId
                   ? state.transient.assistant.text
@@ -2351,6 +2488,7 @@ export async function createPresentationSession(
               const current = state.authoritative.active;
               if (profile !== undefined && current?.session.id === active.session.id) {
                 state = {
+                  ...state,
                   revision: state.revision + 1,
                   authoritative: {
                     ...state.authoritative,
@@ -2424,6 +2562,7 @@ export async function createPresentationSession(
             );
             if (activeSequence < notification.throughSequence) {
               state = {
+                ...state,
                 revision: state.revision + 1,
                 authoritative: {
                   ...state.authoritative,
@@ -2485,7 +2624,19 @@ export async function createPresentationSession(
                 ? state.authoritative.continuity.sessionThroughSequence
                 : 0;
             advanceSessionCursor(Math.max(activeSequence, latestSequence));
+            if (event.type === "session_interrupted" || event.type === "session_settled") {
+              settledRuntimeBoundary = {
+                sessionId: notification.sessionId,
+                throughSequence: notification.throughSequence,
+              };
+            }
+            const refreshedTransient = consumeDurableModelMessage(
+              refreshedRecords,
+              transcript,
+              state.transient,
+            );
             state = {
+              ...state,
               revision: state.revision + 1,
               authoritative: {
                 ...state.authoritative,
@@ -2524,16 +2675,20 @@ export async function createPresentationSession(
               transient: isAssistantTerminalEvent(event)
                 ? activeRun === undefined
                   ? null
-                  : (state.transient ?? {
-                      activity: "working",
-                      assistant: null,
-                      reasoning: null,
-                    })
+                  : event.type === "model_message_completed"
+                    ? {
+                        ...refreshedTransient,
+                        activity: refreshedTransient?.activity ?? "working",
+                        assistant: null,
+                        reasoning: null,
+                      }
+                    : { activity: "working", assistant: null, reasoning: null }
                 : recoveredReasoning === undefined
-                  ? state.transient
+                  ? refreshedTransient
                   : {
-                      activity: state.transient?.activity ?? "working",
-                      assistant: state.transient?.assistant ?? null,
+                      ...refreshedTransient,
+                      activity: refreshedTransient?.activity ?? "working",
+                      assistant: refreshedTransient?.assistant ?? null,
                       reasoning: recoveredReasoning,
                     },
             };
@@ -2548,6 +2703,7 @@ export async function createPresentationSession(
               return;
             }
             state = {
+              ...state,
               revision: state.revision + 1,
               authoritative: {
                 ...state.authoritative,
@@ -2611,6 +2767,7 @@ export async function createPresentationSession(
             return;
           }
           state = {
+            ...state,
             revision: state.revision + 1,
             authoritative: {
               ...state.authoritative,
@@ -4253,6 +4410,7 @@ export async function createPresentationSession(
             projectId: command.projectId,
           });
           state = {
+            ...state,
             revision: state.revision + 1,
             authoritative: {
               ...state.authoritative,
@@ -4306,6 +4464,7 @@ export async function createPresentationSession(
           await options.preferences.setDefaultTarget(command.targetId);
           const targets = await refreshConfiguredTargets();
           state = {
+            ...state,
             revision: state.revision + 1,
             authoritative: {
               ...state.authoritative,
@@ -4341,6 +4500,7 @@ export async function createPresentationSession(
           await options.preferences.setModelPolicy({ field: command.field, value: command.value });
           const targets = await refreshConfiguredTargets();
           state = {
+            ...state,
             revision: state.revision + 1,
             authoritative: { ...state.authoritative, targets },
             draft: state.draft,
@@ -4398,6 +4558,7 @@ export async function createPresentationSession(
               const targets = await refreshConfiguredTargets();
               if (!closed) {
                 state = {
+                  ...state,
                   revision: state.revision + 1,
                   authoritative: { ...state.authoritative, targets },
                   draft: state.draft,
@@ -4439,6 +4600,7 @@ export async function createPresentationSession(
           await webSearchConfiguration.clear();
           const targets = await refreshConfiguredTargets();
           state = {
+            ...state,
             revision: state.revision + 1,
             authoritative: { ...state.authoritative, targets },
             draft: state.draft,
@@ -4478,6 +4640,7 @@ export async function createPresentationSession(
           await webSearchConfiguration.setSyntheticDnsRange(command.range);
           const targets = await refreshConfiguredTargets();
           state = {
+            ...state,
             revision: state.revision + 1,
             authoritative: { ...state.authoritative, targets },
             draft: state.draft,
@@ -5797,6 +5960,7 @@ export async function createPresentationSession(
             } catch {
               if (!closed) {
                 state = {
+                  ...state,
                   revision: state.revision + 1,
                   authoritative: {
                     ...state.authoritative,
@@ -5839,6 +6003,7 @@ export async function createPresentationSession(
         }
         loadedTranscriptStart = Math.max(0, loadedTranscriptStart - historyPageSize);
         state = {
+          ...state,
           revision: state.revision + 1,
           authoritative: {
             ...state.authoritative,
@@ -5883,6 +6048,7 @@ export async function createPresentationSession(
             state.authoritative.sessions.items.map((session) => session.id),
           );
           state = {
+            ...state,
             revision: state.revision + 1,
             authoritative: {
               ...state.authoritative,
@@ -7624,4 +7790,51 @@ function projectWebSearchConfiguration(snapshot: WebSearchConfigurationSnapshot)
     syntheticDnsRange: snapshot.syntheticDnsRange ?? null,
     diagnostic: snapshot.diagnostic,
   };
+}
+
+function isArgumentLifecycleEvent(event: RuntimeEvent): boolean {
+  return (
+    event.type === "model_tool_arguments_started" ||
+    event.type === "model_tool_arguments_completed" ||
+    event.type === "model_response_processing" ||
+    event.type === "model_tool_arguments_settled"
+  );
+}
+
+function projectArgumentCalls(
+  calls: readonly ToolArgumentsDisplay[],
+  event: RuntimeEvent,
+): readonly ToolArgumentsDisplay[] {
+  switch (event.type) {
+    case "model_tool_arguments_started":
+      return [
+        ...calls.filter((call) => call.callId !== event.id),
+        { callId: event.id, name: event.name, status: "generating_arguments" },
+      ];
+    case "model_tool_arguments_completed":
+      return calls.map((call) =>
+        call.callId === event.id ? { ...call, status: "awaiting_model_completion" } : call,
+      );
+    case "model_response_processing":
+      return calls.map((call) =>
+        event.callIds.includes(call.callId) ? { ...call, status: "processing_response" } : call,
+      );
+    case "model_tool_arguments_settled":
+      return calls.filter((call) => call.callId !== event.id);
+    case "tool_requested":
+    case "tool_started":
+      return calls.filter((call) => call.callId !== event.callId);
+    case "model_message_started":
+    case "session_settled":
+    case "session_interrupted":
+      return [];
+    default:
+      return calls;
+  }
+}
+
+function selectedArgumentCall(
+  calls: readonly ToolArgumentsDisplay[],
+): ToolArgumentsDisplay | undefined {
+  return calls.find((call) => call.status === "generating_arguments") ?? calls[0];
 }

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -5690,7 +5690,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
           ...(options[sessionManagedControl] === undefined
             ? {}
             : {
-                agentRoles: await agentRoleCatalog.inspect(),
+                agentRoles: await agentRoleCatalog.reload(),
                 delegationPolicy: resolveFleetPolicy(
                   contextProfile,
                   options[sessionManagedControl].policy,

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -65,7 +65,10 @@ export type CanonicalRuntimeEvent = Exclude<
       | "model_message_delta"
       | "model_reasoning_updated"
       | "mcp_catalog_state_changed"
-      | "model_tool_arguments_started";
+      | "model_tool_arguments_started"
+      | "model_tool_arguments_completed"
+      | "model_response_processing"
+      | "model_tool_arguments_settled";
   }
 >;
 

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -1179,8 +1179,15 @@ export type AuthoritativePresentationSnapshot = {
   };
 };
 
+export type ToolArgumentsDisplay = {
+  readonly callId: string;
+  readonly name: string;
+  readonly status: "generating_arguments" | "awaiting_model_completion" | "processing_response";
+};
+
 export type PresentationTransientState = {
-  readonly toolArguments?: { readonly callId: string; readonly name: string };
+  readonly argumentCalls?: readonly ToolArgumentsDisplay[];
+  readonly toolArguments?: ToolArgumentsDisplay;
   readonly activity: "working" | "replying" | "using_tool" | null;
   readonly assistant: {
     readonly streamId: string;
@@ -1381,10 +1388,11 @@ export type PresentationDisplayState = {
       readonly status: "active" | "completed" | "interrupted" | "failed";
       readonly hasContent: boolean;
     };
+    readonly argumentCalls?: readonly ToolArgumentsDisplay[];
     readonly tool?: {
       readonly callId: string;
       readonly name: string;
-      readonly status: "generating_arguments" | "requested" | "running";
+      readonly status: ToolArgumentsDisplay["status"] | "requested" | "running";
     };
   }[];
 };
@@ -1958,6 +1966,9 @@ export function reconcilePresentationUpdate(
 ): PresentationDisplayState {
   if (update.type === "authoritative_snapshot") {
     return {
+      ...(state.authoritative.active?.session.id === update.snapshot.active?.session.id
+        ? state
+        : {}),
       revision: state.revision + 1,
       authoritative: update.snapshot,
       draft: update.snapshot.active === null ? state.draft : null,
@@ -1971,6 +1982,7 @@ export function reconcilePresentationUpdate(
     update.afterSequence !== state.authoritative.continuity.sessionThroughSequence
   ) {
     return {
+      ...state,
       revision: state.revision + 1,
       authoritative: {
         ...state.authoritative,
@@ -1984,6 +1996,7 @@ export function reconcilePresentationUpdate(
 
   if (update.type === "reasoning_snapshot") {
     return {
+      ...state,
       revision: state.revision + 1,
       authoritative: state.authoritative,
       draft: state.draft,
@@ -1998,6 +2011,7 @@ export function reconcilePresentationUpdate(
   }
 
   return {
+    ...state,
     revision: state.revision + 1,
     authoritative: state.authoritative,
     draft: state.draft,

--- a/packages/presentation/src/presentation.test.ts
+++ b/packages/presentation/src/presentation.test.ts
@@ -78,6 +78,42 @@ const emptyComposer = {
 } as const;
 
 describe("presentation reconciliation", () => {
+  it("preserves the role catalog during same-session updates and clears it on selection", () => {
+    const roles = [
+      {
+        qualifiedId: "builtin:explore",
+        name: "Explore",
+        description: "Explore",
+        definitionDigest: "digest",
+      },
+    ];
+    const initial: PresentationDisplayState = {
+      revision: 1,
+      authoritative: emptySnapshot,
+      draft: null,
+      composer: emptyComposer,
+      transient: null,
+      agentRoles: roles,
+    };
+    const streaming = reconcilePresentationUpdate(initial, {
+      type: "assistant_delta",
+      streamId: "s",
+      afterSequence: 0,
+      text: "Hello",
+    });
+    expect(streaming.agentRoles).toEqual(roles);
+    const refreshed = reconcilePresentationUpdate(streaming, {
+      type: "authoritative_snapshot",
+      snapshot: emptySnapshot,
+    });
+    expect(refreshed.agentRoles).toEqual(roles);
+    const switched = reconcilePresentationUpdate(refreshed, {
+      type: "authoritative_snapshot",
+      snapshot: { ...emptySnapshot, active: null },
+    });
+    expect(switched.agentRoles).toBeUndefined();
+  });
+
   it("replaces a transient assistant delta with durable completion", () => {
     const initial: PresentationDisplayState = {
       revision: 1,

--- a/packages/testkit/src/argument-lifecycle.test.ts
+++ b/packages/testkit/src/argument-lifecycle.test.ts
@@ -1,0 +1,83 @@
+import {
+  AgentSession,
+  createInMemorySessionStore,
+  type ModelDriver,
+  ModelDriverError,
+  type RuntimeEvent,
+} from "@adam-agent/agent";
+import { expect, test } from "vitest";
+
+test("argument completion precedes provider finish and no tool is requested early", async () => {
+  const events: RuntimeEvent[] = [];
+  const model: ModelDriver = {
+    async *stream() {
+      yield { type: "tool_call_start", id: "a", name: "first" };
+      yield { type: "tool_call_delta", id: "a", json: "{}" };
+      expect(events.filter((event) => event.type === "tool_requested")).toEqual([]);
+      yield { type: "tool_call_start", id: "b", name: "second" };
+      yield { type: "text_delta", text: "still working" };
+      yield { type: "tool_call_end", id: "a" };
+      expect(events).toContainEqual({
+        type: "model_tool_arguments_completed",
+        id: "a",
+        name: "first",
+      });
+      expect(events.filter((event) => event.type === "tool_requested")).toEqual([]);
+      yield {
+        type: "reasoning_start",
+        id: "provider-reasoning-0",
+        artifactType: "provider_reasoning",
+      };
+      yield { type: "reasoning_delta", id: "provider-reasoning-0", text: "checking" };
+      yield { type: "reasoning_end", id: "provider-reasoning-0" };
+      yield { type: "tool_call_delta", id: "b", json: "{}" };
+      yield { type: "tool_call_end", id: "b" };
+      expect(events).toContainEqual({
+        type: "model_tool_arguments_completed",
+        id: "b",
+        name: "second",
+      });
+      expect(events.filter((event) => event.type === "tool_requested")).toEqual([]);
+      yield { type: "finish", reason: "tool_calls" };
+    },
+  };
+  const session = new AgentSession({
+    model,
+    store: createInMemorySessionStore(),
+    maximumOutputTokens: 4096,
+  });
+  session.subscribe((event) => events.push(event));
+  await session.run({ text: "work" });
+  expect(events).toContainEqual({ type: "model_response_processing", callIds: ["a", "b"] });
+  expect(events.findIndex((event) => event.type === "model_response_processing")).toBeLessThan(
+    events.findIndex((event) => event.type === "model_message_completed"),
+  );
+});
+
+test.each(["cancelled", "failed"] as const)("pending arguments terminate on %s", async (status) => {
+  const events: RuntimeEvent[] = [];
+  const controller = new AbortController();
+  const model: ModelDriver = {
+    async *stream() {
+      yield { type: "tool_call_start", id: "a", name: "first" };
+      yield { type: "tool_call_delta", id: "a", json: "{}" };
+      yield { type: "tool_call_end", id: "a" };
+      yield { type: "tool_call_start", id: "b", name: "second" };
+      if (status === "cancelled") controller.abort();
+      else throw new ModelDriverError("transport", "Provider failed", { cause: undefined });
+    },
+  };
+  const session = new AgentSession({
+    model,
+    store: createInMemorySessionStore(),
+    maximumOutputTokens: 4096,
+  });
+  session.subscribe((event) => events.push(event));
+  const result = await session.run({ text: "work" }, { signal: controller.signal });
+  expect(result.status).toBe(status);
+  expect(events.filter((event) => event.type === "model_tool_arguments_settled")).toEqual([
+    { type: "model_tool_arguments_settled", id: "a", name: "first", status },
+    { type: "model_tool_arguments_settled", id: "b", name: "second", status },
+  ]);
+  expect(events.filter((event) => event.type === "tool_requested")).toEqual([]);
+});

--- a/packages/testkit/src/presentation-read-ahead.test.ts
+++ b/packages/testkit/src/presentation-read-ahead.test.ts
@@ -5,6 +5,7 @@ import {
   createPermissionPolicy,
   createPresentationSession,
   type ModelDriver,
+  ModelDriverError,
   type SessionRuntimeNotification,
 } from "@adam-agent/agent";
 import {
@@ -279,3 +280,254 @@ test("Presentation ignores completed-run tool and assistant notifications after 
     await rm(root, { recursive: true, force: true });
   }
 });
+
+test.each([false, true])(
+  "Presentation consumes the matching transient at durable handoff and retains equal text from distinct responses (read ahead: %s)",
+  async (readAhead) => {
+    const root = await mkdtemp(join(tmpdir(), "adam-presentation-handoff-"));
+    const releaseSecond = Promise.withResolvers<void>();
+    const firstDurable = Promise.withResolvers<PresentationDisplayState>();
+    const settled = Promise.withResolvers<PresentationDisplayState>();
+    const secondEntered = Promise.withResolvers<void>();
+    const queueDrained = Promise.withResolvers<void>();
+    const duplicates: number[] = [];
+    let secondReleased = false;
+    let calls = 0;
+    const model: ModelDriver = {
+      async *stream() {
+        if (++calls === 1) {
+          yield { type: "text_delta", text: "Identical legitimate answer." };
+          yield { type: "tool_call_start", id: "read", name: "read_file" };
+          yield { type: "tool_call_delta", id: "read", json: '{"path":"evidence.txt"}' };
+          yield { type: "tool_call_end", id: "read" };
+          yield { type: "finish", reason: "tool_calls" };
+        } else {
+          secondEntered.resolve();
+          await releaseSecond.promise;
+          yield { type: "text_delta", text: "Identical legitimate answer." };
+          yield { type: "finish", reason: "stop" };
+        }
+      },
+    };
+    await writeFile(join(root, "evidence.txt"), "Evidence.");
+    const harness = createInMemorySessionLifecycleHarness();
+    const modelTargets = modelTargetsWithDriver(model);
+    const lifecycle = harness.createLifecycle({
+      workspaceRoot: root,
+      stateRoot: join(root, "state"),
+      modelTargets,
+      permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    });
+    const created = await lifecycle.create({ targetIdentity });
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      workspaceRoot: root,
+      stateRoot: join(root, "state"),
+      projectLabel: "handoff",
+      sessionId: created.sessionId,
+      [presentationRuntimeRefreshBarrier]: {
+        async beforeRead(notification) {
+          if (readAhead && notification.event.type === "user_message") await secondEntered.promise;
+          if (notification.event.type === "model_message_completed") queueDrained.resolve();
+        },
+      },
+      [presentationSessionRecordReader]: async (id) =>
+        (await (await harness.sessions.open(id))?.read()) ?? [],
+    });
+    const unsubscribe = presentation.subscribe(() => {
+      const state = presentation.getState();
+      if (
+        !secondReleased &&
+        state.transient?.assistant?.text === "Identical legitimate answer." &&
+        state.authoritative.active?.transcript.items.some(
+          (item) => item.type === "assistant_message",
+        )
+      )
+        duplicates.push(state.revision);
+      if (
+        state.authoritative.active?.transcript.items.some(
+          (item) => item.type === "assistant_message",
+        )
+      )
+        firstDurable.resolve(state);
+      if (state.authoritative.active?.session.status === "settled" && state.transient === null)
+        settled.resolve(state);
+    });
+    try {
+      expect(
+        await presentation.dispatch({
+          type: "submit_prompt",
+          sessionId: created.sessionId,
+          text: "Inspect evidence.",
+          skills: [],
+          thinkingSelection: null,
+        }),
+      ).toMatchObject({ status: "admitted" });
+      const handoff = await withManagedFailureGuard(
+        firstDurable.promise,
+        "first durable assistant response",
+      );
+      expect(handoff.transient?.assistant ?? null).toBeNull();
+      await withManagedFailureGuard(
+        queueDrained.promise,
+        "queued model completion after earlier deltas",
+      );
+      expect(duplicates).toEqual([]);
+      secondReleased = true;
+      releaseSecond.resolve();
+      const final = await withManagedFailureGuard(
+        settled.promise,
+        "two distinct equal responses settled",
+      );
+      const answers = final.authoritative.active?.transcript.items.filter(
+        (item) => item.type === "assistant_message",
+      );
+      expect(answers?.map((item) => item.text)).toEqual([
+        "Identical legitimate answer.",
+        "Identical legitimate answer.",
+      ]);
+      expect(new Set(answers?.map((item) => item.id)).size).toBe(2);
+      expect(final.transient).toBeNull();
+    } finally {
+      releaseSecond.resolve();
+      unsubscribe();
+      await presentation.close();
+      await lifecycle.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);
+
+test.each(["cancel", "failure"] as const)(
+  "Presentation does not revive delayed output after %s",
+  async (ending) => {
+    const root = await mkdtemp(join(tmpdir(), "adam-presentation-terminal-"));
+    const finish = Promise.withResolvers<void>();
+    const live = Promise.withResolvers<void>();
+    const nextLive = Promise.withResolvers<void>();
+    let calls = 0;
+    const settled = Promise.withResolvers<void>();
+    let user: SessionRuntimeNotification | undefined;
+    let delta: SessionRuntimeNotification | undefined;
+    let replayed = false;
+    let terminalSeen = false;
+    const revived: number[] = [];
+    const model: ModelDriver = {
+      async *stream(request) {
+        if (++calls > 1) {
+          yield { type: "text_delta", text: "Next turn works." };
+          yield { type: "finish", reason: "stop" };
+          return;
+        }
+        yield { type: "text_delta", text: "Do not revive this output." };
+        await Promise.race([
+          finish.promise,
+          new Promise<void>((resolve) =>
+            request.signal.addEventListener("abort", () => resolve(), { once: true }),
+          ),
+        ]);
+        if (ending === "failure")
+          throw new ModelDriverError("invalid_request", "Fixture provider failure.", {
+            cause: undefined,
+          });
+        yield { type: "finish", reason: "stop" };
+      },
+    };
+    const harness = createInMemorySessionLifecycleHarness();
+    const modelTargets = modelTargetsWithDriver(model);
+    const lifecycle = harness.createLifecycle({
+      workspaceRoot: root,
+      stateRoot: join(root, "state"),
+      modelTargets,
+      [sessionRuntimeNotificationTransform]: {
+        project(notification) {
+          if (notification.event.type === "user_message") user = notification;
+          if (notification.event.type === "model_message_delta") delta = notification;
+          if (
+            !replayed &&
+            (notification.event.type === "session_interrupted" ||
+              notification.event.type === "session_settled") &&
+            delta !== undefined &&
+            user !== undefined
+          ) {
+            replayed = true;
+            return [
+              notification,
+              { ...delta, notificationId: `${delta.notificationId}:late` },
+              { ...user, notificationId: `${user.notificationId}:late` },
+            ];
+          }
+          return [notification];
+        },
+      },
+    });
+    const created = await lifecycle.create({ targetIdentity });
+    const presentation = await createPresentationSession({
+      lifecycle,
+      modelTargets,
+      workspaceRoot: root,
+      stateRoot: join(root, "state"),
+      projectLabel: "terminal",
+      sessionId: created.sessionId,
+      [presentationSessionRecordReader]: async (id) =>
+        (await (await harness.sessions.open(id))?.read()) ?? [],
+    });
+    const unsubscribe = presentation.subscribe(() => {
+      const state = presentation.getState();
+      if (state.transient?.assistant?.text === "Next turn works.") nextLive.resolve();
+      if (state.transient?.assistant?.text === "Do not revive this output.") {
+        live.resolve();
+        if (terminalSeen) revived.push(state.revision);
+      }
+      if (
+        replayed &&
+        state.transient === null &&
+        (state.authoritative.active?.session.status === "settled" ||
+          state.authoritative.active?.session.status === "interrupted")
+      ) {
+        terminalSeen = true;
+        settled.resolve();
+      }
+    });
+    try {
+      expect(
+        await presentation.dispatch({
+          type: "submit_prompt",
+          sessionId: created.sessionId,
+          text: "Start bounded output.",
+          skills: [],
+          thinkingSelection: null,
+        }),
+      ).toMatchObject({ status: "admitted" });
+      await withManagedFailureGuard(live.promise, "live output before terminal event");
+      if (ending === "cancel")
+        expect(
+          await presentation.dispatch({ type: "cancel_run", sessionId: created.sessionId }),
+        ).toMatchObject({ status: "admitted" });
+      else finish.resolve();
+      await withManagedFailureGuard(settled.promise, "terminal presentation state");
+      expect(
+        await presentation.dispatch({
+          type: "submit_prompt",
+          sessionId: created.sessionId,
+          text: "Continue after terminal.",
+          skills: [],
+          thinkingSelection: null,
+        }),
+      ).toMatchObject({ status: "admitted" });
+      await withManagedFailureGuard(nextLive.promise, "next live turn after late notifications");
+      expect(replayed).toBe(true);
+      expect(revived).toEqual([]);
+      expect(presentation.getState().transient?.assistant?.text).not.toBe(
+        "Do not revive this output.",
+      );
+    } finally {
+      finish.resolve();
+      unsubscribe();
+      await presentation.close();
+      await lifecycle.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
Role completion, naming refreshes, and durable transcript read-ahead could drop agent creation choices, leave submission progress visible, or briefly show the same answer twice. Preserve session-local display fields, reload roles at session boundaries, retire live output by durable response identity, and settle each submission route's progress from its receipt.

Add per-call argument completion and failure/cancellation events so Main and Child distinguish generation, waiting for model completion, and response processing without executing partial arguments or changing persisted event formats.

Validation: causal runtime and Presentation regressions, complete-frame Main/Child and role-selection tests, independent review with its read-ahead finding repaired, final local `pnpm quality:check`. Required hosted `quality` must pass on the exact PR head before merge.
