### PR TITLE
perf: improve Main scrolling and preserve reading anchors

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -6,6 +6,8 @@ Adam Agent uses the terminal mechanics package
 [`@earendil-works/pi-tui`](https://github.com/earendil-works/pi/tree/914cf1472e715297caa30db4b9535d534a9eb718/packages/tui),
 licensed under the MIT License.
 
+The pinned package includes Adam's local patch in `patches/@earendil-works__pi-tui@0.84.2.patch`, including immediate rendering for consumed viewport navigation through Pi's existing input scheduler. The package version and upstream license remain unchanged.
+
 Adam Agent also adapts Pi TUI's bounded CSI, OSC, and APC terminal-sequence stripping behavior into the browser-safe Presentation text projection used by the Turn Composer and TUI renderer.
 
 Adam Agent's bounded tool-preview interaction and syntax-projection strategy is independently adapted from [`badlogic/pi-mono`](https://github.com/badlogic/pi-mono/tree/dcd461925db2edf69a43c8135db1180d418afd54/packages/coding-agent), also licensed under the MIT License.

--- a/apps/tui/src/fixture-scenario.ts
+++ b/apps/tui/src/fixture-scenario.ts
@@ -43,6 +43,7 @@ export const fixtureScenarios = [
   "review-operation-long-provenance",
   "review-recovery",
   "review-unavailable",
+  "scroll-viewport",
   "search",
   "resume",
   "session-selection-history",

--- a/apps/tui/src/pi-viewport-input.test.ts
+++ b/apps/tui/src/pi-viewport-input.test.ts
@@ -1,0 +1,96 @@
+import { type Component, ScrollView, TuiAltScreen } from "@earendil-works/pi-tui";
+import { expect, test, vi } from "vitest";
+import { VirtualTerminal } from "./virtual-terminal.test-support.js";
+
+class InputDocument implements Component {
+  prefix = "line";
+  readonly inputs: string[] = [];
+  render(): string[] {
+    return Array.from({ length: 50 }, (_, index) => `${this.prefix}-${index}`);
+  }
+  handleInput(data: string): void {
+    this.inputs.push(data);
+    this.prefix = "edited";
+  }
+  invalidate(): void {}
+}
+
+const nextInputTurn = () => new Promise<void>((resolve) => process.nextTick(resolve));
+
+// Pi defaults to one wheel line and a four-line PageUp/PageDown overlap.
+test.each([
+  { name: "wheel up", input: "\u001b[<64;5;5M", first: "line-19" },
+  { name: "PageUp", input: "\u001b[5~", first: "line-14" },
+  { name: "PageDown", input: "\u001b[6~", first: "line-26" },
+])(
+  "Pi $name produces a complete input frame without advancing the render timer",
+  async ({ input, first }) => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
+    const terminal = new VirtualTerminal({ columns: 40, rows: 10 });
+    const document = new InputDocument();
+    const scroll = new ScrollView(document, { primary: true, scrollbar: "hidden" });
+    const tui = new TuiAltScreen(terminal);
+    tui.setLayoutRoot(scroll);
+    tui.setFocus(document);
+    try {
+      tui.start();
+      tui.renderNow();
+      scroll.scrollTo(20);
+      tui.renderNow();
+      const before = terminal.output().length;
+      tui.requestRender(); // A streaming frame is already pending when the input arrives.
+      terminal.input(input);
+      await nextInputTurn();
+      expect(terminal.completeFramesAfter(before)).toHaveLength(1);
+      expect(terminal.lines()[0]).toBe(first);
+      expect(document.inputs).toEqual([]);
+    } finally {
+      tui.stop();
+      vi.useRealTimers();
+    }
+  },
+);
+
+test("Pi leaves overlay and focused input routing intact and coalesces streaming renders", async () => {
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
+  const terminal = new VirtualTerminal({ columns: 40, rows: 10 });
+  const document = new InputDocument();
+  const scroll = new ScrollView(document, { primary: true, scrollbar: "hidden" });
+  const tui = new TuiAltScreen(terminal);
+  tui.setLayoutRoot(scroll);
+  tui.setFocus(document);
+  try {
+    tui.start();
+    tui.renderNow();
+    const overlay = new InputDocument();
+    const handle = tui.showOverlay(overlay, { width: 20, maxHeight: 5 });
+    tui.renderNow();
+    const overlayBefore = terminal.output().length;
+    terminal.input("\u001b[5~");
+    await nextInputTurn();
+    expect(overlay.inputs).toEqual(["\u001b[5~"]);
+    expect(scroll.scrollTop).toBe(0);
+    expect(terminal.completeFramesAfter(overlayBefore)).toHaveLength(1);
+    handle.hide();
+    tui.setFocus(document);
+    tui.renderNow();
+    const inputBefore = terminal.output().length;
+    terminal.input("x");
+    await nextInputTurn();
+    expect(document.inputs).toEqual(["x"]);
+    expect(terminal.completeFramesAfter(inputBefore)).toHaveLength(1);
+    const streamBefore = terminal.output().length;
+    for (const prefix of ["stream-a", "stream-b", "stream-final"]) {
+      document.prefix = prefix;
+      tui.requestRender();
+    }
+    await nextInputTurn();
+    expect(terminal.completeFramesAfter(streamBefore)).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(terminal.completeFramesAfter(streamBefore)).toHaveLength(1);
+    expect(terminal.lines()[0]).toBe("stream-final-0");
+  } finally {
+    tui.stop();
+    vi.useRealTimers();
+  }
+});

--- a/apps/tui/src/scroll-input.os.test.ts
+++ b/apps/tui/src/scroll-input.os.test.ts
@@ -1,0 +1,81 @@
+import { mkdir, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { expect, test } from "vitest";
+import { removeTuiFixtureRoot as rm } from "./tui-filesystem.test-support.js";
+import { startTuiFixture } from "./tui-fixture.test-support.js";
+
+test("PTY Main viewport scroll preserves drafts and resize anchors and restores terminal modes", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-main-scroll-"));
+  const workspaceRoot = join(root, "workspace");
+  await mkdir(workspaceRoot);
+  const fixture = startTuiFixture({
+    terminalProcessMarker: join(root, "terminal-process"),
+    external: true,
+    scenario: "scroll-viewport",
+    noColor: true,
+    workspaceRoot,
+    stateRoot: join(root, "state"),
+  });
+  const marker = (index: number) => `MAIN_SCROLL_${String(index).padStart(3, "0")}`;
+  const firstRow = () => {
+    const match = fixture
+      .screen()
+      ?.join("\n")
+      .match(/MAIN_SCROLL_(\d+)/u);
+    expect(match).not.toBeNull();
+    return Number(match?.[1]);
+  };
+  const move = async (input: string, delta: number) => {
+    const before = firstRow();
+    const offset = fixture.output().length;
+    fixture.write(input);
+    await fixture.waitForCompleteFrameAfter(
+      marker(before + delta),
+      offset,
+      delta > 0 ? marker(before) : undefined,
+    );
+    expect(firstRow()).toBe(before + delta);
+    expect(fixture.screen()?.join("\n")).toContain("retained draft");
+  };
+  try {
+    await fixture.waitForScreen("Adam · New session");
+    fixture.write("Show Main rows");
+    await fixture.waitForScreen("Show Main rows");
+    fixture.write("\r");
+    await fixture.waitForScreen("MAIN_SCROLL_119");
+    await fixture.waitForScreen("Adam · Streaming session");
+    const draftOffset = fixture.output().length;
+    fixture.write("retained draft");
+    await fixture.waitForCompleteFrameAfter("retained draft", draftOffset);
+    // At 80x24 the Main viewport is thirteen rows, with four rows of page overlap.
+    await move("\u001b[5~", -9);
+    await move("\u001b[6~", 9);
+    await move("\u001b[<64;8;8M", -1);
+    await move("\u001b[<65;8;8M", 1);
+    await move("\u001b[5~", -9);
+    const anchor = firstRow();
+    for (const columns of [40, 80, 120]) {
+      const offset = fixture.output().length;
+      await fixture.resize(columns, 24);
+      await fixture.waitForCompleteFrameAfter(marker(anchor), offset);
+      expect(firstRow()).toBe(anchor);
+      expect(fixture.screen()?.join("\n")).toContain("retained draft");
+      expect(fixture.screen()?.every((line) => visibleWidth(line) <= columns)).toBe(true);
+    }
+    fixture.write("\u0011");
+    const result = await fixture.closed;
+    expect(result).toMatchObject({ code: 0, signal: null, stderr: "" });
+    for (const mode of ["1049", "1000", "1006", "2004"]) {
+      expect(result.stdout).toContain(`\u001b[?${mode}h`);
+      expect(result.stdout).toContain(`\u001b[?${mode}l`);
+      expect(result.stdout.indexOf(`\u001b[?${mode}h`)).toBeLessThan(
+        result.stdout.lastIndexOf(`\u001b[?${mode}l`),
+      );
+    }
+  } finally {
+    await fixture.cleanup();
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/apps/tui/src/scroll-performance.test.ts
+++ b/apps/tui/src/scroll-performance.test.ts
@@ -1,0 +1,289 @@
+import { writeFile } from "node:fs/promises";
+import { Session } from "node:inspector/promises";
+import { createPermissionPolicy } from "@adam-agent/agent";
+import { expect, test } from "vitest";
+import { AgentConversationViewer } from "./agent-conversation-viewer.js";
+import { startManagedTui } from "./agent-fleet.test-support.js";
+import { awaitEveReceipt as awaitReceipt } from "./public-eve.test-support.js";
+import { TranscriptViewport } from "./transcript-viewport.js";
+
+const document = Array.from(
+  { length: 300 },
+  (_, i) => `Line ${String(i).padStart(3, "0")} **stable Markdown** with 界🙂 text.  \n`,
+).join("");
+const samples = 12;
+type Sample = {
+  scheduledCallbackMilliseconds: number;
+  inputFrameMilliseconds: number;
+  transcriptDocumentRenderMilliseconds: number;
+  childViewerRenderMilliseconds: number;
+  outputBytes: number;
+};
+
+// Real runtime/Presentation/runTui owners; controlled provider waves, never latency thresholds.
+test.each(["main", "todo", "static_widget", "eight_streaming"] as const)(
+  "same long Main scroll workload with %s",
+  async (workload) => {
+    const waves = Array.from({ length: samples * 2 }, () => Promise.withResolvers<void>());
+    const done = waves.map(() => Promise.withResolvers<void>());
+    const counts = waves.map(() => 0);
+    const finish = Promise.withResolvers<void>();
+    const started = Promise.withResolvers<void>();
+    let calls = 0;
+    let children = 0;
+    let renderMilliseconds = 0;
+    let restoreDocumentRender = () => {};
+    const setScrollListener = TranscriptViewport.prototype.setScrollListener;
+    // Observe the actual document instance through its public Component interface.
+    // Both baseline Container and candidate TranscriptDocument use this exact boundary.
+    TranscriptViewport.prototype.setScrollListener = function (listener) {
+      const document = this.document;
+      const render = document.render;
+      document.render = function (width) {
+        const start = performance.now();
+        try {
+          return render.call(this, width);
+        } finally {
+          renderMilliseconds += performance.now() - start;
+        }
+      };
+      restoreDocumentRender = () => {
+        document.render = render;
+      };
+      return setScrollListener.call(this, listener);
+    };
+    const h = await startManagedTui(
+      {
+        async *stream(request) {
+          const call = calls++;
+          if (call === 0 && workload !== "main") {
+            for (let i = 0; i < 4; i++) {
+              const id = `todo-${i}`;
+              yield { type: "tool_call_start", id, name: "create_todo" };
+              yield {
+                type: "tool_call_delta",
+                id,
+                json: JSON.stringify({
+                  title: `Scroll task ${i}`,
+                  details: "Stable fixture Todo.",
+                }),
+              };
+              yield { type: "tool_call_end", id };
+            }
+            yield { type: "finish", reason: "tool_calls" };
+            return;
+          }
+          if (call === (workload === "main" ? 0 : 1)) {
+            yield { type: "text_delta", text: `${document}\nMAIN-END` };
+          } else {
+            yield {
+              type: "text_delta",
+              text: `${document.split("\n").slice(0, 100).join("\n")}\nCHILD-END`,
+            };
+            children++;
+            if (children === (workload === "eight_streaming" ? 8 : 1)) started.resolve();
+            if (workload === "eight_streaming") {
+              const cancelled = new Promise<void>((resolve) => {
+                if (request.signal.aborted) resolve();
+                else request.signal.addEventListener("abort", () => resolve(), { once: true });
+              });
+              for (let wave = 0; wave < waves.length; wave++) {
+                await Promise.race([waves[wave]?.promise, cancelled]);
+                if (request.signal.aborted) return;
+                for (let fragment = 0; fragment < 10; fragment++)
+                  yield {
+                    type: "text_delta",
+                    text: `\nWave ${wave} fragment ${fragment} streaming child text.`,
+                  };
+                counts[wave] = (counts[wave] ?? 0) + 1;
+                if (counts[wave] === 8) done[wave]?.resolve();
+              }
+              await Promise.race([finish.promise, cancelled]);
+            }
+          }
+          yield { type: "finish", reason: "stop" };
+        },
+      },
+      {
+        columns: 120,
+        rows: 40,
+        initialPrompt: "Prepare fixed long Main and four Todos.",
+        permissions: createPermissionPolicy({ allowedEffects: ["read", "write", "delegate"] }),
+      },
+    ).finally(() => {
+      TranscriptViewport.prototype.setScrollListener = setScrollListener;
+    });
+    const { ADAM_SCROLL_REPORT: reportPath } = process.env;
+    const profiler = reportPath === undefined ? undefined : new Session();
+    const measurements: Record<string, Sample[]> = { main: [], child: [] };
+    let childRenderMilliseconds = 0;
+    const childRender = AgentConversationViewer.prototype.render;
+    AgentConversationViewer.prototype.render = function (width) {
+      const start = performance.now();
+      try {
+        return childRender.call(this, width);
+      } finally {
+        childRenderMilliseconds += performance.now() - start;
+      }
+    };
+    try {
+      await h.terminal.waitForScreen("MAIN-END");
+      if (workload !== "main") await h.terminal.waitForScreen("Todos (0/4)");
+      if (workload === "static_widget" || workload === "eight_streaming") {
+        expect(
+          await h.presentation.dispatch({
+            type: "managed_control",
+            commandId: `scroll-${workload}`,
+            command: {
+              type: "spawn_agents",
+              parentSessionId: h.parent.sessionId,
+              entries: Array.from(
+                { length: workload === "eight_streaming" ? 8 : 1 },
+                (_, index) => ({
+                  role: "builtin:explore",
+                  task: `Read scroll evidence ${index}.`,
+                  description: `Scroll ${index}`,
+                }),
+              ),
+            },
+          }),
+        ).toMatchObject({ status: "admitted" });
+        await awaitReceipt(started.promise, "Expected child providers entered");
+        await h.terminal.waitForScreen("Fleet");
+        if (workload === "static_widget") {
+          const settled = Promise.withResolvers<void>();
+          const check = () => {
+            if (
+              h.presentation.getState().authoritative.managedControl?.threads[0]?.turn.outcome
+                ?.status === "completed"
+            )
+              settled.resolve();
+          };
+          const unsubscribe = h.presentation.subscribe(check);
+          try {
+            check();
+            await awaitReceipt(settled.promise, "Static Widget completed outcome");
+          } finally {
+            unsubscribe();
+          }
+        }
+      }
+      if (profiler) {
+        profiler.connect();
+        await profiler.post("Profiler.enable");
+        await profiler.post("Profiler.start");
+      }
+      for (const view of workload === "eight_streaming" ? ["main", "child"] : ["main"]) {
+        if (view === "child") {
+          await h.openFirstAgent();
+          await h.terminal.waitForScreen(`Wave ${samples - 1} fragment 9`);
+        }
+        for (let index = 0; index < samples; index++) {
+          const wave = index + (view === "child" ? samples : 0);
+          const up = index % 2 === 0;
+          const end = view === "main" ? "MAIN-END" : `Wave ${samples - 1} fragment 9`;
+          let offset = h.terminal.output().length;
+          const scheduled = performance.now();
+          const beforeRender = renderMilliseconds;
+          const beforeChildRender = childRenderMilliseconds;
+          const input = new Promise<Sample>((resolve, reject) =>
+            setImmediate(() => {
+              offset = h.terminal.output().length;
+              const entered = performance.now();
+              h.terminal.input(up ? "\x1b[5~" : "\x1b[6~");
+              h.terminal
+                .waitForFrameAfter(
+                  up
+                    ? view === "main"
+                      ? "deepseek-v4-flash.direct"
+                      : "Conversation · @explore-1"
+                    : end,
+                  offset,
+                  up
+                    ? view === "main"
+                      ? "MAIN-END"
+                      : `Wave ${samples - 1} fragment 9`
+                    : undefined,
+                )
+                .then(() => {
+                  resolve({
+                    scheduledCallbackMilliseconds: entered - scheduled,
+                    inputFrameMilliseconds: performance.now() - entered,
+                    transcriptDocumentRenderMilliseconds: renderMilliseconds - beforeRender,
+                    childViewerRenderMilliseconds: childRenderMilliseconds - beforeChildRender,
+                    outputBytes: Buffer.byteLength(h.terminal.output().slice(offset)),
+                  });
+                }, reject);
+            }),
+          );
+          if (workload === "eight_streaming") waves[wave]?.resolve();
+          const sample = await input;
+          if (workload === "eight_streaming")
+            await awaitReceipt(
+              done[wave]?.promise ?? Promise.reject(new Error("Missing wave")),
+              "All eight provider waves emitted",
+            );
+          measurements[view]?.push(sample);
+        }
+      }
+      if (profiler) {
+        const profile = (await profiler.post("Profiler.stop")).profile;
+        await writeFile(`${reportPath}-${workload}.cpuprofile`, JSON.stringify(profile));
+      }
+      if (reportPath !== undefined)
+        await writeFile(
+          `${reportPath}-${workload}.json`,
+          JSON.stringify(
+            {
+              workload,
+              terminal: {
+                columns: 120,
+                rows: 40,
+                adapter: "VirtualTerminal",
+                node: process.version,
+              },
+              documentLines: 300,
+              childInitialDocumentLines: 100,
+              streamingWaves: workload === "eight_streaming" ? samples * 2 : 0,
+              fragmentsPerChildPerWave: 10,
+              scrollKeys:
+                "Alternating PgUp and PgDown; Child manual page stays frozen at wave 11 while providers continue",
+              documentBytes: Buffer.byteLength(document),
+              samples,
+              measurement:
+                "Main transcript document.render elapsed time includes descendants and document geometry generation at the same public Component boundary in both revisions; excludes Pi layout traversal, overlay composition, terminal writes and Adam document construction. Child viewer.render is timed separately at its unchanged public Component boundary, excluding the surrounding overlay frame. Scheduled callback delay measures setImmediate queue entry during controlled provider waves.",
+              measurements,
+              distributions: Object.fromEntries(
+                Object.entries(measurements).map(([view, rows]) => [
+                  view,
+                  Object.fromEntries(
+                    (Object.keys(rows[0] ?? {}) as (keyof Sample)[]).map((key) => [
+                      key,
+                      distribution(rows.map((row) => row[key])),
+                    ]),
+                  ),
+                ]),
+              ),
+            },
+            null,
+            2,
+          ),
+        );
+    } finally {
+      restoreDocumentRender();
+      AgentConversationViewer.prototype.render = childRender;
+      profiler?.disconnect();
+      for (const wave of waves) wave.resolve();
+      finish.resolve();
+      await h.close();
+    }
+  },
+);
+function distribution(values: number[]) {
+  const sorted = [...values].sort((a, b) => a - b);
+  return {
+    p50: sorted[Math.ceil(sorted.length * 0.5) - 1],
+    p95: sorted[Math.ceil(sorted.length * 0.95) - 1],
+    max: sorted.at(-1),
+  };
+}

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -1763,6 +1763,11 @@ function createFixtureModelTargets(options: {
           type: "text_delta",
           text: `Assistant artifact page one\n${"a".repeat(20_000)}\nAssistant artifact page two\n${"b".repeat(250_000)}${responseIdentity}`,
         };
+      } else if (options.scenario === "scroll-viewport") {
+        yield {
+          type: "text_delta",
+          text: `\`\`\`text\n${Array.from({ length: 120 }, (_, index) => `MAIN_SCROLL_${String(index).padStart(3, "0")}`).join("\n")}\n\`\`\``,
+        };
       } else if (options.scenario === "copy-large-assistant") {
         yield {
           type: "text_delta",

--- a/apps/tui/src/transcript-viewport.test.ts
+++ b/apps/tui/src/transcript-viewport.test.ts
@@ -1,0 +1,135 @@
+import type { Component } from "@earendil-works/pi-tui";
+import { expect, test } from "vitest";
+import { TranscriptViewport } from "./transcript-viewport.js";
+
+class Lines implements Component {
+  renders = 0;
+  constructor(public lines: string[]) {}
+  render(width: number): string[] {
+    this.renders += 1;
+    return this.lines.flatMap((line) => {
+      const result: string[] = [];
+      for (let offset = 0; offset < line.length; offset += width)
+        result.push(line.slice(offset, offset + width));
+      return result.length === 0 ? [""] : result;
+    });
+  }
+  invalidate(): void {}
+}
+
+function layout(viewport: TranscriptViewport, width = 20, height = 10): string[] {
+  const contentWidth = viewport.scrollView.getContentWidth(width);
+  const lines = viewport.document.render(contentWidth);
+  viewport.scrollView.updateLayout(lines.length, height, () => {});
+  return lines.slice(viewport.scrollView.scrollTop, viewport.scrollView.scrollTop + height);
+}
+
+function add(viewport: TranscriptViewport, id: string, lines: string[]): Lines {
+  const component = new Lines(lines);
+  viewport.document.addChild(component);
+  viewport.setAnchor(id, component);
+  viewport.setSemanticAnchor(id, component);
+  return component;
+}
+
+test.each([50, 100, 200, 400])("anchor selection reuses the %i-item rendered layout", (count) => {
+  const viewport = new TranscriptViewport();
+  const components = Array.from({ length: count }, (_, index) =>
+    add(viewport, `item-${index}`, [`line-${index}`]),
+  );
+  layout(viewport);
+  viewport.scrollView.scrollTo(0);
+  const before = components.reduce((total, component) => total + component.renders, 0);
+  expect(
+    viewport.selectVisibleAnchor(
+      components.map((_, index) => `item-${index}`),
+      20,
+    ),
+  ).toBe("item-4");
+  expect(components.reduce((total, component) => total + component.renders, 0) - before).toBe(0);
+});
+
+test("manual reading survives streaming, card collapse, older pages and width changes", () => {
+  const viewport = new TranscriptViewport();
+  const render = (prefix: string[], suffix: string[]) => {
+    viewport.clear();
+    add(viewport, "older", prefix);
+    add(viewport, "reading", ["abcdefghijklmnopqrst", "second reading line", "third reading line"]);
+    add(viewport, "streaming", suffix);
+  };
+  const tail = Array.from({ length: 15 }, (_, i) => `tail-${i}`);
+  render(["old-1", "old-2", "tool details", "card running", "card details"], tail);
+  layout(viewport);
+  viewport.scrollView.scrollTo(6);
+  expect(layout(viewport)[0]).toBe("second reading line");
+
+  render(
+    ["old-1", "old-2", "tool details", "card running", "card details"],
+    [...tail, "new streamed line"],
+  );
+  expect(layout(viewport)[0]).toBe("second reading line");
+  expect(viewport.scrollView.scrollTop).toBe(6);
+  render(["old-1", "old-2", "card running", "card details"], tail);
+  expect(layout(viewport)[0]).toBe("second reading line");
+  expect(viewport.scrollView.scrollTop).toBe(5);
+  render(["old-1", "old-2", "card completed"], tail);
+  expect(layout(viewport)[0]).toBe("second reading line");
+  expect(viewport.scrollView.scrollTop).toBe(4);
+  render(["older-a", "older-b", "older-c", "old-1", "old-2", "card completed"], tail);
+  expect(layout(viewport)[0]).toBe("second reading line");
+  expect(viewport.scrollView.scrollTop).toBe(7);
+  expect(viewport.scrollView.isFollowingEnd).toBe(false);
+  expect(layout(viewport, 10)[0]).toBe("klmnopqrst");
+  expect(viewport.scrollView.isFollowingEnd).toBe(false);
+});
+
+test("shortened and deleted reading anchors clamp to available content and can be captured again", () => {
+  const viewport = new TranscriptViewport();
+  const rebuild = (reading: string[] | null) => {
+    viewport.clear();
+    add(viewport, "prefix", ["prefix"]);
+    if (reading !== null) add(viewport, "reading", reading);
+    add(viewport, "tail", ["tail-1", "tail-2", "tail-3", "tail-4", "tail-5"]);
+  };
+  rebuild(["read-1", "read-2", "read-3", "read-4"]);
+  layout(viewport, 20, 3);
+  viewport.scrollView.scrollTo(4);
+  rebuild(["short"]);
+  expect(layout(viewport, 20, 3)[0]).toBe("short");
+  expect(viewport.scrollView.scrollTop).toBe(1);
+  rebuild(null);
+  expect(layout(viewport, 20, 3)[0]).toBe("tail-1");
+  viewport.clear();
+  add(viewport, "prefix", ["older", "prefix"]);
+  add(viewport, "tail", ["tail-1", "tail-2", "tail-3", "tail-4", "tail-5"]);
+  expect(layout(viewport, 20, 3)[0]).toBe("tail-1");
+  expect(viewport.scrollView.scrollTop).toBe(2);
+});
+
+test("Todo or Widget height changes do not turn manual reading into follow-tail", () => {
+  const viewport = new TranscriptViewport();
+  const populate = (count: number) => {
+    viewport.clear();
+    for (let index = 0; index < count; index += 1)
+      add(viewport, `item-${index}`, [`line-${index}`]);
+  };
+  populate(20);
+  layout(viewport, 20, 5);
+  viewport.scrollView.scrollTo(10);
+  expect(layout(viewport, 20, 5)[0]).toBe("line-10");
+  expect(viewport.scrollView.isFollowingEnd).toBe(false);
+
+  // Todo/Widget sibling regions release five rows to the transcript. The user's
+  // current line now happens to be the bottom position, without a scroll action.
+  expect(layout(viewport, 20, 10)[0]).toBe("line-10");
+  expect(viewport.scrollView.isFollowingEnd).toBe(false);
+  populate(21);
+  expect(layout(viewport, 20, 10)[0]).toBe("line-10");
+  expect(viewport.scrollView.isFollowingEnd).toBe(false);
+  expect(layout(viewport, 20, 5)[0]).toBe("line-10");
+
+  viewport.scrollView.scrollBy(100);
+  expect(viewport.scrollView.isFollowingEnd).toBe(true);
+  populate(22);
+  expect(layout(viewport, 20, 5)[0]).toBe("line-17");
+});

--- a/apps/tui/src/transcript-viewport.ts
+++ b/apps/tui/src/transcript-viewport.ts
@@ -19,6 +19,51 @@ type ViewportPosition = {
   readonly screenRow: number;
 };
 
+type ComponentGeometry = { readonly top: number; readonly height: number };
+
+class TranscriptDocument extends Container {
+  readonly #geometry = new Map<Component, ComponentGeometry>();
+  #layoutWidth: number | undefined;
+
+  override addChild(component: Component): void {
+    super.addChild(component);
+    this.#layoutWidth = undefined;
+  }
+
+  override removeChild(component: Component): void {
+    super.removeChild(component);
+    this.#layoutWidth = undefined;
+  }
+
+  override clear(): void {
+    super.clear();
+    this.#geometry.clear();
+    this.#layoutWidth = undefined;
+  }
+
+  override render(width: number): string[] {
+    const lines: string[] = [];
+    this.#geometry.clear();
+    for (const component of this.children) {
+      const rendered = component.render(width);
+      if (!this.#geometry.has(component)) {
+        this.#geometry.set(component, { top: lines.length, height: rendered.length });
+      }
+      for (const line of rendered) lines.push(line);
+    }
+    this.#layoutWidth = width;
+    return lines;
+  }
+
+  geometry(component: Component, width: number): ComponentGeometry | undefined {
+    const boundedWidth = Math.max(1, width);
+    // Record offsets with the same render that produces the document. A query before
+    // the first layout at this width materializes it once; every new frame refreshes it.
+    if (this.#layoutWidth !== boundedWidth) this.render(boundedWidth);
+    return this.#geometry.get(component);
+  }
+}
+
 class AnchoredScrollView extends ScrollView {
   readonly #captureBeforeWidthChange: () => void;
   readonly #desiredScrollTop: () => number | null;
@@ -61,10 +106,14 @@ class AnchoredScrollView extends ScrollView {
     viewportHeight: number,
     requestRender: () => void,
   ): void {
+    const wasFollowingEnd = this.isFollowingEnd;
     super.updateLayout(contentHeight, viewportHeight, requestRender);
     const scrollTop = this.#desiredScrollTop();
     if (scrollTop !== null) {
       super.scrollTo(scrollTop, { disableFollow: true });
+    } else if (!wasFollowingEnd) {
+      // Layout may clamp a manual position to the new bottom without user navigation.
+      super.scrollTo(this.scrollTop, { disableFollow: true });
     }
   }
 
@@ -106,7 +155,7 @@ class AnchoredScrollView extends ScrollView {
 }
 
 export class TranscriptViewport {
-  readonly document = new Container();
+  readonly document = new TranscriptDocument();
   readonly #anchors = new Map<string, Anchor>();
   readonly #semanticAnchors = new Map<string, Anchor>();
   #pendingPosition: ViewportPosition | null = null;
@@ -295,10 +344,12 @@ export class TranscriptViewport {
     const anchor =
       this.#anchors.get(position.anchorId) ?? this.#semanticAnchors.get(position.anchorId);
     if (anchor === undefined) {
+      this.#pendingPosition = null;
       return null;
     }
     const anchorTop = this.#anchorTop(anchor, this.scrollView.contentWidth);
     if (anchorTop === null) {
+      this.#pendingPosition = null;
       return null;
     }
     const height = this.#anchorHeight(anchor, this.scrollView.contentWidth);
@@ -307,26 +358,17 @@ export class TranscriptViewport {
   }
 
   #anchorTop(anchor: Anchor, width: number): number | null {
-    const index = this.document.children.indexOf(anchor.component);
-    return index < 0 ? null : this.#lineOffset(index, resolveMetric(anchor.line, width), width);
+    const geometry = this.document.geometry(anchor.component, width);
+    return geometry === undefined ? null : geometry.top + resolveMetric(anchor.line, width);
   }
 
   #anchorHeight(anchor: Anchor, width: number): number {
     return Math.max(
       1,
       anchor.height === undefined
-        ? anchor.component.render(Math.max(1, width)).length - resolveMetric(anchor.line, width)
+        ? (this.document.geometry(anchor.component, width)?.height ?? 0) -
+            resolveMetric(anchor.line, width)
         : resolveMetric(anchor.height, width),
-    );
-  }
-
-  #lineOffset(index: number, anchorLine: number, width: number): number {
-    const boundedWidth = Math.max(1, width);
-    return (
-      this.document.children
-        .slice(0, index)
-        .reduce((lineCount, component) => lineCount + component.render(boundedWidth).length, 0) +
-      anchorLine
     );
   }
 }

--- a/patches/@earendil-works__pi-tui@0.84.2.patch
+++ b/patches/@earendil-works__pi-tui@0.84.2.patch
@@ -1083,7 +1083,7 @@ index 848119411c1ff2885b8d1efe97f2f297bd4cd470..c49053c1e2060b5e2ebb11210debde0b
      private readonly searchCurrentMatchStyle;
      private readonly openUrl?;
 diff --git a/dist/tui-alt-screen.js b/dist/tui-alt-screen.js
-index 4edcf845ba7866782a8ec7219508a2dce0073a91..8a0c375cec7bbb80c1b2e97279ab3b128434e75a 100644
+index 4edcf845ba7866782a8ec7219508a2dce0073a91..364f2e14cbd4e8bc7890d89686da0a45b235792c 100644
 --- a/dist/tui-alt-screen.js
 +++ b/dist/tui-alt-screen.js
 @@ -59,6 +59,7 @@ export class TuiAltScreen extends TuiBase {
@@ -1102,6 +1102,15 @@ index 4edcf845ba7866782a8ec7219508a2dce0073a91..8a0c375cec7bbb80c1b2e97279ab3b12
          this.searchMatchStyle = options.searchMatchStyle ?? ((text) => `\x1b[4m${text}\x1b[24m`);
          this.searchCurrentMatchStyle = options.searchCurrentMatchStyle ?? ((text) => `\x1b[1;7m${text}\x1b[22;27m`);
          this.openUrl = options.openUrl;
+@@ -406,7 +408,7 @@ export class TuiAltScreen extends TuiBase {
+             if (this.shouldDeferViewportInputToOverlay())
+                 return undefined;
+             this.routeWheel(wheelEvent);
+-            return { consume: true };
++            return { consume: true, immediateRender: true };
+         }
+         const mouseEvent = this.parseSgrMouseEvent(data);
+         if (mouseEvent) {
 @@ -423,7 +425,12 @@ export class TuiAltScreen extends TuiBase {
              return { consume: true };
          const keybindings = getKeybindings();
@@ -1116,6 +1125,70 @@ index 4edcf845ba7866782a8ec7219508a2dce0073a91..8a0c375cec7bbb80c1b2e97279ab3b12
              if (!isRelease)
                  this.openSearch();
              return { consume: true };
+@@ -451,53 +458,53 @@ export class TuiAltScreen extends TuiBase {
+             if (!isRelease) {
+                 this.scrollBy(-Math.max(1, this.getPrimaryScrollView().viewportHeight - PAGE_SCROLL_OVERLAP));
+             }
+-            return { consume: true };
++            return { consume: true, immediateRender: !isRelease };
+         }
+         if (keybindings.matches(data, "tui.altScreen.pageDown")) {
+             if (!isRelease) {
+                 this.scrollBy(Math.max(1, this.getPrimaryScrollView().viewportHeight - PAGE_SCROLL_OVERLAP));
+             }
+-            return { consume: true };
++            return { consume: true, immediateRender: !isRelease };
+         }
+         if (keybindings.matches(data, "tui.altScreen.halfPageUp")) {
+             if (!isRelease)
+                 this.scrollBy(-Math.max(1, Math.floor(this.getPrimaryScrollView().viewportHeight / 2)));
+-            return { consume: true };
++            return { consume: true, immediateRender: !isRelease };
+         }
+         if (keybindings.matches(data, "tui.altScreen.halfPageDown")) {
+             if (!isRelease)
+                 this.scrollBy(Math.max(1, Math.floor(this.getPrimaryScrollView().viewportHeight / 2)));
+-            return { consume: true };
++            return { consume: true, immediateRender: !isRelease };
+         }
+         if (keybindings.matches(data, "tui.altScreen.lineUp")) {
+             if (!isRelease)
+                 this.scrollBy(-1);
+-            return { consume: true };
++            return { consume: true, immediateRender: !isRelease };
+         }
+         if (keybindings.matches(data, "tui.altScreen.lineDown")) {
+             if (!isRelease)
+                 this.scrollBy(1);
+-            return { consume: true };
++            return { consume: true, immediateRender: !isRelease };
+         }
+         if (keybindings.matches(data, "tui.altScreen.previousPrompt")) {
+             if (!isRelease)
+                 this.scrollToPrompt(-1);
+-            return { consume: true };
++            return { consume: true, immediateRender: !isRelease };
+         }
+         if (keybindings.matches(data, "tui.altScreen.nextPrompt")) {
+             if (!isRelease)
+                 this.scrollToPrompt(1);
+-            return { consume: true };
++            return { consume: true, immediateRender: !isRelease };
+         }
+         if (keybindings.matches(data, "tui.altScreen.top")) {
+             if (!isRelease)
+                 this.scrollToTop();
+-            return { consume: true };
++            return { consume: true, immediateRender: !isRelease };
+         }
+         if (keybindings.matches(data, "tui.altScreen.bottom")) {
+             if (!isRelease)
+                 this.scrollToBottom();
+-            return { consume: true };
++            return { consume: true, immediateRender: !isRelease };
+         }
+         return undefined;
+     }
 @@ -824,7 +831,6 @@ export class TuiAltScreen extends TuiBase {
                  this.requestRender();
                  return;
@@ -1137,3 +1210,29 @@ index 4edcf845ba7866782a8ec7219508a2dce0073a91..8a0c375cec7bbb80c1b2e97279ab3b12
          let sourceLines = this.previousScreen;
          if (selection.start.scrollView) {
              if (!this.currentLayout)
+diff --git a/dist/tui.d.ts b/dist/tui.d.ts
+index 5b9b224586c313d8e3d42c9a2f0f05b7a1107f40..812a596eb8fc6b2bb8d280dbe46f8b5fe410ce58 100644
+--- a/dist/tui.d.ts
++++ b/dist/tui.d.ts
+@@ -30,6 +30,8 @@ export interface Component {
+     invalidate(): void;
+ }
+ export type TuiInputListenerResult = {
++    /** Render consumed user input on the same immediate path as focused input. */
++    immediateRender?: boolean;
+     consume?: boolean;
+     data?: string;
+ } | undefined;
+diff --git a/dist/tui.js b/dist/tui.js
+index 94adbdcffd98b770d34ee55771f57ec8004df2eb..13db4bb16728fd0d1a1f03657ce91baab368abe7 100644
+--- a/dist/tui.js
++++ b/dist/tui.js
+@@ -562,6 +562,8 @@ export class TuiBase extends Container {
+             for (const listener of this.inputListeners) {
+                 const result = listener(current);
+                 if (result?.consume) {
++                    if (result.immediateRender)
++                        this.requestImmediateRender();
+                     return;
+                 }
+                 if (result?.data !== undefined) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@earendil-works/pi-tui@0.84.2': d00e1a90b74a594d3cf350f944dd9eee8815d5c01667bb729bd00cdf014740ec
+  '@earendil-works/pi-tui@0.84.2': 74f14cf6871f9d70410666db10ce7d3b661ace7eae2d6d445f4875f3f0f464b4
 
 importers:
 
@@ -55,7 +55,7 @@ importers:
         version: link:../../packages/presentation
       '@earendil-works/pi-tui':
         specifier: 0.84.2
-        version: 0.84.2(patch_hash=d00e1a90b74a594d3cf350f944dd9eee8815d5c01667bb729bd00cdf014740ec)
+        version: 0.84.2(patch_hash=74f14cf6871f9d70410666db10ce7d3b661ace7eae2d6d445f4875f3f0f464b4)
       highlight.js:
         specifier: 11.11.1
         version: 11.11.1
@@ -1438,7 +1438,7 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.8':
     optional: true
 
-  '@earendil-works/pi-tui@0.84.2(patch_hash=d00e1a90b74a594d3cf350f944dd9eee8815d5c01667bb729bd00cdf014740ec)':
+  '@earendil-works/pi-tui@0.84.2(patch_hash=74f14cf6871f9d70410666db10ce7d3b661ace7eae2d6d445f4875f3f0f464b4)':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5


### PR DESCRIPTION
Main wheel and page navigation was consumed before Pi's focused-input immediate scheduler, leaving scrolling on the ordinary frame timer. Extend the pinned Pi patch so viewport input requests the existing immediate path while focused/overlay routing and streaming coalescing remain intact.

Record transcript component geometry during document rendering instead of repeatedly scanning prefixes for each anchor. Preserve manual reading when Todo/Widget height changes or clamping reach the bottom, release removed anchors, and retain explicit user follow-tail behavior.

Validation: independent general and anchor reviews; focused scheduling/geometry regressions; real PTY wheel/page, draft, resize and terminal-restoration coverage; final `pnpm quality:check`. Identical local 300-line Main workloads reduced input-to-frame p50 from 15.37 to 1.11 ms, and from 11.36 to 1.99 ms with eight streaming children. Child response and comparable scoped rendering costs show no clear improvement; timings are diagnostic, not CI thresholds.
