### PR TITLE
perf: keep history startup interactive during catalog loading

### DIFF
--- a/apps/tui/src/main.os.test.ts
+++ b/apps/tui/src/main.os.test.ts
@@ -1574,9 +1574,10 @@ test("the production TUI resumes and explicitly reactivates one committed MCP pr
 
     const resumed = startFixture({ program, stateRoot, workspaceRoot });
     await resumed.waitForRecordedOutput("Select a project session");
+    await resumed.waitForScreen("MCP reactivation session");
     const beforeSessionSelection = resumed.output().length;
     resumed.write("\u001b[B");
-    await resumed.waitForCompleteFrameAfter("MCP reactivation session", beforeSessionSelection);
+    await resumed.waitForCompleteFrameAfter("> MCP reactivation session", beforeSessionSelection);
     const beforeOpen = resumed.output().length;
     resumed.write("\r");
     await resumed.waitForCompleteFrameAfter("Adam · MCP reactivation session", beforeOpen);

--- a/apps/tui/src/project-runtime.ts
+++ b/apps/tui/src/project-runtime.ts
@@ -231,6 +231,7 @@ export async function createProductionProjectRuntime(
         );
       }
       presentationPromise = createPresentationSession({
+        backgroundStartup: true,
         lifecycle,
         modelTargets: options.modelTargets,
         operations: host.operations,

--- a/apps/tui/src/session-picker-startup.os.test.ts
+++ b/apps/tui/src/session-picker-startup.os.test.ts
@@ -1,0 +1,239 @@
+import { mkdir, mkdtemp, rename, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Worker } from "node:worker_threads";
+import {
+  createJsonlSessionStore,
+  createModelTargets,
+  createPresentationSession,
+  createSessionLifecycle,
+  type ModelDriver,
+  type ModelTargets,
+} from "@adam-agent/agent";
+import {
+  createTrustedWorkspaceTrustForTesting,
+  presentationCatalogPageSize,
+  sessionCatalogWorkerFactory,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+import { runTui } from "./tui-app.js";
+import {
+  terminalObservationTimeoutMilliseconds,
+  VirtualTerminal,
+} from "./virtual-terminal.test-support.js";
+
+async function guarded<T>(operation: Promise<T>, missing: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(missing)),
+          terminalObservationTimeoutMilliseconds,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+test.each([
+  "untouched",
+  "search",
+  "close",
+  "new",
+  "history",
+  "more",
+  "exit-held",
+  "missing-workspace",
+] as const)(
+  "background catalog respects the %s startup choice and reclaims its worker",
+  async (choice) => {
+    const root = await mkdtemp(join(tmpdir(), "adam-picker-startup-"));
+    const workspaceRoot = join(root, "workspace");
+    const stateRoot = join(root, "state");
+    await mkdir(workspaceRoot);
+    const configured = createModelTargets({
+      environment: { DEEPSEEK_API_KEY: "fixture-only-no-network" },
+    });
+    const driver: ModelDriver = {
+      async *stream() {
+        yield { type: "text_delta", text: "Saved fixture answer." };
+        yield { type: "finish", reason: "stop" };
+      },
+    };
+    const modelTargets: ModelTargets = {
+      ...configured,
+      async resolve(input) {
+        return { ...(await configured.resolve(input)), driver };
+      },
+    };
+    const heldStart = Promise.withResolvers<() => void>();
+    let workerExit: Promise<void> | undefined;
+    const lifecycle = createSessionLifecycle({
+      workspaceRoot,
+      stateRoot,
+      modelTargets,
+      workspaceTrust: createTrustedWorkspaceTrustForTesting(workspaceRoot),
+      [sessionCatalogWorkerFactory]: (url, options) => {
+        const worker = new Worker(url, options);
+        workerExit = new Promise<void>((resolve) => worker.once("exit", () => resolve()));
+        const post = worker.postMessage.bind(worker);
+        worker.postMessage = (...args: Parameters<Worker["postMessage"]>) => {
+          const [message] = args;
+          if (
+            typeof message === "object" &&
+            message !== null &&
+            "type" in message &&
+            message.type === "start"
+          ) {
+            heldStart.resolve(() => post(...args));
+          } else post(...args);
+        };
+        return worker;
+      },
+    });
+    const terminal = new VirtualTerminal({ columns: 100, rows: 24 });
+    let execution: Promise<void> | undefined;
+    let release: (() => void) | undefined;
+    try {
+      const targetId = "deepseek-v4-flash.direct";
+      if (choice === "search" || choice === "history" || choice === "more") {
+        const target = await modelTargets.resolve({
+          targetId,
+          allowExperimental: false,
+          signal: new AbortController().signal,
+        });
+        const saved = await lifecycle.create({ targetIdentity: target.identity });
+        await lifecycle.continue({
+          sessionId: saved.sessionId,
+          input: { text: "Saved history request" },
+        });
+        await lifecycle.setSessionManualName({ sessionId: saved.sessionId, name: "Saved history" });
+      }
+      if (choice === "more") {
+        const legacy = await createJsonlSessionStore({
+          workspaceRoot,
+          stateRoot,
+          sessionId: "123e4567-e89b-42d3-a456-426614174000",
+        });
+        await legacy.append({
+          schemaVersion: 1,
+          runId: "123e4567-e89b-42d3-a456-426614174000",
+          sequence: 1,
+          event: { type: "user_message", text: "Legacy page" },
+        });
+      }
+      const presentation = await createPresentationSession({
+        lifecycle,
+        modelTargets,
+        workspaceRoot,
+        stateRoot,
+        openProject: true,
+        backgroundStartup: true,
+        [presentationCatalogPageSize]: choice === "more" ? 1 : 20,
+        projectLabel: "workspace",
+      });
+      const catalogComplete = Promise.withResolvers<void>();
+      const seenDrafts: string[] = [];
+      const unsubscribe = presentation.subscribe(() => {
+        const state = presentation.getState();
+        if (state.draft !== null) seenDrafts.push(state.draft.targetId);
+        if (state.authoritative.sessions.health?.status === "complete") catalogComplete.resolve();
+      });
+      execution = runTui({
+        presentation,
+        terminal,
+        startupTargetId: targetId,
+        closeRuntime: () => lifecycle.close().then(() => {}),
+      });
+      release = await guarded(heldStart.promise, "held native catalog start");
+      if (workerExit === undefined) throw new Error("The held catalog has no native worker.");
+      await terminal.waitForScreen("Loading sessions…");
+      expect(presentation.getState().draft).toBeNull();
+      expect(terminal.lines().join("\n")).toContain("New Session");
+      if (choice === "exit-held") {
+        terminal.input("\u0011");
+        await execution;
+        await guarded(workerExit, "catalog worker exit while held");
+      } else if (choice === "missing-workspace") {
+        const beforeFailure = terminal.output().length;
+        await rename(workspaceRoot, join(root, "moved-workspace"));
+        release();
+        await terminal.waitForFrameAfter(
+          "History check failed",
+          beforeFailure,
+          "Loading sessions…",
+        );
+        expect(presentation.getState().authoritative.sessions).toMatchObject({
+          loading: false,
+          health: { status: "failed" },
+          error: { code: "catalog_scan_failed" },
+        });
+        const visibleText = terminal
+          .lines()
+          .map((line) => line.replaceAll("│", "").trim())
+          .join(" ");
+        expect(visibleText).toContain("Existing local sessions were retained.");
+        expect(presentation.getState().draft).toBeNull();
+        terminal.input("\u0011");
+        await execution;
+        await guarded(workerExit, "failed catalog worker exit");
+      } else {
+        if (choice === "search" || choice === "more") {
+          const before = terminal.output().length;
+          terminal.input("Saved");
+          await terminal.waitForFrameAfter("Search: Saved", before);
+        } else if (choice === "close") {
+          const before = terminal.output().length;
+          terminal.input("\u001b");
+          await terminal.waitForFrameAfter("No session", before, "Select a project session");
+        } else if (choice === "new") {
+          terminal.input("\r");
+          await terminal.waitForScreen("Select an exact model target");
+          terminal.input("\r");
+          await terminal.waitForScreen("New session draft");
+          const before = terminal.output().length;
+          terminal.input("Preserve my draft");
+          await terminal.waitForFrameAfter("Preserve my draft", before);
+        }
+        const beforeCompletion = terminal.output().length;
+        release();
+        await guarded(catalogComplete.promise, "completed native catalog");
+        if (choice === "untouched") {
+          await terminal.waitForFrameAfter("New session draft", beforeCompletion);
+          expect(presentation.getState().draft?.targetId).toBe(targetId);
+        } else if (choice === "search" || choice === "history") {
+          await terminal.waitForFrameAfter("Saved history", beforeCompletion);
+          expect(terminal.lines().join("\n")).toContain("Select a project session");
+          if (choice === "search") expect(terminal.lines().join("\n")).toContain("Search: Saved");
+          expect(presentation.getState().draft).toBeNull();
+        } else if (choice === "more") {
+          await terminal.waitForFrameAfter("Load More", beforeCompletion);
+          expect(presentation.getState().draft).toBeNull();
+          const beforePage = terminal.output().length;
+          terminal.input("\u001b[B\r");
+          await terminal.waitForFrameAfter("Saved history", beforePage);
+          expect(terminal.lines().join("\n")).toContain("Search: Saved");
+          expect(presentation.getState().authoritative.active).toBeNull();
+        } else if (choice === "new") {
+          expect(terminal.lines().join("\n")).toContain("Preserve my draft");
+          expect(presentation.getState().composer.renderedText).toBe("Preserve my draft");
+          expect(presentation.getState().draft?.targetId).toBe(targetId);
+        }
+        terminal.input("\u0011");
+        await execution;
+        await guarded(workerExit, "catalog worker exit");
+        if (choice === "close") expect(seenDrafts).toEqual([]);
+      }
+      unsubscribe();
+    } finally {
+      if (terminal.running()) terminal.input("\u0011");
+      await execution?.catch(() => {});
+      await lifecycle.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/apps/tui/src/session-picker.test.ts
+++ b/apps/tui/src/session-picker.test.ts
@@ -278,3 +278,132 @@ test("the MCP wizard accepts Kitty printable classification and commit keys", ()
     [expect.objectContaining({ qualifiedName: "fixture.inspect", effect: "read" })],
   );
 });
+
+function namedSession(id: string, label: string) {
+  return {
+    id,
+    label,
+    targetId: "deepseek-v4-flash.direct",
+    status: "idle" as const,
+    naming: {
+      manualName: label,
+      generatedTitle: null,
+      fallbackTitle: label,
+      displayLabel: label,
+      generation: { status: "not_started" as const },
+    },
+  };
+}
+
+function pickerFixture(sessions = [namedSession("alpha", "Alpha"), namedSession("beta", "Beta")]) {
+  const actions = {
+    onNewSession: vi.fn(),
+    onLoadMore: vi.fn(),
+    onRename: vi.fn(),
+    onSelect: vi.fn(),
+    onClose: vi.fn(),
+  };
+  const picker = new SessionPicker({
+    sessions,
+    hasMore: false,
+    theme: createAdamTuiTheme(true),
+    ...actions,
+  });
+  return { picker, actions };
+}
+
+test("catalog updates preserve search and selected session identity without opening a replacement", () => {
+  const { picker, actions } = pickerFixture();
+  picker.handleInput("a");
+  picker.handleInput("\u001b[B");
+  picker.setCatalog({
+    sessions: [
+      namedSession("new", "A new entry"),
+      namedSession("beta", "Beta"),
+      namedSession("alpha", "Alpha"),
+    ],
+    hasMore: true,
+  });
+  expect(picker.render(80).join("\n")).toContain("Search: a");
+  expect(picker.render(80).join("\n")).toContain("> Beta");
+  expect(actions.onSelect).not.toHaveBeenCalled();
+  picker.handleInput("\r");
+  expect(actions.onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: "beta" }));
+
+  picker.setCatalog({ sessions: [namedSession("alpha", "Alpha")], hasMore: false });
+  expect(actions.onSelect).toHaveBeenCalledTimes(1);
+  expect(picker.render(80).join("\n")).toContain("> Alpha");
+  picker.handleInput("\r");
+  expect(actions.onSelect).toHaveBeenLastCalledWith(expect.objectContaining({ id: "alpha" }));
+});
+
+test("catalog updates retain the diagnostic selection and keep incomplete checks explicit", () => {
+  const { picker, actions } = pickerFixture([]);
+  const diagnostic = (sessionId: string) => ({
+    sessionId,
+    code: "invalid_log" as const,
+    stage: "read" as const,
+    retained: true as const,
+    message: "Invalid log retained.",
+  });
+  picker.setCatalog({
+    sessions: [],
+    hasMore: false,
+    diagnostics: {
+      items: [diagnostic("bad-a"), diagnostic("bad-b")],
+      totalCount: 2,
+      truncated: false,
+    },
+    health: { status: "running", checked: 2, total: 4 },
+  });
+  picker.handleInput("\u001b[B");
+  picker.handleInput("\r");
+  picker.handleInput("\u001b[B");
+  picker.setCatalog({
+    sessions: [],
+    hasMore: false,
+    diagnostics: {
+      items: [diagnostic("bad-b"), diagnostic("bad-new"), diagnostic("bad-a")],
+      totalCount: 3,
+      truncated: false,
+    },
+    health: { status: "running", checked: 3, total: 4 },
+  });
+  const rendered = picker.render(80).join("\n");
+  expect(rendered).toContain("Invalid sessions");
+  expect(rendered).toContain("> bad-b");
+  expect(rendered).toContain("Checking history: 3 / 4 sessions.");
+  expect(rendered).not.toContain("complete");
+  expect(actions.onSelect).not.toHaveBeenCalled();
+});
+
+test("a loading catalog keeps New Session, search and close available without claiming empty history", () => {
+  const { picker, actions } = pickerFixture([]);
+  picker.setCatalog({
+    sessions: [],
+    hasMore: false,
+    loading: true,
+    health: { status: "not_started", checked: 0, total: null },
+  });
+  const rendered = picker.render(36).join("\n");
+  expect(rendered).toContain("New Session");
+  expect(rendered).toContain("Loading sessions…");
+  expect(rendered).toContain("History check not started.");
+  expect(rendered).not.toContain("No matching sessions");
+  picker.handleInput("query");
+  expect(picker.render(80).join("\n")).toContain("Search: query");
+  expect(picker.hasInteracted).toBe(true);
+  picker.handleInput("\r");
+  expect(actions.onNewSession).toHaveBeenCalledTimes(1);
+  picker.handleInput("\u001b");
+  expect(actions.onClose).toHaveBeenCalledTimes(1);
+  picker.setCatalog({
+    sessions: [],
+    hasMore: false,
+    loading: false,
+    health: { status: "failed", checked: 2, total: 4 },
+    error: { code: "read_failed", message: "Saved sessions could not be read." },
+  });
+  expect(picker.render(80).join("\n")).toContain("Saved sessions could not be read.");
+  expect(picker.render(80).join("\n")).toContain("Session list unavailable");
+});

--- a/apps/tui/src/session-picker.ts
+++ b/apps/tui/src/session-picker.ts
@@ -1,4 +1,8 @@
-import type { SessionHistoryDiagnosticsDisplay, SessionSummary } from "@adam-agent/presentation";
+import type {
+  SessionHistoryDiagnosticsDisplay,
+  SessionSummary,
+  SessionSummaryPage,
+} from "@adam-agent/presentation";
 import {
   type Component,
   fuzzyFilter,
@@ -19,33 +23,42 @@ type SessionPickerItem =
   | { readonly kind: "invalid_sessions" }
   | { readonly kind: "load_more" };
 
+export type SessionPickerCatalog = {
+  readonly sessions: readonly SessionSummary[];
+  readonly hasMore: boolean;
+  readonly diagnostics?: SessionHistoryDiagnosticsDisplay;
+} & Pick<SessionSummaryPage, "loading" | "health" | "error">;
+
 export class SessionPicker implements Component {
-  readonly #hasMore: boolean;
-  readonly #diagnostics: SessionHistoryDiagnosticsDisplay;
+  #hasMore: boolean;
+  #diagnostics: SessionHistoryDiagnosticsDisplay;
   readonly #onClose: () => void;
   readonly #onLoadMore: () => void;
   readonly #onNewSession: () => void;
   readonly #onRename: (session: SessionSummary) => void;
   readonly #onSelect: (session: SessionSummary) => void;
-  readonly #sessions: readonly SessionSummary[];
+  #sessions: readonly SessionSummary[];
   readonly #theme: AdamTuiTheme;
+  #loading: SessionSummaryPage["loading"];
+  #health: SessionSummaryPage["health"];
+  #error: SessionSummaryPage["error"];
+  #interacted = false;
   #notice: string | null = null;
   #query = "";
   #selectedIndex = 0;
   #diagnosticIndex = 0;
   #view: "sessions" | "diagnostics" = "sessions";
 
-  constructor(options: {
-    readonly sessions: readonly SessionSummary[];
-    readonly theme: AdamTuiTheme;
-    readonly onNewSession: () => void;
-    readonly onLoadMore: () => void;
-    readonly onRename: (session: SessionSummary) => void;
-    readonly onSelect: (session: SessionSummary) => void;
-    readonly onClose: () => void;
-    readonly hasMore: boolean;
-    readonly diagnostics?: SessionHistoryDiagnosticsDisplay;
-  }) {
+  constructor(
+    options: SessionPickerCatalog & {
+      readonly theme: AdamTuiTheme;
+      readonly onNewSession: () => void;
+      readonly onLoadMore: () => void;
+      readonly onRename: (session: SessionSummary) => void;
+      readonly onSelect: (session: SessionSummary) => void;
+      readonly onClose: () => void;
+    },
+  ) {
     this.#onNewSession = options.onNewSession;
     this.#onClose = options.onClose;
     this.#onLoadMore = options.onLoadMore;
@@ -59,6 +72,35 @@ export class SessionPicker implements Component {
       truncated: false,
     };
     this.#theme = options.theme;
+    this.#loading = options.loading;
+    this.#health = options.health;
+    this.#error = options.error;
+  }
+
+  get hasInteracted(): boolean {
+    return this.#interacted;
+  }
+
+  setCatalog(catalog: SessionPickerCatalog): void {
+    const selectedKey = itemKey(this.#items()[this.#selectedIndex]);
+    const diagnosticId = this.#diagnostics.items[this.#diagnosticIndex]?.sessionId;
+    this.#sessions = catalog.sessions;
+    this.#hasMore = catalog.hasMore;
+    this.#diagnostics = catalog.diagnostics ?? { items: [], totalCount: 0, truncated: false };
+    this.#loading = catalog.loading;
+    this.#health = catalog.health;
+    this.#error = catalog.error;
+    const items = this.#items();
+    const selectedIndex = items.findIndex((item) => itemKey(item) === selectedKey);
+    this.#selectedIndex =
+      selectedIndex < 0 ? Math.min(this.#selectedIndex, items.length - 1) : selectedIndex;
+    const diagnosticIndex = this.#diagnostics.items.findIndex(
+      (item) => item.sessionId === diagnosticId,
+    );
+    this.#diagnosticIndex =
+      diagnosticIndex < 0
+        ? Math.min(this.#diagnosticIndex, Math.max(0, this.#diagnostics.items.length - 1))
+        : diagnosticIndex;
   }
 
   setNotice(notice: string): void {
@@ -66,6 +108,7 @@ export class SessionPicker implements Component {
   }
 
   handleInput(data: string): void {
+    this.#interacted = true;
     const keybindings = getKeybindings();
     if (this.#view === "diagnostics") {
       if (keybindings.matches(data, "tui.select.up")) {
@@ -118,7 +161,7 @@ export class SessionPicker implements Component {
       const selected = items[this.#selectedIndex];
       if (selected?.kind === "new_session") {
         this.#onNewSession();
-      } else if (selected?.kind === "load_more") {
+      } else if (selected?.kind === "load_more" && !this.#loading) {
         this.#onLoadMore();
       } else if (selected?.kind === "invalid_sessions") {
         this.#diagnosticIndex = 0;
@@ -151,6 +194,7 @@ export class SessionPicker implements Component {
       this.#theme.toolTitle("Select a project session"),
       this.#renderNewSession(width),
       `Search: ${safeTerminalText(this.#query)}`,
+      ...this.#renderCatalogStatus(width),
       ...(this.#diagnostics.totalCount === 0
         ? []
         : [
@@ -159,7 +203,15 @@ export class SessionPicker implements Component {
           ]),
       "",
       ...(visibleItems.length === 0
-        ? [this.#theme.editor.selectList.noMatch("  No matching sessions")]
+        ? [
+            this.#theme.editor.selectList.noMatch(
+              this.#loading
+                ? "  Loading sessions…"
+                : this.#error === undefined
+                  ? "  No matching sessions"
+                  : "  Session list unavailable",
+            ),
+          ]
         : visibleItems.map((item, index) =>
             this.#renderResultItem(item, startIndex + index === selectedResultIndex, width),
           )),
@@ -221,8 +273,32 @@ export class SessionPicker implements Component {
               selected,
               width,
             )
-          : renderColumns("Load More", "Use the opaque catalog cursor", selected, width);
+          : renderColumns(
+              this.#loading ? "Loading more…" : "Load More",
+              "Use the opaque catalog cursor",
+              selected,
+              width,
+            );
     return selected ? this.#theme.editor.selectList.selectedText(content) : content;
+  }
+
+  #renderCatalogStatus(width: number): string[] {
+    const health = this.#health;
+    const progress =
+      health === undefined
+        ? undefined
+        : health.status === "not_started"
+          ? "History check not started."
+          : health.status === "complete"
+            ? `History check complete: ${health.checked} sessions.`
+            : health.status === "failed"
+              ? `History check failed after ${health.checked} sessions.`
+              : `Checking history: ${health.checked}${health.total === null ? "" : ` / ${health.total}`} sessions.`;
+    return [
+      ...(this.#loading && this.#sessions.length > 0 ? ["Loading sessions…"] : []),
+      ...(progress === undefined ? [] : [progress]),
+      ...(this.#error === undefined ? [] : [safeTerminalText(this.#error.message)]),
+    ].flatMap((line) => wrapTextWithAnsi(this.#theme.muted(line), Math.max(1, width)));
   }
 
   #diagnosticSummary(): string {
@@ -240,6 +316,7 @@ export class SessionPicker implements Component {
     const visibleItems = items.slice(startIndex, startIndex + 5);
     return [
       this.#theme.toolTitle("Invalid sessions"),
+      ...this.#renderCatalogStatus(width),
       `${this.#diagnostics.totalCount} retained${this.#diagnostics.truncated ? " · first 100 shown" : ""}`,
       "",
       ...visibleItems.flatMap((item, index) => {
@@ -263,6 +340,10 @@ export class SessionPicker implements Component {
       this.#theme.muted("↑/↓ move · Esc back · Ctrl+Q exit"),
     ];
   }
+}
+
+function itemKey(item: SessionPickerItem | undefined): string | undefined {
+  return item?.kind === "session" ? `session:${item.session.id}` : item?.kind;
 }
 
 function renderColumns(

--- a/apps/tui/src/tui-app.ts
+++ b/apps/tui/src/tui-app.ts
@@ -166,8 +166,13 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
   const startupTargetId =
     options.startupTargetId ??
     options.presentation.getState().authoritative.targets.defaultTargetId;
+  const initialCatalog = options.presentation.getState().authoritative.sessions;
+  let startupCatalogPending = initialCatalog.loading === true;
   let newSessionSelected =
-    options.presentation.getState().authoritative.sessions.items.length === 0;
+    !startupCatalogPending &&
+    initialCatalog.error === undefined &&
+    initialCatalog.nextCursor === null &&
+    initialCatalog.items.length === 0;
   let noticeActionId = 0;
   let statusNotice: TuiNotice | null = null;
   const beginNoticeAction = (): number => {
@@ -1649,6 +1654,31 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       agentConversation.viewer.setActivity(state.managedAgentActivity);
     }
     legacyAgentHistory?.navigator.setManagedAgents(state.authoritative.managedAgents);
+    const catalog = state.authoritative.sessions;
+    sessionPicker?.picker.setCatalog({
+      ...catalog,
+      sessions: catalog.items,
+      hasMore: catalog.nextCursor !== null,
+    });
+    if (startupCatalogPending && catalog.loading !== true) {
+      startupCatalogPending = false;
+      if (
+        active === null &&
+        state.draft === null &&
+        catalog.items.length === 0 &&
+        catalog.nextCursor === null &&
+        catalog.error === undefined &&
+        !newSessionSelected &&
+        !sessionPickerDismissed &&
+        !sessionPickerRequested &&
+        sessionPicker?.picker.hasInteracted !== true &&
+        targetPicker === undefined
+      ) {
+        newSessionSelected = true;
+        sessionPicker?.hide();
+        sessionPicker = undefined;
+      }
+    }
     targetPicker?.picker.setTargets(
       state.authoritative.targets.items,
       state.authoritative.targets.defaultTargetId,
@@ -1731,11 +1761,19 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
       }
     }
     const needsSessionChoice =
-      active === null && state.authoritative.sessions.items.length > 0 && !newSessionSelected;
+      active === null &&
+      state.draft === null &&
+      !newSessionSelected &&
+      (catalog.items.length > 0 ||
+        catalog.nextCursor !== null ||
+        catalog.loading === true ||
+        catalog.error !== undefined ||
+        sessionPicker !== undefined);
     if (
       !startupTrustBlocked &&
       active === null &&
       !needsSessionChoice &&
+      newSessionSelected &&
       startupTargetId !== null &&
       startupTargetId !== undefined &&
       !defaultTargetAttempted
@@ -1784,6 +1822,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         tui.requestRender();
       };
       const picker = new SessionPicker({
+        ...state.authoritative.sessions,
         sessions: state.authoritative.sessions.items,
         hasMore: state.authoritative.sessions.nextCursor !== null,
         ...(state.authoritative.sessions.diagnostics === undefined
@@ -1832,8 +1871,6 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
             .dispatch({ type: "load_more_sessions", after })
             .then((receipt) => {
               if (receipt.status === "admitted") {
-                sessionPicker?.hide();
-                sessionPicker = undefined;
                 renderState();
               } else if (sessionPicker?.picker === picker) {
                 picker.setNotice(receipt.message);
@@ -1870,6 +1907,7 @@ export async function runTui(options: RunTuiOptions): Promise<void> {
         (active === null &&
           state.draft === null &&
           !needsSessionChoice &&
+          newSessionSelected &&
           (startupTargetId === null || startupTargetId === undefined || defaultTargetRejected))) &&
       state.authoritative.targets.items.length > 0
     ) {

--- a/apps/tui/src/uir-state-lifecycle.test.ts
+++ b/apps/tui/src/uir-state-lifecycle.test.ts
@@ -170,8 +170,11 @@ test("selecting another session clears the old role catalog and reloads the dest
     expect(h.presentation.getState().agentRoles?.map((role) => role.name)).not.toContain(
       "Original",
     );
-    await h.terminal.waitForFrameAfter("Select a project session", createOffset);
-    await h.press("\x1b", "New session draft", "Select a project session");
+    await h.terminal.waitForFrameAfter(
+      "New session draft",
+      createOffset,
+      "Select a project session",
+    );
     await h.press("@Destination", "New agent · Destination evidence.");
     await h.press("\t", "@Destination");
     await h.press(" Inspect evidence.\r", "Delegation");

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -147,6 +147,11 @@ export {
   createPresentationSession,
 } from "./presentation-session.js";
 export type { RuntimePhaseDiagnostic } from "./runtime-phase-diagnostics.js";
+export type {
+  ProjectSessionCatalogController,
+  ProjectSessionCatalogSnapshot,
+  ProjectSessionCatalogStartOptions,
+} from "./session-catalog-job.js";
 export {
   type CurrentSessionSnapshot,
   createSessionLifecycle,

--- a/packages/agent/src/internal-testing.ts
+++ b/packages/agent/src/internal-testing.ts
@@ -133,6 +133,10 @@ export {
   createWorkspaceTrustWithStorageForTesting,
 } from "./secure-user-configuration.js";
 export {
+  type SessionCatalogWorkerFactory,
+  sessionCatalogWorkerFactory,
+} from "./session-catalog-job.js";
+export {
   sessionDurableContext,
   sessionDurableOutputLimits,
 } from "./session-durable-context.js";

--- a/packages/agent/src/presentation-session.ts
+++ b/packages/agent/src/presentation-session.ts
@@ -15,6 +15,7 @@ import type {
   PresentationCommand,
   PresentationDisplayState,
   PresentationSession,
+  ProjectPathCatalogDisplay,
   RepositoryInstructionsDisplay,
   SessionHistoryDiagnosticsDisplay,
   SessionNaming,
@@ -96,6 +97,8 @@ import {
   effectiveSessionStateRoot,
   type ManagedAgentNotification,
   type ManagedAgentTranscriptRecords,
+  type ProjectSessionCatalogController,
+  type ProjectSessionCatalogSnapshot,
   type ProjectSessionSummary,
   type SessionContextUsageSnapshot,
   type SessionHistoryDiagnostics,
@@ -172,6 +175,8 @@ export type PresentationSessionRecordReader = (
 ) => Promise<readonly SessionRecord[]>;
 
 type PresentationSessionBaseOptions = {
+  /** Keep native catalog and path discovery off the interactive startup boundary. */
+  readonly backgroundStartup?: boolean;
   readonly draftPersistencePolicy?: "process_only" | "recoverable";
   readonly lifecycle: SessionLifecycle;
   readonly modelTargets?: ModelTargets;
@@ -224,6 +229,10 @@ export type CreatePresentationSessionOptions = PresentationSessionBaseOptions &
 export async function createPresentationSession(
   options: CreatePresentationSessionOptions,
 ): Promise<PresentationSession> {
+  const startupAbort = new AbortController();
+  let startupCatalog: ProjectSessionCatalogController | undefined;
+  let startupPaths: Promise<void> | undefined;
+  let startupClosing = false;
   options.lifecycle.enableAutomaticTitles();
   const webSearchConfiguration =
     options.webSearchEnvironment === undefined
@@ -368,7 +377,9 @@ export async function createPresentationSession(
     let loadedTranscriptStart = Math.max(0, transcript.length - historyPageSize);
     const naming =
       created === undefined ? undefined : projectSessionNaming(records, created.sessionId);
-    const catalogPageSize = boundedCatalogPageSize(options[presentationCatalogPageSize]);
+    const catalogPageSize = boundedCatalogPageSize(
+      options[presentationCatalogPageSize] ?? (options.backgroundStartup ? 20 : undefined),
+    );
     const activeSummary: SessionSummary | undefined =
       created === undefined || naming === undefined
         ? undefined
@@ -494,11 +505,18 @@ export async function createPresentationSession(
     ) {
       knownTargets.set(options.targetIdentity.targetId, options.targetIdentity);
     }
-    const catalogPage = await options.lifecycle.listProjectSessionSummaries({
-      limit: catalogPageSize,
-    });
     const workspaceTrustSnapshot = await options.lifecycle.inspectWorkspaceTrust();
-    const projectPaths = await listProjectPaths(options.workspaceRoot);
+    const catalogPage = options.backgroundStartup
+      ? {
+          projectId: workspaceTrustSnapshot.projectId ?? "",
+          items: [],
+          nextCursor: null,
+          diagnostics: { items: [], totalCount: 0, truncated: false },
+        }
+      : await options.lifecycle.listProjectSessionSummaries({ limit: catalogPageSize });
+    let projectPaths: ProjectPathCatalogDisplay = options.backgroundStartup
+      ? { items: [], omittedCount: 0, diagnostic: null, loading: true }
+      : await listProjectPaths(options.workspaceRoot);
     const catalogItems = catalogPage.items.flatMap((snapshot) => {
       if (snapshot.schemaVersion !== 3) return [];
       if (!knownTargets.has(snapshot.targetIdentity.targetId)) {
@@ -627,6 +645,12 @@ export async function createPresentationSession(
         items: initialCatalogItems,
         nextCursor: catalogPage.nextCursor,
         diagnostics: projectSessionHistoryDiagnostics(catalogPage.diagnostics),
+        ...(options.backgroundStartup
+          ? {
+              loading: true,
+              health: { status: "not_started" as const, checked: 0, total: null },
+            }
+          : {}),
       },
       managedAgents: initialManagedAgents,
       active:
@@ -720,10 +744,23 @@ export async function createPresentationSession(
         executionFailure = error.executionFailure;
     };
     let closed = false;
+    const locallyUpdatedCatalog = new Map<
+      string,
+      { readonly summary: SessionSummary; readonly throughSequence: number }
+    >();
+    const locallyCreatedCatalogIds = new Set<string>();
+    const observedCatalogIds = new Set<string>();
     let controlObserver: AbortController | undefined;
     let controlObserverParent: string | undefined;
     let controlObservation = Promise.resolve();
     const publishStateChange = (): void => {
+      const active = state.authoritative.active;
+      if (active !== null) {
+        locallyUpdatedCatalog.set(active.session.id, {
+          summary: active.session,
+          throughSequence: activeSessionThroughSequence,
+        });
+      }
       for (const listener of listeners) {
         notifyObserver(listener);
       }
@@ -1816,6 +1853,7 @@ export async function createPresentationSession(
                 operationThrough: operationCursorSnapshot(),
               },
           sessions: {
+            ...state.authoritative.sessions,
             items: catalogItems,
             nextCursor: state.authoritative.sessions.nextCursor,
           },
@@ -3337,6 +3375,7 @@ export async function createPresentationSession(
             targetIdentity: draftTargetIdentity,
             mode: state.draft?.mode ?? "default",
           });
+          locallyCreatedCatalogIds.add(snapshot.sessionId);
           parentSessionId = snapshot.sessionId;
           await activateSnapshot(snapshot);
           control = await options.lifecycle[sessionManagedControl](parentSessionId);
@@ -5504,6 +5543,8 @@ export async function createPresentationSession(
             if (receipt.runId !== commandId) {
               return;
             }
+            if (!observedCatalogIds.has(receipt.sessionId))
+              locallyCreatedCatalogIds.add(receipt.sessionId);
             admittedSessionId = receipt.sessionId;
             if (activeRun === runState) runState.sessionId = receipt.sessionId;
             admission.resolve(receipt.sessionId);
@@ -5617,6 +5658,7 @@ export async function createPresentationSession(
               : { sourceBoundary: command.sourceBoundary }),
             ...(command.targetId === null ? {} : { targetId: command.targetId }),
           });
+          locallyCreatedCatalogIds.add(snapshot.sessionId);
           const summary = sessionSummaryFromSnapshot(
             snapshot,
             await readActiveBranchRecords(options, snapshot.sessionId),
@@ -6048,6 +6090,10 @@ export async function createPresentationSession(
           };
         }
         try {
+          if (startupCatalog !== undefined) {
+            await startupCatalog.loadMore(command.after);
+            return { status: "admitted", commandId: randomUUID(), resource: null };
+          }
           const page = await options.lifecycle.listProjectSessionSummaries({
             cursor: command.after,
             limit: catalogPageSize,
@@ -6672,6 +6718,108 @@ export async function createPresentationSession(
       };
     };
 
+    if (options.backgroundStartup) {
+      const applyCatalog = (catalog: ProjectSessionCatalogSnapshot): void => {
+        if (closed || startupClosing) return;
+        if (
+          state.authoritative.project.id.length > 0 &&
+          catalog.projectId !== state.authoritative.project.id &&
+          !(catalog.projectId === "" && catalog.phase === "failed")
+        )
+          return;
+        const invalidIds = new Set(catalog.diagnostics.items.map((item) => item.sessionId));
+        const included = new Set<string>();
+        const items = catalog.items.flatMap((item) => {
+          if (item.schemaVersion !== 3) return [];
+          observedCatalogIds.add(item.sessionId);
+          locallyCreatedCatalogIds.delete(item.sessionId);
+          if (!knownTargets.has(item.targetIdentity.targetId))
+            knownTargets.set(item.targetIdentity.targetId, item.targetIdentity);
+          included.add(item.sessionId);
+          const local = locallyUpdatedCatalog.get(item.sessionId);
+          const current = state.authoritative.active?.session;
+          return [
+            current?.id === item.sessionId
+              ? current
+              : local !== undefined && local.throughSequence > item.lastSequence
+                ? local.summary
+                : sessionSummaryFromCatalog(item),
+          ];
+        });
+        for (const [id, local] of locallyUpdatedCatalog) {
+          if (locallyCreatedCatalogIds.has(id) && !included.has(id) && !invalidIds.has(id))
+            items.push(local.summary);
+        }
+        const active = state.authoritative.active;
+        if (active !== null && !items.some((item) => item.id === active.session.id))
+          items.push(active.session);
+        state = {
+          ...state,
+          revision: state.revision + 1,
+          authoritative: {
+            ...state.authoritative,
+            project: {
+              ...state.authoritative.project,
+              id: state.authoritative.project.id || catalog.projectId,
+            },
+            sessions: {
+              items,
+              nextCursor: catalog.nextCursor,
+              diagnostics: projectSessionHistoryDiagnostics(catalog.diagnostics),
+              loading: catalog.phase === "loading",
+              health: catalog.health,
+              ...(catalog.error === undefined ? {} : { error: catalog.error }),
+            },
+          },
+        };
+        publishStateChange();
+      };
+      startupCatalog = options.lifecycle.startProjectSessionCatalog({
+        limit: catalogPageSize,
+        onUpdate: applyCatalog,
+      });
+      startupPaths = listProjectPaths(options.workspaceRoot, startupAbort.signal)
+        .then((paths) => {
+          if (closed || startupClosing) return;
+          projectPaths = { ...paths, loading: false };
+          state = {
+            ...state,
+            revision: state.revision + 1,
+            authoritative: {
+              ...state.authoritative,
+              active:
+                state.authoritative.active === null
+                  ? null
+                  : { ...state.authoritative.active, projectPaths },
+            },
+            draft: state.draft === null ? null : { ...state.draft, projectPaths },
+          };
+          publishStateChange();
+        })
+        .catch(() => {
+          if (closed || startupClosing) return;
+          projectPaths = {
+            items: [],
+            omittedCount: 0,
+            diagnostic: { code: "project_path_catalog_unavailable" },
+            loading: false,
+          };
+          state = {
+            ...state,
+            revision: state.revision + 1,
+            authoritative: {
+              ...state.authoritative,
+              active:
+                state.authoritative.active === null
+                  ? null
+                  : { ...state.authoritative.active, projectPaths },
+            },
+            draft: state.draft === null ? null : { ...state.draft, projectPaths },
+          };
+          publishStateChange();
+        });
+    }
+
     return {
       getState: () => {
         const active = state.authoritative.active;
@@ -6745,6 +6893,10 @@ export async function createPresentationSession(
         if (closed) {
           return;
         }
+        startupClosing = true;
+        startupAbort.abort();
+        await startupCatalog?.close();
+        await startupPaths;
         await persistSettledCurrentTurnDraft();
         closed = true;
         controlObserver?.abort();
@@ -6792,6 +6944,10 @@ export async function createPresentationSession(
       },
     };
   } catch (error) {
+    startupClosing = true;
+    startupAbort.abort();
+    await startupCatalog?.close();
+    await startupPaths;
     unsubscribeLifecycle();
     unsubscribeMetadata();
     unsubscribeManagedAgentEvents();

--- a/packages/agent/src/project-path-catalog.ts
+++ b/packages/agent/src/project-path-catalog.ts
@@ -13,7 +13,11 @@ const maximumDirectoryEntries = 20_000;
 const maximumFiles = 4_096;
 const maximumPathBytes = 4_096;
 
-export async function listProjectPaths(workspaceRoot: string): Promise<ProjectPathCatalog> {
+export async function listProjectPaths(
+  workspaceRoot: string,
+  signal?: AbortSignal,
+): Promise<ProjectPathCatalog> {
+  signal?.throwIfAborted();
   const canonicalRoot = await realpath(workspaceRoot);
   const pending = [canonicalRoot];
   const paths: string[] = [];
@@ -23,6 +27,7 @@ export async function listProjectPaths(workspaceRoot: string): Promise<ProjectPa
   let truncated = false;
 
   while (pending.length > 0 && !truncated) {
+    signal?.throwIfAborted();
     const directory = pending.shift();
     if (directory === undefined) {
       break;
@@ -38,6 +43,7 @@ export async function listProjectPaths(workspaceRoot: string): Promise<ProjectPa
     } catch {
       continue;
     }
+    signal?.throwIfAborted();
     entries.sort((left, right) => left.name.localeCompare(right.name));
     for (const entry of entries) {
       visitedEntries += 1;
@@ -64,6 +70,7 @@ export async function listProjectPaths(workspaceRoot: string): Promise<ProjectPa
     }
   }
   paths.sort((left, right) => left.localeCompare(right));
+  signal?.throwIfAborted();
   return {
     items: paths,
     omittedCount,

--- a/packages/agent/src/session-catalog-job.ts
+++ b/packages/agent/src/session-catalog-job.ts
@@ -1,0 +1,238 @@
+import { createHash, randomUUID } from "node:crypto";
+import { realpath } from "node:fs/promises";
+import { Worker, type WorkerOptions } from "node:worker_threads";
+import { notifyObserver } from "./observer-notification.js";
+import type { PlanEligibleToolProfileV1 } from "./plan-mode.js";
+import type {
+  SessionCatalogAuthorityRequest,
+  SessionCatalogWorkerEvent,
+  SessionCatalogWorkerRequest,
+} from "./session-catalog-protocol.js";
+import type {
+  ProjectSessionSummaryPage,
+  ReadOnlySessionMcpInputs,
+  SessionPlanAuthorityInput,
+} from "./session-lifecycle.js";
+import { SessionLifecycleError } from "./session-lifecycle-error.js";
+import { SessionStoreError } from "./session-store.js";
+
+/** One enumeration generation. Running diagnostics are partial; complete means every entry was inspected. */
+export type ProjectSessionCatalogSnapshot = ProjectSessionSummaryPage & {
+  readonly phase: "loading" | "ready" | "failed";
+  readonly health: {
+    readonly status: "not_started" | "running" | "complete" | "failed";
+    readonly checked: number;
+    readonly total: number | null;
+  };
+  readonly error?: {
+    readonly code: "catalog_unavailable" | "catalog_scan_failed";
+    readonly message: string;
+  };
+};
+
+export type ProjectSessionCatalogController = {
+  /** Continue this generation's compact observations; a new job refreshes external changes. */
+  readonly loadMore: (cursor: string) => Promise<void>;
+  readonly close: () => Promise<void>;
+};
+
+export type ProjectSessionCatalogStartOptions = {
+  readonly limit?: number;
+  readonly onUpdate: (snapshot: ProjectSessionCatalogSnapshot) => void;
+};
+
+/** Tests may hold the native worker transport's start message without replacing catalog behavior. */
+export const sessionCatalogWorkerFactory = Symbol("adam-agent.session-catalog-worker-factory");
+export type SessionCatalogWorkerFactory = (url: URL, options: WorkerOptions) => Worker;
+
+type CatalogAuthority = {
+  readonly resolvePlanProfile: (
+    input: SessionPlanAuthorityInput,
+  ) => Promise<PlanEligibleToolProfileV1>;
+  readonly inspectMcpInputs: (sessionId: string) => Promise<ReadOnlySessionMcpInputs>;
+};
+
+/** One native read-only worker; the owning Lifecycle supplies live authority without tool execution. */
+export function startNativeSessionCatalog(
+  input: ProjectSessionCatalogStartOptions &
+    CatalogAuthority & {
+      readonly workspaceRoot: string;
+      readonly stateRoot: string;
+      readonly supported: boolean;
+      readonly beforeStart?: Promise<void>;
+      readonly workerFactory?: SessionCatalogWorkerFactory;
+    },
+): ProjectSessionCatalogController {
+  const limit = input.limit ?? 20;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new SessionLifecycleError("session_invalid");
+  }
+  let closed = false;
+  let failed = false;
+  let worker: Worker | undefined;
+  let latest: ProjectSessionCatalogSnapshot = {
+    projectId: "",
+    items: [],
+    nextCursor: null,
+    diagnostics: { items: [], totalCount: 0, truncated: false },
+    phase: "loading",
+    health: { status: "not_started", checked: 0, total: null },
+  };
+  let closePromise: Promise<void> | undefined;
+  let termination: Promise<void> | undefined;
+  const exited = Promise.withResolvers<void>();
+  const pages = new Map<number, ReturnType<typeof Promise.withResolvers<void>>>();
+  let nextPageId = 0;
+  const stopWorker = (): Promise<void> => {
+    const current = worker;
+    if (current === undefined) return Promise.resolve();
+    termination ??= (async () => {
+      await current.terminate();
+      await exited.promise;
+    })();
+    return termination;
+  };
+  const publish = (snapshot: ProjectSessionCatalogSnapshot) => {
+    latest = snapshot;
+    if (!closed) notifyObserver(() => input.onUpdate(snapshot));
+  };
+  const fail = (code: "catalog_unavailable" | "catalog_scan_failed") => {
+    if (closed || failed) return;
+    failed = true;
+    for (const page of pages.values()) page.reject(new Error("The history scan is unavailable."));
+    pages.clear();
+    if (latest !== undefined) {
+      publish({
+        ...latest,
+        phase: "failed",
+        health: { ...latest.health, status: "failed" },
+        error: {
+          code,
+          message:
+            code === "catalog_unavailable"
+              ? "Background history loading is unavailable for this session store."
+              : "The history scan could not be completed. Existing local sessions were retained.",
+        },
+      });
+    }
+    // A failed scan has no further work. Its owner still observes termination again during close.
+    void stopWorker().catch(() => {});
+  };
+  const resolveAuthority = async (request: SessionCatalogAuthorityRequest) =>
+    request.type === "plan"
+      ? input.resolvePlanProfile(request.input)
+      : input.inspectMcpInputs(request.sessionId);
+  const handleMessage = (message: SessionCatalogWorkerEvent) => {
+    if (closed || failed) return;
+    if (message.type === "update") {
+      if (message.snapshot.phase === "failed") {
+        latest = message.snapshot;
+        fail(message.snapshot.error?.code ?? "catalog_scan_failed");
+        return;
+      }
+      publish(message.snapshot);
+      return;
+    }
+    if (message.type === "page_settled") {
+      const page = pages.get(message.id);
+      pages.delete(message.id);
+      if (message.ok) page?.resolve();
+      else page?.reject(new SessionLifecycleError("session_invalid"));
+      return;
+    }
+    // The worker sends only already-parsed profile identities, never tool calls or full histories.
+    void resolveAuthority(message.request)
+      .then(
+        (value) => {
+          if (closed || failed) return;
+          worker?.postMessage({
+            type: "authority_result",
+            id: message.id,
+            result: { ok: true, value },
+          } satisfies SessionCatalogWorkerRequest);
+        },
+        (error: unknown) => {
+          if (closed || failed) return;
+          worker?.postMessage({
+            type: "authority_result",
+            id: message.id,
+            result: {
+              ok: false,
+              code:
+                error instanceof SessionLifecycleError
+                  ? error.code
+                  : error instanceof SessionStoreError &&
+                      (error.code === "session_log_invalid" ||
+                        error.code === "session_log_too_large")
+                    ? error.code
+                    : null,
+            },
+          } satisfies SessionCatalogWorkerRequest);
+        },
+      )
+      .catch(() => fail("catalog_scan_failed"));
+  };
+  const started = (async () => {
+    await input.beforeStart;
+    if (closed) return;
+    const canonicalRoot = await realpath(input.workspaceRoot);
+    if (closed) return;
+    publish({
+      projectId: `sha256:${createHash("sha256").update(canonicalRoot).digest("hex")}`,
+      items: [],
+      nextCursor: null,
+      diagnostics: { items: [], totalCount: 0, truncated: false },
+      phase: "loading",
+      health: { status: "not_started", checked: 0, total: null },
+    });
+    if (!input.supported) {
+      fail("catalog_unavailable");
+      return;
+    }
+    if (closed) return;
+    const createWorker = input.workerFactory ?? ((url, options) => new Worker(url, options));
+    worker = createWorker(new URL("./session-catalog-worker.js", import.meta.url), {
+      workerData: {
+        workspaceRoot: input.workspaceRoot,
+        stateRoot: input.stateRoot,
+        limit,
+        generation: randomUUID(),
+      },
+    });
+    worker.on("message", handleMessage);
+    worker.on("error", () => fail("catalog_scan_failed"));
+    worker.once("exit", () => {
+      exited.resolve();
+      if (!closed) fail("catalog_scan_failed");
+    });
+    worker.postMessage({ type: "start" } satisfies SessionCatalogWorkerRequest);
+  })().catch(() => fail("catalog_scan_failed"));
+
+  return {
+    async loadMore(cursor) {
+      await started;
+      if (closed) throw new DOMException("The history catalog was closed.", "AbortError");
+      if (failed || worker === undefined || latest?.nextCursor !== cursor) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      const id = ++nextPageId;
+      const page = Promise.withResolvers<void>();
+      pages.set(id, page);
+      worker.postMessage({ type: "load_more", id, cursor } satisfies SessionCatalogWorkerRequest);
+      return page.promise;
+    },
+    close() {
+      if (closePromise !== undefined) return closePromise;
+      closed = true;
+      for (const page of pages.values()) {
+        page.reject(new DOMException("The history catalog was closed.", "AbortError"));
+      }
+      pages.clear();
+      closePromise = (async () => {
+        await started;
+        await stopWorker();
+      })();
+      return closePromise;
+    },
+  };
+}

--- a/packages/agent/src/session-catalog-protocol.ts
+++ b/packages/agent/src/session-catalog-protocol.ts
@@ -1,0 +1,47 @@
+import type { PlanEligibleToolProfileV1 } from "./plan-mode.js";
+import type { ProjectSessionCatalogSnapshot } from "./session-catalog-job.js";
+import type { ReadOnlySessionMcpInputs, SessionPlanAuthorityInput } from "./session-lifecycle.js";
+import type { SessionLifecycleError } from "./session-lifecycle-error.js";
+
+export type SessionCatalogWorkerData = {
+  readonly workspaceRoot: string;
+  readonly stateRoot: string;
+  readonly limit: number;
+  readonly generation: string;
+};
+
+export type SessionCatalogAuthorityRequest =
+  | { readonly type: "plan"; readonly input: SessionPlanAuthorityInput }
+  | { readonly type: "mcp"; readonly sessionId: string };
+
+export type SessionCatalogAuthorityResult =
+  | {
+      readonly ok: true;
+      readonly value: PlanEligibleToolProfileV1 | ReadOnlySessionMcpInputs;
+    }
+  | {
+      readonly ok: false;
+      readonly code:
+        | SessionLifecycleError["code"]
+        | "session_log_invalid"
+        | "session_log_too_large"
+        | null;
+    };
+
+export type SessionCatalogWorkerRequest =
+  | { readonly type: "start" }
+  | { readonly type: "load_more"; readonly id: number; readonly cursor: string }
+  | {
+      readonly type: "authority_result";
+      readonly id: number;
+      readonly result: SessionCatalogAuthorityResult;
+    };
+
+export type SessionCatalogWorkerEvent =
+  | { readonly type: "update"; readonly snapshot: ProjectSessionCatalogSnapshot }
+  | {
+      readonly type: "authority";
+      readonly id: number;
+      readonly request: SessionCatalogAuthorityRequest;
+    }
+  | { readonly type: "page_settled"; readonly id: number; readonly ok: boolean };

--- a/packages/agent/src/session-catalog-worker.ts
+++ b/packages/agent/src/session-catalog-worker.ts
@@ -1,0 +1,274 @@
+import { createHash } from "node:crypto";
+import { realpath } from "node:fs/promises";
+import { parentPort, workerData } from "node:worker_threads";
+import type { PlanEligibleToolProfileV1 } from "./plan-mode.js";
+import type { ProjectSessionCatalogSnapshot } from "./session-catalog-job.js";
+import type {
+  SessionCatalogAuthorityRequest,
+  SessionCatalogAuthorityResult,
+  SessionCatalogWorkerData,
+  SessionCatalogWorkerEvent,
+  SessionCatalogWorkerRequest,
+} from "./session-catalog-protocol.js";
+import {
+  isGenesisRecord,
+  sessionNamingStateFromRecords,
+  sessionRunBoundaryFromRecords,
+} from "./session-history-folds.js";
+import {
+  createReadOnlySessionInspector,
+  type ProjectSessionSummary,
+  type ReadOnlySessionMcpInputs,
+  type SessionHistoryDiagnostic,
+  sessionHistoryDiagnosticFromError,
+} from "./session-lifecycle.js";
+import { SessionLifecycleError } from "./session-lifecycle-error.js";
+import {
+  createJsonlSessionStoreDirectory,
+  type SessionRecord,
+  type SessionStoreDirectoryEntry,
+  SessionStoreError,
+} from "./session-store.js";
+
+const port = parentPort;
+if (port === null) throw new Error("The session catalog requires a worker message port.");
+const input = workerData as SessionCatalogWorkerData;
+const directory = createJsonlSessionStoreDirectory(input);
+const readRecords = async (sessionId: string): Promise<readonly SessionRecord[]> =>
+  (await directory.readRecords?.(sessionId)) ?? [];
+const post = (message: SessionCatalogWorkerEvent) => port.postMessage(message);
+const pendingAuthority = new Map<
+  number,
+  ReturnType<typeof Promise.withResolvers<SessionCatalogAuthorityResult>>
+>();
+let nextAuthorityId = 0;
+const requestAuthority = async (request: SessionCatalogAuthorityRequest) => {
+  const id = ++nextAuthorityId;
+  const pending = Promise.withResolvers<SessionCatalogAuthorityResult>();
+  pendingAuthority.set(id, pending);
+  post({ type: "authority", id, request });
+  const result = await pending.promise;
+  if (!result.ok) {
+    if (result.code === "session_log_invalid" || result.code === "session_log_too_large") {
+      throw new SessionStoreError(result.code);
+    }
+    if (result.code !== null) throw new SessionLifecycleError(result.code);
+    throw new Error("The current session inspection authority is unavailable.");
+  }
+  return result.value;
+};
+const inspect = createReadOnlySessionInspector({
+  options: input,
+  readRecords,
+  resolvePlanProfile: async (query) =>
+    (await requestAuthority({ type: "plan", input: query })) as PlanEligibleToolProfileV1,
+  inspectMcpInputs: async (sessionId) =>
+    (await requestAuthority({ type: "mcp", sessionId })) as ReadOnlySessionMcpInputs,
+});
+let projectId = "";
+let entries: readonly SessionStoreDirectoryEntry[] = [];
+let position = 0;
+let wantedItems = input.limit;
+let checked = 0;
+let started = false;
+let failed = false;
+let health: ProjectSessionCatalogSnapshot["health"]["status"] = "not_started";
+let phase: ProjectSessionCatalogSnapshot["phase"] = "loading";
+// Compact observations live only for this generation. Full inspection replaces provisional metadata.
+const summaries = new Map<string, ProjectSessionSummary>();
+const diagnostics = new Map<string, SessionHistoryDiagnostic>();
+const healthChecked = new Set<string>();
+let pageWork = Promise.resolve();
+
+function cursor(): string | null {
+  const unread = entries.slice(position).some((entry) => !healthChecked.has(entry.sessionId));
+  return summaries.size > wantedItems || unread
+    ? `project-summaries:v1:${input.generation}:${wantedItems}`
+    : null;
+}
+
+function publish(error?: ProjectSessionCatalogSnapshot["error"]): void {
+  const knownDiagnostics = [...diagnostics.values()].sort((left, right) =>
+    left.sessionId < right.sessionId ? -1 : left.sessionId > right.sessionId ? 1 : 0,
+  );
+  post({
+    type: "update",
+    snapshot: {
+      projectId,
+      items: entries
+        .flatMap((entry) => {
+          const item = summaries.get(entry.sessionId);
+          return item === undefined ? [] : [item];
+        })
+        .slice(0, wantedItems),
+      nextCursor: cursor(),
+      diagnostics: {
+        items: knownDiagnostics.slice(0, 100),
+        totalCount: knownDiagnostics.length,
+        truncated: knownDiagnostics.length > 100,
+      },
+      phase,
+      health: { status: health, checked, total: entries.length },
+      ...(error === undefined ? {} : { error }),
+    },
+  });
+}
+
+function fail(): void {
+  if (failed) return;
+  failed = true;
+  phase = "failed";
+  health = "failed";
+  publish({
+    code: "catalog_scan_failed",
+    message: "The history scan could not be completed. Existing local sessions were retained.",
+  });
+}
+
+function isolate(sessionId: string, error: unknown): boolean {
+  if (error instanceof SessionLifecycleError && error.code === "session_not_found") {
+    summaries.delete(sessionId);
+    diagnostics.delete(sessionId);
+    return true;
+  }
+  const diagnostic = sessionHistoryDiagnosticFromError(sessionId, error);
+  if (diagnostic === undefined) return false;
+  diagnostics.set(sessionId, diagnostic);
+  summaries.delete(sessionId);
+  return true;
+}
+
+function hasAcceptedInput(records: readonly SessionRecord[]): boolean {
+  return records.some((entry) =>
+    entry.schemaVersion === 3
+      ? entry.record.type === "logical_run_started"
+      : entry.event.type === "user_message",
+  );
+}
+
+function summary(sessionId: string, records: readonly SessionRecord[]): ProjectSessionSummary {
+  const first = records[0];
+  if (first === undefined) throw new SessionLifecycleError("session_not_found");
+  if (first.schemaVersion !== 3) {
+    if (records.some((entry) => entry.schemaVersion === 3)) {
+      throw new SessionLifecycleError("session_invalid");
+    }
+    return {
+      schemaVersion: records.some((entry) => entry.schemaVersion === 2) ? 2 : 1,
+      projectId,
+      sessionId,
+      lastSequence: records.length,
+      status: "legacy",
+    };
+  }
+  if (!isGenesisRecord(first) || first.record.sessionId !== sessionId) {
+    throw new SessionLifecycleError("session_invalid");
+  }
+  if (first.record.projectId !== projectId) {
+    throw new SessionLifecycleError("session_project_mismatch");
+  }
+  const current = records.filter((entry) => entry.schemaVersion === 3);
+  if (current.length !== records.length) throw new SessionLifecycleError("session_invalid");
+  return {
+    schemaVersion: 3,
+    projectId,
+    sessionId,
+    lastSequence: records.length,
+    targetIdentity: first.record.targetIdentity,
+    status: sessionRunBoundaryFromRecords(current).status,
+    naming: sessionNamingStateFromRecords(records),
+  };
+}
+
+async function fillPage(): Promise<void> {
+  while (!failed && position < entries.length && summaries.size < wantedItems) {
+    const entry = entries[position++];
+    if (entry === undefined || healthChecked.has(entry.sessionId)) continue;
+    try {
+      const records = await readRecords(entry.sessionId);
+      if (!healthChecked.has(entry.sessionId) && hasAcceptedInput(records)) {
+        summaries.set(entry.sessionId, summary(entry.sessionId, records));
+      }
+    } catch (error) {
+      // An earlier metadata read cannot overwrite the completed health observation for this generation.
+      if (!healthChecked.has(entry.sessionId) && !isolate(entry.sessionId, error)) throw error;
+    }
+  }
+}
+
+async function scanHealth(): Promise<void> {
+  health = "running";
+  publish();
+  for (const entry of entries) {
+    if (failed) return;
+    try {
+      // A fresh native read is the authority for this health result; summary availability is not validation.
+      const records = await readRecords(entry.sessionId);
+      if (hasAcceptedInput(records)) {
+        await inspect({ sessionId: entry.sessionId }, undefined, records);
+        summaries.set(entry.sessionId, summary(entry.sessionId, records));
+      } else {
+        summaries.delete(entry.sessionId);
+      }
+      diagnostics.delete(entry.sessionId);
+    } catch (error) {
+      if (!isolate(entry.sessionId, error)) throw error;
+    }
+    healthChecked.add(entry.sessionId);
+    checked += 1;
+    publish();
+  }
+  pageWork = pageWork.then(async () => {
+    if (failed) return;
+    // Excluding an invalid visible row must not leave the first page artificially short.
+    await fillPage();
+    health = "complete";
+    publish();
+  });
+  await pageWork;
+}
+
+async function start(): Promise<void> {
+  const canonicalRoot = await realpath(input.workspaceRoot);
+  projectId = `sha256:${createHash("sha256").update(canonicalRoot).digest("hex")}`;
+  entries = [...(await directory.listSessionEntries())].sort(
+    (left, right) =>
+      right.modifiedAtMilliseconds - left.modifiedAtMilliseconds ||
+      (left.sessionId < right.sessionId ? -1 : left.sessionId > right.sessionId ? 1 : 0),
+  );
+  publish();
+  await fillPage();
+  phase = "ready";
+  publish();
+  await scanHealth();
+}
+
+port.on("message", (message: SessionCatalogWorkerRequest) => {
+  if (message.type === "start") {
+    if (started) return;
+    started = true;
+    void start().catch(fail);
+    return;
+  }
+  if (message.type === "authority_result") {
+    const pending = pendingAuthority.get(message.id);
+    pendingAuthority.delete(message.id);
+    pending?.resolve(message.result);
+    return;
+  }
+  pageWork = pageWork.then(async () => {
+    if (failed || phase !== "ready" || message.cursor !== cursor()) {
+      post({ type: "page_settled", id: message.id, ok: false });
+      return;
+    }
+    wantedItems += input.limit;
+    try {
+      await fillPage();
+      publish();
+      post({ type: "page_settled", id: message.id, ok: true });
+    } catch {
+      fail();
+      post({ type: "page_settled", id: message.id, ok: false });
+    }
+  });
+});

--- a/packages/agent/src/session-history-folds.ts
+++ b/packages/agent/src/session-history-folds.ts
@@ -954,6 +954,42 @@ function ordinaryContextUsageFromRecords(
   return totals;
 }
 
+/** The same durable run boundary drives compact catalog state and complete snapshots. */
+export function sessionRunBoundaryFromRecords(
+  currentRecords: readonly Extract<SessionRecord, { readonly schemaVersion: 3 }>[],
+) {
+  const latestRun = currentRecords.findLast(
+    (record) => record.record.type === "logical_run_started",
+  );
+  if (latestRun === undefined || latestRun.record.type !== "logical_run_started") {
+    return {
+      latestRun: undefined,
+      settlement: undefined,
+      linkedSettlement: undefined,
+      status: "idle" as const,
+    };
+  }
+  const runId = latestRun.record.runId;
+  const settlement = currentRecords.findLast(
+    (record) =>
+      record.record.type === "runtime_event" &&
+      record.record.runId === runId &&
+      record.record.event.type === "session_settled",
+  );
+  const linkedSettlement = currentRecords.findLast(
+    (record) => record.record.type === "run_settled" && record.record.runId === runId,
+  );
+  return {
+    latestRun,
+    settlement,
+    linkedSettlement,
+    status:
+      settlement === undefined && linkedSettlement === undefined
+        ? ("interrupted" as const)
+        : ("settled" as const),
+  };
+}
+
 export function snapshotFromRecords(
   genesis: SessionGenesisRecord,
   records: readonly SessionRecord[],
@@ -968,9 +1004,8 @@ export function snapshotFromRecords(
   const todo = hasTodoToolProfileV1(genesis.record.promptContext?.toolProfile.definitions ?? [])
     ? todoSummaryV1(todoStoreSnapshotFromRecordsV1(records))
     : undefined;
-  const latestRun = currentRecords.findLast(
-    (record) => record.record.type === "logical_run_started",
-  );
+  const { latestRun, settlement, linkedSettlement, status } =
+    sessionRunBoundaryFromRecords(currentRecords);
   if (latestRun === undefined || latestRun.record.type !== "logical_run_started") {
     const promptContext = promptContextSnapshotFromRecords(genesis, records);
     const skillContext = skillContextRecordFromRecords(genesis, records);
@@ -990,15 +1025,6 @@ export function snapshotFromRecords(
   const runId = latestRun.record.runId;
   const lastResponse = currentRecords.findLast(
     (record) => record.record.type === "model_response_completed" && record.record.runId === runId,
-  );
-  const settlement = currentRecords.findLast(
-    (record) =>
-      record.record.type === "runtime_event" &&
-      record.record.runId === runId &&
-      record.record.event.type === "session_settled",
-  );
-  const linkedSettlement = currentRecords.findLast(
-    (record) => record.record.type === "run_settled" && record.record.runId === runId,
   );
   const lastAttemptStarted = currentRecords.findLast(
     (record) => record.record.type === "provider_attempt_started" && record.record.runId === runId,
@@ -1031,7 +1057,7 @@ export function snapshotFromRecords(
                   ?.text as string,
               }
         : undefined;
-  const isSettled = settlement !== undefined || linkedSettlement !== undefined;
+  const isSettled = status === "settled";
   const promptContext = promptContextSnapshotFromRecords(genesis, records);
   const skillContext = skillContextRecordFromRecords(genesis, records);
   return {

--- a/packages/agent/src/session-lifecycle.ts
+++ b/packages/agent/src/session-lifecycle.ts
@@ -87,6 +87,7 @@ import {
   type McpDiscoveryScheduler,
   McpHostError,
   type McpIdleScheduler,
+  type McpLiveSessionSnapshot,
   type McpRequestScheduler,
   type McpSessionSnapshot,
   type McpTransportFactory,
@@ -178,6 +179,13 @@ import {
   WorkspaceTrustMcpLeaseError,
   type WorkspaceTrustSnapshot,
 } from "./secure-user-configuration.js";
+import {
+  type ProjectSessionCatalogController,
+  type ProjectSessionCatalogStartOptions,
+  type SessionCatalogWorkerFactory,
+  sessionCatalogWorkerFactory,
+  startNativeSessionCatalog,
+} from "./session-catalog-job.js";
 import {
   type AgentSessionDurableContext,
   type AgentSessionDurableOutputLimits,
@@ -292,6 +300,11 @@ import { createSafeWebHttpAdapter } from "./web-safe-http.js";
 import type { WebSearchConfiguration } from "./web-search-configuration.js";
 
 export type { McpSessionSnapshot } from "./mcp-host.js";
+export type {
+  ProjectSessionCatalogController,
+  ProjectSessionCatalogSnapshot,
+  ProjectSessionCatalogStartOptions,
+} from "./session-catalog-job.js";
 export { SessionLifecycleError } from "./session-lifecycle-error.js";
 export type {
   CurrentSessionSnapshot,
@@ -489,6 +502,7 @@ export type ManagedControlComposition = {
 };
 
 export type SessionLifecycleOptions = {
+  readonly [sessionCatalogWorkerFactory]?: SessionCatalogWorkerFactory;
   readonly onPhaseDiagnostic?: (diagnostic: RuntimePhaseDiagnostic) => void;
   readonly managedControl?: ManagedControlComposition;
   readonly [sessionManagedControl]?: ManagedControlComposition;
@@ -538,6 +552,42 @@ export type SessionLifecycleOptions = {
 };
 
 type WebEvidenceProfileV1 = NonNullable<SessionGenesisRecord["record"]["webEvidence"]>;
+
+export type SessionPlanAuthorityInput = {
+  readonly sessionId: string;
+  readonly managedAgentTools?: SessionGenesisRecord["record"]["managedAgentTools"];
+  readonly webEvidence?: WebEvidenceProfileV1;
+  readonly source: Pick<
+    NonNullable<CurrentSessionSnapshot["promptContext"]>["toolProfile"],
+    "version" | "digest"
+  > & {
+    readonly definitions: readonly Pick<
+      NonNullable<CurrentSessionSnapshot["promptContext"]>["toolProfile"]["definitions"][number],
+      "name" | "digest"
+    >[];
+  };
+  readonly mcpProfile?: {
+    readonly digest: `sha256:${string}`;
+    readonly tools: readonly {
+      readonly qualifiedName: string;
+      readonly serverId: string;
+      readonly originalName: string;
+      readonly serverDefinitionDigest: `sha256:${string}`;
+      readonly definitionDigest: `sha256:${string}`;
+      readonly effect: ToolEffect;
+    }[];
+  };
+  readonly policyVersion: PlanPolicyVersion;
+};
+
+export type SessionPlanAuthorityResolver = (
+  input: SessionPlanAuthorityInput,
+) => Promise<PlanEligibleToolProfileV1>;
+
+export type ReadOnlySessionMcpInputs = {
+  readonly trusted: boolean;
+  readonly live?: McpLiveSessionSnapshot;
+};
 
 export type SessionContinueResult = {
   readonly result: AgentExecutionResult;
@@ -948,6 +998,10 @@ export interface SessionLifecycle {
     readonly cursor?: string;
     readonly limit?: number;
   }): Promise<ProjectSessionSummaryPage>;
+  /** Native background display discovery; health completion is separate from summary availability. */
+  startProjectSessionCatalog(
+    input: ProjectSessionCatalogStartOptions,
+  ): ProjectSessionCatalogController;
   previewNewSession(input: {
     readonly targetIdentity: ModelTargetIdentity;
     readonly thinkingSelection?: ThinkingPolicySelectionV1;
@@ -1092,6 +1146,138 @@ const nodeSessionTitleDeadlineScheduler: SessionTitleDeadlineScheduler = {
   },
 };
 
+/** Shared read-only inspection used by ordinary Lifecycle calls and native catalog workers. */
+export function createReadOnlySessionInspector(dependencies: {
+  readonly options: Pick<SessionLifecycleOptions, "workspaceRoot" | "stateRoot">;
+  readonly readRecords: (sessionId: string) => Promise<readonly SessionRecord[]>;
+  readonly lineage?: SessionLineageTraversal;
+  readonly resolvePlanProfile: SessionPlanAuthorityResolver;
+  readonly inspectMcpInputs: (sessionId: string) => Promise<ReadOnlySessionMcpInputs>;
+}) {
+  const { options } = dependencies;
+  const lineage =
+    dependencies.lineage ??
+    createSessionLineageTraversal({
+      workspaceRoot: options.workspaceRoot,
+      readRecords: dependencies.readRecords,
+    });
+  const validatedHistories = new WeakSet<readonly SessionRecord[]>();
+  const validatedPromptPrefixes = new WeakMap<
+    SessionRecord,
+    {
+      readonly records: readonly SessionRecord[];
+      readonly inheritedMessages: string;
+    }
+  >();
+
+  const inspectSession = async (
+    input: { readonly sessionId: string },
+    artifactCache = createArtifactMaterializationCache(),
+    suppliedRecords?: readonly SessionRecord[],
+  ): Promise<SessionSnapshot> => {
+    const records: readonly SessionRecord[] =
+      suppliedRecords === undefined
+        ? await dependencies.readRecords(input.sessionId)
+        : suppliedRecords;
+    const first = records[0];
+    if (first === undefined) {
+      throw new SessionLifecycleError("session_not_found");
+    }
+    const projectId = await canonicalProjectId(options.workspaceRoot);
+    if (first.schemaVersion === 1 || first.schemaVersion === 2) {
+      if (records.some((record) => record.schemaVersion === 3)) {
+        throw new SessionLifecycleError("session_invalid");
+      }
+      return {
+        schemaVersion: records.some((record) => record.schemaVersion === 2) ? 2 : 1,
+        sessionId: input.sessionId,
+        projectId,
+        status: "legacy",
+        lastSequence: records.length,
+      };
+    }
+    if (!isGenesisRecord(first) || first.record.sessionId !== input.sessionId) {
+      throw new SessionLifecycleError("session_invalid");
+    }
+    if (first.record.projectId !== projectId) {
+      throw new SessionLifecycleError("session_project_mismatch");
+    }
+    if (!validatedHistories.has(records)) {
+      validateCurrentSessionHistory(first, records, options.workspaceRoot);
+      if (isDeeplyImmutable(records)) validatedHistories.add(records);
+    }
+    await lineage.validateSessionLineage(first, records);
+    await validateMcpAuthorityFromLineage(lineage, first, records);
+    await validatePlanToolProfilesFromLineage(
+      lineage,
+      first,
+      records,
+      undefined,
+      dependencies.resolvePlanProfile,
+    );
+    await skillResourceBytesFromLineage(lineage, first, records);
+    const artifactInspection = await inspectModelResponseArtifactLineage(
+      options,
+      lineage,
+      first,
+      records,
+      artifactCache,
+    );
+    if (artifactInspection.degradation === undefined) {
+      await validatePromptProjectionDigests(
+        options,
+        lineage,
+        first,
+        artifactInspection.records,
+        artifactCache,
+        { rawRecords: records, cache: validatedPromptPrefixes },
+      );
+    }
+    const replayRecords =
+      artifactInspection.degradation === undefined ? artifactInspection.records : records;
+    const snapshot = snapshotFromRecords(first, replayRecords, artifactInspection);
+    const inheritedContext =
+      artifactInspection.degradation === undefined
+        ? await contextSnapshotFromLineage(options, lineage, first, replayRecords, artifactCache)
+        : undefined;
+    const [mcpWorkspaceConfirmation, mcpServerApprovals, mcpCommittedProfile, mcpCatalogState] =
+      await Promise.all([
+        mcpWorkspaceConfirmationFromLineage(lineage, first, records),
+        mcpServerApprovalsFromLineage(lineage, first, records),
+        mcpCommittedProfileFromLineage(lineage, first, records),
+        mcpCatalogStateFromLineage(lineage, first, records),
+      ]);
+    let mcp: McpSessionSnapshot | undefined;
+    const liveMcpInputs = await dependencies.inspectMcpInputs(input.sessionId);
+    if (liveMcpInputs.trusted) {
+      try {
+        mcp = await inspectMcpConfiguration(
+          options.workspaceRoot,
+          mcpWorkspaceConfirmation?.sourceDigest,
+          mcpServerApprovals,
+          liveMcpInputs.live,
+          mcpActivationFailureFromRecords(records),
+          mcpCommittedProfile,
+          mcpCatalogState,
+          mcpActivationFromRecords(records),
+        );
+      } catch (error) {
+        if (error instanceof McpConfigurationError) {
+          throw new SessionLifecycleError("mcp_config_invalid");
+        }
+        throw error;
+      }
+    }
+    return {
+      ...snapshot,
+      ...(inheritedContext === undefined ? {} : { context: inheritedContext }),
+      ...(mcp === undefined ? {} : { mcp }),
+    };
+  };
+
+  return inspectSession;
+}
+
 export function createSessionLifecycle(providedOptions: SessionLifecycleOptions): SessionLifecycle {
   const effectiveStateRoot = effectiveSessionStateRoot(providedOptions.stateRoot);
   const sharedArtifactStore = createLazyArtifactStore(join(effectiveStateRoot, "artifacts"));
@@ -1161,6 +1347,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
   let activeSession: AgentSession | undefined;
   let activeSessionSettlement: Promise<boolean> | undefined;
   let lifecycleClosing = false;
+  let catalogJob: ProjectSessionCatalogController | undefined;
   let automaticTitlesEnabled = options[sessionAutomaticTitlesEnabled] ?? true;
   let lifecycleClosePromise: Promise<McpCloseResult> | undefined;
   let workspaceMcpLeasePromise: Promise<WorkspaceTrustMcpLease> | undefined;
@@ -2531,124 +2718,29 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
     mcpIdleTimers.set(sessionId, { generationId, cancel: scheduled.cancel });
   };
 
-  const validatedHistories = new WeakSet<readonly SessionRecord[]>();
-  const validatedPromptPrefixes = new WeakMap<
-    SessionRecord,
-    {
-      readonly records: readonly SessionRecord[];
-      readonly inheritedMessages: string;
-    }
-  >();
-
-  const inspectSession = async (
-    input: { readonly sessionId: string },
-    artifactCache = createArtifactMaterializationCache(),
-    suppliedRecords?: readonly SessionRecord[],
-  ): Promise<SessionSnapshot> => {
-    const records: readonly SessionRecord[] =
-      suppliedRecords === undefined
-        ? await readSessionRecords(options, input.sessionId)
-        : suppliedRecords;
-    const first = records[0];
-    if (first === undefined) {
-      throw new SessionLifecycleError("session_not_found");
-    }
-    const projectId = await canonicalProjectId(options.workspaceRoot);
-    if (first.schemaVersion === 1 || first.schemaVersion === 2) {
-      if (records.some((record) => record.schemaVersion === 3)) {
-        throw new SessionLifecycleError("session_invalid");
-      }
-      return {
-        schemaVersion: records.some((record) => record.schemaVersion === 2) ? 2 : 1,
-        sessionId: input.sessionId,
-        projectId,
-        status: "legacy",
-        lastSequence: records.length,
-      };
-    }
-    if (!isGenesisRecord(first) || first.record.sessionId !== input.sessionId) {
-      throw new SessionLifecycleError("session_invalid");
-    }
-    if (first.record.projectId !== projectId) {
-      throw new SessionLifecycleError("session_project_mismatch");
-    }
-    if (!validatedHistories.has(records)) {
-      validateCurrentSessionHistory(first, records, options.workspaceRoot);
-      if (isDeeplyImmutable(records)) validatedHistories.add(records);
-    }
-    await lineage.validateSessionLineage(first, records);
-    await validateMcpAuthorityFromLineage(lineage, first, records);
-    const planTools = records.some(
-      (entry) =>
-        entry.schemaVersion === 3 &&
-        (entry.record.type === "plan_cycle_entered" ||
-          entry.record.type === "plan_cycle_inherited"),
-    )
-      ? await toolsForSession(
-          input.sessionId,
-          first.record.managedAgentTools,
-          first.record.webEvidence,
-        )
-      : options.tools;
-    await validatePlanToolProfilesFromLineage(lineage, first, records, planTools);
-    await skillResourceBytesFromLineage(lineage, first, records);
-    const artifactInspection = await inspectModelResponseArtifactLineage(
-      options,
-      lineage,
-      first,
-      records,
-      artifactCache,
+  const resolveCatalogPlanProfile: SessionPlanAuthorityResolver = async (input) => {
+    const tools = await toolsForSession(
+      input.sessionId,
+      input.managedAgentTools,
+      input.webEvidence,
     );
-    if (artifactInspection.degradation === undefined) {
-      await validatePromptProjectionDigests(
-        options,
-        lineage,
-        first,
-        artifactInspection.records,
-        artifactCache,
-        { rawRecords: records, cache: validatedPromptPrefixes },
-      );
-    }
-    const replayRecords =
-      artifactInspection.degradation === undefined ? artifactInspection.records : records;
-    const snapshot = snapshotFromRecords(first, replayRecords, artifactInspection);
-    const inheritedContext =
-      artifactInspection.degradation === undefined
-        ? await contextSnapshotFromLineage(options, lineage, first, replayRecords, artifactCache)
-        : undefined;
-    const [mcpWorkspaceConfirmation, mcpServerApprovals, mcpCommittedProfile, mcpCatalogState] =
-      await Promise.all([
-        mcpWorkspaceConfirmationFromLineage(lineage, first, records),
-        mcpServerApprovalsFromLineage(lineage, first, records),
-        mcpCommittedProfileFromLineage(lineage, first, records),
-        mcpCatalogStateFromLineage(lineage, first, records),
-      ]);
-    let mcp: McpSessionSnapshot | undefined;
-    if ((await inspectWorkspaceTrust()).status === "trusted") {
-      try {
-        mcp = await inspectMcpConfiguration(
-          options.workspaceRoot,
-          mcpWorkspaceConfirmation?.sourceDigest,
-          mcpServerApprovals,
-          mcpHost.snapshot(input.sessionId),
-          mcpActivationFailureFromRecords(records),
-          mcpCommittedProfile,
-          mcpCatalogState,
-          mcpActivationFromRecords(records),
-        );
-      } catch (error) {
-        if (error instanceof McpConfigurationError) {
-          throw new SessionLifecycleError("mcp_config_invalid");
-        }
-        throw error;
-      }
-    }
+    return planToolProfileFromAuthority(input.source, tools, input.mcpProfile, input.policyVersion);
+  };
+  const inspectCatalogMcpInputs = async (sessionId: string): Promise<ReadOnlySessionMcpInputs> => {
+    const trusted = (await inspectWorkspaceTrust()).status === "trusted";
+    const live = trusted ? mcpHost.snapshot(sessionId) : undefined;
     return {
-      ...snapshot,
-      ...(inheritedContext === undefined ? {} : { context: inheritedContext }),
-      ...(mcp === undefined ? {} : { mcp }),
+      trusted,
+      ...(live === undefined ? {} : { live }),
     };
   };
+  const inspectSession = createReadOnlySessionInspector({
+    options,
+    readRecords: (sessionId) => readSessionRecords(options, sessionId),
+    lineage,
+    resolvePlanProfile: resolveCatalogPlanProfile,
+    inspectMcpInputs: inspectCatalogMcpInputs,
+  });
 
   const inspectSessionContextUsage = async (
     input: { readonly sessionId: string },
@@ -3810,6 +3902,7 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
       const runningSession = activeSessionSettlement;
       activeSession?.abort();
       lifecycleClosePromise = (async (): Promise<McpCloseResult> => {
+        await catalogJob?.close();
         await runningSession;
         const controlSettlements = await Promise.allSettled(
           [...managedControls].map(
@@ -5721,6 +5814,23 @@ export function createSessionLifecycle(providedOptions: SessionLifecycleOptions)
                 },
         ),
       };
+    },
+    startProjectSessionCatalog(input) {
+      if (lifecycleClosing) throw new SessionLifecycleError("project_owner_unavailable");
+      const previous = catalogJob?.close();
+      catalogJob = startNativeSessionCatalog({
+        ...input,
+        workspaceRoot: options.workspaceRoot,
+        stateRoot: effectiveStateRoot,
+        supported: providedOptions[sessionStoreDirectory] === undefined,
+        ...(providedOptions[sessionCatalogWorkerFactory] === undefined
+          ? {}
+          : { workerFactory: providedOptions[sessionCatalogWorkerFactory] }),
+        ...(previous === undefined ? {} : { beforeStart: previous }),
+        resolvePlanProfile: resolveCatalogPlanProfile,
+        inspectMcpInputs: inspectCatalogMcpInputs,
+      });
+      return catalogJob;
     },
     async previewNewSession(input) {
       return withOwner(async () => {
@@ -8996,7 +9106,7 @@ function sessionStoreDirectoryFrom(
   return directory;
 }
 
-function sessionHistoryDiagnosticFromError(
+export function sessionHistoryDiagnosticFromError(
   sessionId: string,
   error: unknown,
 ): SessionHistoryDiagnostic | undefined {
@@ -9081,21 +9191,9 @@ function planToolProfile(
 }
 
 function planToolProfileFromAuthority(
-  source: NonNullable<CurrentSessionSnapshot["promptContext"]>["toolProfile"],
+  source: SessionPlanAuthorityInput["source"],
   tools: ToolRegistry,
-  mcpProfile:
-    | {
-        readonly digest: `sha256:${string}`;
-        readonly tools: readonly {
-          readonly qualifiedName: string;
-          readonly serverId: string;
-          readonly originalName: string;
-          readonly serverDefinitionDigest: `sha256:${string}`;
-          readonly definitionDigest: `sha256:${string}`;
-          readonly effect: ToolEffect;
-        }[];
-      }
-    | undefined,
+  mcpProfile: SessionPlanAuthorityInput["mcpProfile"],
   policyVersion: PlanPolicyVersion,
 ): PlanEligibleToolProfileV1 {
   const mcpTools = new Map(
@@ -9164,8 +9262,9 @@ async function validatePlanToolProfilesFromLineage(
   genesis: SessionGenesisRecord,
   records: readonly SessionRecord[],
   tools: ToolRegistry | undefined,
+  resolveExpectedProfile?: SessionPlanAuthorityResolver,
 ): Promise<void> {
-  if (tools === undefined) {
+  if (tools === undefined && resolveExpectedProfile === undefined) {
     throw new SessionLifecycleError("session_invalid");
   }
   for (const entry of records) {
@@ -9190,12 +9289,33 @@ async function validatePlanToolProfilesFromLineage(
     ) {
       throw new SessionLifecycleError("session_invalid");
     }
-    const expected = planToolProfileFromAuthority(
-      promptContext.toolProfile,
-      tools,
-      mcpProfile,
-      entry.record.policyVersion,
-    );
+    const expected =
+      resolveExpectedProfile === undefined
+        ? planToolProfileFromAuthority(
+            promptContext.toolProfile,
+            tools as ToolRegistry,
+            mcpProfile,
+            entry.record.policyVersion,
+          )
+        : await resolveExpectedProfile({
+            sessionId: genesis.record.sessionId,
+            ...(genesis.record.managedAgentTools === undefined
+              ? {}
+              : { managedAgentTools: genesis.record.managedAgentTools }),
+            ...(genesis.record.webEvidence === undefined
+              ? {}
+              : { webEvidence: genesis.record.webEvidence }),
+            source: {
+              version: promptContext.toolProfile.version,
+              digest: promptContext.toolProfile.digest,
+              definitions: promptContext.toolProfile.definitions.map(({ name, digest }) => ({
+                name,
+                digest,
+              })),
+            },
+            ...(mcpProfile === undefined ? {} : { mcpProfile }),
+            policyVersion: entry.record.policyVersion,
+          });
     const transitionExpected =
       genesis.record.managedAgentTools === "managed-agent-tools.a3-long-lived.v1"
         ? createPlanToolProfileV1({

--- a/packages/presentation/src/index.ts
+++ b/packages/presentation/src/index.ts
@@ -199,6 +199,13 @@ export type SessionSummaryPage = {
   readonly items: readonly SessionSummary[];
   readonly nextCursor: string | null;
   readonly diagnostics?: SessionHistoryDiagnosticsDisplay;
+  readonly loading?: boolean;
+  readonly health?: {
+    readonly status: "not_started" | "running" | "complete" | "failed";
+    readonly checked: number;
+    readonly total: number | null;
+  };
+  readonly error?: { readonly code: string; readonly message: string };
 };
 
 export type SessionHistoryDiagnosticDisplay = {
@@ -748,7 +755,10 @@ export type McpDisplay = {
 export type ProjectPathCatalogDisplay = {
   readonly items: readonly string[];
   readonly omittedCount: number;
-  readonly diagnostic: { readonly code: "project_path_catalog_truncated" } | null;
+  readonly diagnostic: {
+    readonly code: "project_path_catalog_truncated" | "project_path_catalog_unavailable";
+  } | null;
+  readonly loading?: boolean;
 };
 
 export type SkillCatalogDisplay = {

--- a/packages/testkit/src/background-catalog.os.test.ts
+++ b/packages/testkit/src/background-catalog.os.test.ts
@@ -1,0 +1,164 @@
+import { mkdir, mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Worker } from "node:worker_threads";
+import { createJsonlSessionStoreDirectory, type SessionRecord } from "@adam-agent/agent";
+import { sessionCatalogWorkerFactory } from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+import { withManagedFailureGuard } from "./managed-agent-test-support.js";
+import {
+  createPresentationSession,
+  createSessionLifecycle,
+  settledModelTargets,
+  targetIdentity,
+} from "./presentation-session.test-support.js";
+
+test.each(["deleted", "invalid-beyond-display-cap", "renamed-at-same-sequence"] as const)(
+  "background catalog reconciles a formerly selected session that is %s",
+  async (change) => {
+    const root = await mkdtemp(join(tmpdir(), "adam-background-catalog-"));
+    const workspaceRoot = join(root, "workspace");
+    const stateRoot = join(root, "state");
+    await mkdir(workspaceRoot);
+    const heldAuthority = Promise.withResolvers<() => void>();
+    let hold = true;
+    const lifecycle = createSessionLifecycle({
+      workspaceRoot,
+      stateRoot,
+      modelTargets: settledModelTargets(),
+      [sessionCatalogWorkerFactory]: (url, options) => {
+        const worker = new Worker(url, options);
+        const post = worker.postMessage.bind(worker);
+        worker.postMessage = (...args: Parameters<Worker["postMessage"]>) => {
+          const message = args[0];
+          if (hold && message?.type === "authority_result") {
+            hold = false;
+            heldAuthority.resolve(() => post(...args));
+          } else post(...args);
+        };
+        return worker;
+      },
+    });
+    let release: (() => void) | undefined;
+    try {
+      const previous = await lifecycle.create({ targetIdentity });
+      await lifecycle.continue({
+        sessionId: previous.sessionId,
+        input: { text: "Previous session" },
+      });
+      await lifecycle.setSessionManualName({
+        sessionId: previous.sessionId,
+        name: "Previous session",
+      });
+      const current = await lifecycle.create({ targetIdentity });
+      await lifecycle.continue({
+        sessionId: current.sessionId,
+        input: { text: "Current session" },
+      });
+      await lifecycle.setSessionManualName({
+        sessionId: current.sessionId,
+        name: "Current session",
+      });
+      const sessionRoot = join(
+        stateRoot,
+        "projects",
+        previous.projectId.slice("sha256:".length),
+        "sessions",
+      );
+      if (change === "invalid-beyond-display-cap") {
+        // These valid v1 UUIDs sort before any randomUUID-created v4 session.
+        for (let i = 0; i < 100; i++)
+          await writeFile(
+            join(sessionRoot, `00000000-0000-1000-8000-${String(i).padStart(12, "0")}.jsonl`),
+            "{invalid}\n",
+          );
+      }
+      const presentation = await createPresentationSession({
+        lifecycle,
+        workspaceRoot,
+        stateRoot,
+        projectLabel: "workspace",
+        sessionId: previous.sessionId,
+        backgroundStartup: true,
+      });
+      try {
+        const complete = Promise.withResolvers<void>();
+        const unsubscribe = presentation.subscribe(() => {
+          if (presentation.getState().authoritative.sessions.health?.status === "complete")
+            complete.resolve();
+        });
+        try {
+          release = await withManagedFailureGuard(
+            heldAuthority.promise,
+            "held catalog authority response",
+          );
+          expect(
+            presentation.getState().authoritative.sessions.items.map((item) => item.id),
+          ).toContain(current.sessionId);
+          await expect(
+            presentation.dispatch({ type: "select_session", sessionId: current.sessionId }),
+          ).resolves.toMatchObject({ status: "admitted" });
+          const previousPath = join(sessionRoot, `${previous.sessionId}.jsonl`);
+          if (change === "deleted") await unlink(previousPath);
+          else if (change === "renamed-at-same-sequence") {
+            const before = await readFile(previousPath, "utf8");
+            const entries = before
+              .trimEnd()
+              .split("\n")
+              .map((line) => JSON.parse(line) as SessionRecord);
+            const after = `${entries
+              .map((entry) =>
+                JSON.stringify(
+                  entry.schemaVersion === 3 && entry.record.type === "session_manual_name_set"
+                    ? { ...entry, record: { ...entry.record, name: "External session" } }
+                    : entry,
+                ),
+              )
+              .join("\n")}\n`;
+            expect(Buffer.byteLength(after)).toBe(Buffer.byteLength(before));
+            await writeFile(previousPath, after);
+          } else await writeFile(previousPath, "{invalid}\n");
+          release();
+          await withManagedFailureGuard(complete.promise, "complete background catalog");
+          const state = presentation.getState();
+          expect(state.authoritative.active?.session.id).toBe(current.sessionId);
+          expect(state.authoritative.sessions.items.map((item) => item.id)).toEqual([
+            current.sessionId,
+            ...(change === "renamed-at-same-sequence" ? [previous.sessionId] : []),
+          ]);
+          if (change === "renamed-at-same-sequence")
+            expect(
+              state.authoritative.sessions.items.find((item) => item.id === previous.sessionId)
+                ?.label,
+            ).toBe("External session");
+          if (change === "invalid-beyond-display-cap") {
+            expect(state.authoritative.sessions.diagnostics).toMatchObject({
+              totalCount: 101,
+              truncated: true,
+            });
+            expect(state.authoritative.sessions.diagnostics?.items).toHaveLength(100);
+            expect(
+              state.authoritative.sessions.diagnostics?.items.some(
+                (item) => item.sessionId === previous.sessionId,
+              ),
+            ).toBe(false);
+          }
+          const records = await createJsonlSessionStoreDirectory({
+            workspaceRoot,
+            stateRoot,
+          }).readRecords?.(current.sessionId);
+          expect(records?.length).toBeGreaterThan(0);
+        } finally {
+          unsubscribe();
+        }
+      } finally {
+        release?.();
+        await presentation.close();
+      }
+    } finally {
+      release?.();
+      await lifecycle.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/packages/testkit/src/presentation-session.os.test.ts
+++ b/packages/testkit/src/presentation-session.os.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -18,6 +18,7 @@ import {
 } from "@adam-agent/agent/internal-testing";
 import { expect, test } from "vitest";
 import { FakeModelDriver } from "./index.js";
+import { withManagedFailureGuard } from "./managed-agent-test-support.js";
 
 const targetIdentity: ModelTargetIdentity = {
   targetId: "deepseek-v4-flash.direct",
@@ -552,3 +553,59 @@ test.each(["missing", "corrupt"] as const)(
     }
   },
 );
+
+test("Presentation startup publishes project paths after returning and preserves the current session", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-background-paths-"));
+  const workspaceRoot = join(root, "workspace");
+  const stateRoot = join(root, "state");
+  await mkdir(join(workspaceRoot, "src"), { recursive: true });
+  await mkdir(join(workspaceRoot, "node_modules"));
+  await writeFile(join(workspaceRoot, "README.md"), "PRIVATE_README_BYTES");
+  await writeFile(join(workspaceRoot, "src", "entry.ts"), "PRIVATE_SOURCE_BYTES");
+  await writeFile(join(workspaceRoot, "node_modules", "excluded.js"), "excluded");
+  await symlink(join(workspaceRoot, "README.md"), join(workspaceRoot, "linked"));
+  const lifecycle = createSessionLifecycle({ stateRoot, workspaceRoot });
+  try {
+    const session = await lifecycle.create({ targetIdentity });
+    const presentation = await createPresentationSession({
+      lifecycle,
+      projectLabel: "workspace",
+      workspaceRoot,
+      stateRoot,
+      sessionId: session.sessionId,
+      backgroundStartup: true,
+    });
+    try {
+      expect(presentation.getState().authoritative.active?.projectPaths).toEqual({
+        items: [],
+        omittedCount: 0,
+        diagnostic: null,
+        loading: true,
+      });
+      const loaded = Promise.withResolvers<void>();
+      const unsubscribe = presentation.subscribe(() => {
+        if (presentation.getState().authoritative.active?.projectPaths.loading === false)
+          loaded.resolve();
+      });
+      try {
+        await withManagedFailureGuard(loaded.promise, "background project path catalog");
+        expect(presentation.getState().authoritative.active?.session.id).toBe(session.sessionId);
+        expect(presentation.getState().authoritative.active?.projectPaths).toEqual({
+          items: ["README.md", "src/entry.ts"],
+          omittedCount: 0,
+          diagnostic: null,
+          loading: false,
+        });
+        expect(JSON.stringify(presentation.getState())).not.toContain("PRIVATE_README_BYTES");
+        expect(JSON.stringify(presentation.getState())).not.toContain("PRIVATE_SOURCE_BYTES");
+      } finally {
+        unsubscribe();
+      }
+    } finally {
+      await presentation.close();
+    }
+  } finally {
+    await lifecycle.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/testkit/src/session-catalog-worker.os.test.ts
+++ b/packages/testkit/src/session-catalog-worker.os.test.ts
@@ -1,0 +1,661 @@
+import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Worker } from "node:worker_threads";
+import {
+  createCodingToolRegistry,
+  createJsonlSessionStoreDirectory,
+  createPermissionPolicy,
+  type ProjectSessionCatalogController,
+  type ProjectSessionCatalogSnapshot,
+  type SessionLifecycle,
+  SessionLifecycleError,
+  SessionStoreError,
+} from "@adam-agent/agent";
+import {
+  createTrustedWorkspaceTrustForTesting,
+  sessionCatalogWorkerFactory,
+  sessionStoreDirectory,
+} from "@adam-agent/agent/internal-testing";
+import { expect, test } from "vitest";
+import { withManagedFailureGuard } from "./managed-agent-test-support.js";
+import {
+  createSessionLifecycle,
+  settledModelTargets,
+  targetIdentity,
+} from "./presentation-session.test-support.js";
+
+function observeCatalog(lifecycle: SessionLifecycle, limit = 100) {
+  const updates: ProjectSessionCatalogSnapshot[] = [];
+  const listeners = new Set<(snapshot: ProjectSessionCatalogSnapshot) => void>();
+  const controller = lifecycle.startProjectSessionCatalog({
+    limit,
+    onUpdate(snapshot) {
+      updates.push(snapshot);
+      for (const listener of listeners) listener(snapshot);
+    },
+  });
+  return {
+    controller,
+    updates,
+    async until(predicate: (snapshot: ProjectSessionCatalogSnapshot) => boolean) {
+      const existing = updates.find(predicate);
+      if (existing !== undefined) return existing;
+      if (updates.some((snapshot) => snapshot.phase === "failed")) {
+        throw new Error("The native catalog failed before the requested state.");
+      }
+      const pending = Promise.withResolvers<ProjectSessionCatalogSnapshot>();
+      const listener = (snapshot: ProjectSessionCatalogSnapshot) => {
+        if (predicate(snapshot)) pending.resolve(snapshot);
+        else if (snapshot.phase === "failed") {
+          pending.reject(new Error("The native catalog failed before the requested state."));
+        }
+      };
+      listeners.add(listener);
+      try {
+        return await withManagedFailureGuard(pending.promise, "the requested native catalog state");
+      } finally {
+        listeners.delete(listener);
+      }
+    },
+  };
+}
+
+test("native background summaries paginate before full health and converge to the strict catalog", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-catalog-worker-pages-"));
+  const workspaceRoot = join(root, "workspace");
+  const stateRoot = join(root, "state");
+  await mkdir(workspaceRoot);
+  const author = createSessionLifecycle({
+    workspaceRoot,
+    stateRoot,
+    modelTargets: settledModelTargets(),
+  });
+  const trust = createTrustedWorkspaceTrustForTesting(workspaceRoot);
+  const requested = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const reader = createSessionLifecycle({
+    workspaceRoot,
+    stateRoot,
+    workspaceTrust: {
+      ...trust,
+      async load() {
+        requested.resolve();
+        await release.promise;
+        return trust.load();
+      },
+    },
+  });
+  let catalog: ReturnType<typeof observeCatalog> | undefined;
+  try {
+    for (const name of ["First history", "Second history", "Third history"]) {
+      const session = await author.create({ targetIdentity });
+      await author.continue({ sessionId: session.sessionId, input: { text: name } });
+      await author.setSessionManualName({ sessionId: session.sessionId, name });
+    }
+    await author.create({ targetIdentity });
+    const expected = await author.listProjectSessionSummaries();
+    catalog = observeCatalog(reader, 1);
+    const first = await catalog.until((snapshot) => snapshot.phase === "ready");
+    expect(first.items).toEqual(expected.items.slice(0, 1));
+    expect(first.health.status).not.toBe("complete");
+    await withManagedFailureGuard(
+      requested.promise,
+      "the live authority request after summary publication",
+    );
+    if (first.nextCursor === null) throw new Error("Expected another summary page.");
+    await catalog.controller.loadMore(first.nextCursor);
+    const second = await catalog.until((snapshot) => snapshot.items.length === 2);
+    expect(second.items).toEqual(expected.items.slice(0, 2));
+    await expect(catalog.controller.loadMore(first.nextCursor)).rejects.toMatchObject({
+      code: "session_invalid",
+    });
+    release.resolve();
+    const complete = await catalog.until((snapshot) => snapshot.health.status === "complete");
+    expect(complete.health).toEqual({ status: "complete", checked: 4, total: 4 });
+    if (complete.nextCursor === null) throw new Error("Expected the remaining history page.");
+    await catalog.controller.loadMore(complete.nextCursor);
+    const final = await catalog.until(
+      (snapshot) => snapshot.items.length === 3 && snapshot.nextCursor === null,
+    );
+    expect(final.items).toEqual(expected.items);
+    expect(final.diagnostics).toEqual(expected.diagnostics);
+  } finally {
+    release.resolve();
+    await catalog?.controller.close();
+    await reader.close();
+    await author.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("native full health uses the owning Lifecycle's exact built-in Todo authority", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-catalog-worker-plan-"));
+  const workspaceRoot = join(root, "workspace");
+  const stateRoot = join(root, "state");
+  await mkdir(workspaceRoot);
+  const tools = createCodingToolRegistry({ workspaceRoot, stateRoot });
+  const author = createSessionLifecycle({
+    workspaceRoot,
+    stateRoot,
+    tools,
+    modelTargets: settledModelTargets(),
+  });
+  let reader: SessionLifecycle | undefined;
+  let controller: ProjectSessionCatalogController | undefined;
+  try {
+    const session = await author.create({ targetIdentity });
+    await author.continue({
+      sessionId: session.sessionId,
+      input: { text: "Keep the exact Todo Plan authority." },
+    });
+    await author.enterPlan({ sessionId: session.sessionId });
+    const valid = observeCatalog(author);
+    controller = valid.controller;
+    const validComplete = await valid.until((snapshot) => snapshot.health.status === "complete");
+    expect(validComplete.items.map((item) => item.sessionId)).toEqual([session.sessionId]);
+    expect(validComplete.diagnostics.totalCount).toBe(0);
+    await controller.close();
+    reader = createSessionLifecycle({
+      workspaceRoot,
+      stateRoot,
+      tools: {
+        definitions: () => tools.definitions(),
+        resolve(name) {
+          const adapter = tools.resolve(name);
+          // Same names, definitions and digests do not grant the built-in Todo identity.
+          return adapter !== undefined &&
+            ["create_todo", "update_todo", "update_todos"].includes(name)
+            ? { ...adapter }
+            : adapter;
+        },
+      },
+    });
+    const strict = await reader.listProjectSessions();
+    expect(strict.items).toEqual([]);
+    expect(strict.diagnostics).toMatchObject({
+      totalCount: 1,
+      items: [{ code: "invalid_history" }],
+    });
+    const invalid = observeCatalog(reader);
+    controller = invalid.controller;
+    const invalidComplete = await invalid.until(
+      (snapshot) => snapshot.health.status === "complete",
+    );
+    expect(invalidComplete.items).toEqual([]);
+    expect(invalidComplete.diagnostics).toEqual(strict.diagnostics);
+  } finally {
+    await controller?.close();
+    await reader?.close();
+    await author.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test.each([true, false])(
+  "native full health keeps current MCP trust=%s and systemic failure semantics",
+  async (trusted) => {
+    const root = await mkdtemp(join(tmpdir(), "adam-catalog-worker-mcp-"));
+    const workspaceRoot = join(root, "workspace");
+    const stateRoot = join(root, "state");
+    await mkdir(workspaceRoot);
+    const author = createSessionLifecycle({
+      workspaceRoot,
+      stateRoot,
+      modelTargets: settledModelTargets(),
+    });
+    const trust = createTrustedWorkspaceTrustForTesting(workspaceRoot);
+    const reader = createSessionLifecycle({
+      workspaceRoot,
+      stateRoot,
+      workspaceTrust: {
+        ...trust,
+        async load() {
+          return { ...(await trust.load()), status: trusted ? "trusted" : "untrusted" };
+        },
+      },
+    });
+    let controller: ProjectSessionCatalogController | undefined;
+    try {
+      const session = await author.create({ targetIdentity });
+      await author.continue({
+        sessionId: session.sessionId,
+        input: { text: "MCP inspection boundary" },
+      });
+      await writeFile(join(workspaceRoot, ".mcp.json"), "{invalid configuration");
+      if (trusted)
+        await expect(reader.listProjectSessions()).rejects.toMatchObject({
+          code: "mcp_config_invalid",
+        });
+      else
+        expect((await reader.listProjectSessions()).items.map((item) => item.sessionId)).toEqual([
+          session.sessionId,
+        ]);
+      const catalog = observeCatalog(reader);
+      controller = catalog.controller;
+      const outcome = await catalog.until(
+        (snapshot) => snapshot.health.status === (trusted ? "failed" : "complete"),
+      );
+      expect(outcome.diagnostics.totalCount).toBe(0);
+      if (trusted) {
+        expect(outcome).toMatchObject({
+          phase: "failed",
+          error: { code: "catalog_scan_failed" },
+          health: { checked: 0, total: 1 },
+        });
+      } else {
+        expect(outcome.items.map((item) => item.sessionId)).toEqual([session.sessionId]);
+        expect(outcome.health).toEqual({ status: "complete", checked: 1, total: 1 });
+      }
+    } finally {
+      await controller?.close();
+      await reader.close();
+      await author.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);
+
+test("native catalog close reclaims its worker while a read-only authority request is held", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-catalog-worker-close-"));
+  const workspaceRoot = join(root, "workspace");
+  const stateRoot = join(root, "state");
+  await mkdir(workspaceRoot);
+  const author = createSessionLifecycle({
+    workspaceRoot,
+    stateRoot,
+    modelTargets: settledModelTargets(),
+  });
+  const trust = createTrustedWorkspaceTrustForTesting(workspaceRoot);
+  const requested = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const exited = Promise.withResolvers<void>();
+  const reader = createSessionLifecycle({
+    workspaceRoot,
+    stateRoot,
+    [sessionCatalogWorkerFactory](url, options) {
+      const worker = new Worker(url, options);
+      worker.once("exit", () => exited.resolve());
+      return worker;
+    },
+    workspaceTrust: {
+      ...trust,
+      async load() {
+        requested.resolve();
+        await release.promise;
+        return trust.load();
+      },
+    },
+  });
+  let catalog: ReturnType<typeof observeCatalog> | undefined;
+  try {
+    const session = await author.create({ targetIdentity });
+    await author.continue({
+      sessionId: session.sessionId,
+      input: { text: "Close while health is pending." },
+    });
+    catalog = observeCatalog(reader);
+    await catalog.until((snapshot) => snapshot.phase === "ready");
+    await withManagedFailureGuard(requested.promise, "the held read-only authority request");
+    await withManagedFailureGuard(
+      reader.close(),
+      "Lifecycle close with a held worker authority request",
+    );
+    await withManagedFailureGuard(exited.promise, "native history worker exit");
+    expect(catalog.updates.some((snapshot) => snapshot.health.status === "complete")).toBe(false);
+    await expect(catalog.controller.loadMore("closed")).rejects.toMatchObject({
+      name: "AbortError",
+    });
+  } finally {
+    release.resolve();
+    await catalog?.controller.close();
+    await reader.close();
+    await author.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("native authority transport preserves the frozen isolation errors and fails on unknown errors", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-catalog-worker-authority-errors-"));
+  const workspaceRoot = join(root, "workspace");
+  const stateRoot = join(root, "state");
+  await mkdir(workspaceRoot);
+  const author = createSessionLifecycle({
+    workspaceRoot,
+    stateRoot,
+    modelTargets: settledModelTargets(),
+  });
+  const trust = createTrustedWorkspaceTrustForTesting(workspaceRoot);
+  try {
+    const session = await author.create({ targetIdentity });
+    await author.continue({
+      sessionId: session.sessionId,
+      input: { text: "Retain the authority error classification." },
+    });
+    for (const { error, code } of [
+      { error: new SessionLifecycleError("session_invalid"), code: "invalid_history" },
+      { error: new SessionStoreError("session_log_invalid"), code: "invalid_log" },
+      { error: new SessionStoreError("session_log_too_large"), code: "log_too_large" },
+      { error: new Error("External authority unavailable"), code: null },
+    ]) {
+      const reader = createSessionLifecycle({
+        workspaceRoot,
+        stateRoot,
+        workspaceTrust: {
+          ...trust,
+          async load() {
+            throw error;
+          },
+        },
+      });
+      const catalog = observeCatalog(reader);
+      try {
+        const outcome = await catalog.until(
+          (snapshot) => snapshot.health.status === (code === null ? "failed" : "complete"),
+        );
+        if (code === null) {
+          await expect(reader.listProjectSessions()).rejects.toBe(error);
+          expect(outcome.error?.code).toBe("catalog_scan_failed");
+          expect(outcome.diagnostics.totalCount).toBe(0);
+        } else {
+          expect(outcome.items).toEqual([]);
+          expect(outcome.diagnostics).toMatchObject({
+            totalCount: 1,
+            items: [{ sessionId: session.sessionId, code, retained: true }],
+          });
+          expect(outcome.diagnostics).toEqual((await reader.listProjectSessions()).diagnostics);
+        }
+      } finally {
+        await catalog.controller.close();
+        await reader.close();
+      }
+    }
+  } finally {
+    await author.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("background health refresh reads changed native bytes and preserves isolated log diagnostics", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-catalog-worker-refresh-"));
+  const workspaceRoot = join(root, "workspace");
+  const stateRoot = join(root, "state");
+  await mkdir(workspaceRoot);
+  const lifecycle = createSessionLifecycle({
+    workspaceRoot,
+    stateRoot,
+    modelTargets: settledModelTargets(),
+  });
+  let controller: ProjectSessionCatalogController | undefined;
+  try {
+    const session = await lifecycle.create({ targetIdentity });
+    await lifecycle.continue({ sessionId: session.sessionId, input: { text: "Refresh catalog" } });
+    await lifecycle.setSessionManualName({ sessionId: session.sessionId, name: "Before" });
+    const first = observeCatalog(lifecycle);
+    controller = first.controller;
+    await first.until((snapshot) => snapshot.health.status === "complete");
+    const path = join(
+      stateRoot,
+      "projects",
+      session.projectId.replace(/^sha256:/u, ""),
+      "sessions",
+      `${session.sessionId}.jsonl`,
+    );
+    const original = await readFile(path, "utf8");
+    const changed = original.replace('"name":"Before"', '"name":false   ');
+    expect(changed).not.toBe(original);
+    expect(Buffer.byteLength(changed)).toBe(Buffer.byteLength(original));
+    await writeFile(path, changed);
+    const refreshed = observeCatalog(lifecycle);
+    controller = refreshed.controller;
+    const complete = await refreshed.until((snapshot) => snapshot.health.status === "complete");
+    expect(complete.items).toEqual([]);
+    expect(complete.diagnostics).toMatchObject({
+      totalCount: 1,
+      items: [{ sessionId: session.sessionId, code: "invalid_log" }],
+    });
+    expect(complete.diagnostics).toEqual((await lifecycle.listProjectSessions()).diagnostics);
+    await expect(lifecycle.inspect({ sessionId: session.sessionId })).rejects.toMatchObject({
+      code: "session_log_invalid",
+    });
+  } finally {
+    await controller?.close();
+    await lifecycle.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test.each(["rename", "repair", "append", "delete"] as const)(
+  "full health replaces provisional metadata after concurrent %s without losing page bounds",
+  async (change) => {
+    const root = await mkdtemp(join(tmpdir(), "adam-catalog-worker-convergence-"));
+    const workspaceRoot = join(root, "workspace");
+    const stateRoot = join(root, "state");
+    await mkdir(workspaceRoot);
+    const author = createSessionLifecycle({
+      workspaceRoot,
+      stateRoot,
+      modelTargets: settledModelTargets(),
+    });
+    const trust = createTrustedWorkspaceTrustForTesting(workspaceRoot);
+    const requested = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    let firstAuthorityRead = true;
+    const reader = createSessionLifecycle({
+      workspaceRoot,
+      stateRoot,
+      workspaceTrust: {
+        ...trust,
+        async load() {
+          if (firstAuthorityRead) {
+            firstAuthorityRead = false;
+            requested.resolve();
+            await release.promise;
+          }
+          return trust.load();
+        },
+      },
+    });
+    let catalog: ReturnType<typeof observeCatalog> | undefined;
+    try {
+      const sessions = [];
+      for (const [index, name] of ["Gate", "Before", "Tail"].entries()) {
+        const session = await author.create({ targetIdentity });
+        await author.continue({
+          sessionId: session.sessionId,
+          input: { text: `Catalog observation ${index}` },
+        });
+        await author.setSessionManualName({ sessionId: session.sessionId, name });
+        const path = join(
+          stateRoot,
+          "projects",
+          session.projectId.replace(/^sha256:/u, ""),
+          "sessions",
+          `${session.sessionId}.jsonl`,
+        );
+        await utimes(path, 3_000 - index, 3_000 - index);
+        sessions.push({ id: session.sessionId, path });
+      }
+      const target = sessions[1];
+      if (target === undefined) throw new Error("Expected the second catalog fixture.");
+      const original = await readFile(target.path, "utf8");
+      if (change === "repair") {
+        await writeFile(target.path, original.replace('"name":"Before"', '"name":false   '));
+        await utimes(target.path, 2_999, 2_999);
+      }
+      catalog = observeCatalog(reader, 2);
+      const provisional = await catalog.until((snapshot) => snapshot.phase === "ready");
+      expect(provisional.items).toHaveLength(2);
+      expect(provisional.diagnostics.totalCount).toBe(change === "repair" ? 1 : 0);
+      await withManagedFailureGuard(
+        requested.promise,
+        "the first health entry before the changed history is read",
+      );
+      if (change === "delete") {
+        await rm(target.path);
+      } else if (change === "append") {
+        await author.continue({ sessionId: target.id, input: { text: "A newly settled run." } });
+        await author.setSessionManualName({ sessionId: target.id, name: "After!" });
+      } else {
+        const changed = original.replace('"name":"Before"', '"name":"After!"');
+        expect(Buffer.byteLength(changed)).toBe(Buffer.byteLength(original));
+        await writeFile(target.path, changed);
+      }
+      release.resolve();
+      const complete = await catalog.until((snapshot) => snapshot.health.status === "complete");
+      expect(complete.items).toHaveLength(2);
+      expect(complete.diagnostics).toEqual({ items: [], totalCount: 0, truncated: false });
+      expect(complete.health).toEqual({ status: "complete", checked: 3, total: 3 });
+      if (change === "delete") {
+        expect(complete.items.map((item) => item.sessionId)).toEqual([
+          sessions[0]?.id,
+          sessions[2]?.id,
+        ]);
+        expect(complete.nextCursor).toBeNull();
+      } else {
+        expect(complete.items.map((item) => item.sessionId)).toEqual([sessions[0]?.id, target.id]);
+        const strict = (await author.listProjectSessionSummaries()).items.find(
+          (item) => item.sessionId === target.id,
+        );
+        expect(complete.items.find((item) => item.sessionId === target.id)).toEqual(strict);
+        expect(strict).toMatchObject({ naming: { manualName: "After!" } });
+        if (complete.nextCursor === null)
+          throw new Error("The tail row still needs a continuation page.");
+        await catalog.controller.loadMore(complete.nextCursor);
+        const next = await catalog.until((snapshot) => snapshot.items.length === 3);
+        expect(next.items.map((item) => item.sessionId)).toEqual(
+          sessions.map((session) => session.id),
+        );
+        expect(next.nextCursor).toBeNull();
+      }
+    } finally {
+      release.resolve();
+      await catalog?.controller.close();
+      await reader.close();
+      await author.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);
+
+test("a custom session store explicitly declines the native background scan without changing strict catalog access", async () => {
+  const root = await mkdtemp(join(tmpdir(), "adam-catalog-worker-custom-"));
+  const workspaceRoot = join(root, "workspace");
+  const stateRoot = join(root, "state");
+  await mkdir(workspaceRoot);
+  const lifecycle = createSessionLifecycle({
+    workspaceRoot,
+    stateRoot,
+    [sessionStoreDirectory]: createJsonlSessionStoreDirectory({ workspaceRoot, stateRoot }),
+  });
+  const catalog = observeCatalog(lifecycle);
+  try {
+    const unavailable = await catalog.until((snapshot) => snapshot.phase === "failed");
+    expect(unavailable).toMatchObject({
+      error: { code: "catalog_unavailable" },
+      health: { status: "failed", checked: 0, total: null },
+    });
+    expect((await lifecycle.listProjectSessions()).items).toEqual([]);
+  } finally {
+    await catalog.controller.close();
+    await lifecycle.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test.each(["ancestor", "artifact"] as const)(
+  "full background health revalidates changed %s dependencies across generations",
+  async (change) => {
+    const root = await mkdtemp(join(tmpdir(), "adam-catalog-worker-lineage-"));
+    const workspaceRoot = join(root, "workspace");
+    const stateRoot = join(root, "state");
+    const skillRoot = join(workspaceRoot, ".agents", "skills", "catalog-check");
+    await mkdir(skillRoot, { recursive: true });
+    await writeFile(
+      join(skillRoot, "SKILL.md"),
+      "---\nname: catalog-check\ndescription: Check retained catalog evidence.\n---\nKeep the recorded procedure.\n",
+    );
+    const lifecycle = createSessionLifecycle({
+      workspaceRoot,
+      stateRoot,
+      modelTargets: settledModelTargets(),
+      permissions: createPermissionPolicy({ allowedEffects: ["read"] }),
+    });
+    let controller: ProjectSessionCatalogController | undefined;
+    try {
+      const parent = await lifecycle.create({ targetIdentity });
+      const activated = await lifecycle.continue({
+        sessionId: parent.sessionId,
+        input: {
+          text: "Record the selected procedure.",
+          skills: ["skill:v1:project:.:catalog-check"],
+        },
+      });
+      expect(activated.snapshot.skillContext?.active).toEqual([
+        expect.objectContaining({ qualifiedId: "skill:v1:project:.:catalog-check" }),
+      ]);
+      const named = await lifecycle.setSessionManualName({
+        sessionId: parent.sessionId,
+        name: "Before",
+      });
+      const child = await lifecycle.branch({
+        parentSessionId: parent.sessionId,
+        atSequence: named.snapshot.lastSequence,
+      });
+      await lifecycle.continue({
+        sessionId: child.sessionId,
+        input: { text: "Use the inherited procedure." },
+      });
+      const initial = observeCatalog(lifecycle);
+      controller = initial.controller;
+      const healthy = await initial.until((snapshot) => snapshot.health.status === "complete");
+      expect(healthy.diagnostics.totalCount).toBe(0);
+      expect(healthy.items).toHaveLength(2);
+      await controller.close();
+      if (change === "ancestor") {
+        const path = join(
+          stateRoot,
+          "projects",
+          parent.projectId.replace(/^sha256:/u, ""),
+          "sessions",
+          `${parent.sessionId}.jsonl`,
+        );
+        const before = await readFile(path, "utf8");
+        const after = before.replace('"name":"Before"', '"name":"After!"');
+        expect(after).not.toBe(before);
+        expect(Buffer.byteLength(after)).toBe(Buffer.byteLength(before));
+        await writeFile(path, after);
+      } else {
+        const records = await createJsonlSessionStoreDirectory({
+          workspaceRoot,
+          stateRoot,
+        }).readRecords?.(parent.sessionId);
+        const activation = records?.find(
+          (record) =>
+            record.schemaVersion === 3 && record.record.type === "skill_activation_batch_committed",
+        );
+        if (
+          activation?.schemaVersion !== 3 ||
+          activation.record.type !== "skill_activation_batch_committed"
+        ) {
+          throw new Error("Expected the retained Skill activation.");
+        }
+        const artifact = activation.record.skillContext.active[0]?.artifact;
+        if (artifact === undefined) throw new Error("Expected the retained Skill artifact.");
+        await rm(join(stateRoot, "artifacts", artifact.id.slice("sha256:".length)));
+      }
+      const strict = await lifecycle.listProjectSessionSummaries();
+      expect(strict.diagnostics.totalCount).toBe(change === "ancestor" ? 1 : 2);
+      const refreshed = observeCatalog(lifecycle);
+      controller = refreshed.controller;
+      const complete = await refreshed.until((snapshot) => snapshot.health.status === "complete");
+      expect(complete.items).toEqual(strict.items);
+      expect(complete.diagnostics).toEqual(strict.diagnostics);
+      expect(complete.health).toEqual({ status: "complete", checked: 2, total: 2 });
+    } finally {
+      await controller?.close();
+      await lifecycle.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
Existing-history startup waited for every session to be inspected and named before opening the TUI. Production now opens an interactive loading picker, loads twenty summaries per page, and completes strict health inspection in a Lifecycle-owned worker. The worker shares the existing inspector and asks the actual owner for read-only Plan/MCP authority; opening or resuming a session still validates current history. No persistent index or dependency is added.

Catalog updates preserve search, selected identities and drafts. Path discovery also runs after initial Presentation construction. Closing reclaims the worker; failures, deleted rows and same-sequence naming rewrites have explicit handling. The original full catalog interfaces retain their contracts.

Validation: independent review; native worker authority, corruption, concurrency and shutdown tests; held-worker UI and real PTY measurements; final `pnpm quality:check` (2,536 passed, 18 existing opt-in skips). On the same existing-history workload, interactive first-frame median is 367 ms versus 4.43 s before either step; first summaries arrive around 1.76 s and the complete check around 4.72 s. During the scan, 36 input-frame samples have a 1.01 ms median. These are diagnostic measurements, not latency thresholds or a claim of faster total scanning.

