### PR TITLE
test(tui): wait for input receivers before follow-up actions

### DIFF
--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -2273,11 +2273,14 @@ test("production Main permission preempts and restores the exact child composer 
   });
   try {
     await fixture.waitForScreen("Adam · New session");
+    const initialRunOffset = fixture.output().length;
     fixture.write("Start child\r");
     await fixture.waitForScreen("Confirm delegation");
     fixture.write("\r");
     await fixture.waitForScreen("MAIN_READY");
     await waitForFileContents(join(controlRoot, "child-started"), "started\n");
+    // Streaming text and child dispatch do not settle the Main run.
+    await fixture.waitForCompleteFrameAfter("provider reported · idle", initialRunOffset);
     fixture.write("Trigger Main permission\r");
     await waitForFileContents(join(controlRoot, "main-permission-ready"), "ready\n");
     let offset = fixture.output().length;

--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -2271,55 +2271,76 @@ test("production Main permission preempts and restores the exact child composer 
     stateRoot,
     controlRoot,
   });
+  let completed = false;
+  let waiting = "New session";
   try {
     await fixture.waitForScreen("Adam · New session");
     const initialRunOffset = fixture.output().length;
     fixture.write("Start child\r");
+    waiting = "Confirm delegation";
     await fixture.waitForScreen("Confirm delegation");
     fixture.write("\r");
+    waiting = "MAIN_READY";
     await fixture.waitForScreen("MAIN_READY");
+    waiting = "child-started file";
     await waitForFileContents(join(controlRoot, "child-started"), "started\n");
     // Streaming text and child dispatch do not settle the Main run.
+    waiting = "Main idle after initial run";
     await fixture.waitForCompleteFrameAfter("provider reported · idle", initialRunOffset);
     fixture.write("Trigger Main permission\r");
+    waiting = "main-permission-ready file";
     await waitForFileContents(join(controlRoot, "main-permission-ready"), "ready\n");
     let offset = fixture.output().length;
     fixture.write("/agents\r");
+    waiting = "Agents workspace";
     await fixture.waitForCompleteFrameAfter("Agents workspace", offset);
     offset = fixture.output().length;
     fixture.write("\r");
+    waiting = "Conversation";
     await fixture.waitForCompleteFrameAfter("Conversation", offset);
     offset = fixture.output().length;
     fixture.write("\r");
+    waiting = "Child composer";
     await fixture.waitForCompleteFrameAfter("Cooperative", offset);
     offset = fixture.output().length;
     fixture.write("Kept private child draft");
+    waiting = "Child draft rendered";
     await fixture.waitForCompleteFrameAfter("Kept private child draft", offset);
     offset = fixture.output().length;
     await writeFile(join(controlRoot, "release-main-permission"), "release\n");
+    waiting = "Main permission overlay";
     await fixture.waitForCompleteFrameAfter("Permission required", offset);
     expect(fixture.screen()?.join("\n")).toContain("main-permission.txt");
     await expect(stat(join(workspaceRoot, "main-permission.txt"))).rejects.toMatchObject({
       code: "ENOENT",
     });
+    // The title appears while preview loading still leaves Enter on Deny.
+    waiting = "Main permission Allow enabled";
+    await fixture.waitForCompleteFrameAfter("> Allow", offset, "Loading canonical preview…");
     offset = fixture.output().length;
     fixture.write("\r");
+    waiting = "Restore child draft after Main permission";
     await fixture.waitForCompleteFrameAfter(
       "Kept private child draft",
       offset,
       "Permission required",
     );
+    waiting = "main-permission.txt approved file";
     await waitForFileContents(join(workspaceRoot, "main-permission.txt"), "approved\n");
     offset = fixture.output().length;
     fixture.write(" remains");
+    waiting = "Restored child composer editable";
     await fixture.waitForCompleteFrameAfter("Kept private child draft remains", offset);
     for (const visible of ["Enter compose", "Agents workspace", "↓ navigate"]) {
+      waiting = visible;
       offset = fixture.output().length;
       fixture.write("\u001b[27;1:1u\u001b[27;1:2u\u001b[27;1:3u");
       await fixture.waitForCompleteFrameAfter(visible, offset);
     }
+    waiting = "MAIN_RESPONDED";
     await fixture.waitForScreen("MAIN_RESPONDED");
     fixture.write("\u0011");
+    waiting = "PTY process close";
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
     const records = await (
       await createJsonlManagedAgentControlStore({ stateRoot, workspaceRoot })
@@ -2339,7 +2360,12 @@ test("production Main permission preempts and restores the exact child composer 
           : [],
       ),
     ).toEqual(["Start child", "Trigger Main permission"]);
+    completed = true;
   } finally {
+    if (!completed)
+      console.error(
+        `Permission routing failure while waiting for ${waiting}:\n${fixture.screen()?.join("\n")}`,
+      );
     await fixture.cleanup();
     await rm(testRoot, { recursive: true, force: true });
   }

--- a/apps/tui/src/tui-filesystem.test-support.ts
+++ b/apps/tui/src/tui-filesystem.test-support.ts
@@ -4,7 +4,8 @@ import { join } from "node:path";
 import { observeFilesystemEffect } from "./filesystem-observation.test-support.js";
 import { cleanupActiveTuiFixtures } from "./tui-fixture.test-support.js";
 
-const missingFilesystemEffectFailureMilliseconds = 30_000;
+// Keep missing-effect diagnostics inside the runner deadline, like frame observations.
+const missingFilesystemEffectFailureMilliseconds = 10_000;
 
 export async function removeTuiFixtureRoot(
   path: string,

--- a/apps/tui/src/uir-state-lifecycle.test.ts
+++ b/apps/tui/src/uir-state-lifecycle.test.ts
@@ -118,6 +118,7 @@ test("selecting another session clears the old role catalog and reloads the dest
   try {
     expect(h.presentation.getState().agentRoles?.map((role) => role.name)).toContain("Original");
     await writeFile(roleFile, definition("Destination"));
+    const createOffset = h.terminal.output().length;
     expect(
       await h.presentation.dispatch({
         type: "create_session",
@@ -127,7 +128,8 @@ test("selecting another session clears the old role catalog and reloads the dest
     expect(h.presentation.getState().agentRoles?.map((role) => role.name)).not.toContain(
       "Original",
     );
-    await h.press("\x1b", "New session draft");
+    await h.terminal.waitForFrameAfter("Select a project session", createOffset);
+    await h.press("\x1b", "New session draft", "Select a project session");
     await h.press("@Destination", "New agent · Destination evidence.");
     await h.press("\t", "@Destination");
     await h.press(" Inspect evidence.\r", "Delegation");


### PR DESCRIPTION
Two UI tests could send input before its receiver was ready. The session-switch test accepted draft text still visible behind the picker. The permission-routing test treated streamed Main output as run completion and the permission title as proof that its canonical preview had enabled Allow.

Require a complete frame with the picker absent after Esc, a fresh Main idle frame before the second prompt, and enabled Allow after preview loading before approving. Preserve the permission, independent-draft, and durable-input assertions. Add phase/screen failure diagnostics and let the filesystem observation guard report the missing effect before the unchanged runner deadline.

Controlled provider-finish and canonical-preview holds reproduced the busy rejection and unintended denial respectively. Validation includes exact cases, owning suites, related concurrent cases, independent review, and final local `pnpm quality:check`.
