### PR TITLE
perf: reduce duplicate catalog reads and naming work

### DIFF
--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -8387,8 +8387,9 @@ test("slash Artifacts opens one bounded assistant artifact page", async () => {
       workspaceRoot,
     });
     await fixture.waitForScreen("Adam · New session");
+    const beforePrompt = fixture.output().length;
     fixture.write("Produce an artifact-backed answer\r");
-    await fixture.waitForRecordedOutput("Adam · Streaming session");
+    await fixture.waitForCompleteFrameAfter("Assistant response stored as artifact", beforePrompt);
     const beforeArtifacts = fixture.output().length;
     fixture.write("/artifacts \r");
     const opened = await Promise.race([

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -156,6 +156,8 @@ export {
   type McpConfigurationResult,
   type McpSessionSnapshot,
   type ProjectSessionCatalogPage,
+  type ProjectSessionSummary,
+  type ProjectSessionSummaryPage,
   type RepositoryInstructionsReloadResult,
   type SessionBranchInput,
   type SessionCommand,

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -96,6 +96,7 @@ import {
   effectiveSessionStateRoot,
   type ManagedAgentNotification,
   type ManagedAgentTranscriptRecords,
+  type ProjectSessionSummary,
   type SessionContextUsageSnapshot,
   type SessionHistoryDiagnostics,
   type SessionLifecycle,
@@ -493,27 +494,18 @@ export async function createPresentationSession(
     ) {
       knownTargets.set(options.targetIdentity.targetId, options.targetIdentity);
     }
-    const catalogPage = await options.lifecycle.listProjectSessions({ limit: catalogPageSize });
+    const catalogPage = await options.lifecycle.listProjectSessionSummaries({
+      limit: catalogPageSize,
+    });
     const workspaceTrustSnapshot = await options.lifecycle.inspectWorkspaceTrust();
     const projectPaths = await listProjectPaths(options.workspaceRoot);
-    const catalogItems = (
-      await Promise.all(
-        catalogPage.items.map(async (snapshot) => {
-          if (snapshot.schemaVersion !== 3) {
-            return null;
-          }
-          if (!knownTargets.has(snapshot.targetIdentity.targetId)) {
-            knownTargets.set(snapshot.targetIdentity.targetId, snapshot.targetIdentity);
-          }
-          return sessionSummaryFromSnapshot(
-            snapshot,
-            snapshot.sessionId === created?.sessionId
-              ? records
-              : await readActiveBranchRecords(options, snapshot.sessionId),
-          );
-        }),
-      )
-    ).filter((candidate): candidate is SessionSummary => candidate !== null);
+    const catalogItems = catalogPage.items.flatMap((snapshot) => {
+      if (snapshot.schemaVersion !== 3) return [];
+      if (!knownTargets.has(snapshot.targetIdentity.targetId)) {
+        knownTargets.set(snapshot.targetIdentity.targetId, snapshot.targetIdentity);
+      }
+      return [sessionSummaryFromCatalog(snapshot)];
+    });
     const summary =
       created === undefined
         ? undefined
@@ -6056,22 +6048,13 @@ export async function createPresentationSession(
           };
         }
         try {
-          const page = await options.lifecycle.listProjectSessions({
+          const page = await options.lifecycle.listProjectSessionSummaries({
             cursor: command.after,
             limit: catalogPageSize,
           });
-          const additions = (
-            await Promise.all(
-              page.items.map(async (snapshot) =>
-                snapshot.schemaVersion === 3
-                  ? sessionSummaryFromSnapshot(
-                      snapshot,
-                      await readActiveBranchRecords(options, snapshot.sessionId),
-                    )
-                  : null,
-              ),
-            )
-          ).filter((candidate): candidate is SessionSummary => candidate !== null);
+          const additions = page.items.flatMap((snapshot) =>
+            snapshot.schemaVersion === 3 ? [sessionSummaryFromCatalog(snapshot)] : [],
+          );
           const knownSessionIds = new Set(
             state.authoritative.sessions.items.map((session) => session.id),
           );
@@ -7331,6 +7314,22 @@ function projectSessionHistoryDiagnostics(
     })),
     totalCount: diagnostics.totalCount,
     truncated: diagnostics.truncated,
+  };
+}
+
+function sessionSummaryFromCatalog(
+  snapshot: Extract<ProjectSessionSummary, { schemaVersion: 3 }>,
+): SessionSummary {
+  const naming = {
+    ...snapshot.naming,
+    generation: projectSessionTitleGeneration(snapshot.naming.generation),
+  };
+  return {
+    id: snapshot.sessionId,
+    label: naming.displayLabel,
+    naming,
+    targetId: snapshot.targetIdentity.targetId,
+    status: snapshot.status,
   };
 }
 

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -197,6 +197,7 @@ import {
   type ModelResponseArtifactInspection,
   planCycleSnapshotFromRecords,
   promptContextRecordFromRecords,
+  type SessionNamingHistoryState,
   sessionNamingStateFromRecords,
   skillContextRecordFromRecords,
   skillResourceBytesFromRecords,
@@ -569,6 +570,19 @@ export type ProjectSessionCatalogPage = {
   readonly diagnostics: SessionHistoryDiagnostics;
 };
 
+export type ProjectSessionSummary =
+  | Exclude<SessionSnapshot, CurrentSessionSnapshot>
+  | (Pick<
+      CurrentSessionSnapshot,
+      "schemaVersion" | "sessionId" | "projectId" | "lastSequence" | "status" | "targetIdentity"
+    > & {
+      readonly naming: SessionNamingHistoryState;
+    });
+
+export type ProjectSessionSummaryPage = Omit<ProjectSessionCatalogPage, "items"> & {
+  readonly items: readonly ProjectSessionSummary[];
+};
+
 export type SessionHistoryDiagnosticCode = "invalid_history" | "invalid_log" | "log_too_large";
 
 export type SessionHistoryDiagnostic = {
@@ -929,6 +943,11 @@ export interface SessionLifecycle {
     readonly cursor?: string;
     readonly limit?: number;
   }): Promise<ProjectSessionCatalogPage>;
+  /** Display metadata from the full validated catalog; opening a session still requires inspect/resume. */
+  listProjectSessionSummaries(input?: {
+    readonly cursor?: string;
+    readonly limit?: number;
+  }): Promise<ProjectSessionSummaryPage>;
   previewNewSession(input: {
     readonly targetIdentity: ModelTargetIdentity;
     readonly thinkingSelection?: ThinkingPolicySelectionV1;
@@ -2528,7 +2547,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
   ): Promise<SessionSnapshot> => {
     const records: readonly SessionRecord[] =
       suppliedRecords === undefined
-        ? await storeDirectory.open(input.sessionId).then((store) => store?.read() ?? [])
+        ? await readSessionRecords(options, input.sessionId)
         : suppliedRecords;
     const first = records[0];
     if (first === undefined) {
@@ -3230,6 +3249,110 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       );
     }
     return plan;
+  };
+
+  const collectProjectSessionCatalog = async (input: {
+    readonly cursor?: string;
+    readonly limit?: number;
+  }) => {
+    const limit = input.limit ?? 100;
+    if (!Number.isSafeInteger(limit) || limit <= 0 || limit > 100) {
+      throw new SessionLifecycleError("session_invalid");
+    }
+    const afterSessionId = decodeProjectSessionCatalogCursor(input.cursor);
+    const projectId = await canonicalProjectId(options.workspaceRoot);
+    const directoryEntries = await storeDirectory.listSessionEntries();
+    const catalogEntries: Array<{
+      readonly sessionId: string;
+      readonly modifiedAtMilliseconds: number;
+      readonly snapshot: SessionSnapshot;
+      readonly naming: SessionNamingHistoryState;
+    }> = [];
+    const diagnostics: SessionHistoryDiagnostic[] = [];
+    for (const entry of directoryEntries) {
+      let records: readonly SessionRecord[];
+      try {
+        records = await readSessionRecords(options, entry.sessionId);
+      } catch (error) {
+        const diagnostic = sessionHistoryDiagnosticFromError(entry.sessionId, error);
+        if (diagnostic === undefined) {
+          throw error;
+        }
+        diagnostics.push(diagnostic);
+        continue;
+      }
+      if (
+        !records.some((entry) =>
+          entry.schemaVersion === 3
+            ? entry.record.type === "logical_run_started"
+            : entry.event.type === "user_message",
+        )
+      ) {
+        continue;
+      }
+      try {
+        // Keep the fresh authoritative boundary after admission filtering. The
+        // same validated version supplies both the full snapshot and its naming.
+        const freshRecords = await readSessionRecords(options, entry.sessionId);
+        if (
+          !freshRecords.some((record) =>
+            record.schemaVersion === 3
+              ? record.record.type === "logical_run_started"
+              : record.event.type === "user_message",
+          )
+        )
+          continue;
+        const snapshot = await inspectSession(
+          { sessionId: entry.sessionId },
+          undefined,
+          freshRecords,
+        );
+        catalogEntries.push({
+          ...entry,
+          snapshot,
+          naming: sessionNamingStateFromRecords(freshRecords),
+        });
+      } catch (error) {
+        if (error instanceof SessionLifecycleError && error.code === "session_not_found") {
+          continue;
+        }
+        const diagnostic = sessionHistoryDiagnosticFromError(entry.sessionId, error);
+        if (diagnostic === undefined) {
+          throw error;
+        }
+        diagnostics.push(diagnostic);
+      }
+    }
+    catalogEntries.sort(
+      (left, right) =>
+        right.modifiedAtMilliseconds - left.modifiedAtMilliseconds ||
+        (left.sessionId < right.sessionId ? -1 : left.sessionId > right.sessionId ? 1 : 0),
+    );
+    const cursorIndex =
+      afterSessionId === undefined
+        ? -1
+        : catalogEntries.findIndex((entry) => entry.sessionId === afterSessionId);
+    const start =
+      afterSessionId === undefined ? 0 : cursorIndex < 0 ? catalogEntries.length : cursorIndex + 1;
+    const selectedEntries = catalogEntries.slice(start, start + limit);
+    const selectedIds = selectedEntries.map((entry) => entry.sessionId);
+    const lastSessionId = selectedIds.at(-1);
+    diagnostics.sort((left, right) =>
+      left.sessionId < right.sessionId ? -1 : left.sessionId > right.sessionId ? 1 : 0,
+    );
+    return {
+      projectId,
+      items: selectedEntries,
+      nextCursor:
+        lastSessionId !== undefined && start + selectedIds.length < catalogEntries.length
+          ? encodeProjectSessionCatalogCursor(lastSessionId)
+          : null,
+      diagnostics: {
+        items: diagnostics.slice(0, 100),
+        totalCount: diagnostics.length,
+        truncated: diagnostics.length > 100,
+      },
+    };
   };
 
   return {
@@ -5576,89 +5699,27 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       );
     },
     async listProjectSessions(input = {}) {
-      const limit = input.limit ?? 100;
-      if (!Number.isSafeInteger(limit) || limit <= 0 || limit > 100) {
-        throw new SessionLifecycleError("session_invalid");
-      }
-      const afterSessionId = decodeProjectSessionCatalogCursor(input.cursor);
-      const projectId = await canonicalProjectId(options.workspaceRoot);
-      const directoryEntries = await storeDirectory.listSessionEntries();
-      const catalogEntries: Array<{
-        readonly sessionId: string;
-        readonly modifiedAtMilliseconds: number;
-        readonly snapshot: SessionSnapshot;
-      }> = [];
-      const diagnostics: SessionHistoryDiagnostic[] = [];
-      for (const entry of directoryEntries) {
-        let records: readonly SessionRecord[];
-        try {
-          records = await readSessionRecords(options, entry.sessionId);
-        } catch (error) {
-          const diagnostic = sessionHistoryDiagnosticFromError(entry.sessionId, error);
-          if (diagnostic === undefined) {
-            throw error;
-          }
-          diagnostics.push(diagnostic);
-          continue;
-        }
-        if (
-          !records.some((entry) =>
-            entry.schemaVersion === 3
-              ? entry.record.type === "logical_run_started"
-              : entry.event.type === "user_message",
-          )
-        ) {
-          continue;
-        }
-        try {
-          catalogEntries.push({
-            ...entry,
-            snapshot: await inspectSession({ sessionId: entry.sessionId }),
-          });
-        } catch (error) {
-          if (error instanceof SessionLifecycleError && error.code === "session_not_found") {
-            continue;
-          }
-          const diagnostic = sessionHistoryDiagnosticFromError(entry.sessionId, error);
-          if (diagnostic === undefined) {
-            throw error;
-          }
-          diagnostics.push(diagnostic);
-        }
-      }
-      catalogEntries.sort(
-        (left, right) =>
-          right.modifiedAtMilliseconds - left.modifiedAtMilliseconds ||
-          (left.sessionId < right.sessionId ? -1 : left.sessionId > right.sessionId ? 1 : 0),
-      );
-      const cursorIndex =
-        afterSessionId === undefined
-          ? -1
-          : catalogEntries.findIndex((entry) => entry.sessionId === afterSessionId);
-      const start =
-        afterSessionId === undefined
-          ? 0
-          : cursorIndex < 0
-            ? catalogEntries.length
-            : cursorIndex + 1;
-      const selectedEntries = catalogEntries.slice(start, start + limit);
-      const selectedIds = selectedEntries.map((entry) => entry.sessionId);
-      const lastSessionId = selectedIds.at(-1);
-      diagnostics.sort((left, right) =>
-        left.sessionId < right.sessionId ? -1 : left.sessionId > right.sessionId ? 1 : 0,
-      );
+      const page = await collectProjectSessionCatalog(input);
+      return { ...page, items: page.items.map(({ snapshot }) => snapshot) };
+    },
+    async listProjectSessionSummaries(input = {}) {
+      const page = await collectProjectSessionCatalog(input);
       return {
-        projectId,
-        items: selectedEntries.map((entry) => entry.snapshot),
-        nextCursor:
-          lastSessionId !== undefined && start + selectedIds.length < catalogEntries.length
-            ? encodeProjectSessionCatalogCursor(lastSessionId)
-            : null,
-        diagnostics: {
-          items: diagnostics.slice(0, 100),
-          totalCount: diagnostics.length,
-          truncated: diagnostics.length > 100,
-        },
+        ...page,
+        items: page.items.map(
+          ({ snapshot, naming }): ProjectSessionSummary =>
+            snapshot.schemaVersion !== 3
+              ? snapshot
+              : {
+                  schemaVersion: 3,
+                  sessionId: snapshot.sessionId,
+                  projectId: snapshot.projectId,
+                  lastSequence: snapshot.lastSequence,
+                  status: snapshot.status,
+                  targetIdentity: snapshot.targetIdentity,
+                  naming,
+                },
+        ),
       };
     },
     async previewNewSession(input) {
@@ -8974,7 +9035,9 @@ async function readSessionRecords(
   options: SessionLifecycleOptions,
   sessionId: string,
 ): Promise<readonly SessionRecord[]> {
-  const store = await sessionStoreDirectoryFrom(options).open(sessionId);
+  const directory = sessionStoreDirectoryFrom(options);
+  if (directory.readRecords !== undefined) return (await directory.readRecords(sessionId)) ?? [];
+  const store = await directory.open(sessionId);
   return store?.read() ?? [];
 }
 

--- a/packages/agent/src/session-store.ts
+++ b/packages/agent/src/session-store.ts
@@ -1149,6 +1149,8 @@ export interface SessionStoreDirectoryEntry {
 
 export interface SessionStoreDirectory<RecordType extends SessionRecord = SessionRecord> {
   byteLength?(sessionId: string): Promise<number | undefined>;
+  /** Read and validate a fresh record snapshot without opening an append-capable store. */
+  readRecords?(sessionId: string): Promise<readonly RecordType[] | undefined>;
   create(sessionId: string): Promise<SessionStore<RecordType>>;
   listSessionEntries(): Promise<readonly SessionStoreDirectoryEntry[]>;
   listSessionIds(): Promise<readonly string[]>;
@@ -3601,6 +3603,12 @@ export function createJsonlSessionStoreDirectory<
         }
         throw error;
       }
+    },
+    async readRecords(sessionId) {
+      validateSessionId(sessionId);
+      const sessionPath = await resolveSessionPath({ ...options, sessionId });
+      const log = await readLog(sessionPath);
+      return log?.records as readonly RecordType[] | undefined;
     },
     async open(sessionId) {
       validateSessionId(sessionId);

--- a/packages/testkit/src/catalog-read.os.test.ts
+++ b/packages/testkit/src/catalog-read.os.test.ts
@@ -1,0 +1,190 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createJsonlSessionStoreDirectory } from "@adam-agent/agent";
+import {
+  presentationCatalogPageSize,
+  presentationSessionRecordReader,
+  sessionStoreDirectory,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+import { withManagedFailureGuard } from "./managed-agent-test-support.js";
+import {
+  createPresentationSession,
+  createSessionLifecycle,
+  settledModelTargets,
+  targetIdentity,
+} from "./presentation-session.test-support.js";
+
+test("Presentation catalog names and pagination use Lifecycle's validated records without separate history reads", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-catalog-naming-"));
+  const workspaceRoot = join(root, "workspace");
+  const stateRoot = join(root, "state");
+  await mkdir(workspaceRoot);
+  const lifecycle = createSessionLifecycle({
+    workspaceRoot,
+    stateRoot,
+    modelTargets: settledModelTargets(),
+  });
+  try {
+    const sessions = [];
+    for (const name of ["First named session", "Second named session"]) {
+      const session = await lifecycle.create({ targetIdentity });
+      await lifecycle.continue({ sessionId: session.sessionId, input: { text: name } });
+      await lifecycle.setSessionManualName({ sessionId: session.sessionId, name });
+      sessions.push(session.sessionId);
+    }
+    const directory = createJsonlSessionStoreDirectory({ workspaceRoot, stateRoot });
+    const presentationReads: string[] = [];
+    const presentation = await createPresentationSession({
+      lifecycle,
+      workspaceRoot,
+      stateRoot,
+      projectLabel: "workspace",
+      openProject: true,
+      [presentationCatalogPageSize]: 1,
+      [presentationSessionRecordReader]: async (sessionId) => {
+        presentationReads.push(sessionId);
+        return (await directory.open(sessionId))?.read() ?? [];
+      },
+    });
+    try {
+      expect(
+        presentation.getState().authoritative.sessions.items.map(({ label }) => label),
+      ).toEqual(["Second named session"]);
+      const cursor = presentation.getState().authoritative.sessions.nextCursor;
+      if (cursor === null) throw new Error("The first catalog page needs a continuation cursor.");
+      await expect(
+        presentation.dispatch({ type: "load_more_sessions", after: cursor }),
+      ).resolves.toMatchObject({ status: "admitted" });
+      expect(
+        presentation
+          .getState()
+          .authoritative.sessions.items.map(({ id, label }) => ({ id, label })),
+      ).toEqual([
+        { id: sessions[1], label: "Second named session" },
+        { id: sessions[0], label: "First named session" },
+      ]);
+      expect(presentationReads).toEqual([]);
+    } finally {
+      await presentation.close();
+    }
+  } finally {
+    await lifecycle.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test.each(["rewrite", "append", "disappear", "genesis-only", "invalid-log"] as const)(
+  "full catalog summaries observe %s after the admission read without mixing naming versions",
+  async (change) => {
+    const root = await mkdtemp(join(tmpdir(), "adam-catalog-coherence-"));
+    const workspaceRoot = join(root, "workspace");
+    const stateRoot = join(root, "state");
+    await mkdir(workspaceRoot);
+    const modelTargets = settledModelTargets();
+    const author = createSessionLifecycle({ workspaceRoot, stateRoot, modelTargets });
+    const directory = createJsonlSessionStoreDirectory({ workspaceRoot, stateRoot });
+    const readReady = Promise.withResolvers<void>();
+    const releaseRead = Promise.withResolvers<void>();
+    let holdNextRead = true;
+    const reader = createSessionLifecycle({
+      workspaceRoot,
+      stateRoot,
+      modelTargets,
+      [sessionStoreDirectory]: {
+        ...directory,
+        async readRecords(sessionId) {
+          const records = await directory.readRecords?.(sessionId);
+          if (holdNextRead) {
+            holdNextRead = false;
+            readReady.resolve();
+            await releaseRead.promise;
+          }
+          return records;
+        },
+      },
+    });
+    try {
+      const session = await author.create({ targetIdentity });
+      await author.continue({ sessionId: session.sessionId, input: { text: "Catalog coherence" } });
+      const named = await author.setSessionManualName({
+        sessionId: session.sessionId,
+        name: "Before",
+      });
+      await author.close();
+      const path = join(
+        stateRoot,
+        "projects",
+        session.projectId.replace(/^sha256:/u, ""),
+        "sessions",
+        `${session.sessionId}.jsonl`,
+      );
+      const original = await readFile(path, "utf8");
+      const pending = reader.listProjectSessionSummaries();
+      await withManagedFailureGuard(readReady.promise, "catalog admission read");
+      if (change === "disappear") {
+        await rm(path);
+      } else if (change === "genesis-only") {
+        const records = original.trimEnd().split("\n");
+        const admissionIndex = records.findIndex((line) =>
+          line.includes('"type":"logical_run_started"'),
+        );
+        expect(admissionIndex).toBeGreaterThan(0);
+        await writeFile(path, `${records.slice(0, admissionIndex).join("\n")}\n`, "utf8");
+      } else if (change === "append") {
+        const store = await directory.open(session.sessionId);
+        if (store === undefined) throw new Error("Expected the catalog fixture log.");
+        await store.append({
+          schemaVersion: 3,
+          sequence: named.snapshot.lastSequence + 1,
+          record: { type: "session_manual_name_set", recordVersion: 1, name: "After!" },
+        });
+      } else {
+        const rewritten =
+          change === "rewrite"
+            ? original.replace('"name":"Before"', '"name":"After!"')
+            : original.replace('"name":"Before"', '"name":false   ');
+        expect(rewritten).not.toBe(original);
+        expect(Buffer.byteLength(rewritten)).toBe(Buffer.byteLength(original));
+        await writeFile(path, rewritten, "utf8");
+      }
+      releaseRead.resolve();
+      const page = await withManagedFailureGuard(pending, "fresh catalog summary");
+      if (change === "disappear" || change === "genesis-only") {
+        expect(page.items).toEqual([]);
+        expect(page.diagnostics).toEqual({ items: [], totalCount: 0, truncated: false });
+        const full = await reader.listProjectSessions();
+        expect(full.items).toEqual([]);
+        expect(full.diagnostics).toEqual(page.diagnostics);
+      } else if (change === "invalid-log") {
+        expect(page.items).toEqual([]);
+        expect(page.diagnostics).toMatchObject({
+          totalCount: 1,
+          items: [
+            { sessionId: session.sessionId, code: "invalid_log", stage: "read", retained: true },
+          ],
+        });
+      } else {
+        expect(page.items).toMatchObject([
+          {
+            sessionId: session.sessionId,
+            schemaVersion: 3,
+            targetIdentity,
+            status: named.snapshot.status,
+            lastSequence: named.snapshot.lastSequence + (change === "append" ? 1 : 0),
+            naming: { manualName: "After!", displayLabel: "After!" },
+          },
+        ]);
+        const full = await reader.listProjectSessions();
+        expect(full.items).toEqual([await reader.inspect({ sessionId: session.sessionId })]);
+        expect(full.diagnostics).toEqual(page.diagnostics);
+      }
+    } finally {
+      releaseRead.resolve();
+      await reader.close();
+      await author.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/packages/testkit/src/context-compaction.test.ts
+++ b/packages/testkit/src/context-compaction.test.ts
@@ -620,6 +620,10 @@ test.each(["missing", "corrupt"] as const)(
       ) {
         throw new Error("Expected an artifact-backed response fixture.");
       }
+      const warmCatalog = await lifecycle.listProjectSessions();
+      expect(warmCatalog.items).toMatchObject([
+        { sessionId: created.sessionId, status: "settled" },
+      ]);
       const artifactId = response.record.response.text.reference.id;
       const artifactPath = join(stateRoot, "artifacts", artifactId.slice("sha256:".length));
       if (damage === "missing") {
@@ -630,6 +634,27 @@ test.each(["missing", "corrupt"] as const)(
       }
 
       const restarted = createSessionLifecycle(options);
+      for (const catalogLifecycle of [lifecycle, restarted]) {
+        const catalog = await catalogLifecycle.listProjectSessions();
+        expect(catalog.items).toMatchObject([
+          {
+            sessionId: created.sessionId,
+            degradation: {
+              code:
+                damage === "missing"
+                  ? "model_response_artifact_missing"
+                  : "model_response_artifact_corrupt",
+              artifactId,
+              field: "text",
+            },
+          },
+        ]);
+        const summaries = await catalogLifecycle.listProjectSessionSummaries();
+        expect(summaries.items).toMatchObject([
+          { sessionId: created.sessionId, status: "settled" },
+        ]);
+        expect(summaries.diagnostics).toEqual(catalog.diagnostics);
+      }
       await expect(restarted.inspect({ sessionId: created.sessionId })).resolves.toMatchObject({
         status: "settled",
         degradation: {

--- a/packages/testkit/src/presentation-session.test.ts
+++ b/packages/testkit/src/presentation-session.test.ts
@@ -11961,11 +11961,11 @@ test("PresentationSession rejects a failed catalog page inside CommandReceipt", 
     });
     const presentationLifecycle: SessionLifecycle = {
       ...lifecycle,
-      async listProjectSessions(input) {
+      async listProjectSessionSummaries(input) {
         if (input?.cursor !== undefined) {
           throw new Error("injected catalog read failure");
         }
-        return lifecycle.listProjectSessions(input);
+        return lifecycle.listProjectSessionSummaries(input);
       },
     };
     const presentation = await createPresentationSession({

--- a/packages/testkit/src/session-lifecycle.test.ts
+++ b/packages/testkit/src/session-lifecycle.test.ts
@@ -1374,7 +1374,7 @@ test("SessionLifecycle isolates one invalid session from the project catalog", a
     if (validEntry === undefined) {
       throw new Error("Expected the valid catalog directory entry.");
     }
-    let validOpenCount = 0;
+    let validEntryPresent = true;
     disappearing = createSessionLifecycle({
       modelTargets: modelTargetsWithDriver(new FakeModelDriver([])),
       stateRoot,
@@ -1387,8 +1387,17 @@ test("SessionLifecycle isolates one invalid session from the project catalog", a
         },
         listSessionIds: () => harness.sessions.listSessionIds(),
         async open(sessionId) {
-          validOpenCount += 1;
-          return validOpenCount === 1 ? harness.sessions.open(sessionId) : undefined;
+          if (!validEntryPresent) return undefined;
+          const store = await harness.sessions.open(sessionId);
+          if (store === undefined) return undefined;
+          return {
+            ...store,
+            async read() {
+              const records = await store.read();
+              validEntryPresent = false;
+              return records;
+            },
+          };
         },
       },
     });


### PR DESCRIPTION
Startup catalog construction repeatedly read the same JSONL logs, then Presentation parsed them again to obtain session names. Add fresh byte-validated record reads and a summary port backed by the existing full catalog inspection. Preserve distinct admission and authoritative read boundaries, derive naming from the inspected version, and keep the full snapshot API, pagination and global diagnostics unchanged.

Validation: independent review; real same-length rewrites, append, disappearance and genesis-only replacement; warm/cold missing and corrupt artifact cases; final `pnpm quality:check` (2,505 passed, 18 existing opt-in skips). On the same isolated history workload, full-catalog read bytes fell from 82.0 MB to 41.1 MB and first-frame median from 4.34 s to 3.22 s. Complete catalog validation still takes about 3.4 s; responsive background startup is a separate follow-up.
