### PR TITLE
fix(tui): keep Fleet eligibility independent of preview

### DIFF
--- a/apps/tui/src/agent-fleet.test.ts
+++ b/apps/tui/src/agent-fleet.test.ts
@@ -1936,7 +1936,7 @@ test("40×12 child composer visibly distinguishes Accepted from Delivered across
 });
 
 test.each([false, true])(
-  "Fleet reconciles expired selection and retains the open viewer row (viewer=%s)",
+  "Fleet expires selection independently of the open viewer and mode refresh (viewer=%s)",
   async (openViewer) => {
     const firstFinish = Promise.withResolvers<void>();
     const started = Promise.withResolvers<void>();
@@ -1993,7 +1993,12 @@ test.each([false, true])(
       ).toMatchObject({ status: "admitted" });
       await started.promise;
       await h.press("\u001b[B", "Fleet");
-      await h.press("\u001b[B", "● @explore-1");
+      const inputOffset = h.terminal.output().length;
+      h.terminal.input("\u001b[B");
+      // Pi's input frame must run on the next-tick path without waiting for a render timer.
+      await new Promise<void>((resolve) => process.nextTick(resolve));
+      expect(h.terminal.output().slice(inputOffset)).toContain("@explore-1");
+      expect(h.terminal.lines().join("\n")).toContain("● @explore-1");
       if (openViewer) await h.press("\r", "Conversation");
       const first = h.presentation.getState().authoritative.managedControl?.threads[0];
       if (first === undefined) throw new Error("Missing selected thread");
@@ -2018,7 +2023,9 @@ test.each([false, true])(
         return lines.slice(lines.findIndex((line) => line.startsWith("Fleet"))).join("\n");
       };
       if (openViewer) {
-        expect(fleet()).toContain("● @explore-1");
+        expect(fleet()).not.toContain("@explore-1");
+        await h.press("m", "Conversation");
+        expect(fleet()).not.toContain("@explore-1");
         await h.press("\u001b[27u", "● Main");
       }
       expect(fleet()).toContain("● Main");

--- a/apps/tui/src/agent-widget.test.ts
+++ b/apps/tui/src/agent-widget.test.ts
@@ -295,3 +295,60 @@ test.each([
     widget.dispose();
   }
 });
+
+test("Widget animation redraws while linger expiration separately changes membership", () => {
+  const timers = new Map<object, { milliseconds: number; fire: () => void }>();
+  let animations = 0;
+  let changes = 0;
+  const widget = new AgentWidget(createAdamTuiTheme(true), () => 12, {
+    scheduler: {
+      schedule(milliseconds, fire) {
+        const key = {};
+        timers.set(key, { milliseconds, fire });
+        return {
+          cancel() {
+            timers.delete(key);
+          },
+        };
+      },
+    },
+    onAnimation: () => {
+      animations += 1;
+    },
+    onChange: () => {
+      changes += 1;
+    },
+  });
+  const thread = agentViewThread();
+  const snapshot: ManagedWorkspaceSnapshot = {
+    parentSessionId: "parent",
+    revision: 1,
+    status: "ready",
+    completions: [],
+    threads: [thread],
+  };
+  try {
+    widget.setSnapshot(snapshot);
+    const before = widget.render(80);
+    const animation = [...timers.values()].find((timer) => timer.milliseconds === 80);
+    expect(animation).toBeDefined();
+    animation?.fire();
+    expect(widget.render(80)).not.toEqual(before);
+    expect(animations).toBe(1);
+    expect(changes).toBe(0);
+    widget.setSnapshot({
+      ...snapshot,
+      threads: [{ ...thread, turn: { ...thread.turn, phase: "idle", label: "Completed" } }],
+    });
+    expect(widget.visibleThreads()).toHaveLength(1);
+    const linger = [...timers.values()].find((timer) => timer.milliseconds === 4000);
+    expect(linger).toBeDefined();
+    linger?.fire();
+    expect(widget.visibleThreads()).toHaveLength(0);
+    expect(widget.render(80)).toEqual([]);
+    expect(changes).toBe(1);
+    expect([...timers.values()]).toEqual([]);
+  } finally {
+    widget.dispose();
+  }
+});

--- a/apps/tui/src/agent-widget.ts
+++ b/apps/tui/src/agent-widget.ts
@@ -49,6 +49,7 @@ export class AgentWidget implements Component {
       readonly settings?: () => AgentUiSettings;
       readonly scheduler?: DeadlineScheduler;
       readonly onChange?: () => void;
+      readonly onAnimation?: () => void;
     } = {},
   ) {}
   setSnapshot(snapshot: ManagedWorkspaceSnapshot | undefined): void {
@@ -102,7 +103,7 @@ export class AgentWidget implements Component {
       this.#animation = undefined;
       if (this.#disposed) return;
       this.#frame = (this.#frame + 1) % 10;
-      this.options.onChange?.();
+      this.options.onAnimation?.();
       this.synchronizeAnimation();
     });
   }

