### PR TITLE
test: make TUI readiness independent of title success

### DIFF
--- a/apps/tui/src/fixture-settlement.os.test.ts
+++ b/apps/tui/src/fixture-settlement.os.test.ts
@@ -1,0 +1,99 @@
+import { access, mkdir, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PresentationSession } from "@adam-agent/presentation";
+import { expect, test } from "vitest";
+import { awaitEveReceipt as awaitReceipt } from "./public-eve.test-support.js";
+import { runTuiFixture } from "./test-fixture.js";
+import {
+  readFilesRecursively,
+  removeTuiFixtureRoot as rm,
+  waitForFileContents,
+} from "./tui-filesystem.test-support.js";
+import { VirtualTerminal } from "./virtual-terminal.test-support.js";
+
+test.each(["completed", "failed"] as const)(
+  "reasoning storage baseline waits for naming to settle as %s without requiring a title",
+  async (outcome) => {
+    const root = await mkdtemp(join(tmpdir(), "adam-fixture-settlement-"));
+    const workspaceRoot = join(root, "workspace");
+    const stateRoot = join(root, "state");
+    const controlRoot = join(root, "control");
+    await mkdir(workspaceRoot);
+    await mkdir(controlRoot);
+    const terminal = new VirtualTerminal();
+    const titleStarted = Promise.withResolvers<void>();
+    const releaseTitle = Promise.withResolvers<void>();
+    const mainReady = Promise.withResolvers<void>();
+    const namingSettled = Promise.withResolvers<string>();
+    let presentation: PresentationSession | undefined;
+    let unsubscribe: (() => void) | undefined;
+    const execution = runTuiFixture({
+      scenario: "reasoning-artifact",
+      workspaceRoot,
+      stateRoot,
+      controlRoot,
+      terminal,
+      async titleResponse() {
+        titleStarted.resolve();
+        await releaseTitle.promise;
+        return outcome === "completed" ? "Fixture title" : "";
+      },
+      onPresentationReady(current) {
+        presentation = current;
+        unsubscribe = current.subscribe(() => {
+          const state = current.getState();
+          const active = state.authoritative.active;
+          if (
+            active?.parentRun?.phase === "ready" &&
+            active.transcript.items.some((item) => item.type === "reasoning_block")
+          )
+            mainReady.resolve();
+          if (
+            active?.session.naming.generation.status === outcome &&
+            state.authoritative.continuity.status === "current"
+          )
+            namingSettled.resolve(
+              `${JSON.stringify({
+                sessionId: active.session.id,
+                throughSequence: state.authoritative.continuity.sessionThroughSequence,
+                naming: outcome,
+              })}\n`,
+            );
+        });
+      },
+    });
+    try {
+      await terminal.waitForScreen("Adam · New session");
+      const beforePrompt = terminal.output().length;
+      terminal.input("Freeze a completed reasoning view\r");
+      await awaitReceipt(titleStarted.promise, "held title producer");
+      await awaitReceipt(mainReady.promise, "Main ready with title still held");
+      expect(presentation?.getState().authoritative.active?.session.naming.generation.status).toBe(
+        "in_progress",
+      );
+      await expect(access(join(controlRoot, "reasoning-session-settled"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      releaseTitle.resolve();
+      const marker = await awaitReceipt(namingSettled.promise, "settled title projection");
+      await waitForFileContents(join(controlRoot, "reasoning-session-settled"), marker);
+      await terminal.waitForFrameAfter("Thinking done · adam", beforePrompt);
+      const baseline = await readFilesRecursively(stateRoot);
+      const beforeExpand = terminal.output().length;
+      terminal.input("\u0014");
+      await waitForFileContents(join(controlRoot, "artifact-read-1-range"), "0:16384\n");
+      await terminal.waitForFrameAfter("Large reasoning · plain view", beforeExpand);
+      expect(await readFilesRecursively(stateRoot)).toBe(baseline);
+      expect(presentation?.getState().authoritative.active?.session.naming.generation.status).toBe(
+        outcome,
+      );
+    } finally {
+      releaseTitle.resolve();
+      unsubscribe?.();
+      if (terminal.running()) terminal.input("\u0011");
+      await execution;
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/apps/tui/src/main.test.ts
+++ b/apps/tui/src/main.test.ts
@@ -3711,8 +3711,21 @@ test("the production session picker opens the exact focused existing session", a
     await fixture.waitForRecordedOutput("Select a project session");
     const beforeSelection = fixture.output().length;
     fixture.write("\u001b[B\r");
-    await fixture.waitForRecordedOutput("Adam · Streaming session", beforeSelection);
+    await fixture.waitForCompleteFrameAfter(
+      "Seeded project session for deepseek-v4-flash.direct",
+      beforeSelection,
+      "Select a project session",
+    );
     await fixture.waitForRecordedOutput("deepseek-v4-flash.direct · Certified", beforeSelection);
+    expect(
+      fixture
+        .screen()
+        ?.some(
+          (line) =>
+            line.includes("Seeded project session for deepseek-v4-flash.direct") &&
+            !line.includes("Adam ·"),
+        ),
+    ).toBe(true);
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
   } finally {
@@ -4473,9 +4486,9 @@ test("the footer exposes authoritative project context and run facts", async () 
     });
     await fixture.waitForScreen("Adam · New session");
     await fixture.resize(120, 40);
+    const beforePrompt = fixture.output().length;
     fixture.write("Produce an artifact-backed answer\r");
-    await fixture.waitForRecordedOutput("Adam · Streaming session");
-    await fixture.waitForRecordedOutput("Assistant response stored as artifact");
+    await fixture.waitForCompleteFrameAfter("Assistant response stored as artifact", beforePrompt);
     const afterFirstAnswer = fixture.output().lastIndexOf("Assistant response stored as artifact");
     await fixture.waitForCompleteFrameAfter(" · idle", afterFirstAnswer);
     const beforeCompaction = fixture.output().length;
@@ -5612,9 +5625,11 @@ test("thinking selection changed during a run applies only to the next prompt", 
       beforeNextSelection,
     );
     await fixture.waitForRecordedOutput("Next thinking Off", beforeNextSelection);
+    const beforeCompletion = fixture.output().length;
     await writeFile(join(controlRoot, "release-model"), "release\n", "utf8");
-    await fixture.waitForRecordedOutput("Thinking policy: max.");
-    await fixture.waitForRecordedOutput("Adam · Streaming session");
+    await fixture.waitForCompleteFrameAfter("Thinking policy: max.", beforeCompletion);
+    const firstResult = fixture.output().lastIndexOf("Thinking policy: max.");
+    await fixture.waitForCompleteFrameAfter(" · idle", firstResult);
     const beforeSecondPrompt = fixture.output().length;
     fixture.write("Second prompt\r");
     await fixture.waitForRecordedOutput("Thinking policy: off.", beforeSecondPrompt);
@@ -5800,8 +5815,7 @@ test("Ctrl+T expands cumulative live provider reasoning and preserves disclosure
     await writeFile(join(controlRoot, "release-model"), "release\n", "utf8");
     await fixture.waitForRecordedOutput("Thinking done · adam");
     await fixture.waitForRecordedOutput("Reasoning answer.");
-    await fixture.waitForRecordedOutput(" · idle", beforeCompletion);
-    await fixture.waitForRecordedOutput("Adam · Streaming session", beforeCompletion);
+    await fixture.waitForCompleteFrameAfter(" · idle", beforeCompletion);
     beforeFrame = fixture.output().length;
     await fixture.resize(80, 24);
     frame = latestSynchronizedFrame(fixture.output().slice(beforeFrame)).join("\n");
@@ -5862,7 +5876,7 @@ test("repeated completed reasoning folds keep the selected block visible without
     await writeFile(join(controlRoot, "release-reasoning"), "release\n", "utf8");
     await writeFile(join(controlRoot, "release-model"), "release\n", "utf8");
     await waitForPath(join(controlRoot, "reasoning-session-settled"));
-    await waitForPhysicalText(terminal, "Adam · Streaming session");
+    await waitForPhysicalText(terminal, "Reasoning answer.");
     const durableStateBeforeFolds = await readFilesRecursively(stateRoot);
 
     for (let cycle = 0; cycle < 4; cycle += 1) {
@@ -6197,7 +6211,6 @@ test("Ctrl+T reads artifact-backed provider reasoning without placing it in the 
     fixture.write("Store provider reasoning out of line\r");
     await fixture.waitForCompleteFrameAfter("Thinking done · adam", beforePrompt);
     await waitForPath(join(controlRoot, "reasoning-session-settled"));
-    await fixture.waitForRecordedOutput("Adam · Streaming session");
     let frame = latestSynchronizedFrame(fixture.output().slice(beforePrompt)).join("\n");
     expect(frame).not.toContain("Artifact reasoning evidence");
     const durableStateBeforeExpand = await readFilesRecursively(stateRoot);
@@ -6272,7 +6285,6 @@ test("continued scrolling loads only the adjacent oversized reasoning range", as
     terminal.input("Traverse provider reasoning ranges\r");
     await waitForPath(join(controlRoot, "reasoning-session-settled"));
     await waitForPhysicalText(terminal, "Thinking done · adam");
-    await waitForPhysicalText(terminal, "Adam · Streaming session");
     const durableStateBeforeNavigation = await readFilesRecursively(stateRoot);
     await inputAndWaitForPhysicalFrame(terminal, "\u0014");
     await waitForPath(join(controlRoot, "artifact-read-1-settled"));
@@ -6315,7 +6327,6 @@ test("a late downward reasoning range cannot replace the page selected while it 
     terminal.input("Keep a reordered reasoning range out of the viewport\r");
     await waitForPath(join(controlRoot, "reasoning-session-settled"));
     await waitForPhysicalText(terminal, "Thinking done · adam");
-    await waitForPhysicalText(terminal, "Adam · Streaming session");
     await inputAndWaitForPhysicalFrame(terminal, "\u0014");
     await waitForPath(join(controlRoot, "artifact-read-1-settled"));
     await waitForPhysicalText(terminal, "Large reasoning · plain view · 1-16384 of 270028 bytes");
@@ -6469,7 +6480,6 @@ test("folding oversized reasoning rejects a late range before a clean retry", as
     terminal.input("Hold one provider reasoning range\r");
     await waitForPath(join(controlRoot, "reasoning-session-settled"));
     await waitForPhysicalText(terminal, "Thinking done · adam");
-    await waitForPhysicalText(terminal, "Adam · Streaming session");
     await inputAndWaitForPhysicalFrame(terminal, "\u0014");
     await waitForPath(join(controlRoot, "reasoning-page-read-pending"));
 
@@ -6566,7 +6576,6 @@ test.each(["missing", "truncated", "same-size corrupt"] as const)(
       fixture.write("Recover one unavailable reasoning range\r");
       await fixture.waitForCompleteFrameAfter("Thinking done · adam", beforePrompt);
       await waitForPath(join(controlRoot, "reasoning-session-settled"));
-      await fixture.waitForRecordedOutput("Adam · Streaming session");
       const artifactRoot = join(stateRoot, "artifacts");
       const artifactRelativePaths = (await readdir(artifactRoot, { recursive: true })).filter(
         (path): path is string => typeof path === "string" && !path.endsWith(".tmp"),
@@ -8076,7 +8085,7 @@ test("an older asynchronous copy receipt cannot survive a newer overlay action",
     await terminal.waitForFrameAfter("Session facts", beforeCopyReceipt);
     const beforeClose = terminal.output().length;
     terminal.input("\u001b[27;1;27~");
-    await terminal.waitForFrameAfter("Adam · Streaming session", beforeClose);
+    await terminal.waitForFrameAfter("Read complete", beforeClose, "Session facts");
 
     expect(terminal.lines().join("\n")).not.toContain("Copied last assistant response.");
     terminal.input("\u0011");
@@ -8364,8 +8373,9 @@ test("an artifact-backed assistant response remains visible in the transcript", 
       workspaceRoot,
     });
     await fixture.waitForScreen("Adam · New session");
+    const beforePrompt = fixture.output().length;
     fixture.write("Produce an artifact-backed answer\r");
-    await fixture.waitForRecordedOutput("Adam · Streaming session");
+    await fixture.waitForCompleteFrameAfter("Assistant response stored as artifact", beforePrompt);
     expect(fixture.output()).toContain("Assistant response stored as artifact");
     fixture.write("\u0011");
     await expect(fixture.closed).resolves.toMatchObject({ code: 0, signal: null, stderr: "" });
@@ -8653,9 +8663,9 @@ test("completed durable-context compaction renders an explicit chronology marker
       workspaceRoot,
     });
     await fixture.waitForScreen("Adam · New session");
+    const beforePrompt = fixture.output().length;
     fixture.write("Produce an artifact-backed answer\r");
-    await fixture.waitForRecordedOutput("Assistant response stored as artifact");
-    await fixture.waitForRecordedOutput("Adam · Streaming session");
+    await fixture.waitForCompleteFrameAfter("Assistant response stored as artifact", beforePrompt);
     const afterFirstAnswer = fixture.output().lastIndexOf("Assistant response stored as artifact");
     await fixture.waitForCompleteFrameAfter(" · idle", afterFirstAnswer);
     const beforeCompaction = fixture.output().length;

--- a/apps/tui/src/scroll-input.os.test.ts
+++ b/apps/tui/src/scroll-input.os.test.ts
@@ -45,7 +45,8 @@ test("PTY Main viewport scroll preserves drafts and resize anchors and restores 
     await fixture.waitForScreen("Show Main rows");
     fixture.write("\r");
     await fixture.waitForScreen("MAIN_SCROLL_119");
-    await fixture.waitForScreen("Adam · Streaming session");
+    const answerOffset = fixture.output().lastIndexOf("MAIN_SCROLL_119");
+    await fixture.waitForCompleteFrameAfter(" · idle", answerOffset);
     const draftOffset = fixture.output().length;
     fixture.write("retained draft");
     await fixture.waitForCompleteFrameAfter("retained draft", draftOffset);

--- a/apps/tui/src/test-fixture.ts
+++ b/apps/tui/src/test-fixture.ts
@@ -163,6 +163,7 @@ const contextProfile: ContextProfile = {
 };
 
 export type TuiFixtureOptions = {
+  readonly titleResponse?: () => Promise<string>;
   readonly clipboard?: ClipboardAdapter;
   readonly controlRoot?: string;
   readonly deadlineScheduler?: DeadlineScheduler;
@@ -1055,9 +1056,51 @@ function observeTuiDispatch(
   let artifactReadCount = 0;
   let reasoningSettlementObserved = false;
   let targetNavigationSettlementObserved = false;
+  let reasoningSettlementWrite: Promise<void> | undefined;
+  const observeReasoningSettlement = (): void => {
+    const state = presentation.getState();
+    const active = state.authoritative.active;
+    if (
+      reasoningSettlementObserved ||
+      controlRoot === undefined ||
+      ![
+        "reasoning-streaming",
+        "reasoning-artifact",
+        "reasoning-artifact-race",
+        "reasoning-artifact-reorder",
+        "reasoning-artifact-session-race",
+        "reasoning-large-multiple",
+        "reasoning-large-live",
+      ].includes(options.scenario ?? "") ||
+      state.authoritative.continuity.status !== "current" ||
+      active?.session.status !== "settled" ||
+      active.parentRun?.phase !== "ready" ||
+      active.parentRun.editor !== "ready" ||
+      active.session.naming.generation.status === "in_progress" ||
+      !active.transcript.items.some((item) => item.type === "reasoning_block") ||
+      state.transient !== null ||
+      state.composer.sealed ||
+      state.composer.renderedText !== ""
+    )
+      return;
+    // Main readiness includes title admission; a title may finish unsuccessfully.
+    // Freeze storage only after both naming and submitted-draft cleanup have settled.
+    reasoningSettlementObserved = true;
+    reasoningSettlementWrite = writeFile(
+      join(controlRoot, "reasoning-session-settled"),
+      `${JSON.stringify({
+        sessionId: active.session.id,
+        throughSequence: state.authoritative.continuity.sessionThroughSequence,
+        naming: active.session.naming.generation.status,
+      })}\n`,
+      "utf8",
+    );
+    void reasoningSettlementWrite.catch(() => {});
+  };
   return {
     async close() {
       await presentation.close();
+      await reasoningSettlementWrite;
       if (options.presentationCloseMarker !== undefined) {
         await writeFile(options.presentationCloseMarker, "closed\n", "utf8");
       }
@@ -1138,7 +1181,9 @@ function observeTuiDispatch(
         return settled;
       }
       if (!observeDispatch) {
-        return receipt;
+        const settled = await receipt;
+        if (command.type === "submit_prompt") observeReasoningSettlement();
+        return settled;
       }
       if (command.type === "decide_permission") {
         await writeFile(
@@ -1188,29 +1233,16 @@ function observeTuiDispatch(
           "utf8",
         );
       }
-      return receipt;
+      const settled = await receipt;
+      if (command.type === "submit_prompt") observeReasoningSettlement();
+      return settled;
     },
     getState: () => presentation.getState(),
-    subscribe: (onChange) =>
-      presentation.subscribe(() => {
+    subscribe: (onChange) => {
+      const unsubscribe = presentation.subscribe(() => {
         onChange();
         const state = presentation.getState();
-        if (
-          !reasoningSettlementObserved &&
-          (options.scenario === "reasoning-streaming" ||
-            options.scenario === "reasoning-artifact" ||
-            options.scenario === "reasoning-artifact-race" ||
-            options.scenario === "reasoning-artifact-reorder" ||
-            options.scenario === "reasoning-artifact-session-race" ||
-            options.scenario === "reasoning-large-multiple" ||
-            options.scenario === "reasoning-large-live") &&
-          controlRoot !== undefined &&
-          state.authoritative.active?.session.status === "settled" &&
-          state.transient === null
-        ) {
-          reasoningSettlementObserved = true;
-          void writeFile(join(controlRoot, "reasoning-session-settled"), "settled\n", "utf8");
-        }
+        observeReasoningSettlement();
         if (
           !targetNavigationSettlementObserved &&
           options.scenario === "target-navigation" &&
@@ -1226,7 +1258,10 @@ function observeTuiDispatch(
             "utf8",
           );
         }
-      }),
+      });
+      observeReasoningSettlement();
+      return unsubscribe;
+    },
   };
 }
 
@@ -1276,6 +1311,7 @@ function optionValue(arguments_: readonly string[], option: string): string | un
 }
 
 function createFixtureModelTargets(options: {
+  readonly titleResponse?: () => Promise<string>;
   readonly controlRoot?: string;
   readonly launch?: TuiFixtureOptions["launch"];
   readonly scenario?: FixtureScenario;
@@ -1314,7 +1350,9 @@ function createFixtureModelTargets(options: {
           type: "text_delta",
           text:
             request.maximumOutputTokens === 64
-              ? "Streaming session"
+              ? options.titleResponse === undefined
+                ? "Streaming session"
+                : await options.titleResponse()
               : JSON.stringify({
                   schemaVersion: 1,
                   objective: "Preserve the active TUI fixture task.",


### PR DESCRIPTION
Several TUI behavior tests waited for a successful automatic title instead of the behavior they exercised. Automatic naming is best-effort, so a valid artifact or reasoning result could be ready while that title never appeared. Replace these gates with action-specific result frames or actual idle state.

For reasoning tests that compare stored bytes, the shared fixture marker now waits for Main/editor readiness, submitted-draft cleanup and naming quiescence, including unsuccessful title outcomes. A held-title regression proves the storage baseline is withheld until title settlement, then checks both successful and invalid-title completion while artifact navigation leaves storage unchanged. Product behavior and timeouts are unchanged.

Validation: independent review; two-case RED/GREEN; all 15 affected behavior cases; real PTY scrolling; final `pnpm quality:check`.
