### PR TITLE
fix(tui): preserve themed agent content and tree structure

### DIFF
--- a/apps/tui/src/agent-conversation-viewer.test.ts
+++ b/apps/tui/src/agent-conversation-viewer.test.ts
@@ -1,3 +1,5 @@
+import type { ManagedAgentTranscriptPageResource } from "@adam-agent/presentation";
+import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
 import { expect, test } from "vitest";
 import { AgentConversationViewer } from "./agent-conversation-viewer.js";
 import { agentViewThread } from "./agent-view.test-support.js";
@@ -9,6 +11,23 @@ test.each([
   ["log", "2026-09-06T00:00:00Z INFO **literal log**", "**literal log**"],
   ["parser failure", `${"> ".repeat(60)}deep evidence`, "> > > > >"],
 ])("viewer retains %s content literally in full Markdown mode", async (_kind, text, literal) => {
+  const viewer = await textViewer(text);
+  try {
+    expect(viewer.render(80).join("\n")).toContain(literal);
+    viewer.handleInput("m");
+    expect(viewer.render(80).join("\n")).toContain("m raw");
+    expect(viewer.render(80).join("\n")).toContain(literal);
+  } finally {
+    viewer.dispose();
+  }
+});
+
+async function textViewer(
+  text: string,
+  noColor = true,
+  maximum = 30,
+  items?: ManagedAgentTranscriptPageResource["items"],
+) {
   const thread = agentViewThread();
   const read = Promise.withResolvers<void>();
   const unexpected = async () => {
@@ -17,8 +36,8 @@ test.each([
   const viewer = new AgentConversationViewer({
     thread,
     drafts: new Map(),
-    theme: createAdamTuiTheme(true),
-    maximumLines: () => 30,
+    theme: createAdamTuiTheme(noColor),
+    maximumLines: () => maximum,
     renderMode: "full",
     onChange: () => read.resolve(),
     onClose() {},
@@ -38,7 +57,7 @@ test.each([
         childSessionId: thread.turn.childSessionId,
         throughSequence: 1,
         olderCursor: null,
-        items: [
+        items: items ?? [
           {
             type: "assistant_message",
             id: "answer",
@@ -52,13 +71,131 @@ test.each([
       };
     },
   });
+  await read.promise;
+  return viewer;
+}
+
+test("mixed assistant Markdown keeps formatted prose beside fenced and bare literal evidence", async () => {
+  const viewer = await textViewer(
+    "# Answer\n\n**strong prose**\n\n```diff\n--- a/a\n+++ b/a\n-**old**\n+**new**\n```\n\n**after code**\n\n2026-09-09T00:00:00Z INFO **literal log**\n\n**after log**",
+    false,
+    60,
+  );
   try {
-    await read.promise;
-    expect(viewer.render(80).join("\n")).toContain(literal);
-    viewer.handleInput("m");
-    expect(viewer.render(80).join("\n")).toContain("m raw");
-    expect(viewer.render(80).join("\n")).toContain(literal);
+    const output = viewer.render(120).join("\n");
+    for (const text of ["strong prose", "after code", "after log"])
+      expect(stripTerminalSequences(output)).toContain(text);
+    expect(output).not.toContain("**strong prose**");
+    expect(output).not.toContain("**after code**");
+    expect(output).not.toContain("**after log**");
+    expect(output).toContain("+**new**");
+    expect(output).toContain("**literal log**");
+    expect(output).toContain("\u001b[1m");
   } finally {
     viewer.dispose();
   }
 });
+
+test.each([40, 80, 120])(
+  "short viewer separates identity, body and actions at %i columns",
+  async (width) => {
+    for (const noColor of [false, true]) {
+      const viewer = await textViewer("Short e\u0301 中 answer.", noColor, 20);
+      try {
+        const rendered = viewer.render(width);
+        const lines = rendered.map((line) => stripTerminalSequences(line).trimEnd());
+        const body = lines.indexOf("Short e\u0301 中 answer.");
+        expect(body).toBeGreaterThan(1);
+        expect(lines[body - 1]).toBe("");
+        expect(lines[body + 1]).toBe("");
+        expect(lines).toHaveLength(7);
+        expect(lines[0]).toContain("Conversation · @explore-1");
+        expect(lines.at(-1)).toContain("Esc back");
+        expect(rendered.every((line) => visibleWidth(line) <= width)).toBe(true);
+        if (noColor) {
+          expect(rendered.join("\n")).not.toContain("\u001b[38;");
+          expect(rendered.join("\n")).not.toContain("\u001b[48;");
+        }
+      } finally {
+        viewer.dispose();
+      }
+    }
+  },
+);
+
+test("viewer read_text reuses numbered syntax highlighting and literal evidence notices", async () => {
+  const viewer = await textViewer("", false, 30, [
+    {
+      type: "tool_call",
+      id: "read",
+      sequence: 1,
+      sourceSessionId: "child-1",
+      branchBoundary: null,
+      callId: "read",
+      qualifiedName: "read_file",
+      kind: "read",
+      effect: "read",
+      label: "read_file",
+      subject: { type: "path", value: "answer.ts" },
+      source: null,
+      durationMs: null,
+      status: "completed",
+      outcome: { status: "completed" },
+      resultSummary: null,
+      artifacts: [],
+      changePreviewRef: null,
+      preview: {
+        kind: "read_text",
+        language: "typescript",
+        lines: [{ number: 23, text: "const answer = '**literal**';" }],
+        omittedBytes: 5,
+        sourceTruncated: true,
+      },
+    },
+  ]);
+  try {
+    const rendered = viewer.render(80).join("\n");
+    const plain = stripTerminalSequences(rendered);
+    expect(plain).toContain("23 │ const answer = '**literal**';");
+    expect(plain).toContain("5 bytes omitted from bounded preview");
+    expect(plain).toContain("tool output truncated at source");
+    expect(rendered).toContain("\u001b[38;2;203;166;247mconst");
+  } finally {
+    viewer.dispose();
+  }
+});
+
+test.each([
+  {
+    source: "#!/bin/sh\nprintf first\n\nprintf '**literal**\\n'",
+    literal: "**literal**",
+    prose: undefined,
+  },
+  {
+    source:
+      "2026-09-09T00:00:00Z INFO **literal**\n```ts\nconst answer = 1;\n```\n**formatted prose**",
+    literal: "**literal**",
+    prose: "formatted prose",
+  },
+  {
+    source:
+      "diff --git a/a b/a\n--- a/a\n+++ b/a\n-**old**\n+**literal**\n# Conclusion\n**formatted prose**",
+    literal: "**literal**",
+    prose: "formatted prose",
+  },
+])(
+  "evidence segmentation preserves blank script lines and adjacent Markdown: $source",
+  async ({ source, literal, prose }) => {
+    const viewer = await textViewer(source, true, 60);
+    try {
+      const output = viewer.render(120).join("\n");
+      expect(output).toContain(literal);
+      if (prose !== undefined) {
+        expect(output).toContain(prose);
+        expect(output).not.toContain(`**${prose}**`);
+      }
+    } finally {
+      viewer.dispose();
+    }
+  },
+);

--- a/apps/tui/src/agent-conversation-viewer.ts
+++ b/apps/tui/src/agent-conversation-viewer.ts
@@ -36,7 +36,12 @@ import {
   truncateToWidth,
   wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
-import { agentElapsedLabel } from "./agent-widget.js";
+import {
+  agentElapsedLabel,
+  agentHeading,
+  agentSelectionRow,
+  agentStatus,
+} from "./agent-view-format.js";
 import { focusedWheelDirection } from "./focused-wheel-input.js";
 import { safeTerminalText } from "./safe-terminal-text.js";
 import { parseTaskBudgetFollowUp } from "./task-budget-input.js";
@@ -879,17 +884,23 @@ export class AgentConversationViewer implements Component {
     if (
       this.#renderMode === "raw" ||
       kind === "literal" ||
-      (kind === "tool" && this.#renderMode !== "full") ||
-      /^(?:diff --git |@@ |--- |\+\+\+ |#!|\$ |\d{4}-\d\d-\d\d[T ])/mu.test(safe)
+      (kind === "tool" && this.#renderMode !== "full")
     )
       return [...wrapTextWithAnsi(safe, width), ...omission];
     let entry = this.#markdown.get(id);
     if (entry === undefined) {
       entry = {
-        component: new Markdown(safe, 0, 0, this.options.theme.markdown, undefined, {
-          preserveOrderedListMarkers: true,
-          preserveBackslashEscapes: true,
-        }),
+        component: new Markdown(
+          protectBareEvidence(safe),
+          0,
+          0,
+          this.options.theme.markdown,
+          undefined,
+          {
+            preserveOrderedListMarkers: true,
+            preserveBackslashEscapes: true,
+          },
+        ),
         text: safe,
         failed: false,
       };
@@ -897,7 +908,7 @@ export class AgentConversationViewer implements Component {
     } else if (entry.text !== safe) {
       if (!safe.startsWith(entry.text)) entry.failed = false;
       entry.text = safe;
-      entry.component.setText(safe);
+      entry.component.setText(protectBareEvidence(safe));
     }
     if (!entry.failed) {
       try {
@@ -989,27 +1000,33 @@ export class AgentConversationViewer implements Component {
     const maximum = this.options.maximumLines();
     if (state.phase === "pending")
       return [
-        "Exporting confirmed fields…",
-        `${state.thread.handle} · ${state.thread.turn.turnId.slice(0, 8)}`,
-        "Esc close",
+        this.options.theme.toolTitle("Exporting confirmed fields…"),
+        this.options.theme.reference(
+          `${state.thread.handle} · ${state.thread.turn.turnId.slice(0, 8)}`,
+        ),
+        this.options.theme.muted("Esc close"),
       ].map((line) => truncateToWidth(line, width));
     if (state.phase === "ready" && state.result !== undefined)
       return [
-        this.options.theme.primary(`Export ready · ${state.thread.handle}`),
-        `${state.result.artifact.byteCount} bytes · JSON`,
-        ...wrapTextWithAnsi(state.result.artifact.id, width),
-        "v open export · Esc back",
+        agentHeading(this.options.theme, "Export ready", state.thread),
+        this.options.theme.muted(`${state.result.artifact.byteCount} bytes · JSON`),
+        ...wrapTextWithAnsi(this.options.theme.text(state.result.artifact.id), width),
+        this.options.theme.muted("v open export · Esc back"),
       ].map((line) => truncateToWidth(line, width));
     if (state.phase === "confirm") {
       const lines = [
-        this.options.theme.primary("Confirm export"),
-        `${state.thread.handle} · turn ${state.thread.turn.turnId.slice(0, 8)}`,
+        this.options.theme.toolTitle("Confirm export"),
+        this.options.theme.reference(
+          `${state.thread.handle} · turn ${state.thread.turn.turnId.slice(0, 8)}`,
+        ),
         ...wrapTextWithAnsi(
           `Fields: ${agentExportFields.filter((field) => state.fields.has(field)).join(", ")}`,
           width,
         ),
-        state.fields.has("reasoning") ? "Reasoning INCLUDED" : "Reasoning excluded",
-        "Enter export · Esc fields",
+        this.options.theme.statusWarning(
+          state.fields.has("reasoning") ? "Reasoning INCLUDED" : "Reasoning excluded",
+        ),
+        this.options.theme.muted("Enter export · Esc fields"),
       ];
       state.confirmRendered = lines.length <= maximum;
       return lines.map((line) => truncateToWidth(line, width));
@@ -1026,14 +1043,20 @@ export class AgentConversationViewer implements Component {
     const visible = agentExportFields.slice(start, start + count);
     state.visible = new Set(visible.map((_, index) => start + index));
     return [
-      this.options.theme.primary(`Export agent · ${state.thread.handle}`),
-      `16 KiB / 32 items · ${agentExportFields.length - visible.length} hidden`,
-      ...visible.map(
-        (field, index) =>
-          `${start + index === state.selected ? "●" : "○"} [${state.fields.has(field) ? "x" : " "}] ${labels[field]}`,
+      agentHeading(this.options.theme, "Export agent", state.thread),
+      this.options.theme.muted(
+        `16 KiB / 32 items · ${agentExportFields.length - visible.length} hidden`,
+      ),
+      ...visible.map((field, index) =>
+        agentSelectionRow(
+          this.options.theme,
+          this.options.theme.text(`[${state.fields.has(field) ? "x" : " "}] ${labels[field]}`),
+          start + index === state.selected,
+          width,
+        ),
       ),
       ...(state.notice ? [safeTerminalText(state.notice)] : []),
-      "Space toggle · Enter review · Esc back",
+      this.options.theme.muted("Space toggle · Enter review · Esc back"),
     ].map((line) => truncateToWidth(line, width));
   }
   private resourceEntries(): readonly AgentConversationResource[] {
@@ -1182,24 +1205,30 @@ export class AgentConversationViewer implements Component {
       const entries = state.entries.slice(start, start + count);
       state.visible = new Set(entries.map((_, index) => start + index));
       return [
-        this.options.theme.primary(
-          `${state.inputOnly ? "Input receipts" : "Conversation resources"} · ${state.thread.handle}`,
+        agentHeading(
+          this.options.theme,
+          state.inputOnly ? "Input receipts" : "Conversation resources",
+          state.thread,
         ),
-        ...entries.map(
-          (entry, index) =>
-            `${start + index === state.selected ? "●" : "○"} ${safeTerminalText(entry.label)}`,
+        ...entries.map((entry, index) =>
+          agentSelectionRow(
+            this.options.theme,
+            this.options.theme.text(safeTerminalText(entry.label)),
+            start + index === state.selected,
+            width,
+          ),
         ),
         ...(entries.length === 0 ? ["No resources on this transcript page."] : []),
         ...(start > 0 || start + entries.length < state.entries.length
           ? [`↑ ${start} hidden · ↓ ${state.entries.length - start - entries.length} hidden`]
           : []),
         ...(state.notice ? [safeTerminalText(state.notice)] : []),
-        "Enter open · Esc conversation",
+        this.options.theme.muted("Enter open · Esc conversation"),
       ].map((line) => truncateToWidth(line, width));
     }
     const entry = state.entries[state.selected];
     const page = state.page;
-    const body = wrapTextWithAnsi(safeTerminalText(page.text), width);
+    const body = wrapTextWithAnsi(this.options.theme.text(safeTerminalText(page.text)), width);
     const footer = [
       ...(entry?.kind === "input" &&
       state.thread.turn.turnId === this.#thread.turn.turnId &&
@@ -1215,10 +1244,10 @@ export class AgentConversationViewer implements Component {
     state.maximumScroll = Math.max(0, body.length - height);
     state.scroll = Math.min(state.scroll, state.maximumScroll);
     return [
-      this.options.theme.primary(
-        `${entry?.kind === "reasoning" ? "Reasoning" : entry?.kind === "tool" ? "Tool" : entry?.kind === "input" ? "Input" : "Artifact"} page · ${state.thread.handle} · literal`,
+      `${agentHeading(this.options.theme, `${entry?.kind === "reasoning" ? "Reasoning" : entry?.kind === "tool" ? "Tool" : entry?.kind === "input" ? "Input" : "Artifact"} page`, state.thread)}${this.options.theme.muted(" · literal")}`,
+      this.options.theme.muted(
+        `Bytes ${page.offset}-${page.offset + page.byteCount} of ${page.totalByteCount}`,
       ),
-      `Bytes ${page.offset}-${page.offset + page.byteCount} of ${page.totalByteCount}`,
       ...body.slice(state.scroll, state.scroll + height),
       ...footer,
     ].map((line) => truncateToWidth(line, width));
@@ -1232,6 +1261,7 @@ export class AgentConversationViewer implements Component {
         "d: exact agent details · Ctrl+D: discard retained draft",
         "t: confirm retarget to the current turn",
         "x x: cancel the exact turn",
+        "e: export a completed turn · s: suppress its pending Main delivery",
         "v: bounded resources · i: exact input receipts",
         "m: raw/assistant/full Markdown",
         "Home/End: scroll start/follow tail",
@@ -1243,9 +1273,9 @@ export class AgentConversationViewer implements Component {
       this.#helpMaximumScroll = Math.max(0, lines.length - height);
       this.#helpScroll = Math.min(this.#helpScroll, this.#helpMaximumScroll);
       return [
-        this.options.theme.primary("Conversation help"),
-        ...lines.slice(this.#helpScroll, this.#helpScroll + height),
-        "↑↓ / wheel scroll · Esc conversation",
+        this.options.theme.toolTitle("Conversation help"),
+        ...lines.slice(this.#helpScroll, this.#helpScroll + height).map(this.options.theme.text),
+        this.options.theme.muted("↑↓ / wheel scroll · Esc conversation"),
       ].map((line) => truncateToWidth(line, width));
     }
     const completion = this.#completion;
@@ -1297,11 +1327,14 @@ export class AgentConversationViewer implements Component {
         ? undefined
         : toolArgumentPhaseLabel(this.#activity.tool.status);
     const header = [
-      this.options.theme.primary(`Conversation · ${thread.handle} · ${thread.displayName}`),
-      safeTerminalText(thread.description),
-      `${thread.turn.label}${agentElapsedLabel(thread)}`,
+      `${agentHeading(this.options.theme, "Conversation", thread)} · ${this.options.theme.muted(safeTerminalText(thread.displayName))}`,
+      `${agentStatus(this.options.theme, thread)}${completion === undefined || width >= 60 ? this.options.theme.muted(agentElapsedLabel(thread)) : ""}${completion === undefined ? "" : this.options.theme.muted(` · ${completion.userSeen ? "Seen" : "Unseen"} · Main ${completion.consumption}`)}`,
       ...(argumentPhase !== undefined && this.#activity?.tool !== undefined
-        ? [`${argumentPhase} · ${safeTerminalText(this.#activity.tool.name)}`]
+        ? [
+            this.options.theme.toolTitle(
+              `${argumentPhase} · ${safeTerminalText(this.#activity.tool.name)}`,
+            ),
+          ]
         : []),
       ...(thread.turn.diagnostic === undefined
         ? []
@@ -1311,25 +1344,15 @@ export class AgentConversationViewer implements Component {
         : wrapTextWithAnsi(safeTerminalText(thread.turn.attention.question), width)),
     ];
     const footer = [
-      ...(completion === undefined
-        ? []
-        : [
-            `${completion.userSeen ? "Seen" : "Unseen"} · Main ${completion.consumption}`,
-            ...(!this.#composing ? ["e export"] : []),
-          ]),
       ...(this.#suppressTarget !== undefined
         ? [
             "Suppress from Main? s confirm · Esc cancel",
             "Skip automatic delivery of this completion.",
           ]
-        : completion?.consumption === "pending" && !this.#composing
-          ? ["s Suppress from Main"]
-          : []),
+        : []),
       ...(this.#cancelTarget === undefined
-        ? !this.#composing && thread.actions?.includes("cancel")
-          ? ["x x cancel"]
-          : []
-        : [`x again to cancel ${thread.handle}`]),
+        ? []
+        : [this.options.theme.statusWarning(`x again to cancel ${thread.handle}`)]),
       ...(this.#retargetPending
         ? ["Retarget draft to the current turn? Enter confirm · Esc cancel"]
         : []),
@@ -1341,7 +1364,7 @@ export class AgentConversationViewer implements Component {
       `${this.#followTail ? "Following tail" : "Manual scroll · End tail"} · m ${this.#renderMode === "raw" ? "raw" : `${this.#renderMode} Markdown`}`,
       ...(olderCursor === null ? [] : ["PgUp at top: older transcript page"]),
       ...(this.#newerCursors.length === 0 ? [] : ["PgDown at bottom: newer page · End latest"]),
-      ...(this.#notice ? [safeTerminalText(this.#notice)] : []),
+      ...(this.#notice ? [this.options.theme.statusWarning(safeTerminalText(this.#notice))] : []),
       ...(liveOmittedBytes > 0 ? [`Live preview · ${liveOmittedBytes} bytes omitted`] : []),
       ...(this.resourceEntries().length > 0 ? ["v resources · i input receipts"] : []),
       ...(() => {
@@ -1380,30 +1403,34 @@ export class AgentConversationViewer implements Component {
         return this.textLines(item.id, item.text ?? "Assistant output in artifact", width);
       if (item.type === "tool_call") {
         const lines = wrapTextWithAnsi(
-          safeTerminalText(
-            `Tool · ${item.label} · ${item.status}${item.resultSummary === null ? "" : ` · ${item.resultSummary}`}`,
-          ),
+          `${this.options.theme.toolTitle(safeTerminalText(`Tool · ${item.label}`))} · ${this.options.theme.muted(safeTerminalText(item.status))}${item.resultSummary === null ? "" : ` · ${this.options.theme.text(safeTerminalText(item.resultSummary))}`}`,
           width,
         );
-        if (item.preview?.kind === "read_text") {
+        if (
+          item.preview?.kind === "read_text" &&
+          this.#renderMode === "full" &&
+          (item.preview.language === null ||
+            item.preview.language === "text" ||
+            item.preview.language === "markdown")
+        ) {
           const preview = item.preview;
           lines.push(
             ...this.textLines(
               `${item.id}:result`,
               preview.lines.map((line) => line.text).join("\n"),
               width,
-              preview.language === null ||
-                preview.language === "text" ||
-                preview.language === "markdown"
-                ? "tool"
-                : "literal",
+              "tool",
             ),
           );
           if (preview.omittedBytes > 0)
-            lines.push(`… ${preview.omittedBytes} bytes omitted · v resources`);
-          if (preview.sourceTruncated) lines.push("Tool output truncated at source");
-        } else if (item.preview !== null)
+            lines.push(
+              this.options.theme.muted(`… ${preview.omittedBytes} bytes omitted · v resources`),
+            );
+          if (preview.sourceTruncated)
+            lines.push(this.options.theme.muted("Tool output truncated at source"));
+        } else if (item.preview !== null) {
           lines.push(...new ToolPreview(item.preview, true, this.options.theme).render(width));
+        }
         return lines;
       }
       if (item.type === "reasoning_block") return [`Reasoning · ${item.status}`];
@@ -1420,6 +1447,7 @@ export class AgentConversationViewer implements Component {
     const maximum = this.options.maximumLines();
     if (this.#details) {
       const details = [
+        this.options.theme.text(safeTerminalText(thread.description)),
         ...header.slice(1),
         ...configurationDetails,
         `Role: ${thread.role}`,
@@ -1427,12 +1455,12 @@ export class AgentConversationViewer implements Component {
         `Turn: ${thread.turn.turnId}`,
         `Attempt: ${thread.turn.attemptId}`,
         ...(config === undefined ? [] : [`Configuration: ${config.digest}`]),
-      ].flatMap((line) => wrapTextWithAnsi(safeTerminalText(line), width));
+      ].flatMap((line) => wrapTextWithAnsi(line, width));
       const height = Math.max(1, maximum - 2);
       this.#detailMaximumScroll = Math.max(0, details.length - height);
       this.#detailScroll = Math.min(this.#detailScroll, this.#detailMaximumScroll);
       return [
-        this.options.theme.primary(`Conversation details · ${thread.handle}`),
+        agentHeading(this.options.theme, "Conversation details", thread),
         ...details.slice(this.#detailScroll, this.#detailScroll + height),
         `↑↓ scroll · ${details.length - Math.min(height, details.length)} hidden · Esc back`,
       ].map((line) => truncateToWidth(line, width));
@@ -1494,21 +1522,83 @@ export class AgentConversationViewer implements Component {
         Math.max(0, footer.length - essential.length) +
         Math.max(0, compactBody.length - this.#bodyHeight);
       return [
-        this.options.theme.primary(`Conversation · ${thread.handle}`),
+        agentHeading(this.options.theme, "Conversation", thread),
         `${this.#followTail ? "Tail" : "Manual · End tail"} · d details · ? help · ${hidden} lines hidden · m ${this.#renderMode}`,
         ...compactBody.slice(this.#scrollOffset, this.#scrollOffset + this.#bodyHeight),
         ...essential,
       ].map((line) => truncateToWidth(line, width));
     }
-    this.#bodyHeight = Math.max(1, this.options.maximumLines() - header.length - footer.length);
+    const separated = maximum >= header.length + footer.length + 3;
+    this.#bodyHeight = Math.max(1, maximum - header.length - footer.length - (separated ? 2 : 0));
     this.#maximumScroll = Math.max(0, body.length - this.#bodyHeight);
     this.#scrollOffset = this.#followTail
       ? this.#maximumScroll
       : Math.min(this.#scrollOffset, this.#maximumScroll);
     return [
       ...header,
+      ...(separated ? [""] : []),
       ...body.slice(this.#scrollOffset, this.#scrollOffset + this.#bodyHeight),
-      ...footer,
+      ...(separated ? [""] : []),
+      ...footer.map(this.options.theme.muted),
     ].map((line) => truncateToWidth(line, width));
   }
+}
+
+/** Keep unfenced evidence blocks literal without disabling Markdown elsewhere in the answer. */
+function protectBareEvidence(text: string): string {
+  const lines = text.split("\n");
+  const result: string[] = [];
+  let fence: { character: string; length: number } | undefined;
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    const marker = /^ {0,3}(`{3,}|~{3,})(.*)$/u.exec(line);
+    if (fence !== undefined) {
+      result.push(line);
+      if (
+        marker?.[1]?.[0] === fence.character &&
+        marker[1].length >= fence.length &&
+        marker[2]?.trim() === ""
+      )
+        fence = undefined;
+      continue;
+    }
+    if (marker?.[1] !== undefined) {
+      fence = { character: marker[1][0] ?? "`", length: marker[1].length };
+      result.push(line);
+      continue;
+    }
+    if (!/^(?:diff --git |@@ |--- |\+\+\+ |#!|\$ |\d{4}-\d\d-\d\d[T ])/u.test(line)) {
+      result.push(line);
+      continue;
+    }
+    const kind = /^(?:#!|\$ )/u.test(line) ? "shell" : /^\d{4}-/u.test(line) ? "log" : "diff";
+    const literal = [line];
+    while (index + 1 < lines.length) {
+      const next = lines[index + 1] ?? "";
+      if (/^ {0,3}(?:`{3,}|~{3,})/u.test(next)) break;
+      if (kind === "shell") {
+        // Blank lines are valid source. Explicit Markdown starts a new section after a blank.
+        if (literal.at(-1)?.trim() === "" && /^(?:#{1,6}\s|(?:\*\*|__)\S)/u.test(next)) break;
+      } else if (kind === "log") {
+        if (!/^(?:\d{4}-\d\d-\d\d[T ]|[ \t]+\S|at )/u.test(next)) break;
+      } else if (
+        !/^(?:[ +\-\\]|@@|diff --git |index |(?:new|deleted) file mode |(?:old|new) mode |(?:dis)?similarity index |(?:rename|copy) (?:from|to) |$)/u.test(
+          next,
+        )
+      )
+        break;
+      literal.push(next);
+      index += 1;
+    }
+    const delimiter = "~".repeat(
+      Math.max(
+        3,
+        ...literal.flatMap((entry) =>
+          [...entry.matchAll(/~+/gu)].map((match) => match[0].length + 1),
+        ),
+      ),
+    );
+    result.push(`${delimiter}text`, ...literal, delimiter);
+  }
+  return result.join("\n");
 }

--- a/apps/tui/src/agent-delegation.test.ts
+++ b/apps/tui/src/agent-delegation.test.ts
@@ -72,7 +72,7 @@ test("direct delegation reviews finite execution and token bounds before one exa
     await h.press("\x1b[B\x1b[B\x1b[B\x1b[B\x1b[B\r", "Enter apply");
     await h.press("\x01\x0bNamed evidence work\r", "Description updated.");
     expect(requests).toHaveLength(0);
-    await h.press("\r", "@explore-1 · Explore · Completed");
+    await h.press("\r", "@explore-1 · Completed · Explore");
     expect(requests).toHaveLength(1);
     const admission = (await h.store.read()).find((record) => record.event.type === "admitted");
     expect(admission?.event).toMatchObject({
@@ -144,7 +144,7 @@ test("a Main model delegation uses the exact editable grant in its pending permi
     expect(
       (await h.store.read()).filter((record) => record.event.type === "admitted"),
     ).toHaveLength(0);
-    await h.press("\r", "@explore-1 · Explore · Completed");
+    await h.press("\r", "@explore-1 · Completed · Explore");
     const admission = (await h.store.read()).find((record) => record.event.type === "admitted");
     expect(admission?.event).toMatchObject({
       context: { mode: "task" },
@@ -286,7 +286,7 @@ test.each([
         await h.press("\x1b[A\r", "Context updated.");
       }
       expect(requests).toHaveLength(0);
-      await h.press("\r", "@explore-1 · Explore · Completed");
+      await h.press("\r", "@explore-1 · Completed · Explore");
       expect(requests).toHaveLength(1);
       const text = JSON.stringify(requests[0]?.messages);
       if (choice === "keep") expect(text).toContain("REQUESTED CHILD SKILL BODY");

--- a/apps/tui/src/agent-fleet.os.test.ts
+++ b/apps/tui/src/agent-fleet.os.test.ts
@@ -41,7 +41,7 @@ test("owner-private child draft survives a cold TUI and Lifecycle rebuild separa
       }),
     ).toMatchObject({ status: "admitted" });
     await started.promise;
-    await h.terminal.waitForScreen("@explore-1 · Explore · Running");
+    await h.terminal.waitForScreen("@explore-1 · Running · Explore");
     await h.openFirstAgent();
     await h.press("\r", "Cooperative");
     await h.press("Child draft survives restart.", "Child draft survives restart.");
@@ -248,8 +248,8 @@ test("Agents settings persist privately and Reset restores concrete defaults wit
     expect((await stat(path)).mode & 0o777).toBe(0o600);
     expect(h.presentation.getState().authoritative).toEqual(before);
     await h.press("\u001b", "Fleet fixture", "Agent settings");
-    await h.press("/agents settings\r", "● Widget · off");
-    await h.press("\u001b[F", "● Reset defaults");
+    await h.press("/agents settings\r", "> Widget · off");
+    await h.press("\u001b[F", "> Reset defaults");
     await h.press("\r", "Defaults restored");
     expect(JSON.parse(await readFile(path, "utf8"))).toEqual({
       schemaVersion: 1,

--- a/apps/tui/src/agent-fleet.test-support.ts
+++ b/apps/tui/src/agent-fleet.test-support.ts
@@ -318,8 +318,8 @@ export async function startManagedTui(
     },
     async openFirstAgent(handle = "@explore-1") {
       await terminal.waitForScreen("Fleet");
-      await press("\u001b[B", "● Main");
-      await press("\u001b[B", `● ${handle}`);
+      await press("\u001b[B", "> Main");
+      await press("\u001b[B", `> ${handle}`);
       await press("\r", `Conversation · ${handle}`);
     },
     press,

--- a/apps/tui/src/agent-fleet.test.ts
+++ b/apps/tui/src/agent-fleet.test.ts
@@ -157,7 +157,7 @@ test.each([40, 80, 120])(
       expect(childCalls).toBe(0);
       await h.press("\r", "Batch admitted; Main ready.");
       await prepared.promise;
-      await h.terminal.waitForScreen("⎿ Starting");
+      await h.terminal.waitForScreen("└─ Starting");
       const screen = h.terminal.lines().join("\n");
       const lines = h.terminal.lines().map((line) => line.trim());
       // The physical terminal exposes the continuation cell after each wide character.
@@ -521,7 +521,7 @@ test("ConversationViewer follows live output, preserves manual scroll, and survi
       }),
     ).toMatchObject({ status: "admitted" });
     await started.promise;
-    await h.terminal.waitForScreen("@explore-1 · Explore · Running");
+    await h.terminal.waitForScreen("@explore-1 · Running · Explore");
     await h.openFirstAgent();
     expect(h.conversationText()).toContain("First live line.");
     await h.press("d", "Conversation details");
@@ -748,7 +748,7 @@ test("live transcript elision is counted separately from the bounded Markdown co
       }),
     ).toMatchObject({ status: "admitted" });
     await started.promise;
-    await h.terminal.waitForScreen("@explore-1 · Explore · Running");
+    await h.terminal.waitForScreen("@explore-1 · Running · Explore");
     await h.openFirstAgent();
     expect(h.presentation.getState().managedAgentActivity?.[0]?.assistant).toMatchObject({
       totalByteCount: 20000,
@@ -820,7 +820,7 @@ test("child permission preempts and restores the exact independent composer with
       }),
     ).toMatchObject({ status: "admitted" });
     await started.promise;
-    await h.terminal.waitForScreen("@explore-1 · Explore · Running");
+    await h.terminal.waitForScreen("@explore-1 · Running · Explore");
     await h.openFirstAgent();
     await h.press("\r", "Cooperative");
     await h.press("Kept child draft", "Kept child draft");
@@ -884,7 +884,7 @@ test("viewer x x cancels the exact turn only on two presses and retains unknown 
       }),
     ).toMatchObject({ status: "admitted" });
     await started.promise;
-    await h.terminal.waitForScreen("@explore-1 · Explore · Running");
+    await h.terminal.waitForScreen("@explore-1 · Running · Explore");
     await h.openFirstAgent();
     await h.press("\u001b[120;1:1u", "x again to cancel");
     h.terminal.input("\u001b[120;1:2u\u001b[120;1:3u");
@@ -1247,7 +1247,10 @@ test("Widget retains elapsed and optional model while details expose current usa
       },
     });
     await started.promise;
-    await h.terminal.waitForScreen("elapsed");
+    await h.terminal.waitForScreen("@explore-1 · Running");
+    expect(
+      h.terminal.lines().find((line) => line.includes("└─") && line.includes("Timed child")),
+    ).toMatch(/\d+s\s*$/u);
     await h.press("/agents settings\r", "Agent settings");
     await h.press("\u001b[B\u001b[B\r", "Model/thinking · shown");
     await h.press("\u001b", "thinking default");
@@ -1808,8 +1811,9 @@ test("a queued cancellation keeps per-thread export available without creating a
     await h.press("x", "x again to cancel");
     await h.press("x", "Cancelled");
     await h.press("\r", "Enter result / export");
-    await h.press("\r", "e export");
-    expect(h.terminal.lines().join("\n")).toContain("e export");
+    await h.press("\r", "Conversation · @explore-9");
+    await h.press("?", "e: export");
+    await h.press("\u001b", "Conversation · @explore-9");
     await h.press("e", "Export agent");
     await h.press("\r", "Confirm export");
     await h.press("\r", "Export ready");
@@ -1998,7 +2002,7 @@ test.each([false, true])(
       // Pi's input frame must run on the next-tick path without waiting for a render timer.
       await new Promise<void>((resolve) => process.nextTick(resolve));
       expect(h.terminal.output().slice(inputOffset)).toContain("@explore-1");
-      expect(h.terminal.lines().join("\n")).toContain("● @explore-1");
+      expect(h.terminal.lines().join("\n")).toContain("> @explore-1");
       if (openViewer) await h.press("\r", "Conversation");
       const first = h.presentation.getState().authoritative.managedControl?.threads[0];
       if (first === undefined) throw new Error("Missing selected thread");
@@ -2026,9 +2030,9 @@ test.each([false, true])(
         expect(fleet()).not.toContain("@explore-1");
         await h.press("m", "Conversation");
         expect(fleet()).not.toContain("@explore-1");
-        await h.press("\u001b[27u", "● Main");
+        await h.press("\u001b[27u", "> Main");
       }
-      expect(fleet()).toContain("● Main");
+      expect(fleet()).toContain("> Main");
       expect(fleet()).not.toContain("@explore-1");
       expect(fleet()).toContain("@explore-2");
       await h.press("\r", "Fleet · ↓ navigate");

--- a/apps/tui/src/agent-fleet.ts
+++ b/apps/tui/src/agent-fleet.ts
@@ -20,9 +20,16 @@ import {
   matchesKey,
   SelectList,
   truncateToWidth,
+  visibleWidth,
   wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
-import { agentElapsedLabel } from "./agent-widget.js";
+import {
+  agentElapsedLabel,
+  agentHeading,
+  agentSelectionRow,
+  agentStatus,
+  agentTimedLine,
+} from "./agent-view-format.js";
 import { focusedWheelDirection } from "./focused-wheel-input.js";
 import { safeTerminalText } from "./safe-terminal-text.js";
 import type { AdamTuiTheme } from "./theme.js";
@@ -107,11 +114,18 @@ export class AgentFleet implements Component {
     const rows = this.rows();
     if (rows.length === 0) return [];
     const maximum = this.options.maximumLines?.() ?? 7;
+    const theme = this.options.theme;
     const entries = [
-      { id: null, text: "Main" },
+      { id: null, text: theme.text("Main"), identity: "Main" },
       ...rows.map((thread) => ({
         id: thread.threadId,
-        text: `${thread.handle} · ${safeTerminalText(thread.displayName)} · ${thread.turn.label}${agentElapsedLabel(thread)} · ${safeTerminalText(thread.description)}${this.drafts.get(thread.threadId)?.text || this.options.hasDraft?.(thread) ? ` · Draft to ${thread.handle}` : ""}`,
+        identity: thread.handle,
+        text: agentTimedLine(
+          theme,
+          `${theme.reference(safeTerminalText(thread.handle))} · ${agentStatus(theme, thread)}${width >= 72 ? ` · ${theme.muted(safeTerminalText(thread.displayName))}` : ""} · ${theme.text(safeTerminalText(thread.description))}${this.drafts.get(thread.threadId)?.text || this.options.hasDraft?.(thread) ? theme.muted(` · Draft to ${thread.handle}`) : ""}`,
+          thread,
+          Math.max(0, width - 2),
+        ),
       })),
     ];
     const selectedIndex = Math.max(
@@ -121,11 +135,14 @@ export class AgentFleet implements Component {
     if (maximum === 1) {
       const entry = entries[this.#active ? selectedIndex : 0];
       this.#visibleIds = new Set([entry?.id ?? null]);
+      const line = truncateToWidth(
+        `${(this.#active ? theme.toolTitle : theme.muted)("Fleet")} ${this.#active ? theme.toolTitle(">") : " "} ${theme.reference(entry?.identity ?? "Main")} · ${theme.muted(`+${entries.length - 1} · ${this.#active ? "Enter/Esc" : "↓ navigate"}`)}`,
+        width,
+      );
       return [
-        truncateToWidth(
-          `Fleet ${this.#active ? "●" : "○"} ${entry?.text.split(" · ")[0] ?? "Main"} · +${entries.length - 1} · ${this.#active ? "Enter/Esc" : "↓ navigate"}`,
-          width,
-        ),
+        this.#active
+          ? theme.selectionBackground(line + " ".repeat(Math.max(0, width - visibleWidth(line))))
+          : line,
       ];
     }
     const body = Math.max(1, maximum - 1);
@@ -133,12 +150,12 @@ export class AgentFleet implements Component {
     const visible = entries.slice(start, start + body);
     const below = entries.length - start - visible.length;
     this.#visibleIds = new Set(visible.map((entry) => entry.id));
+    const overflow = `${start ? ` · ${start} above` : ""}${below ? ` · ${below} below` : ""}`;
+    const hint = this.#active ? (width < 60 ? "Enter/Esc" : "Enter open · Esc Main") : "↓ navigate";
     return [
-      this.options.theme.muted(
-        `${this.#active ? "Fleet · Enter open · Esc Main" : "Fleet · ↓ navigate"}${start ? ` · ↑${start}` : ""}${below ? ` · ↓${below}` : ""}`,
-      ),
-      ...visible.map(
-        (entry) => `${this.#active && this.#selected === entry.id ? "●" : "○"} ${entry.text}`,
+      (this.#active ? theme.toolTitle : theme.muted)(`Fleet · ${hint}${overflow}`),
+      ...visible.map((entry) =>
+        agentSelectionRow(theme, entry.text, this.#active && this.#selected === entry.id, width),
       ),
     ].map((line) => truncateToWidth(line, width));
   }
@@ -582,9 +599,9 @@ export class AgentWorkspace implements Component {
       this.#helpMaximumScroll = Math.max(0, lines.length - height);
       this.#helpScroll = Math.min(this.#helpScroll, this.#helpMaximumScroll);
       return [
-        this.options.theme.primary("Agents help"),
+        this.options.theme.toolTitle("Agents help"),
         ...lines.slice(this.#helpScroll, this.#helpScroll + height),
-        "↑↓ / wheel scroll · Esc back",
+        this.options.theme.muted("↑↓ / wheel scroll · Esc back"),
       ].map((line) => truncateToWidth(line, width));
     }
     if (this.#settingsOpen) {
@@ -603,12 +620,23 @@ export class AgentWorkspace implements Component {
         entries.slice(start, start + maximum).map((_, index) => start + index),
       );
       return [
-        this.options.theme.primary("Agent settings"),
+        this.options.theme.toolTitle("Agent settings"),
         ...entries
           .slice(start, start + maximum)
-          .map((entry, index) => `${start + index === this.#settingIndex ? "●" : "○"} ${entry}`),
-        this.#pending ? "Saving…" : this.#notice || "User-local display preferences",
-        `↑↓ select · Enter change · Esc close${entries.length > maximum ? ` · ${entries.length - Math.min(maximum, entries.length)} hidden` : ""}`,
+          .map((entry, index) =>
+            agentSelectionRow(
+              this.options.theme,
+              this.options.theme.text(entry),
+              start + index === this.#settingIndex,
+              width,
+            ),
+          ),
+        this.options.theme.muted(
+          this.#pending ? "Saving…" : this.#notice || "User-local display preferences",
+        ),
+        this.options.theme.muted(
+          `↑↓ select · Enter change · Esc close${entries.length > maximum ? ` · ${entries.length - Math.min(maximum, entries.length)} hidden` : ""}`,
+        ),
       ].map((line) => truncateToWidth(line, width));
     }
     const thread = this.rows().find((entry) => this.key(entry) === this.#selected);
@@ -617,14 +645,16 @@ export class AgentWorkspace implements Component {
       const config = thread.turn.configuration;
       const budget = thread.budget;
       lines.push(
-        this.options.theme.primary(`Agent details · ${thread.handle} · ${thread.displayName}`),
-        safeTerminalText(thread.description),
-        `${thread.turn.label}${agentElapsedLabel(thread)}`,
+        agentHeading(this.options.theme, "Agent details", thread),
+        this.options.theme.text(safeTerminalText(thread.description)),
+        `${agentStatus(this.options.theme, thread)}${this.options.theme.muted(agentElapsedLabel(thread))}`,
       );
       if (config !== undefined)
         lines.push(
-          `${safeTerminalText(config.targetId)} · thinking ${safeTerminalText(config.thinking)}`,
-          `${config.contextWindowTokens ?? "unknown"} context tokens`,
+          this.options.theme.muted(
+            `${safeTerminalText(config.targetId)} · thinking ${safeTerminalText(config.thinking)}`,
+          ),
+          this.options.theme.muted(`${config.contextWindowTokens ?? "unknown"} context tokens`),
         );
       if (budget !== undefined)
         lines.push(
@@ -632,12 +662,14 @@ export class AgentWorkspace implements Component {
           `${budget.unknownReserved} unknown · ${budget.available === null ? "no cumulative budget" : `${budget.available} available`}`,
         );
       if (thread.turn.diagnostic !== undefined)
-        lines.push(safeTerminalText(thread.turn.diagnostic));
+        lines.push(this.options.theme.statusWarning(safeTerminalText(thread.turn.diagnostic)));
       if (thread.turn.attention?.question !== undefined)
-        lines.push(safeTerminalText(thread.turn.attention.question));
+        lines.push(
+          this.options.theme.statusWarning(safeTerminalText(thread.turn.attention.question)),
+        );
       if (thread.turn.outcome !== undefined) {
         if (!thread.turn.hasStarted) lines.push("No agent session was started.");
-        lines.push(safeTerminalText(thread.turn.outcome.summary));
+        lines.push(this.options.theme.text(safeTerminalText(thread.turn.outcome.summary)));
       }
       lines.push(
         `Role: ${thread.role}`,
@@ -667,7 +699,9 @@ export class AgentWorkspace implements Component {
         0,
         lines.length,
         title,
-        `↑↓ detail · ${Math.max(0, details.length - height)} lines hidden`,
+        this.options.theme.muted(
+          `↑↓ detail · ${Math.max(0, details.length - height)} lines hidden`,
+        ),
         ...details.slice(this.#detailScroll, this.#detailScroll + height),
         `${thread.turn.hasStarted ? "Enter conversation · " : thread.turn.outcome !== undefined ? "Enter result / export · " : ""}${thread.actions?.includes("cancel") ? "x x cancel · " : ""}Esc list`,
       );
@@ -695,10 +729,12 @@ export class AgentWorkspace implements Component {
           : "Enter open · d details · h history · t types · s settings · ? help · Esc back",
         ...(controls ? [controls] : []),
       ];
+      const separated = this.options.maximumLines() >= 12;
       const maximum = Math.max(
         1,
         this.options.maximumLines() -
           2 -
+          (separated ? 2 : 0) -
           hints.length -
           Number(this.#armed !== undefined || Boolean(this.#notice)),
       );
@@ -710,21 +746,40 @@ export class AgentWorkspace implements Component {
       const visible = threads.slice(start, start + maximum);
       this.#visibleIds = new Set(visible.map((entry) => this.key(entry)));
       lines.push(
-        this.options.theme.primary(
+        this.options.theme.toolTitle(
           `${this.#history ? "Agents history" : "Agents workspace"} · ${threads.length} ${this.#history ? "turns" : "threads"}`,
         ),
       );
-      lines.push(...hints);
+      if (separated) lines.push("");
       lines.push(
-        ...visible.map(
-          (entry) =>
-            `${this.key(entry) === this.#selected ? "●" : "○"} ${entry.handle} · ${width < 48 ? `${entry.turn.label.split(" · ")[0]} · ${safeTerminalText(entry.description)}` : `${safeTerminalText(entry.displayName)} · ${safeTerminalText(entry.description)} · ${entry.turn.label}`}${agentElapsedLabel(entry)}${entry.lifecycle === "closed" ? " · Closed" : ""}${this.options.hasDraft?.(entry) ? ` · Draft to ${entry.handle}` : ""}`,
+        ...visible.map((entry) =>
+          agentSelectionRow(
+            this.options.theme,
+            agentTimedLine(
+              this.options.theme,
+              `${this.options.theme.reference(safeTerminalText(entry.handle))} · ${agentStatus(this.options.theme, entry)}${width >= 72 ? ` · ${this.options.theme.muted(safeTerminalText(entry.displayName))}` : ""} · ${this.options.theme.text(safeTerminalText(entry.description))}${entry.lifecycle === "closed" ? this.options.theme.muted(" · Closed") : ""}${this.options.hasDraft?.(entry) ? this.options.theme.muted(` · Draft to ${entry.handle}`) : ""}`,
+              entry,
+              Math.max(0, width - 2),
+            ),
+            this.key(entry) === this.#selected,
+            width,
+          ),
         ),
       );
       if (start > 0 || start + visible.length < threads.length)
-        lines.push(`↑ ${start} hidden · ↓ ${threads.length - start - visible.length} hidden`);
+        lines.push(
+          this.options.theme.muted(
+            `${start} above · ${threads.length - start - visible.length} below`,
+          ),
+        );
       if (threads.length === 0)
-        lines.push(this.#snapshot.diagnostic ?? "No agents in this Session.");
+        lines.push(
+          this.options.theme.muted(
+            safeTerminalText(this.#snapshot.diagnostic ?? "No agents in this Session."),
+          ),
+        );
+      if (separated) lines.push("");
+      lines.push(...hints.map(this.options.theme.muted));
     }
     if (this.#armed !== undefined)
       lines.push(
@@ -784,7 +839,7 @@ export class AgentSessionTransition implements Component {
   }
   render(width: number): string[] {
     return [
-      this.options.theme.primary("Switch Session"),
+      this.options.theme.toolTitle("Switch Session"),
       `${this.options.transition.runningCount} running · ${this.options.transition.queuedCount} queued`,
       ...(this.#pending === undefined
         ? this.#list.render(width)
@@ -794,7 +849,7 @@ export class AgentSessionTransition implements Component {
               : "Suspending queued and settling running agents…",
           ]),
       ...(this.#notice ? wrapTextWithAnsi(this.#notice, width) : []),
-      "Enter choose · Esc stay",
+      this.options.theme.muted("Enter choose · Esc stay"),
     ].map((line) => truncateToWidth(line, width));
   }
 }

--- a/apps/tui/src/agent-input.test.ts
+++ b/apps/tui/src/agent-input.test.ts
@@ -53,7 +53,7 @@ test("actual child Enter accepts one exact input, delivers at the read boundary,
       }),
     ).toMatchObject({ status: "admitted" });
     await started.promise;
-    await h.terminal.waitForScreen("@explore-1 · Explore · Running");
+    await h.terminal.waitForScreen("@explore-1 · Running · Explore");
     await h.openFirstAgent();
     await h.press("\r", "To @explore-1");
     await h.press("Use this exact later evidence.", "Use this exact later evidence.");
@@ -129,7 +129,7 @@ test.each(["cooperative", "interrupt"] as const)(
         }),
       ).toMatchObject({ status: "admitted" });
       await started.promise;
-      await h.terminal.waitForScreen("@explore-1 · Explore · Running");
+      await h.terminal.waitForScreen("@explore-1 · Running · Explore");
       await h.openFirstAgent();
       await h.press("\r", "Cooperative");
       if (mode === "interrupt") await h.press("\t", "Interrupt after current effect");
@@ -246,7 +246,7 @@ test("a retained child draft rejects after another turn starts without rebinding
       }),
     ).toMatchObject({ status: "admitted" });
     await started.promise;
-    await h.terminal.waitForScreen("@explore-1 · Explore · Running");
+    await h.terminal.waitForScreen("@explore-1 · Running · Explore");
     await h.openFirstAgent();
     await h.press("\r", "Cooperative");
     await h.press("Draft for the first turn only.", "Draft for the first turn only.");
@@ -271,7 +271,7 @@ test("a retained child draft rejects after another turn starts without rebinding
       }),
     ).toMatchObject({ status: "admitted", control: { status: "accepted" } });
     await secondStarted.promise;
-    await h.terminal.waitForFrameAfter("@explore-1 · Explore · Running", before);
+    await h.terminal.waitForFrameAfter("@explore-1 · Running · Explore", before);
     await h.press("\u001b[B\r", "Conversation");
     await h.press("\r", "Draft for the first turn only.");
     await h.press("\r", "The selected turn changed.");
@@ -341,7 +341,7 @@ test.each(["wait", "suspend"] as const)(
       expect(h.presentation.getState().authoritative.managedControl?.threads[8]?.turn.phase).toBe(
         "queued",
       );
-      await h.terminal.waitForScreen("@explore-1 · Explore · Running");
+      await h.terminal.waitForScreen("@explore-1 · Running · Explore");
       await h.openFirstAgent();
       await h.press("\r", "Cooperative");
       await h.press("Only the source child draft.", "Only the source child draft.");
@@ -416,7 +416,7 @@ test("two deliberate Enter submissions with identical text admit two distinct ch
       }),
     ).toMatchObject({ status: "admitted" });
     await started.promise;
-    await h.terminal.waitForScreen("@explore-1 · Explore · Running");
+    await h.terminal.waitForScreen("@explore-1 · Running · Explore");
     await h.openFirstAgent();
     await h.press("\r", "Cooperative");
     await h.press("Check again.", "Check again.");
@@ -481,7 +481,7 @@ test("late durable acceptance cannot clear a draft explicitly retargeted to a ne
       }),
     ).toMatchObject({ status: "admitted" });
     await started.promise;
-    await h.terminal.waitForScreen("@explore-1 · Explore · Running");
+    await h.terminal.waitForScreen("@explore-1 · Running · Explore");
     await h.openFirstAgent();
     await h.press("\r", "Cooperative");
     await h.press("Still the intended draft.", "Still the intended draft.");

--- a/apps/tui/src/agent-navigation.os.test.ts
+++ b/apps/tui/src/agent-navigation.os.test.ts
@@ -27,13 +27,13 @@ test("production child viewer wheel preserves manual tail control and the indepe
       await fixture.waitForCompleteFrameAfter(expected, offset, absentText);
     };
     const openViewer = async () => {
-      await press("\u001b[B", "● Main");
-      await press("\u001b[B", "● @explore-1");
+      await press("\u001b[B", "> Main");
+      await press("\u001b[B", "> @explore-1");
       await press("\r", "Child-live-49");
     };
     const closeViewer = async () => {
       await press("\u001b[27;1;27~", "Fleet", "Conversation ·");
-      await press("\u001b[27;1;27~", "Fleet", "● @explore-1");
+      await press("\u001b[27;1;27~", "Fleet", "> @explore-1");
     };
     const mainViewport = () => fixture.screen()?.filter((line) => line.includes("Main-evidence-"));
     await fixture.waitForScreen("Adam · New session");

--- a/apps/tui/src/agent-role-input.test.ts
+++ b/apps/tui/src/agent-role-input.test.ts
@@ -80,7 +80,7 @@ test("direct delegation reads only its explicitly attached immutable resource", 
     ).toMatchObject({ status: "admitted" });
     await h.press("\r", "Delegation");
     await h.press("\r", "Input accepted for @explore-1");
-    await h.terminal.waitForScreen("○ @explore-1 · Explore · Completed");
+    await h.terminal.waitForScreen("  @explore-1 · Completed · Explore");
     expect(requests).toHaveLength(4);
     expect(JSON.stringify(requests[3]?.messages)).toContain("EXPLICIT LATER ATTACHMENT");
     const sessionId = h.presentation.getState().authoritative.active?.session.id;
@@ -176,7 +176,7 @@ test("model delegation links only an exact explicitly selected parent attachment
       });
     await h.press(" Delegate one selected artifact.\r", "Delegation");
     await h.press("\r", "Parent delegated one artifact.");
-    await h.terminal.waitForScreen("○ @explore-1 · Explore · Completed");
+    await h.terminal.waitForScreen("  @explore-1 · Completed · Explore");
     expect(children).toHaveLength(2);
     expect(JSON.stringify(children)).toContain("SELECTED IMMUTABLE BODY");
     expect(JSON.stringify(children)).not.toContain("unselected.txt");
@@ -234,7 +234,7 @@ test("direct role and exact-thread messages preserve folded pasted evidence", as
       ).toBe(true);
       await h.press("\r", "Delegation");
       await h.press("\r", mention === "@Explore" ? "Completed" : "Input accepted for @explore-1");
-      await h.terminal.waitForScreen("○ @explore-1 · Explore · Completed");
+      await h.terminal.waitForScreen("  @explore-1 · Completed · Explore");
       expect(h.terminal.lines().join("\n")).not.toContain("Submitting prompt…");
       expect(JSON.stringify(requests.at(-1)?.messages)).toContain(marker);
       expect(h.presentation.getState().composer.renderedText).toBe("");
@@ -303,7 +303,7 @@ test("requested Skill preactivation is atomic and preserves the rest of the chil
         entries: [entry],
       }),
     ).toMatchObject({ status: "admitted" });
-    await h.terminal.waitForScreen("@explore-1 · Explore · Completed");
+    await h.terminal.waitForScreen("@explore-1 · Completed · Explore");
     expect(requests).toHaveLength(2);
     expect(JSON.stringify(requests[0]?.messages)).toContain("REQUESTED SKILL BODY");
     expect(JSON.stringify(requests[0]?.messages)).toContain("skill:v1:project:.:independent");
@@ -341,7 +341,7 @@ test("the direct delegation overlay shares an explicitly selected older message"
     await h.press("\x1b[B\x1b[B\x1b[B\x1b[B\r", "[x] user");
     await h.press("\x1b[A\x1b[A\x1b[A\x1b[A\r", "Context updated.");
     expect(requests).toHaveLength(2);
-    await h.press("\r", "@explore-1 · Explore · Completed");
+    await h.press("\r", "@explore-1 · Completed · Explore");
     expect(requests).toHaveLength(3);
     expect(JSON.stringify(requests[2]?.messages)).toContain("EXPLICIT OLDER CONTEXT");
     expect(JSON.stringify(requests[2]?.messages)).toContain("Inspect this direct task.");
@@ -441,7 +441,7 @@ test("delegation shares only the selected initial context and does not absorb la
     await h.press("LATER MAIN MESSAGE MUST STAY IN MAIN\r", "Main context recorded.");
     await h.terminal.waitForScreen("provider reported · idle");
     release.resolve();
-    await h.terminal.waitForScreen("@explore-3 · Explore · Completed");
+    await h.terminal.waitForScreen("@explore-3 · Completed · Explore");
     expect(requests.map((request) => JSON.stringify(request.messages))).toEqual(texts);
     expect(texts.join("\n")).not.toContain("LATER MAIN MESSAGE");
     const admissions = (await h.store.read()).filter((record) => record.event.type === "admitted");
@@ -521,7 +521,7 @@ test("a lifetime alias restores the exact thread and cannot be rebound after clo
         entries: [entry],
       }),
     ).toMatchObject({ status: "admitted" });
-    await h.terminal.waitForScreen("@explore-1 · Explore · Completed");
+    await h.terminal.waitForScreen("@explore-1 · Completed · Explore");
     const thread = h.presentation.getState().authoritative.managedControl?.threads[0];
     if (thread === undefined) throw new Error("Missing thread.");
     await h.press("@证据", "[Agent] @explore-1 · Alias evidence");
@@ -545,7 +545,7 @@ test("a lifetime alias restores the exact thread and cannot be rebound after clo
     );
     await cold.press("\r", "Delegation");
     await cold.press("\r", "Input accepted for @explore-1");
-    await cold.terminal.waitForScreen("@explore-1 · Explore · Completed");
+    await cold.terminal.waitForScreen("@explore-1 · Completed · Explore");
     const resumedControl = await cold.lifecycle[sessionManagedControl](h.parent.sessionId);
     if (resumedControl === undefined) throw new Error("Missing restored control.");
     const current = (await resumedControl.inspect({ parentSessionId: h.parent.sessionId }))
@@ -613,7 +613,7 @@ test.each(["cooperative", "interrupt"] as const)(
       await h.press("\t", "@Explore");
       await h.press(" Inspect evidence.", "Inspect evidence.");
       await h.press("\r", "Delegation");
-      await h.press("\r", "@explore-1 · Explore · Running");
+      await h.press("\r", "@explore-1 · Running · Explore");
       await h.press("@explore-1", "[Agent] @explore-1 · Inspect evidence.");
       await h.press("\t", "@explore-1");
       await h.press(" Use this explicit later context.", "Use this explicit later context.");
@@ -752,7 +752,7 @@ test("a selected exact handle starts a confirmed new turn in that thread", async
     await h.press("\r", "Delegation");
     expect(requests).toHaveLength(1);
     await h.press("\r", "Input accepted for @explore-1");
-    await h.terminal.waitForScreen("○ @explore-1 · Explore · Completed");
+    await h.terminal.waitForScreen("  @explore-1 · Completed · Explore");
     await h.openFirstAgent();
     await h.terminal.waitForScreen("Exact handle continued.");
     const threads = h.presentation.getState().authoritative.managedControl?.threads;
@@ -830,7 +830,7 @@ test.each(["default", "plan"] as const)(
       await h.press("\x1b", "Inspect this direct request.");
       expect(await h.sessions.listSessionIds()).toEqual(before);
       await h.press("\r", "Delegation");
-      await h.press("\r", "Completed");
+      await h.press("\r", "Completed", "Admitting agent…");
       const active = h.presentation.getState().authoritative.active;
       expect(active?.session.id).toBeDefined();
       expect(active?.session.id).not.toBe(h.parent.sessionId);

--- a/apps/tui/src/agent-types.ts
+++ b/apps/tui/src/agent-types.ts
@@ -15,6 +15,7 @@ import {
   truncateToWidth,
   wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
+import { agentSelectionRow } from "./agent-view-format.js";
 import { safeTerminalText } from "./safe-terminal-text.js";
 import type { AdamTuiTheme } from "./theme.js";
 
@@ -500,12 +501,18 @@ export class AgentTypes implements Component {
       const capacity = Math.max(1, this.options.maximumLines() - 10);
       const start = Math.max(0, this.#selected - capacity + 1);
       content = [
-        "n create · d duplicate · e eject built-in · Space enable/disable · r Reload · ! diagnostics · Esc",
+        this.options.theme.muted(
+          "n create · d duplicate · e eject built-in · Space enable/disable · r Reload · ! diagnostics · Esc",
+        ),
         ...this.#catalog.definitions
           .slice(start, start + capacity)
-          .map(
-            (entry, index) =>
-              `${index + start === this.#selected ? "●" : "○"} ${entry.name} · ${entry.enabled ? (entry.available ? "enabled" : "shadowed") : "disabled"} · ${entry.source?.kind ?? "builtin"}`,
+          .map((entry, index) =>
+            agentSelectionRow(
+              this.options.theme,
+              `${this.options.theme.reference(safeTerminalText(entry.name))} · ${(entry.enabled ? (entry.available ? this.options.theme.statusSuccess : this.options.theme.statusWarning) : this.options.theme.muted)(entry.enabled ? (entry.available ? "enabled" : "shadowed") : "disabled")} · ${this.options.theme.muted(safeTerminalText(entry.source?.kind ?? "builtin"))}`,
+              index + start === this.#selected,
+              width,
+            ),
           ),
         ...(role === undefined
           ? []
@@ -515,10 +522,16 @@ export class AgentTypes implements Component {
               `Tools: ${role.tools.join(", ")}`,
               `Skills: ${role.skills ? "frozen catalog" : "none"} · Web: ${role.web ? "effective Main" : "none"}`,
               `Target: ${role.model ?? "inherit Main"} · ${role.thinking ?? "effective thinking"}`,
-            ]),
+            ].map((line) =>
+              this.options.theme.text(safeTerminalText(line).replace(/[\r\n]/gu, " ")),
+            )),
         ...this.#catalog.diagnostics
           .slice(0, 2)
-          .map((diagnostic) => `! ${diagnostic.source}: ${diagnostic.message}`),
+          .map((diagnostic) =>
+            this.options.theme.statusWarning(
+              safeTerminalText(`! ${diagnostic.source}: ${diagnostic.message}`),
+            ),
+          ),
       ];
     }
     if (this.#step === 11 || this.#diagnostics) {
@@ -543,9 +556,7 @@ export class AgentTypes implements Component {
     }
     return [
       this.options.theme.toolTitle(safeTerminalText(heading)),
-      ...(this.#step === undefined || this.#step === 11
-        ? content.map((line) => safeTerminalText(line).replace(/[\r\n]/gu, " "))
-        : content),
+      ...content,
       this.options.theme.muted(safeTerminalText(this.#pending ? "Saving…" : this.#notice)),
     ].map((line) => truncateToWidth(line, width));
   }

--- a/apps/tui/src/agent-uxr-navigation.test.ts
+++ b/apps/tui/src/agent-uxr-navigation.test.ts
@@ -3,9 +3,10 @@ import type {
   ManagedControlThread,
   ManagedWorkspaceSnapshot,
 } from "@adam-agent/presentation";
+import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
 import { expect, test } from "vitest";
 import { AgentConversationViewer } from "./agent-conversation-viewer.js";
-import { AgentWorkspace } from "./agent-fleet.js";
+import { AgentFleet, AgentWorkspace } from "./agent-fleet.js";
 import { agentViewThread } from "./agent-view.test-support.js";
 import { createAdamTuiTheme } from "./theme.js";
 
@@ -43,14 +44,16 @@ test("d opens exact details without changing list selection; focused wheel and E
   const { view, opened } = workspace(threads);
   view.render(80);
   view.handleInput("\u001b[<65;10;8M");
-  const selected = view.render(80).join("\n");
-  expect(selected).toContain("● @explore-2");
+  const selected = view.render(80).map(stripTerminalSequences).join("\n");
+  expect(selected).toContain("> @explore-2");
   view.handleInput("d");
-  expect(view.render(80).join("\n")).toContain("Agent details · @explore-2");
+  expect(view.render(80).map(stripTerminalSequences).join("\n")).toContain(
+    "Agent details · @explore-2",
+  );
   view.handleInput("\u001b[F");
-  expect(view.render(80).join("\n")).toContain("thread-2");
+  expect(view.render(80).map(stripTerminalSequences).join("\n")).toContain("thread-2");
   view.handleInput("\u001b");
-  expect(view.render(80).join("\n")).toBe(selected);
+  expect(view.render(80).map(stripTerminalSequences).join("\n")).toBe(selected);
   expect(opened).toEqual([]);
 });
 
@@ -82,13 +85,17 @@ test("never-started cancelled turns open an overview and historical started turn
   const { view, opened } = workspace([thread]);
   view.render(80);
   view.handleInput("\r");
-  expect(view.render(80).join("\n")).toContain("Agent details · @explore-1");
+  expect(view.render(80).map(stripTerminalSequences).join("\n")).toContain(
+    "Agent details · @explore-1",
+  );
   expect(opened).toEqual([]);
   view.handleInput("\u001b");
   view.handleInput("h");
   view.render(80);
   view.handleInput("d");
-  expect(view.render(80).join("\n")).toContain("Agent details · @explore-1");
+  expect(view.render(80).map(stripTerminalSequences).join("\n")).toContain(
+    "Agent details · @explore-1",
+  );
   view.handleInput("\u001b");
   view.render(80);
   view.handleInput("\r");
@@ -124,7 +131,10 @@ async function conversation(text = "Retained child draft") {
     isMainCommand: (input) => input === "/agents",
     onChange: () => {
       read.resolve();
-      if (resourceRequested && viewer.render(80).join("\n").includes("Artifact page"))
+      if (
+        resourceRequested &&
+        viewer.render(80).map(stripTerminalSequences).join("\n").includes("Artifact page")
+      )
         resourceRead.resolve();
     },
     onClose() {},
@@ -188,24 +198,26 @@ async function conversation(text = "Retained child draft") {
 test("viewer details retain drafts and wheel pauses tail across details and help", async () => {
   const { viewer, drafts } = await conversation();
   try {
-    const tail = viewer.render(80).join("\n");
+    const tail = viewer.render(80).map(stripTerminalSequences).join("\n");
     expect(tail).toContain("Transcript line 30");
     viewer.handleInput("\u001b[<64;8;9M");
-    const scrolled = viewer.render(80).join("\n");
+    const scrolled = viewer.render(80).map(stripTerminalSequences).join("\n");
     expect(scrolled).not.toContain("Transcript line 30");
     viewer.handleInput("d");
-    expect(viewer.render(80).join("\n")).toContain("Conversation details");
+    expect(viewer.render(80).map(stripTerminalSequences).join("\n")).toContain(
+      "Conversation details",
+    );
     expect(drafts.get("thread-1")?.text).toBe("Retained child draft");
     viewer.handleInput("\u001b");
-    expect(viewer.render(80).join("\n")).toBe(scrolled);
+    expect(viewer.render(80).map(stripTerminalSequences).join("\n")).toBe(scrolled);
     viewer.handleInput("?");
-    expect(viewer.render(80).join("\n")).toContain("Conversation help");
+    expect(viewer.render(80).map(stripTerminalSequences).join("\n")).toContain("Conversation help");
     viewer.handleInput("\u001b");
-    expect(viewer.render(80).join("\n")).toBe(scrolled);
+    expect(viewer.render(80).map(stripTerminalSequences).join("\n")).toBe(scrolled);
     viewer.handleInput("\u001b[<65;8;9M");
-    expect(viewer.render(80).join("\n")).toBe(tail);
+    expect(viewer.render(80).map(stripTerminalSequences).join("\n")).toBe(tail);
     viewer.handleInput("\u0004");
-    expect(viewer.render(80).join("\n")).not.toContain("Draft to");
+    expect(viewer.render(80).map(stripTerminalSequences).join("\n")).not.toContain("Draft to");
     expect(drafts.has("thread-1")).toBe(false);
   } finally {
     viewer.dispose();
@@ -217,14 +229,16 @@ test("viewer Enter rejects a Main command before creating an input receipt and r
   try {
     viewer.handleInput("\r");
     viewer.handleInput("\r");
-    expect(viewer.render(80).join("\n")).toContain(
+    expect(viewer.render(80).map(stripTerminalSequences).join("\n")).toContain(
       "Run this command in Main. Child draft retained.",
     );
     expect(sent).toEqual([]);
     expect(drafts.get("thread-1")).toMatchObject({ text: "/agents" });
     expect(drafts.get("thread-1")).not.toHaveProperty("inputId");
     viewer.handleInput("\u001b");
-    expect(viewer.render(80).join("\n")).toContain("Draft to @explore-1");
+    expect(viewer.render(80).map(stripTerminalSequences).join("\n")).toContain(
+      "Draft to @explore-1",
+    );
   } finally {
     viewer.dispose();
   }
@@ -235,23 +249,149 @@ test("resource focus consumes details/help keys and wheel without changing the c
   try {
     viewer.render(80);
     viewer.handleInput("\u001b[<64;8;9M");
-    const conversationFrame = viewer.render(80).join("\n");
+    const conversationFrame = viewer.render(80).map(stripTerminalSequences).join("\n");
     viewer.handleInput("v");
-    expect(viewer.render(80).join("\n")).toContain("Conversation resources");
+    expect(viewer.render(80).map(stripTerminalSequences).join("\n")).toContain(
+      "Conversation resources",
+    );
     viewer.handleInput("\r");
     await resourceRead;
-    const resourceFrame = viewer.render(80).join("\n");
+    const resourceFrame = viewer.render(80).map(stripTerminalSequences).join("\n");
     expect(resourceFrame).toContain("Resource line 1\n");
     viewer.handleInput("d");
     viewer.handleInput("?");
-    expect(viewer.render(80).join("\n")).toBe(resourceFrame);
+    expect(viewer.render(80).map(stripTerminalSequences).join("\n")).toBe(resourceFrame);
     viewer.handleInput("\u001b[<65;8;9M");
-    expect(viewer.render(80).join("\n")).not.toContain("Resource line 1\n");
+    expect(viewer.render(80).map(stripTerminalSequences).join("\n")).not.toContain(
+      "Resource line 1\n",
+    );
     viewer.handleInput("\u001b");
-    expect(viewer.render(80).join("\n")).toContain("Conversation resources");
+    expect(viewer.render(80).map(stripTerminalSequences).join("\n")).toContain(
+      "Conversation resources",
+    );
     viewer.handleInput("\u001b");
-    expect(viewer.render(80).join("\n")).toBe(conversationFrame);
+    expect(viewer.render(80).map(stripTerminalSequences).join("\n")).toBe(conversationFrame);
   } finally {
     viewer.dispose();
   }
+});
+
+test.each([40, 80, 120])(
+  "Fleet selection uses the current theme and readable overflow at %i columns",
+  (width) => {
+    for (const noColor of [false, true]) {
+      const view = new AgentFleet({
+        theme: createAdamTuiTheme(noColor),
+        onChange() {},
+        onOpen() {},
+        maximumLines: () => 4,
+      });
+      view.setSnapshot({
+        parentSessionId: "parent",
+        revision: 1,
+        status: "ready",
+        completions: [],
+        threads: Array.from({ length: 8 }, (_, index) => agentViewThread(index + 1)),
+      });
+      view.render(width);
+      for (let index = 0; index < 5; index += 1) {
+        view.handleMainInput("\u001b[B", true);
+        view.render(width);
+      }
+      const lines = view.render(width);
+      const plain = lines.map(stripTerminalSequences);
+      expect(plain[0]).toContain("2 above");
+      expect(plain[0]).toContain("4 below");
+      const selected = lines.find((line) =>
+        stripTerminalSequences(line).startsWith("> @explore-4"),
+      );
+      expect(selected).toBeDefined();
+      expect(stripTerminalSequences(selected ?? "")).toContain("Running");
+      expect(visibleWidth(selected ?? "")).toBe(width);
+      expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+      if (noColor) expect(lines.join("\n")).not.toContain("\u001b[");
+      else {
+        expect(selected).toContain("\u001b[48;2;49;50;68m");
+        expect(selected).toContain("\u001b[38;2;137;220;235m@explore-4");
+      }
+    }
+  },
+);
+
+test("truncated Fleet selection keeps its surface through every terminal cell", () => {
+  const thread = agentViewThread();
+  const view = new AgentFleet({ theme: createAdamTuiTheme(false), onChange() {}, onOpen() {} });
+  view.setSnapshot({
+    parentSessionId: "parent",
+    revision: 1,
+    status: "ready",
+    completions: [],
+    threads: [
+      {
+        ...thread,
+        description: "long description ".repeat(10),
+        turn: { ...thread.turn, startedAtUnixMilliseconds: Date.now() - 1000 },
+      },
+    ],
+  });
+  view.render(40);
+  view.handleMainInput("\u001b[B", true);
+  view.render(40);
+  view.handleMainInput("\u001b[B", true);
+  const row = view
+    .render(40)
+    .find((line) => stripTerminalSequences(line).startsWith("> @explore-1"));
+  expect(row).toBeDefined();
+  expect(stripTerminalSequences(row ?? "")).toContain("...");
+  let background = "default";
+  const cells: string[] = [];
+  // Interpret the SGR adapter output, including foreground RGB parameters which may contain zeros.
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: interpret actual terminal SGR sequences in this adapter assertion.
+  for (const token of (row ?? "").split(/(\x1b\[[0-9;]*m)/u)) {
+    if (!token.startsWith("\u001b[")) {
+      cells.push(...Array.from(token, () => background));
+      continue;
+    }
+    const parameters = token.slice(2, -1).split(";").map(Number);
+    for (let index = 0; index < parameters.length; index += 1) {
+      const code = parameters[index];
+      if ((code === 38 || code === 48) && parameters[index + 1] === 2) {
+        if (code === 48) background = parameters.slice(index + 2, index + 5).join(";");
+        index += 4;
+      } else if (code === 0 || code === 49) background = "default";
+    }
+  }
+  expect(cells).toHaveLength(40);
+  expect(new Set(cells)).toEqual(new Set(["49;50;68"]));
+});
+
+test("historical completed outcomes without an end timestamp retain unknown elapsed", () => {
+  const original = agentViewThread();
+  const completed: ManagedControlThread = {
+    ...original,
+    turn: {
+      ...original.turn,
+      phase: "idle",
+      label: "Completed",
+      lastOutcome: "completed",
+      startedAtUnixMilliseconds: 1000,
+      outcome: {
+        type: "outcome",
+        status: "completed",
+        summary: "Historical completion",
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          reasoningTokens: 0,
+          providerCalls: 0,
+          unknownCalls: 0,
+        },
+        transcript: { sequence: 0, digest: `sha256:${"a".repeat(64)}` },
+      },
+    },
+  };
+  const { view } = workspace([completed]);
+  expect(view.render(80).map(stripTerminalSequences).join("\n")).toContain("?s");
+  view.handleInput("d");
+  expect(view.render(80).map(stripTerminalSequences).join("\n")).toContain("elapsed unknown");
 });

--- a/apps/tui/src/agent-view-format.ts
+++ b/apps/tui/src/agent-view-format.ts
@@ -1,0 +1,82 @@
+import type { ManagedControlThread } from "@adam-agent/presentation";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { safeTerminalText } from "./safe-terminal-text.js";
+import type { AdamTuiTheme } from "./theme.js";
+
+export function agentElapsedLabel(thread: ManagedControlThread, compact = false): string {
+  const start = thread.turn.startedAtUnixMilliseconds;
+  if (start === undefined) return "";
+  const end =
+    thread.turn.outcome === undefined
+      ? thread.residency === "live"
+        ? Date.now()
+        : undefined
+      : thread.turn.outcome.atUnixMilliseconds;
+  if (compact)
+    return end === undefined ? "?s" : `${Math.max(0, Math.floor((end - start) / 1000))}s`;
+  return end === undefined
+    ? " · elapsed unknown"
+    : ` · elapsed ${Math.max(0, Math.floor((end - start) / 1000))}s`;
+}
+
+export function agentStatusStyle(
+  theme: AdamTuiTheme,
+  thread: ManagedControlThread,
+): (text: string) => string {
+  const turn = thread.turn;
+  if (turn.outcome?.status === "failed" || (turn.phase === "idle" && turn.lastOutcome === "failed"))
+    return theme.statusError;
+  if (
+    turn.phase === "waiting" ||
+    turn.phase === "queued" ||
+    turn.attention !== undefined ||
+    turn.health === "stalled" ||
+    turn.recovery === "required"
+  )
+    return theme.statusWarning;
+  if (turn.phase === "idle")
+    return turn.lastOutcome === "completed" ? theme.statusSuccess : theme.muted;
+  return theme.reference;
+}
+
+export function agentStatus(theme: AdamTuiTheme, thread: ManagedControlThread): string {
+  return agentStatusStyle(theme, thread)(safeTerminalText(thread.turn.label));
+}
+
+export function agentHeading(
+  theme: AdamTuiTheme,
+  title: string,
+  thread: ManagedControlThread,
+): string {
+  return `${theme.toolTitle(title)} · ${theme.reference(safeTerminalText(thread.handle))}`;
+}
+
+/** Reserve a bounded time field after truncating the descriptive part by display cells. */
+export function agentTimedLine(
+  theme: AdamTuiTheme,
+  content: string,
+  thread: ManagedControlThread,
+  width: number,
+): string {
+  const elapsed = agentElapsedLabel(thread, true);
+  if (!elapsed || width < 24) return truncateToWidth(content, width);
+  const available = Math.max(0, width - visibleWidth(elapsed) - 1);
+  const body = truncateToWidth(content, available);
+  return (
+    body +
+    " ".repeat(Math.max(1, width - visibleWidth(body) - visibleWidth(elapsed))) +
+    theme.muted(elapsed)
+  );
+}
+
+export function agentSelectionRow(
+  theme: AdamTuiTheme,
+  content: string,
+  selected: boolean,
+  width: number,
+): string {
+  const line = truncateToWidth(`${selected ? theme.toolTitle(">") : " "} ${content}`, width);
+  return selected
+    ? theme.selectionBackground(line + " ".repeat(Math.max(0, width - visibleWidth(line))))
+    : line;
+}

--- a/apps/tui/src/agent-widget.test.ts
+++ b/apps/tui/src/agent-widget.test.ts
@@ -111,9 +111,11 @@ test.each([40, 80, 120])(
         ]);
         const lines = widget.render(width);
         const text = stripTerminalSequences(lines.join("\n"));
-        expect(text).toContain("审查 · 核查 e\u0301 证据");
+        if (width >= 80) expect(text).toContain("审查 · 核查 e\u0301 证据");
+        expect(text).toContain("读取 e\u0301 文件");
+        expect(text).toContain("@explore-1");
         expect(text).toContain("Permission required");
-        expect(text).toContain("Queued @explore-2");
+        expect(text).toContain("@explore-2 · Queued");
         expect(text).not.toMatch(/used|reserved|fixture-target|sha256:/u);
         expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
         if (noColor) expect(lines.join("\n").replaceAll("\u001b[0m", "")).toBe(text);
@@ -252,7 +254,7 @@ test.each([2, 3])(
       expect(lines.join("\n")).toContain("1 error");
       expect(lines.join("\n")).not.toContain("running");
       if (maximum === 2) expect(lines[0]).toBe("● Agents 4 · 2 attention · 1 error");
-      else expect(lines[1]).toBe("└─ Failed · Explore · Evidence 4");
+      else expect(lines[1]).toBe("└─ @explore-4 · Failed · Evidence 4");
       expect(lines.every((line) => visibleWidth(line) <= 40)).toBe(true);
     } finally {
       widget.dispose();
@@ -352,3 +354,150 @@ test("Widget animation redraws while linger expiration separately changes member
     widget.dispose();
   }
 });
+
+test.each([false, true])(
+  "Widget preserves literal tree glyphs and connects final visible children (noColor=%s)",
+  (noColor) => {
+    const threads = [agentViewThread(1), agentViewThread(2)];
+    let maximum = 12;
+    const widget = new AgentWidget(createAdamTuiTheme(noColor), () => maximum, {
+      settings: () => ({ ...defaultAgentUiSettings, showModel: true }),
+      scheduler: {
+        schedule() {
+          return { cancel() {} };
+        },
+      },
+    });
+    try {
+      widget.setSnapshot({
+        parentSessionId: "parent",
+        revision: 1,
+        status: "ready",
+        completions: [],
+        threads,
+      });
+      widget.setActivity(
+        threads.map((thread) => ({
+          agentId: thread.threadId,
+          attemptId: thread.turn.attemptId,
+          childSessionId: thread.turn.childSessionId,
+          activity: "replying",
+          assistant: { itemId: "literal", text: "literal tree: ├─ child └─ leaf │ trunk" },
+        })),
+      );
+      const lines = () => widget.render(120).map(stripTerminalSequences);
+      const full = lines();
+      expect(full).toHaveLength(7);
+      expect(full[1]).toMatch(/^├─ /u);
+      expect(full[2]).toBe("│  ├─ literal tree: ├─ child └─ leaf │ trunk");
+      expect(full[3]).toBe("│  └─ fixture-target · thinking default");
+      expect(full[4]).toMatch(/^└─ /u);
+      expect(full[5]).toBe("   ├─ literal tree: ├─ child └─ leaf │ trunk");
+      expect(full[6]).toBe("   └─ fixture-target · thinking default");
+      maximum = 4;
+      const compressed = lines();
+      expect(compressed).toHaveLength(4);
+      expect(compressed[1]).toMatch(/^└─ /u);
+      expect(compressed[2]).toBe("   └─ literal tree: ├─ child └─ leaf │ trunk");
+      expect(compressed[3]).toMatch(/^… /u);
+      maximum = 3;
+      expect(lines()[1]).toMatch(/^└─ /u);
+      expect(lines().some((line) => /^ {3}[├└]/u.test(line))).toBe(false);
+    } finally {
+      widget.dispose();
+    }
+  },
+);
+
+test.each([40, 80, 120])(
+  "Widget recomputes all child branches and queued roots within %i cells",
+  (width) => {
+    for (const noColor of [false, true]) {
+      const first = agentViewThread();
+      let maximum = 7;
+      const widget = new AgentWidget(createAdamTuiTheme(noColor), () => maximum, {
+        settings: () => ({ ...defaultAgentUiSettings, showModel: true }),
+        scheduler: {
+          schedule() {
+            return { cancel() {} };
+          },
+        },
+      });
+      try {
+        widget.setSnapshot({
+          parentSessionId: "parent",
+          revision: 1,
+          status: "ready",
+          completions: [],
+          threads: [
+            {
+              ...first,
+              turn: {
+                ...first.turn,
+                phase: "settling",
+                label: "Settling",
+                lastOutcome: "failed",
+                outcome: {
+                  type: "outcome",
+                  status: "failed",
+                  summary: "Failed",
+                  error: { code: "E", message: "literal │" },
+                  usage: {
+                    inputTokens: 0,
+                    outputTokens: 0,
+                    reasoningTokens: 0,
+                    providerCalls: 0,
+                    unknownCalls: 0,
+                  },
+                  transcript: { sequence: 0, digest: `sha256:${"a".repeat(64)}` },
+                },
+              },
+            },
+            ...[2, 3, 4].map((index) => {
+              const thread = agentViewThread(index);
+              const { hasStarted: _hasStarted, ...turn } = thread.turn;
+              return {
+                ...thread,
+                turn: {
+                  ...turn,
+                  phase: "queued" as const,
+                  label: "Queued",
+                },
+              };
+            }),
+          ],
+        });
+        widget.setActivity([
+          {
+            agentId: first.threadId,
+            attemptId: first.turn.attemptId,
+            childSessionId: first.turn.childSessionId,
+            activity: "replying",
+            assistant: { itemId: "body", text: "├─ └─ │ e\u0301 中" },
+          },
+        ]);
+        const rendered = widget.render(width);
+        const full = rendered.map(stripTerminalSequences);
+        expect(full).toHaveLength(7);
+        expect(full[1]).toMatch(/^├─ /u);
+        expect(full[2]).toBe("│  ├─ Settling · ├─ └─ │ e\u0301 中");
+        expect(full[3]).toBe("│  ├─ E: literal │");
+        expect(full[4]).toBe("│  └─ fixture-target · thinking default");
+        expect(full[5]).toBe("└─ 3 queued · /agents");
+        expect(full[6]).toMatch(/^… /u);
+        expect(rendered.every((line) => visibleWidth(line) <= width)).toBe(true);
+        maximum = 5;
+        const partial = widget.render(width).map(stripTerminalSequences);
+        expect(partial[2]).toBe("│  └─ Settling · ├─ └─ │ e\u0301 中");
+        expect(partial[3]).toBe("└─ 3 queued · /agents");
+        maximum = 4;
+        const parents = widget.render(width).map(stripTerminalSequences);
+        expect(parents[1]).toMatch(/^├─ /u);
+        expect(parents[2]).toBe("└─ 3 queued · /agents");
+        expect(parents.some((line) => /^│ {2}[├└]/u.test(line))).toBe(false);
+      } finally {
+        widget.dispose();
+      }
+    }
+  },
+);

--- a/apps/tui/src/agent-widget.ts
+++ b/apps/tui/src/agent-widget.ts
@@ -5,11 +5,11 @@
  */
 import type {
   AgentUiSettings,
-  ManagedControlThread,
   ManagedWorkspaceSnapshot,
   PresentationDisplayState,
 } from "@adam-agent/presentation";
 import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { agentStatus, agentStatusStyle, agentTimedLine } from "./agent-view-format.js";
 import {
   type DeadlineHandle,
   type DeadlineScheduler,
@@ -18,20 +18,6 @@ import {
 import { safeTerminalText } from "./safe-terminal-text.js";
 import type { AdamTuiTheme } from "./theme.js";
 import { toolArgumentPhaseLabel } from "./tool-argument-phase.js";
-
-export function agentElapsedLabel(thread: ManagedControlThread): string {
-  const start = thread.turn.startedAtUnixMilliseconds;
-  if (start === undefined) return "";
-  const end =
-    thread.turn.outcome === undefined
-      ? thread.residency === "live"
-        ? Date.now()
-        : undefined
-      : thread.turn.outcome.atUnixMilliseconds;
-  return end === undefined
-    ? " · elapsed unknown"
-    : ` · elapsed ${Math.max(0, Math.floor((end - start) / 1000))}s`;
-}
 
 export class AgentWidget implements Component {
   #snapshot: ManagedWorkspaceSnapshot | undefined;
@@ -151,13 +137,15 @@ export class AgentWidget implements Component {
     const attentionCount = threads.filter(needsAttention).length;
     const errorCount = threads.filter(hasError).length;
     const urgentCounts = [
-      ...(attentionCount ? [`${attentionCount} attention`] : []),
-      ...(errorCount ? [`${errorCount} error${errorCount === 1 ? "" : "s"}`] : []),
+      ...(attentionCount ? [this.theme.statusWarning(`${attentionCount} attention`)] : []),
+      ...(errorCount
+        ? [this.theme.statusError(`${errorCount} error${errorCount === 1 ? "" : "s"}`)]
+        : []),
     ];
     const maximum = Math.max(2, this.maximumLines());
     if (maximum === 2 && (waiting.length || settling.length || attentionCount || errorCount)) {
       return [
-        this.theme.primary(
+        this.theme.toolTitle(
           `● Agents ${threads.length}${urgentCounts.length ? ` · ${urgentCounts.join(" · ")}` : ""}`,
         ),
         boundedCountSummary(
@@ -172,19 +160,16 @@ export class AgentWidget implements Component {
         ),
       ].map((line) => truncateToWidth(line, width));
     }
-    const renderThread = (thread: (typeof threads)[number], compressed = false): string[] => {
+    type Node = {
+      readonly head: (columns: number) => string;
+      readonly children: readonly string[];
+    };
+    const threadNode = (thread: (typeof threads)[number], compressed = false): Node => {
       const activity = this.#activity.find(
         (item) => item.agentId === thread.threadId && item.attemptId === thread.turn.attemptId,
       );
       const config = thread.turn.configuration;
       const isQueued = isQueuedThread(thread);
-      const priorityStatus =
-        compressed &&
-        (needsAttention(thread) ||
-          hasError(thread) ||
-          thread.turn.phase === "waiting" ||
-          thread.turn.phase === "settling");
-      const elapsed = agentElapsedLabel(thread);
       const argumentPhase =
         activity?.tool === undefined ? undefined : toolArgumentPhaseLabel(activity.tool.status);
       const content =
@@ -198,36 +183,68 @@ export class AgentWidget implements Component {
         content !== thread.turn.label
           ? `${thread.turn.label} · ${content}`
           : content;
-      return [
-        `├─ ${isQueued ? `${safeTerminalText(thread.turn.label.split(" · ")[0] ?? thread.turn.label)} ${safeTerminalText(thread.handle)} · ` : priorityStatus ? `${safeTerminalText(thread.turn.label)} · ` : thread.turn.phase === "executing" ? `${["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"][this.#frame]} ` : ""}${this.theme.reference(safeTerminalText(thread.displayName))} · ${thread.turn.phase === "idle" && !priorityStatus ? `${safeTerminalText(thread.turn.label)} · ` : ""}${safeTerminalText(thread.description)}${elapsed}`,
-        ...(!isQueued && thread.turn.phase !== "idle"
-          ? [`   ⎿ ${safeTerminalText(visibleContent)}`]
-          : []),
-        ...(thread.turn.outcome?.error === undefined
-          ? []
-          : [
-              `   ⎿ ${safeTerminalText(`${thread.turn.outcome.error.code}: ${thread.turn.outcome.error.message}`)}`,
-            ]),
-        ...(settings?.showModel && config !== undefined
-          ? [
-              `   ${safeTerminalText(config.targetId)} · thinking ${safeTerminalText(config.thinking)}`,
-            ]
-          : []),
-      ];
+      const contentStyle =
+        activity?.tool !== undefined
+          ? this.theme.toolTitle
+          : content === thread.turn.label
+            ? agentStatusStyle(this.theme, thread)
+            : this.theme.text;
+      return {
+        head: (columns) => {
+          const spinner =
+            thread.turn.phase === "executing"
+              ? `${this.theme.reference(["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"][this.#frame] ?? "⠋")} `
+              : "";
+          const status =
+            compressed || isQueued || thread.turn.phase === "idle" || columns < 55
+              ? ` · ${agentStatus(this.theme, thread)}`
+              : "";
+          const role =
+            columns >= 55 ? ` · ${this.theme.muted(safeTerminalText(thread.displayName))}` : "";
+          return agentTimedLine(
+            this.theme,
+            `${spinner}${this.theme.reference(safeTerminalText(thread.handle))}${status}${role} · ${this.theme.text(safeTerminalText(thread.description))}`,
+            thread,
+            columns,
+          );
+        },
+        children: [
+          ...(!isQueued && thread.turn.phase !== "idle"
+            ? [contentStyle(safeTerminalText(visibleContent))]
+            : []),
+          ...(thread.turn.outcome?.error === undefined
+            ? []
+            : [
+                this.theme.statusError(
+                  safeTerminalText(
+                    `${thread.turn.outcome.error.code}: ${thread.turn.outcome.error.message}`,
+                  ),
+                ),
+              ]),
+          ...(settings?.showModel && config !== undefined
+            ? [
+                this.theme.muted(
+                  `${safeTerminalText(config.targetId)} · thinking ${safeTerminalText(config.thinking)}`,
+                ),
+              ]
+            : []),
+        ],
+      };
     };
-    const normal = [...finished, ...active, ...queued].flatMap((thread) => renderThread(thread));
+    const normal = [...finished, ...active, ...queued].map((thread) => threadNode(thread));
+    const normalHeight = normal.reduce((sum, node) => sum + 1 + node.children.length, 0);
     const statusCounts = [
-      `${running.length} running`,
-      ...(waiting.length ? [`${waiting.length} waiting`] : []),
-      ...(settling.length ? [`${settling.length} settling`] : []),
-      `${queued.length} queued`,
+      this.theme.reference(`${running.length} running`),
+      ...(waiting.length ? [this.theme.statusWarning(`${waiting.length} waiting`)] : []),
+      ...(settling.length ? [this.theme.reference(`${settling.length} settling`)] : []),
+      this.theme.statusWarning(`${queued.length} queued`),
     ];
     const lines = [
-      this.theme.primary(
-        `● Agents${normal.length + 1 > maximum ? ` · ${(urgentCounts.length ? urgentCounts : statusCounts).join(" · ")}` : ""}`,
-      ),
+      `${this.theme.toolTitle("● Agents")}${normalHeight + 1 > maximum ? ` · ${(urgentCounts.length ? urgentCounts : statusCounts).join(" · ")}` : ""}`,
     ];
-    if (normal.length + 1 <= maximum) lines.push(...normal);
+    const visible: Node[] = [];
+    let footer: string | undefined;
+    if (normalHeight + 1 <= maximum) visible.push(...normal);
     else {
       const showQueueSummary = queued.length > 0 && maximum > 2;
       let budget = maximum - 2 - Number(showQueueSummary);
@@ -249,13 +266,17 @@ export class AgentWidget implements Component {
           else hiddenRunning += 1;
           continue;
         }
-        const full = renderThread(thread, true);
-        const rendered = full.slice(0, budget);
-        lines.push(...rendered);
-        budget -= rendered.length;
-        hiddenDetails += full.length - rendered.length;
+        const node = threadNode(thread, true);
+        const children = node.children.slice(0, budget - 1);
+        visible.push({ ...node, children });
+        budget -= 1 + children.length;
+        hiddenDetails += node.children.length - children.length;
       }
-      if (showQueueSummary) lines.push(`├─ ${queued.length} queued · /agents`);
+      if (showQueueSummary)
+        visible.push({
+          head: () => this.theme.statusWarning(`${queued.length} queued · /agents`),
+          children: [],
+        });
       const compact = width < 60;
       const hidden = [
         ...(hiddenRunning ? [`${hiddenRunning} ${compact ? "run" : "running"}`] : []),
@@ -265,10 +286,24 @@ export class AgentWidget implements Component {
         ...(hiddenFinished ? [`${hiddenFinished} ${compact ? "done" : "finished"}`] : []),
         ...(hiddenDetails ? [`${hiddenDetails} ${compact ? "line" : "detail lines"}`] : []),
       ];
-      lines.push(compact ? `… hidden ${hidden.join("/")}` : `… ${hidden.join(" / ")} hidden`);
+      footer = this.theme.muted(
+        compact ? `… hidden ${hidden.join("/")}` : `… ${hidden.join(" / ")} hidden · /agents`,
+      );
     }
-    const lastBranch = lines.findLastIndex((line) => line.includes("├─"));
-    if (lastBranch >= 0) lines[lastBranch] = (lines[lastBranch] ?? "").replace("├─", "└─");
+    // The final visible structure owns connectors. Never search or rewrite rendered content.
+    for (const [index, node] of visible.entries()) {
+      const last = index === visible.length - 1;
+      const prefix = last ? "└─ " : "├─ ";
+      lines.push(this.theme.overlay(prefix) + node.head(Math.max(0, width - visibleWidth(prefix))));
+      for (const [childIndex, child] of node.children.entries()) {
+        const childPrefix = `${last ? "   " : "│  "}${childIndex === node.children.length - 1 ? "└─ " : "├─ "}`;
+        lines.push(
+          this.theme.overlay(childPrefix) +
+            truncateToWidth(child, Math.max(0, width - visibleWidth(childPrefix))),
+        );
+      }
+    }
+    if (footer !== undefined) lines.push(footer);
     return lines.map((line) => truncateToWidth(line, width));
   }
 }

--- a/apps/tui/src/production-control.os.test.ts
+++ b/apps/tui/src/production-control.os.test.ts
@@ -124,11 +124,11 @@ test("ordinary production at an intermediate height keeps Agent, Todo, Plan, Att
     terminal.resize(40, 12);
     await terminal.waitForFrameAfter("/help", before);
     for (const [keys, visible, absent] of [
-      ["\u001b[B", "Fleet ● Main", undefined],
-      ["\u001b[B", "Fleet ● @explore-1", undefined],
+      ["\u001b[B", "Fleet > Main", undefined],
+      ["\u001b[B", "Fleet > @explore-1", undefined],
       ["\r", "Conversation · @explore-1", undefined],
       ["\u001b[27;1;27~", "Fleet", "Conversation ·"],
-      ["\u001b[27;1;27~", "Fleet ○ Main", undefined],
+      ["\u001b[27;1;27~", "Fleet   Main", undefined],
       ["Main after child navigation", "Main after child navigation", undefined],
     ] as const) {
       before = terminal.output().length;

--- a/apps/tui/src/responsiveness.os.test.ts
+++ b/apps/tui/src/responsiveness.os.test.ts
@@ -301,7 +301,7 @@ test("ordinary production keeps representative history, Todo and two unfinished 
     await press("permission", "Start two performance children\r", "Confirm delegation");
     expect(childRequests).toBe(0);
     expect(await controlStore.read()).toEqual([]);
-    await press("admission", "\r", "@explore-2 · Explore · Running");
+    await press("admission", "\r", "@explore-2 · Running · Explore");
     await terminal.waitForScreen("Main responsiveness ready.");
     await awaitEveReceipt(
       childrenStarted.promise,
@@ -343,8 +343,8 @@ test("ordinary production keeps representative history, Todo and two unfinished 
       await press("todoClose", "\u001b[27;1;27~", "Main responsiveness ready.", "Todos · revision");
       await press("agents", "/agents\r", "Agents workspace");
       await press("agentsClose", "\u001b[27;1;27~", "Fleet", "Agents workspace");
-      await press("fleet", "\u001b[B", "● Main");
-      await press("childSelect", "\u001b[B", "● @explore-1");
+      await press("fleet", "\u001b[B", "> Main");
+      await press("childSelect", "\u001b[B", "> @explore-1");
       await press("childOpen", "\r", "Conversation · @explore-1");
       const state = presentation.getState();
       const selected = state.authoritative.managedControl?.threads.find(
@@ -361,7 +361,7 @@ test("ordinary production keeps representative history, Todo and two unfinished 
         status: "generating_arguments",
       });
       await press("childBack", "\u001b[27;1;27~", "Fleet", "Conversation ·");
-      await press("fleetClose", "\u001b[27;1;27~", "Fleet", "● @explore-1");
+      await press("fleetClose", "\u001b[27;1;27~", "Fleet", "> @explore-1");
     }
     await press(
       "mainConcurrentEnter",
@@ -374,8 +374,8 @@ test("ordinary production keeps representative history, Todo and two unfinished 
         .authoritative.managedControl?.threads.map((thread) => thread.turn.phase),
     ).toEqual(["executing", "executing"]);
     release.resolve();
-    await terminal.waitForScreen("@explore-1 · Explore · Completed");
-    await terminal.waitForScreen("@explore-2 · Explore · Completed");
+    await terminal.waitForScreen("@explore-1 · Completed · Explore");
+    await terminal.waitForScreen("@explore-2 · Completed · Explore");
     await press("mainEnter", "Final Main response\r", "Final Main response durably accepted.");
     await terminal.waitForScreen(" · idle");
     phase("final durable history");

--- a/apps/tui/src/theme.ts
+++ b/apps/tui/src/theme.ts
@@ -17,6 +17,7 @@ export type AdamTuiTheme = {
   readonly danger: (text: string) => string;
   readonly deny: (text: string) => string;
   readonly editor: EditorTheme;
+  readonly selectionBackground: (text: string) => string;
   readonly inverseSelection: (text: string) => string;
   readonly keyword: (text: string) => string;
   readonly markdown: MarkdownTheme;
@@ -119,6 +120,11 @@ export function createAdamTuiTheme(noColor = noColorRequested()): AdamTuiTheme {
     danger: red,
     allow: green,
     deny: red,
+    // Pi truncation can insert a full reset inside the row; the selection surface must continue.
+    selectionBackground: noColor
+      ? identity
+      : (value) =>
+          `\u001b[48;2;49;50;68m${value.replaceAll("\u001b[0m", "\u001b[0m\u001b[48;2;49;50;68m").replaceAll("\u001b[49m", "\u001b[49m\u001b[48;2;49;50;68m").replaceAll("\u001b[m", "\u001b[m\u001b[48;2;49;50;68m")}\u001b[49m`,
     inverseSelection: (value) => background(205, 214, 244)(crust(value)),
     userText: text,
     userBackground: background(49, 50, 68),

--- a/apps/tui/src/todo-navigator.test.ts
+++ b/apps/tui/src/todo-navigator.test.ts
@@ -31,7 +31,7 @@ test("TodoNavigator renders authoritative counts and opens exact read-only detai
       itemRevision: 2,
       status: "pending",
       title: item.title,
-      details: "Exact detail",
+      details: "# Todo heading\n\n**Exact detail**",
       dependencyIds: ["10000000-0000-4000-8000-000000000002"],
     },
   };
@@ -64,6 +64,8 @@ test("TodoNavigator renders authoritative counts and opens exact read-only detai
   const detailed = navigator.render(80).join("\n");
   expect(detailed).toContain("Todo detail · read-only");
   expect(detailed).toContain("Exact detail");
+  expect(detailed).not.toContain("**Exact detail**");
+  expect(detailed).toContain("\u001b[1m");
   expect(detailed).toContain("10000000-0000-4000-8000-000000000002");
   expect(detailed).toContain("Esc back");
 });

--- a/apps/tui/src/todo-navigator.ts
+++ b/apps/tui/src/todo-navigator.ts
@@ -9,6 +9,7 @@ import {
   getKeybindings,
   isKeyRelease,
   isKeyRepeat,
+  Markdown,
   matchesKey,
   SelectList,
   truncateToWidth,
@@ -38,6 +39,7 @@ export class TodoNavigator implements Component {
   #cursor: string | null = null;
   #compactCollapsed: boolean;
   #detail: TodoEntityResource | null = null;
+  #detailMarkdown: { text: string; component: Markdown } | undefined;
   #generation = 0;
   #list: GroupedTodoList;
   #notice: string | null = null;
@@ -134,14 +136,14 @@ export class TodoNavigator implements Component {
     if (this.#detail !== null) {
       const { item } = this.#detail;
       const bodyLines = [
-        safeTerminalText(item.title),
-        `${item.status} · item revision ${item.itemRevision} · created ${item.createdOrdinal}`,
-        `ID ${item.id}`,
+        this.#theme.text(safeTerminalText(item.title)),
+        `${(item.status === "completed" ? this.#theme.statusSuccess : item.status === "in_progress" ? this.#theme.reference : this.#theme.statusWarning)(item.status)}${this.#theme.muted(` · item revision ${item.itemRevision} · created ${item.createdOrdinal}`)}`,
+        this.#theme.muted(`ID ${item.id}`),
         ...(item.activeForm === undefined ? [] : [`Active: ${safeTerminalText(item.activeForm)}`]),
         "",
         ...(item.details === undefined
           ? [this.#theme.muted("No details.")]
-          : safeTerminalText(item.details).split("\n")),
+          : this.#renderDetails(item.details, width)),
         "",
         item.dependencyIds.length === 0
           ? this.#theme.muted("Dependencies: none")
@@ -174,6 +176,23 @@ export class TodoNavigator implements Component {
     ]
       .slice(0, maximumContentHeight)
       .map((line) => truncateToWidth(line, width));
+  }
+
+  #renderDetails(text: string, width: number): string[] {
+    const safe = safeTerminalText(text);
+    if (this.#detailMarkdown?.text !== safe)
+      this.#detailMarkdown = {
+        text: safe,
+        component: new Markdown(safe, 0, 0, this.#theme.markdown, undefined, {
+          preserveOrderedListMarkers: true,
+          preserveBackslashEscapes: true,
+        }),
+      };
+    try {
+      return this.#detailMarkdown.component.render(Math.max(1, width));
+    } catch {
+      return wrapTextWithAnsi(safe, Math.max(1, width));
+    }
   }
 
   #createList(page: TodoPageResource): GroupedTodoList {

--- a/apps/tui/src/uir-state-lifecycle.test.ts
+++ b/apps/tui/src/uir-state-lifecycle.test.ts
@@ -5,10 +5,12 @@ import { expect, test } from "vitest";
 import { startManagedTui } from "./agent-fleet.test-support.js";
 
 test.each(["Explore", "Research"] as const)(
-  "%s remains selectable and admits a child after Main reasoning, tool, text and naming updates",
+  "%s remains selectable through Main updates, live preview modes, completion and continued Main",
   async (role) => {
     let requests = 0;
     const generated = Promise.withResolvers<void>();
+    const childReady = Promise.withResolvers<void>();
+    const finishChild = Promise.withResolvers<void>();
     const h = await startManagedTui(
       {
         async *stream(request) {
@@ -39,8 +41,17 @@ test.each(["Explore", "Research"] as const)(
           }
           yield {
             type: "text_delta",
-            text: requests === 2 ? "Main inspection complete." : "Role child completed.",
+            text:
+              requests === 2
+                ? "Main inspection complete."
+                : requests === 3
+                  ? "# Child evidence\n\n**Live answer**\n\n```diff\n+literal change\n```"
+                  : "Main continued after child.",
           };
+          if (requests === 3) {
+            childReady.resolve();
+            await finishChild.promise;
+          }
           yield { type: "usage", inputTokens: 100, outputTokens: 20 };
           yield { type: "finish", reason: "stop" };
         },
@@ -73,7 +84,37 @@ test.each(["Explore", "Research"] as const)(
       await h.press(`@${role}`, `New agent · ${role}`);
       await h.press("\t", `@${role}`);
       await h.press(" Inspect the evidence.\r", "Delegation");
-      await h.press("\r", "Completed");
+      const handle = `@${role.toLowerCase()}-1`;
+      await h.press("\r", `${handle} · Running`);
+      await childReady.promise;
+      await h.openFirstAgent(handle);
+      await h.press("m", "m full Markdown");
+      expect(h.conversationText()).toContain("Live answer");
+      expect(h.conversationText()).not.toContain("**Live answer**");
+      expect(h.conversationText()).toContain("+literal change");
+      await h.press("m", "m raw");
+      expect(h.conversationText()).toContain("**Live answer**");
+      await h.press("m", "m assistant Markdown");
+      expect(h.conversationText()).not.toContain("**Live answer**");
+      await h.press("d", "Conversation details");
+      await h.press("\u001b[27u", `Conversation · ${handle}`, "Conversation details");
+      await h.press("\u001b[27u", "Fleet", "Conversation ·");
+      const child = h.presentation.getState().authoritative.managedControl?.threads[0];
+      if (child === undefined) throw new Error("Missing role child");
+      finishChild.resolve();
+      await h.presentation.dispatch({
+        type: "managed_control",
+        commandId: `${role}-combined-completion`,
+        command: {
+          type: "wait_agents",
+          parentSessionId: h.parent.sessionId,
+          mode: "all",
+          targets: [{ threadId: child.threadId, expectedTurnId: child.turn.turnId }],
+        },
+      });
+      await h.terminal.waitForScreen(`${handle} · Completed`);
+      await h.press("\u001b[27u", "Fleet · ↓ navigate");
+      await h.press("Continue Main after the child.\r", "Main continued after child.");
       expect(droppedRoles).toEqual([]);
       expect(
         (await h.store.read()).filter((record) => record.event.type === "admitted"),
@@ -82,6 +123,7 @@ test.each(["Explore", "Research"] as const)(
         `builtin:${role.toLowerCase()}`,
       );
     } finally {
+      finishChild.resolve();
       unsubscribe();
       await h.close();
     }

--- a/apps/tui/src/uir-stream-performance.test.ts
+++ b/apps/tui/src/uir-stream-performance.test.ts
@@ -80,7 +80,7 @@ test.each(["saturated", "short_ack"] as const)(
       expect(threads).toHaveLength(16);
       expect(threads.filter((thread) => thread.turn.phase === "executing")).toHaveLength(8);
       expect(threads.filter((thread) => thread.turn.phase === "queued")).toHaveLength(8);
-      await h.press("\x1b[B", "● Main");
+      await h.press("\x1b[B", "> Main");
       if (profiler !== undefined) {
         profiler.connect();
         await profiler.post("Profiler.enable");
@@ -91,7 +91,7 @@ test.each(["saturated", "short_ack"] as const)(
       for (let wave = 0; wave < waveCount; wave += 1) {
         const waveStart = performance.now();
         const offset = h.terminal.output().length;
-        const expected = wave % 2 === 0 ? "● @explore-1" : "● Main";
+        const expected = wave % 2 === 0 ? "> @explore-1" : "> Main";
         const input = new Promise<{
           scheduledInputMilliseconds: number;
           frameMilliseconds: number;


### PR DESCRIPTION
## Changes

Agent panels now use the current theme consistently, with exact handles, semantic status colors and whole-row Fleet selection. Widget connectors are generated from the final visible tree after compression, preserving ancestor branches and literal tree glyphs in content. Narrow rows prioritize identity/status and use readable overflow counts.

Conversation previews format Markdown around literal evidence, reuse numbered syntax highlighting for code reads, and separate short answers from navigation controls. Todo details render Markdown. Historical completed records without an end timestamp retain unknown elapsed time.

## Validation

Independent specification/engineering review and corrective reviews passed. Regressions cover mixed evidence boundaries, selection color through every truncated-row cell, tree compression/queued roots, 40/80/120 columns, Unicode and NO_COLOR. Combined Explore/Research tests exercise Main updates, role creation, live preview modes, details, completion and continued Main input. Production PTY, resize, Todo, export and responsiveness contracts were exercised on WSL2.

Final full `pnpm quality:check` passed: 2,430 tests, eighteen existing opt-in skips, plus code, Markdown, TypeScript and browser checks. Earlier local OS timeout clusters also reproduced on the unchanged baseline before the host update/reboot; the final gate passed with the original configuration. One separate draft test now waits for admission cleanup before its unchanged empty-composer and cold-restart assertions.