--- a/apps/tui/src/responsiveness.os.test.ts
+++ b/apps/tui/src/responsiveness.os.test.ts
@@ -305,8 +305,36 @@ test("ordinary production keeps representative history, Todo and two unfinished 
     await terminal.waitForScreen("Main responsiveness ready.");
     await awaitEveReceipt(
       childrenStarted.promise,
-      "Both real child providers must reach their unfinished argument boundary.",
+      "Both real child providers must start before observing their argument boundaries.",
     );
+    const argumentsReady = Promise.withResolvers<void>();
+    const observeArguments = () => {
+      const state = presentation.getState();
+      const threads = state.authoritative.managedControl?.threads ?? [];
+      if (
+        threads.length === 2 &&
+        threads.every((thread) =>
+          state.managedAgentActivity?.some(
+            (activity) =>
+              activity.agentId === thread.threadId &&
+              activity.attemptId === thread.turn.attemptId &&
+              activity.tool?.name === "read_file" &&
+              activity.tool.status === "generating_arguments",
+          ),
+        )
+      )
+        argumentsReady.resolve();
+    };
+    const unsubscribeArguments = presentation.subscribe(observeArguments);
+    try {
+      observeArguments();
+      await awaitEveReceipt(
+        argumentsReady.promise,
+        "Both exact child attempts must publish unfinished read_file arguments.",
+      );
+    } finally {
+      unsubscribeArguments();
+    }
     expect(childRequests).toBe(2);
     for (let index = 0; index < 5; index++) {
       await press("todos", "/todos\r", "Todos · revision 4");
@@ -317,8 +345,18 @@ test("ordinary production keeps representative history, Todo and two unfinished 
       await press("agentsClose", "\u001b[27;1;27~", "Fleet", "Agents workspace");
       await press("fleet", "\u001b[B", "● Main");
       await press("childSelect", "\u001b[B", "● @explore-1");
-      await press("childOpen", "\r", "Generating arguments · read_file");
-      expect(presentation.getState().managedAgentActivity?.[0]?.tool).toMatchObject({
+      await press("childOpen", "\r", "Conversation · @explore-1");
+      const state = presentation.getState();
+      const selected = state.authoritative.managedControl?.threads.find(
+        (thread) => thread.handle === "@explore-1",
+      );
+      expect(
+        state.managedAgentActivity?.find(
+          (activity) =>
+            activity.agentId === selected?.threadId &&
+            activity.attemptId === selected?.turn.attemptId,
+        )?.tool,
+      ).toMatchObject({
         name: "read_file",
         status: "generating_arguments",
       });

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -358,6 +358,20 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         registry: commandRegistry,
       }),
     );
+    // Fleet input belongs to the focused editor route so Pi schedules its immediate input frame.
+    const handleEditorInput = created.handleInput.bind(created);
+    created.handleInput = (data) => {
+      if (
+        permission === undefined &&
+        created.focused &&
+        focusedCloseableOverlay() === undefined &&
+        terminalSizeIsSupported(physicalTerminal.columns, physicalTerminal.rows) &&
+        options.presentation.getState().agentUiSettings?.fleetEnabled !== false &&
+        agentFleet.handleMainInput(data, created.getText() === "")
+      )
+        return;
+      handleEditorInput(data);
+    };
     created.setStructuredCompletion(structuredEditorCompletion);
     for (const prompt of authoritativePromptHistory(active)) {
       created.addToHistory(prompt);
@@ -461,6 +475,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     {
       scheduler: deadlineScheduler,
       onChange: () => renderState(),
+      onAnimation: () => tui.requestRender(),
       settings: () => options.presentation.getState().agentUiSettings ?? defaultAgentUiSettings,
     },
   );
@@ -1588,16 +1603,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
     synchronizeTodoCompactOverlay(active);
     agentWidget.setSnapshot(state.authoritative.managedControl);
     agentWidget.setActivity(state.managedAgentActivity);
-    const visibleFleetThreads = [...agentWidget.visibleThreads()];
-    const viewingThread = state.authoritative.managedControl?.threads.find(
-      (thread) => thread.threadId === agentConversation?.threadId,
-    );
-    if (
-      viewingThread !== undefined &&
-      !visibleFleetThreads.some((thread) => thread.threadId === viewingThread.threadId)
-    )
-      visibleFleetThreads.push(viewingThread);
-    agentFleet.setSnapshot(state.authoritative.managedControl, visibleFleetThreads);
+    agentFleet.setSnapshot(state.authoritative.managedControl, agentWidget.visibleThreads());
     if (state.authoritative.managedControl !== undefined)
       agentWorkspace?.workspace.setSnapshot(
         state.authoritative.managedControl,
@@ -6873,16 +6879,6 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       (isKeyRepeat(data) || isKeyRelease(data))
     )
       return { consume: true };
-    if (
-      permission === undefined &&
-      editor.focused &&
-      focusedCloseableOverlay() === undefined &&
-      terminalSizeIsSupported(physicalTerminal.columns, physicalTerminal.rows) &&
-      options.presentation.getState().agentUiSettings?.fleetEnabled !== false &&
-      agentFleet.handleMainInput(data, editor.getText() === "")
-    ) {
-      return { consume: true };
-    }
     if (
       !terminalSizeIsSupported(physicalTerminal.columns, physicalTerminal.rows) &&
       !commandRegistry.matchesInput(data, "interrupt")


### PR DESCRIPTION
## Changes

Expired completed agents stay out of Fleet when their conversation remains open or its Markdown mode changes. Fleet selection falls back to Main through the existing eligibility projection, independently of viewer identity.

Route Fleet navigation through the focused editor so Pi schedules its immediate input frame. Separate Widget animation redraws from lifecycle reconciliation while retaining completed-display expiry.

## Validation

Independent specification/engineering review passed. The focused Fleet, Widget, navigation and saturated-stream group passed 61 tests; PTY Fleet and representative responsiveness passed 15 tests. Regressions reproduce expired viewer membership and the original delayed input route, and distinguish animation from linger membership updates. Final full `pnpm quality:check` passed: 2,412 tests, eighteen existing opt-in skips, plus code, Markdown, TypeScript and browser checks.

The first hosted run exposed an existing responsiveness-test race: provider entry did not establish both child argument boundaries, and activity index zero did not identify the selected thread. A controlled delayed second provider reproduced the failure. The corrected fixture observes both exact argument states before navigation and waits for the selected conversation overlay. Independent corrective review and final full Quality pass with the same 2,412 tests.
